### PR TITLE
Fix api typecheck errors

### DIFF
--- a/packages/api/src/application/cqrs/commands/ReconciliationCommandHandlers.ts
+++ b/packages/api/src/application/cqrs/commands/ReconciliationCommandHandlers.ts
@@ -18,6 +18,13 @@ import {
 import { IEventBus } from "../../../infrastructure/events/IEventBus";
 import { DomainEvent } from "../../../domain/events/DomainEvent";
 
+interface EventData {
+  job_id?: string;
+  source_adapter?: string;
+  target_adapter?: string;
+  date_range?: { start: string; end: string };
+}
+
 export class ReconciliationCommandHandlers {
   constructor(
     private eventStore: IEventStore,
@@ -79,13 +86,6 @@ export class ReconciliationCommandHandlers {
     const correlationId = command.correlation_id || lastEvent.metadata.correlation_id;
 
     // Create retry event (could be a new event type)
-    interface EventData {
-      job_id?: string;
-      source_adapter?: string;
-      target_adapter?: string;
-      date_range?: { start: string; end: string };
-    }
-
     const eventData = lastEvent.data as EventData;
     const retryEventData: ReconciliationStartedData = {
       reconciliation_id: command.reconciliation_id,

--- a/packages/api/src/application/cqrs/projections/ReconciliationProjections.ts
+++ b/packages/api/src/application/cqrs/projections/ReconciliationProjections.ts
@@ -46,6 +46,53 @@ export interface ErrorHotspotsView {
   tenant_id: string;
 }
 
+interface OrdersFetchedData {
+  count: number;
+  reconciliation_id: string;
+}
+
+interface PaymentsFetchedData {
+  count: number;
+  reconciliation_id: string;
+}
+
+interface RecordMatchedData {
+  reconciliation_id: string;
+}
+
+interface RecordUnmatchedData {
+  reconciliation_id: string;
+  source_id?: string;
+  target_id?: string;
+}
+
+interface ReconciliationCompletedData {
+  reconciliation_id: string;
+  summary: {
+    matched_count: number;
+    unmatched_source_count: number;
+    unmatched_target_count: number;
+    errors_count: number;
+    duration_ms: number;
+    accuracy_percentage: number;
+  };
+  completed_at: string;
+}
+
+interface ReconciliationFailedData {
+  reconciliation_id: string;
+  failed_at: string;
+  error: {
+    type: string;
+    message: string;
+  };
+}
+
+interface ErrorHotspotData extends ReconciliationFailedData {
+  job_id?: string;
+  step?: string;
+}
+
 export class ReconciliationProjectionHandlers {
   constructor(private db: Pool = pool) {}
 
@@ -92,11 +139,6 @@ export class ReconciliationProjectionHandlers {
   /**
    * Handle OrdersFetched event
    */
-  interface OrdersFetchedData {
-    count: number;
-    reconciliation_id: string;
-  }
-
   async handleOrdersFetched(eventEnvelope: EventEnvelope): Promise<void> {
     const data = eventEnvelope.data as OrdersFetchedData;
     const query = `
@@ -113,11 +155,6 @@ export class ReconciliationProjectionHandlers {
   /**
    * Handle PaymentsFetched event
    */
-  interface PaymentsFetchedData {
-    count: number;
-    reconciliation_id: string;
-  }
-
   async handlePaymentsFetched(eventEnvelope: EventEnvelope): Promise<void> {
     const data = eventEnvelope.data as PaymentsFetchedData;
     const query = `
@@ -134,10 +171,6 @@ export class ReconciliationProjectionHandlers {
   /**
    * Handle RecordMatched event
    */
-  interface RecordMatchedData {
-    reconciliation_id: string;
-  }
-
   async handleRecordMatched(eventEnvelope: EventEnvelope): Promise<void> {
     const data = eventEnvelope.data as RecordMatchedData;
     const query = `
@@ -154,12 +187,6 @@ export class ReconciliationProjectionHandlers {
   /**
    * Handle RecordUnmatched event
    */
-  interface RecordUnmatchedData {
-    reconciliation_id: string;
-    source_id?: string;
-    target_id?: string;
-  }
-
   async handleRecordUnmatched(eventEnvelope: EventEnvelope): Promise<void> {
     const data = eventEnvelope.data as RecordUnmatchedData;
     const query = `
@@ -184,19 +211,6 @@ export class ReconciliationProjectionHandlers {
   /**
    * Handle ReconciliationCompleted event
    */
-  interface ReconciliationCompletedData {
-    reconciliation_id: string;
-    summary: {
-      matched_count: number;
-      unmatched_source_count: number;
-      unmatched_target_count: number;
-      errors_count: number;
-      duration_ms: number;
-      accuracy_percentage: number;
-    };
-    completed_at: string;
-  }
-
   async handleReconciliationCompleted(eventEnvelope: EventEnvelope): Promise<void> {
     const data = eventEnvelope.data as ReconciliationCompletedData;
     const query = `
@@ -232,15 +246,6 @@ export class ReconciliationProjectionHandlers {
   /**
    * Handle ReconciliationFailed event
    */
-  interface ReconciliationFailedData {
-    reconciliation_id: string;
-    failed_at: string;
-    error: {
-      type: string;
-      message: string;
-    };
-  }
-
   async handleReconciliationFailed(eventEnvelope: EventEnvelope): Promise<void> {
     const data = eventEnvelope.data as ReconciliationFailedData;
     const query = `
@@ -289,11 +294,6 @@ export class ReconciliationProjectionHandlers {
   /**
    * Update error hotspots view
    */
-  interface ErrorHotspotData extends ReconciliationFailedData {
-    job_id?: string;
-    step?: string;
-  }
-
   private async updateErrorHotspots(eventEnvelope: EventEnvelope): Promise<void> {
     const data = eventEnvelope.data as ErrorHotspotData;
     const tenantId = eventEnvelope.metadata.tenant_id;

--- a/packages/api/src/application/eventsourcing/EventProjectionService.ts
+++ b/packages/api/src/application/eventsourcing/EventProjectionService.ts
@@ -9,6 +9,10 @@ import { ReconciliationProjectionHandlers } from "../cqrs/projections/Reconcilia
 import { EventEnvelope } from "../../domain/eventsourcing/EventEnvelope";
 import { DomainEvent } from "../../domain/events/DomainEvent";
 
+interface ReconciliationEvent extends DomainEvent {
+  reconciliationId?: string;
+}
+
 export class EventProjectionService {
   private projectionHandlers: ReconciliationProjectionHandlers;
 
@@ -24,10 +28,6 @@ export class EventProjectionService {
     // Subscribe to domain events from event bus
     this.eventBus.subscribe("reconciliation.started", async (event: DomainEvent) => {
       // Fetch full event from event store
-      interface ReconciliationEvent extends DomainEvent {
-        reconciliationId?: string;
-      }
-
       const reconciliationEvent = event as ReconciliationEvent;
       const reconciliationId = reconciliationEvent.reconciliationId;
       if (!reconciliationId) {

--- a/packages/api/src/infrastructure/security/encryption.ts
+++ b/packages/api/src/infrastructure/security/encryption.ts
@@ -12,6 +12,12 @@ const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 16;
 const AUTH_TAG_LENGTH = 16;
 
+interface EncryptedDataFormat {
+  iv: string;
+  encrypted: string;
+  authTag: string;
+}
+
 /**
  * Get encryption key from SecretsManager or config (backward compatibility)
  */
@@ -79,12 +85,6 @@ export function encrypt(data: string, keyName: string = "ENCRYPTION_KEY"): strin
  */
 export function decrypt(encryptedData: string, keyName: string = "ENCRYPTION_KEY"): string {
   const key = getEncryptionKey(keyName);
-
-  interface EncryptedDataFormat {
-    iv: string;
-    encrypted: string;
-    authTag: string;
-  }
 
   let parsed: EncryptedDataFormat | null = null;
   let iv: Buffer;

--- a/packages/api/src/middleware/feature-flags.ts
+++ b/packages/api/src/middleware/feature-flags.ts
@@ -38,6 +38,12 @@ export interface FeatureFlagRequest extends Request {
   featureFlagContext?: FeatureFlagContext;
 }
 
+interface RequestWithUser extends Request {
+  tenantId?: string;
+  userId?: string;
+  user?: { tenantId?: string; id?: string };
+}
+
 /**
  * Feature flag service interface
  */
@@ -155,12 +161,6 @@ export function getFeatureFlagService(): FeatureFlagService {
 export function featureFlagsMiddleware() {
   return async (req: FeatureFlagRequest, _res: Response, next: NextFunction) => {
     try {
-      interface RequestWithUser extends Request {
-        tenantId?: string;
-        userId?: string;
-        user?: { tenantId?: string; id?: string };
-      }
-
       const reqWithUser = req as RequestWithUser;
       const context: FeatureFlagContext = {
         tenantId: reqWithUser.tenantId || reqWithUser.user?.tenantId,

--- a/packages/api/src/middleware/usage-tracking.ts
+++ b/packages/api/src/middleware/usage-tracking.ts
@@ -28,6 +28,11 @@ export interface UsageTrackingRequest extends Request {
   usageMetrics?: UsageMetrics;
 }
 
+interface RequestWithUser extends Request {
+  tenantId?: string;
+  user?: { tenantId?: string };
+}
+
 /**
  * Usage tracking service interface
  */
@@ -117,11 +122,6 @@ export function setUsageTrackingService(service: UsageTrackingService): void {
 export function usageTrackingMiddleware() {
   return async (req: UsageTrackingRequest, res: Response, next: NextFunction) => {
     const startTime = Date.now();
-    interface RequestWithUser extends Request {
-      tenantId?: string;
-      user?: { tenantId?: string };
-    }
-
     const reqWithUser = req as RequestWithUser;
     const tenantId = reqWithUser.tenantId || reqWithUser.user?.tenantId || "anonymous";
 
@@ -174,11 +174,6 @@ export async function getCurrentUsage(
   req: UsageTrackingRequest,
   period: "day" | "week" | "month" = "day"
 ) {
-  interface RequestWithUser extends Request {
-    tenantId?: string;
-    user?: { tenantId?: string };
-  }
-
   const reqWithUser = req as RequestWithUser;
   const tenantId = reqWithUser.tenantId || reqWithUser.user?.tenantId;
   if (!tenantId) {

--- a/packages/api/src/routes/exports.ts
+++ b/packages/api/src/routes/exports.ts
@@ -15,6 +15,14 @@ import { PDFGenerator } from "../services/export/pdf-generator";
 import { query } from "../db";
 import { sendError } from "../utils/api-response";
 
+interface ExecutionSummary {
+  matched?: number;
+  unmatched?: number;
+  errors?: number;
+  accuracy?: number;
+  totalTransactions?: number;
+}
+
 const router = Router();
 const pdfGenerator = new PDFGenerator();
 
@@ -93,14 +101,6 @@ router.post("/", authMiddleware, async (req: AuthRequest, res: Response) => {
     if (format === "csv") {
       try {
         // Get report data
-        interface ExecutionSummary {
-          matched?: number;
-          unmatched?: number;
-          errors?: number;
-          accuracy?: number;
-          totalTransactions?: number;
-        }
-
         const executions = await query<{ summary: ExecutionSummary | null }>(
           `SELECT summary FROM executions WHERE job_id = $1 ORDER BY completed_at DESC LIMIT 1`,
           [jobId]

--- a/packages/api/src/routes/reports.ts
+++ b/packages/api/src/routes/reports.ts
@@ -7,6 +7,14 @@ import { Permission } from "../infrastructure/security/Permissions";
 import { query } from "../db";
 import { handleRouteError } from "../utils/error-handler";
 
+interface ExecutionSummary {
+  matched?: number;
+  unmatched?: number;
+  errors?: number;
+  accuracy?: number;
+  totalTransactions?: number;
+}
+
 const router = Router();
 
 const getReportSchema = z.object({
@@ -65,14 +73,6 @@ router.get(
       const dateEnd = endDate || new Date().toISOString();
 
       // Get execution summary
-      interface ExecutionSummary {
-        matched?: number;
-        unmatched?: number;
-        errors?: number;
-        accuracy?: number;
-        totalTransactions?: number;
-      }
-
       const executions = await query<{
         id: string;
         summary: ExecutionSummary | null;

--- a/packages/api/src/routes/v2/compliance.ts
+++ b/packages/api/src/routes/v2/compliance.ts
@@ -10,6 +10,10 @@ import { EdgeAgent } from "../../services/privacy-preserving/edge-agent";
 import { handleRouteError } from "../../utils/error-handler";
 import { AuthRequest } from "../../middleware/auth";
 
+interface RequestWithUser extends Request {
+  user?: { id?: string };
+}
+
 const router = Router();
 
 /**
@@ -51,10 +55,6 @@ router.post("/exports", async (req: Request, res: Response) => {
  */
 router.get("/exports", async (req: Request, res: Response) => {
   try {
-    interface RequestWithUser extends Request {
-      user?: { id?: string };
-    }
-
     const reqWithUser = req as RequestWithUser;
     const customerId = reqWithUser.user?.id || (req.query.customerId as string);
 

--- a/packages/api/src/services/export/pdf-generator.ts
+++ b/packages/api/src/services/export/pdf-generator.ts
@@ -6,6 +6,14 @@
 import PDFDocument from "pdfkit";
 import { query } from "../../db";
 
+interface ExecutionSummary {
+  matched?: number;
+  unmatched?: number;
+  errors?: number;
+  accuracy?: number;
+  totalTransactions?: number;
+}
+
 export interface ReconciliationReportData {
   jobId: string;
   jobName: string;
@@ -264,14 +272,6 @@ export class PDFGenerator {
     const dateEnd = endDate || new Date();
 
     // Get latest execution
-    interface ExecutionSummary {
-      matched?: number;
-      unmatched?: number;
-      errors?: number;
-      accuracy?: number;
-      totalTransactions?: number;
-    }
-
     const executions = await query<{
       id: string;
       summary: ExecutionSummary | null;

--- a/packages/api/src/services/predictive/adaptive-pipelines.ts
+++ b/packages/api/src/services/predictive/adaptive-pipelines.ts
@@ -18,6 +18,14 @@ export interface AdaptivePipelineConfig {
   observedErrors?: string[];
 }
 
+export interface Pipeline {
+  usesAI?: boolean;
+  model?: string;
+  engine?: string;
+  route?: string;
+  [key: string]: unknown;
+}
+
 export class AdaptivePipelines {
   private router: PredictiveRouter;
   private metaModels: MetaModels;
@@ -25,14 +33,6 @@ export class AdaptivePipelines {
   constructor() {
     this.router = new PredictiveRouter();
     this.metaModels = new MetaModels();
-  }
-
-  interface Pipeline {
-    usesAI?: boolean;
-    model?: string;
-    engine?: string;
-    route?: string;
-    [key: string]: unknown;
   }
 
   /**

--- a/packages/api/src/services/pricing/pricing-optimizer.ts
+++ b/packages/api/src/services/pricing/pricing-optimizer.ts
@@ -16,6 +16,13 @@ export interface PricingRecommendation {
   estimatedRevenueChange: number;
 }
 
+interface CustomerSegments {
+  lowUsage: number;
+  mediumUsage: number;
+  highUsage: number;
+  enterprise: number;
+}
+
 export class PricingOptimizer {
   private prisma: PrismaClient;
 
@@ -58,13 +65,6 @@ export class PricingOptimizer {
       highUsage: 0,
       enterprise: 0,
     };
-  }
-
-  interface CustomerSegments {
-    lowUsage: number;
-    mediumUsage: number;
-    highUsage: number;
-    enterprise: number;
   }
 
   /**

--- a/packages/api/src/services/pricing/usage-simulator.ts
+++ b/packages/api/src/services/pricing/usage-simulator.ts
@@ -21,6 +21,17 @@ export interface UsageSimulation {
   estimatedCost: number;
 }
 
+interface HistoricalUsage {
+  reconComparisons: number;
+  validations: number;
+  transformations: number;
+  mappings: number;
+  workflowSteps: number;
+  aiTokens: number;
+  storageBytes: number;
+  webhookTriggers: number;
+}
+
 export class UsageSimulator {
   private prisma: PrismaClient;
 
@@ -112,17 +123,6 @@ export class UsageSimulator {
     }
 
     return usage;
-  }
-
-  interface HistoricalUsage {
-    reconComparisons: number;
-    validations: number;
-    transformations: number;
-    mappings: number;
-    workflowSteps: number;
-    aiTokens: number;
-    storageBytes: number;
-    webhookTriggers: number;
   }
 
   /**

--- a/packages/api/src/services/reconciliation-graph/graph-engine-supabase.ts
+++ b/packages/api/src/services/reconciliation-graph/graph-engine-supabase.ts
@@ -15,6 +15,30 @@ interface GraphUpdate {
   timestamp: Date;
 }
 
+interface NodeRow {
+  id: string;
+  node_type: string;
+  job_id: string;
+  source_id: string | null;
+  target_id: string | null;
+  data: unknown;
+  amount: number;
+  currency: string;
+  timestamp: string | Date;
+  confidence: number;
+  metadata: Record<string, unknown> | null;
+}
+
+interface EdgeRow {
+  id: string;
+  source_node_id: string;
+  target_node_id: string;
+  edge_type: string;
+  confidence: number;
+  metadata: Record<string, unknown> | null;
+  created_at: string | Date;
+}
+
 export class ReconciliationGraphEngineSupabase extends EventEmitter {
   private updateSubscribers: Map<string, Set<(update: GraphUpdate) => void>> = new Map();
 
@@ -215,20 +239,6 @@ export class ReconciliationGraphEngineSupabase extends EventEmitter {
       throw new Error(`Failed to query nodes: ${nodesError.message}`);
     }
 
-    interface NodeRow {
-      id: string;
-      node_type: string;
-      job_id: string;
-      source_id: string | null;
-      target_id: string | null;
-      data: unknown;
-      amount: number;
-      currency: string;
-      timestamp: string | Date;
-      confidence: number;
-      metadata: Record<string, unknown> | null;
-    }
-
     const nodes: ReconciliationNode[] = (nodesData || []).map((n: NodeRow) => ({
       id: n.id,
       type: n.node_type,
@@ -253,16 +263,6 @@ export class ReconciliationGraphEngineSupabase extends EventEmitter {
 
     if (edgesError) {
       throw new Error(`Failed to query edges: ${edgesError.message}`);
-    }
-
-    interface EdgeRow {
-      id: string;
-      source_node_id: string;
-      target_node_id: string;
-      edge_type: string;
-      confidence: number;
-      metadata: Record<string, unknown> | null;
-      created_at: string | Date;
     }
 
     const edges: ReconciliationEdge[] = (edgesData || []).map((e: EdgeRow) => ({

--- a/packages/api/src/services/rewrite/pipeline-rewriter.ts
+++ b/packages/api/src/services/rewrite/pipeline-rewriter.ts
@@ -25,6 +25,26 @@ export interface PipelineChange {
   newLogic: Record<string, unknown>;
 }
 
+interface OutdatedPattern {
+  type: 'outdated_node' | 'incompatible_node' | 'inefficient_logic';
+  nodeId: string;
+  oldLogic: Record<string, unknown>;
+  newLogic: Record<string, unknown>;
+}
+
+interface WorkflowStep {
+  id: string;
+  type: string;
+  config?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface WorkflowRun {
+  workflowId: string;
+  steps?: WorkflowStep[];
+  [key: string]: unknown;
+}
+
 export class PipelineRewriter {
   private prisma: PrismaClient;
 
@@ -110,26 +130,6 @@ export class PipelineRewriter {
       backwardCompatible: true,
       risk: changes.length > 5 ? 'medium' : 'low',
     };
-  }
-
-  interface OutdatedPattern {
-    type: 'outdated_node' | 'incompatible_node' | 'inefficient_logic';
-    nodeId: string;
-    oldLogic: Record<string, unknown>;
-    newLogic: Record<string, unknown>;
-  }
-
-  interface WorkflowStep {
-    id: string;
-    type: string;
-    config?: Record<string, unknown>;
-    [key: string]: unknown;
-  }
-
-  interface WorkflowRun {
-    workflowId: string;
-    steps?: WorkflowStep[];
-    [key: string]: unknown;
   }
 
   /**

--- a/packages/api/src/services/verticals/edtech/qti-validator.ts
+++ b/packages/api/src/services/verticals/edtech/qti-validator.ts
@@ -16,6 +16,17 @@ export interface QTIValidationResult {
   warnings: string[];
 }
 
+interface Syllabus {
+  outcomes?: string[];
+  [key: string]: unknown;
+}
+
+interface LearningOutcome {
+  id: string;
+  description: string;
+  [key: string]: unknown;
+}
+
 export class QTIValidator {
   /**
    * Validate QTI (Question and Test Interoperability) format
@@ -31,17 +42,6 @@ export class QTIValidator {
       errors: [],
       warnings: [],
     };
-  }
-
-  interface Syllabus {
-    outcomes?: string[];
-    [key: string]: unknown;
-  }
-
-  interface LearningOutcome {
-    id: string;
-    description: string;
-    [key: string]: unknown;
   }
 
   /**

--- a/packages/api/src/services/verticals/legaltech/contract-diff.ts
+++ b/packages/api/src/services/verticals/legaltech/contract-diff.ts
@@ -18,6 +18,14 @@ export interface ContractDiff {
   riskScore: number;
 }
 
+interface Obligation {
+  party: string;
+  obligation: string;
+  deadline?: string;
+  penalty?: string;
+  [key: string]: unknown;
+}
+
 export class ContractDiffService {
   private prisma: PrismaClient;
 
@@ -61,14 +69,6 @@ export class ContractDiffService {
   }>> {
     // TODO: Implement obligation extraction
     return [];
-  }
-
-  interface Obligation {
-    party: string;
-    obligation: string;
-    deadline?: string;
-    penalty?: string;
-    [key: string]: unknown;
   }
 
   /**

--- a/packages/web/src/components/SecureMobileApp.tsx
+++ b/packages/web/src/components/SecureMobileApp.tsx
@@ -18,6 +18,11 @@ interface SecurityHeaders {
   "Permissions-Policy": string;
 }
 
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
 /**
  * Secure Mobile-First Component
  *
@@ -119,11 +124,6 @@ export default function SecureMobileApp({
 
     try {
       // Type assertion for BeforeInstallPromptEvent
-      interface BeforeInstallPromptEvent extends Event {
-        prompt: () => Promise<void>;
-        userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
-      }
-
       const promptEvent = installPrompt as unknown as BeforeInstallPromptEvent;
       if (promptEvent.prompt) {
         await promptEvent.prompt();


### PR DESCRIPTION
## Description

Resolved TypeScript compilation errors by moving interface declarations from inside class bodies to the module level in several files. This aligns with TypeScript's syntax rules, which do not permit nested interface declarations within classes.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (verified `tsc --noEmit` passes)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The following interfaces were moved to the top-level scope in their respective files:
- `ReconciliationProjections.ts`: `OrdersFetchedData`, `PaymentsFetchedData`, `RecordMatchedData`, `RecordUnmatchedData`, `ReconciliationCompletedData`, `ReconciliationFailedData`, `ErrorHotspotData`
- `adaptive-pipelines.ts`: `Pipeline`
- `pricing-optimizer.ts`: `CustomerSegments`
- `usage-simulator.ts`: `HistoricalUsage`
- `pipeline-rewriter.ts`: `OutdatedPattern`, `WorkflowStep`, `WorkflowRun`
- `qti-validator.ts`: `Syllabus`, `LearningOutcome`
- `contract-diff.ts`: `Obligation`

---
<a href="https://cursor.com/background-agent?bcId=bc-a8bd10f5-344e-413c-b965-5d5785ce9e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8bd10f5-344e-413c-b965-5d5785ce9e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

