### PR TITLE
Run project build and type check

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^16.0.7",
+    "@settler/api": "*",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -33,10 +33,10 @@
       "@settler/sdk/*": ["../sdk/dist/*"],
       "@settler/types": ["../types/dist"],
       "@settler/types/*": ["../types/dist/*"],
-      "@settler/api": ["../api/src"],
-      "@settler/api/*": ["../api/src/*"]
+      "@settler/api": ["../api/dist"],
+      "@settler/api/*": ["../api/dist/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "../api/src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "**/__tests__/**"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "**/__tests__/**", "../api"]
 }


### PR DESCRIPTION
Fix TypeScript typecheck errors in the `@settler/web` package.

The web package's `tsconfig.json` was incorrectly including API source files, causing typecheck failures due to missing dependencies. This PR updates the `tsconfig.json` to exclude API source files and correctly map `@settler/api` to its built `dist` directory, ensuring typechecking uses pre-built declaration files.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1cf67ef-11ca-444f-8ea6-bcf1a7c81c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1cf67ef-11ca-444f-8ea6-bcf1a7c81c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

