### PR TITLE
Fix web package typecheck errors

### DIFF
--- a/packages/api/src/utils/logger.ts
+++ b/packages/api/src/utils/logger.ts
@@ -29,7 +29,7 @@ const traceContextFormat = winston.format((info: any) => {
     ...info,
     ...traceContext,
   };
-})();
+});
 
 const logFormat = winston.format.combine(
   traceContextFormat,

--- a/packages/web/src/app/actions/auth.ts
+++ b/packages/web/src/app/actions/auth.ts
@@ -101,7 +101,7 @@ export async function signUpUser(
 
     // 4. Send welcome email (trial welcome)
     try {
-      const { sendTrialWelcomeEmail } = await import('@/../../api/src/lib/email-lifecycle' as any);
+      const { sendTrialWelcomeEmail } = await import('@settler/api/lib/email-lifecycle');
       await sendTrialWelcomeEmail(
         {
           email: authData.user.email!,

--- a/packages/web/src/app/api/cron/email-lifecycle/route.ts
+++ b/packages/web/src/app/api/cron/email-lifecycle/route.ts
@@ -7,7 +7,6 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/server';
-// @ts-ignore - API package types not available in web package
 import {
   sendTrialGatedFeaturesEmail,
   sendTrialCaseStudyEmail,
@@ -16,7 +15,7 @@ import {
   sendTrialEndedEmail,
   LifecycleUser,
   TrialData,
-} from '@/../../api/src/lib/email-lifecycle';
+} from '@settler/api/lib/email-lifecycle';
 
 // Simple logger for web package
 const logInfo = (message: string, meta?: Record<string, unknown>) => {

--- a/packages/web/src/app/api/cron/low-activity/route.ts
+++ b/packages/web/src/app/api/cron/low-activity/route.ts
@@ -6,8 +6,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/server';
-// @ts-ignore - API package types not available in web package
-import { sendLowActivityEmail, LifecycleUser } from '@/../../api/src/lib/email-lifecycle';
+import { sendLowActivityEmail, LifecycleUser } from '@settler/api/lib/email-lifecycle';
 
 const logInfo = (message: string, meta?: Record<string, unknown>) => {
   console.log(`[INFO] ${message}`, meta || '');

--- a/packages/web/src/app/api/cron/monthly-summary/route.ts
+++ b/packages/web/src/app/api/cron/monthly-summary/route.ts
@@ -6,8 +6,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/server';
-// @ts-ignore - API package types not available in web package
-import { sendMonthlySummaryEmail, LifecycleUser } from '@/../../api/src/lib/email-lifecycle';
+import { sendMonthlySummaryEmail, LifecycleUser } from '@settler/api/lib/email-lifecycle';
 
 const logInfo = (message: string, meta?: Record<string, unknown>) => {
   console.log(`[INFO] ${message}`, meta || '');

--- a/packages/web/src/app/api/user/upgrade/route.ts
+++ b/packages/web/src/app/api/user/upgrade/route.ts
@@ -4,8 +4,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-// @ts-ignore - API package types not available in web package
-import { sendPaidWelcomeEmail, LifecycleUser } from '@/../../api/src/lib/email-lifecycle';
+import { sendPaidWelcomeEmail, LifecycleUser } from '@settler/api/lib/email-lifecycle';
 
 export async function POST(request: NextRequest) {
   try {

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -37,6 +37,6 @@
       "@settler/api/*": ["../api/src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "**/__tests__/**", "../api/**/*"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "../api/src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "**/__tests__/**"]
 }


### PR DESCRIPTION
Fix TypeScript build errors in the `@settler/web` package by updating `tsconfig.json` and import paths, and correcting a logger type issue.

The `@settler/web` package was failing to build due to `TS6307` errors because its `tsconfig.json` incorrectly excluded files from the `@settler/api` package while importing them. This PR updates the `include` and `paths` in `packages/web/tsconfig.json` to correctly resolve these cross-package imports using a new alias. Additionally, a `TS2349` error in `packages/api/src/utils/logger.ts` was resolved by correcting the `winston.format` usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-62cc4b30-7637-482c-9748-fe4087dc4fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62cc4b30-7637-482c-9748-fe4087dc4fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

