### PR TITLE
Fix typescript build errors in adapters

### DIFF
--- a/packages/adapters/src/paypal-enhanced.ts
+++ b/packages/adapters/src/paypal-enhanced.ts
@@ -36,7 +36,7 @@ export class PayPalEnhancedAdapter implements EnhancedAdapter {
   /**
    * Normalize webhook payload to canonical format
    */
-  normalizeWebhook(payload: Record<string, any>, tenantId: string>, tenantId: string): NormalizedEvent[] {
+  normalizeWebhook(payload: Record<string, any>, tenantId: string): NormalizedEvent[] {
     const events: NormalizedEvent[] = [];
     const eventType = payload.event_type || payload.eventType;
     const resource = payload.resource || payload;
@@ -281,49 +281,49 @@ export class PayPalEnhancedAdapter implements EnhancedAdapter {
     }
   }
 
-    /**
-     * Map PayPal transaction type to canonical type
-     */
-    private mapTransactionType(payment: any): TransactionType {
-      if (payment.state === 'refunded') return 'refund';
-      if (payment.state === 'denied' || payment.state === 'failed') return 'chargeback';
-      if (payment.state === 'completed' || payment.state === 'approved') return 'capture';
-      return 'authorization';
-    }
+  /**
+   * Map PayPal transaction type to canonical type
+   */
+  private mapTransactionType(payment: any): TransactionType {
+    if (payment.state === 'refunded') return 'refund';
+    if (payment.state === 'denied' || payment.state === 'failed') return 'chargeback';
+    if (payment.state === 'completed' || payment.state === 'approved') return 'capture';
+    return 'authorization';
+  }
 
-    /**
-     * Map PayPal status to canonical status
-     */
-    private mapTransactionStatus(payment: any): TransactionStatus {
-      if (payment.state === 'refunded') return 'refunded';
-      if (payment.state === 'denied' || payment.state === 'failed') return 'failed';
-      if (payment.state === 'completed' || payment.state === 'approved') return 'succeeded';
-      return 'pending';
-    }
+  /**
+   * Map PayPal status to canonical status
+   */
+  private mapTransactionStatus(payment: any): TransactionStatus {
+    if (payment.state === 'refunded') return 'refunded';
+    if (payment.state === 'denied' || payment.state === 'failed') return 'failed';
+    if (payment.state === 'completed' || payment.state === 'approved') return 'succeeded';
+    return 'pending';
+  }
 
-    /**
-     * Map PayPal payout status to canonical status
-     */
-    private mapSettlementStatus(payout: any): SettlementStatus {
-      if (payout.payout_status === 'SUCCESS' || payout.status === 'COMPLETED') return 'completed';
-      if (payout.payout_status === 'FAILED' || payout.status === 'FAILED') return 'failed';
-      return 'pending';
-    }
+  /**
+   * Map PayPal payout status to canonical status
+   */
+  private mapSettlementStatus(payout: any): SettlementStatus {
+    if (payout.payout_status === 'SUCCESS' || payout.status === 'COMPLETED') return 'completed';
+    if (payout.payout_status === 'FAILED' || payout.status === 'FAILED') return 'failed';
+    return 'pending';
+  }
 
-    /**
-     * Map PayPal refund/dispute status to canonical status
-     */
-    private mapRefundDisputeStatus(raw: any): RefundDisputeStatus {
-      if (raw.state === 'completed' || raw.status === 'COMPLETED') return 'completed';
-      if (raw.state === 'failed' || raw.status === 'FAILED') return 'lost';
-      if (raw.state === 'cancelled' || raw.status === 'CANCELLED') return 'reversed';
-      return 'pending';
-    }
+  /**
+   * Map PayPal refund/dispute status to canonical status
+   */
+  private mapRefundDisputeStatus(raw: any): RefundDisputeStatus {
+    if (raw.state === 'completed' || raw.status === 'COMPLETED') return 'completed';
+    if (raw.state === 'failed' || raw.status === 'FAILED') return 'lost';
+    if (raw.state === 'cancelled' || raw.status === 'CANCELLED') return 'reversed';
+    return 'pending';
+  }
 
-    /**
-     * Generate ID
-     */
-    private generateId(): string {
-      return `paypal_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-    }
+  /**
+   * Generate ID
+   */
+  private generateId(): string {
+    return `paypal_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  }
   }


### PR DESCRIPTION
Fix TypeScript build errors in `paypal-enhanced.ts` by removing a duplicate function parameter and correcting method indentation.

The build was failing due to a syntax error in the `normalizeWebhook` function signature (`tenantId: string>` appeared twice), which caused a cascade of TypeScript errors (`TS1005`, `TS1109`, `TS1434`, `TS1128`, `TS1011`). Correcting this parameter and adjusting method indentation resolves the build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-48a26491-73c9-4b97-9146-7ad21afda401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48a26491-73c9-4b97-9146-7ad21afda401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

