### PR TITLE
Fix turbo json build error

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
-  "tasks": {
+  "pipeline": {
     "build": {
       "dependsOn": ["^build", "typecheck"],
       "outputs": ["dist/**", ".next/**", "build/**"],


### PR DESCRIPTION
Update `turbo.json` to use `pipeline` instead of `tasks` to resolve a Turborepo v1 parse error.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1da4637-9b0c-4e5d-ad2e-bd3298102c19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1da4637-9b0c-4e5d-ad2e-bd3298102c19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

