### PR TITLE
Fix web type errors

### DIFF
--- a/packages/web/src/app/dashboard/billing/invoices/page.tsx
+++ b/packages/web/src/app/dashboard/billing/invoices/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/Navigation";

--- a/packages/web/src/app/dashboard/billing/payment-methods/page.tsx
+++ b/packages/web/src/app/dashboard/billing/payment-methods/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/Navigation";

--- a/packages/web/src/app/dashboard/jobs/[jobId]/page.tsx
+++ b/packages/web/src/app/dashboard/jobs/[jobId]/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
-import { Loader2, ArrowLeft, CheckCircle2, AlertCircle, Clock, Download, RefreshCw } from "lucide-react";
+import { Loader2, ArrowLeft, CheckCircle2, Clock, Download, RefreshCw } from "lucide-react";
 import Link from "next/link";
 
 interface JobDetail {
@@ -40,7 +40,6 @@ interface JobDetail {
 
 export default function JobDetailPage() {
   const params = useParams();
-  const router = useRouter();
   const jobId = params.jobId as string;
   const [job, setJob] = useState<JobDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/packages/web/src/app/dashboard/jobs/[jobId]/page.tsx
+++ b/packages/web/src/app/dashboard/jobs/[jobId]/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
-import { Loader2, ArrowLeft, CheckCircle2, Clock, Download, RefreshCw } from "lucide-react";
+import { Loader2, ArrowLeft, CheckCircle2, AlertCircle, Clock, Download, RefreshCw } from "lucide-react";
 import Link from "next/link";
 
 interface JobDetail {

--- a/packages/web/src/app/dashboard/jobs/page.tsx
+++ b/packages/web/src/app/dashboard/jobs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";

--- a/packages/web/src/app/edge-ai/nodes/[nodeId]/page.tsx
+++ b/packages/web/src/app/edge-ai/nodes/[nodeId]/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
-import { Loader2, ArrowLeft, Server, Activity, Zap, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Loader2, ArrowLeft, Server, Activity, Zap, CheckCircle2 } from "lucide-react";
 import Link from "next/link";
 
 interface NodeDetail {
@@ -29,7 +29,6 @@ interface NodeDetail {
 
 export default function NodeDetailPage() {
   const params = useParams();
-  const router = useRouter();
   const nodeId = params.nodeId as string;
   const [node, setNode] = useState<NodeDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/packages/web/src/app/edge-ai/nodes/page.tsx
+++ b/packages/web/src/app/edge-ai/nodes/page.tsx
@@ -133,7 +133,6 @@ export default function EdgeNodesPage() {
                     asChild
                     variant="outline"
                     size="sm"
-                    onClick={() => router.push(`/edge-ai/nodes/${node.id}`)}
                   >
                     <Link href={`/edge-ai/nodes/${node.id}`}>View Details</Link>
                   </Button>


### PR DESCRIPTION
## Description
This PR resolves TypeScript build errors (`TS6133` and `TS2304`) that were preventing successful deployments. It achieves this by removing unused imports and variables, and correcting the usage of the `router` object in several Next.js pages.

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Verified `tsc --noEmit` passes)

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues
Closes #

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Additional Notes
Specifically addressed:
- `TS6133: '...' is declared but its value is never read.` for various `Card` components and `AlertCircle` imports.
- `TS6133: 'router' is declared but its value is never read.` for `useRouter` hooks.
- `TS2304: Cannot find name 'router'.` by removing a redundant `onClick` handler on a `Button` wrapping a `Link` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-f414d616-d408-47b7-9b27-224ef65ded40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f414d616-d408-47b7-9b27-224ef65ded40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

