### PR TITLE
Fix serverless function build pattern

### DIFF
--- a/packages/api/api/index.ts
+++ b/packages/api/api/index.ts
@@ -1,0 +1,5 @@
+// Vercel serverless function handler
+// Export the Express app - Vercel will automatically handle it with @vercel/node
+import app from '../src/index';
+
+export default app;

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -5,6 +5,6 @@
     "rootDir": "./src",
     "composite": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "api/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/packages/api/vercel.json
+++ b/packages/api/vercel.json
@@ -1,20 +1,16 @@
 {
   "version": 2,
-  "routes": [
+  "rewrites": [
     {
-      "src": "/health",
-      "dest": "/dist/index.js"
-    },
-    {
-      "src": "/api/(.*)",
-      "dest": "/dist/index.js"
+      "source": "/(.*)",
+      "destination": "/api/index"
     }
   ],
   "env": {
     "NODE_ENV": "production"
   },
   "functions": {
-    "dist/index.js": {
+    "api/index.ts": {
       "maxDuration": 30
     }
   }


### PR DESCRIPTION
Configure Vercel to deploy the Express app as a serverless function to fix build failure.

The previous Vercel configuration referenced `dist/index.js` for serverless functions, which was not correctly detected. This PR moves the Express app's entry point to `api/index.ts`, which Vercel automatically recognizes as a serverless function, and updates `vercel.json` to route all requests to this new handler.

---
<a href="https://cursor.com/background-agent?bcId=bc-dce5ab0c-2d6a-40ea-af30-8bb2266f8c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dce5ab0c-2d6a-40ea-af30-8bb2266f8c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

