### PR TITLE
Fix settler api build errors

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -59,7 +59,8 @@
     "@sentry/node": "^7.91.0",
     "@sentry/profiling-node": "^7.91.0",
     "@supabase/supabase-js": "^2.39.0",
-    "@upstash/redis": "^1.25.0"
+    "@upstash/redis": "^1.25.0",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
@@ -71,6 +72,7 @@
     "@types/bcrypt": "^5.0.2",
     "@types/uuid": "^9.0.7",
     "@types/compression": "^1.7.5",
+    "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.57.1",

--- a/packages/api/src/utils/webhook-signature.ts
+++ b/packages/api/src/utils/webhook-signature.ts
@@ -16,7 +16,7 @@ export async function verifyWebhookSignature(
     throw new Error(`Unknown adapter: ${adapter}`);
   }
 
-  const config = configs[0];
+  const config = configs[0]!; // Safe: we checked length above
   const payloadBuffer = typeof payload === 'string' ? Buffer.from(payload) : payload;
 
   switch (adapter) {

--- a/packages/api/src/utils/xml-safe.ts
+++ b/packages/api/src/utils/xml-safe.ts
@@ -19,7 +19,7 @@ export function safeParseXML(xml: string): Promise<any> {
       // CRITICAL: Disable external entities to prevent XXE
       // This is the default, but explicitly set for security
       // noEnt: false, // Must be false (default)
-    }, (err, result) => {
+    }, (err: Error | null, result: any) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
Fix TypeScript build errors by adding missing `xml2js` dependency, resolving `config` possibly undefined, and explicitly typing `xml-safe` callback parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1c4b19c-b8de-4a29-a9a7-891ad0ee13c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f1c4b19c-b8de-4a29-a9a7-891ad0ee13c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

