### PR TITLE
Fix conflicting functions and builds properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,33 @@ on:
   pull_request:
     branches: [main, develop]
 
+# Only run checks when relevant files change
+# Skip for documentation-only changes, license, etc.
+paths:
+  - 'packages/**'
+  - 'config/**'
+  - 'scripts/**'
+  - 'tests/**'
+  - '.github/workflows/**'
+  - '*.json'
+  - '*.js'
+  - '*.ts'
+  - '*.yml'
+  - '*.yaml'
+  - 'tsconfig.json'
+  - '.eslintrc.js'
+  - '.prettierignore'
+  - '.gitignore'
+paths-ignore:
+  - '**/*.md'
+  - 'LICENSE'
+  - 'docs/**'
+  - 'business/**'
+  - 'marketing/**'
+  - 'strategic/**'
+  - 'grafana-dashboards/**'
+  - 'sre/**'
+
 jobs:
   validate-env:
     name: Validate Environment Schema

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,6 +4,27 @@ on:
   pull_request:
     branches: [main]
 
+# Only deploy when relevant files change
+paths:
+  - 'packages/**'
+  - 'config/**'
+  - 'scripts/**'
+  - '*.json'
+  - '*.js'
+  - '*.ts'
+  - '*.yml'
+  - '*.yaml'
+  - 'tsconfig.json'
+paths-ignore:
+  - '**/*.md'
+  - 'LICENSE'
+  - 'docs/**'
+  - 'business/**'
+  - 'marketing/**'
+  - 'strategic/**'
+  - 'grafana-dashboards/**'
+  - 'sre/**'
+
 jobs:
   deploy-preview:
     name: Deploy Preview

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,6 +5,27 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Only deploy when relevant files change (unless manually triggered)
+paths:
+  - 'packages/**'
+  - 'config/**'
+  - 'scripts/**'
+  - '*.json'
+  - '*.js'
+  - '*.ts'
+  - '*.yml'
+  - '*.yaml'
+  - 'tsconfig.json'
+paths-ignore:
+  - '**/*.md'
+  - 'LICENSE'
+  - 'docs/**'
+  - 'business/**'
+  - 'marketing/**'
+  - 'strategic/**'
+  - 'grafana-dashboards/**'
+  - 'sre/**'
+
 jobs:
   deploy:
     name: Deploy to Production

--- a/packages/api/vercel.json
+++ b/packages/api/vercel.json
@@ -1,11 +1,5 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "dist/index.js",
-      "use": "@vercel/node"
-    }
-  ],
   "routes": [
     {
       "src": "/health",


### PR DESCRIPTION
Remove `builds` property from `vercel.json` and add path filters to GitHub Actions workflows.

This fixes a Vercel deployment error where `functions` and `builds` properties conflicted, and ensures GitHub checks run only when relevant files change, preventing unnecessary runs for documentation-only updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-02413480-ca49-4e3b-a3fe-e9fb803e6525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02413480-ca49-4e3b-a3fe-e9fb803e6525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

