### PR TITLE
Build settler web package

### DIFF
--- a/packages/web/src/app/dashboard/jobs/[jobId]/page.tsx
+++ b/packages/web/src/app/dashboard/jobs/[jobId]/page.tsx
@@ -48,7 +48,7 @@ interface JobDetail {
 
 export default function JobDetailPage() {
   const params = useParams();
-  const jobId = params.jobId as string;
+  const jobId = params?.jobId as string | undefined;
   const [job, setJob] = useState<JobDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -107,6 +107,27 @@ export default function JobDetailPage() {
     };
     return variants[status];
   };
+
+  if (!jobId) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 dark:from-slate-900 dark:via-slate-800 dark:to-black">
+        <Navigation />
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 pt-24">
+          <Card>
+            <CardContent className="pt-6">
+              <div className="text-center py-12">
+                <p className="text-slate-600 dark:text-slate-400 mb-4">Invalid job ID</p>
+                <Button asChild>
+                  <Link href="/dashboard/jobs">Back to Jobs</Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Description

This PR fixes a TypeScript build error occurring in `src/app/dashboard/jobs/[jobId]/page.tsx`. The `useParams()` hook can return `null` for the `params` object, leading to a type error when attempting to access `params.jobId` directly.

The changes address this by:
1.  Safely accessing `params.jobId` using optional chaining (`params?.jobId`).
2.  Adding an early return that displays an "Invalid job ID" message and a link back to the jobs list if `jobId` is `null` or `undefined`.

This ensures the application handles cases where the `jobId` parameter is missing gracefully, preventing build failures and improving user experience.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The build was failing with the error: `Type error: 'params' is possibly 'null'.` at `params.jobId`. This fix resolves that specific error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d16364fb-7e79-4fa6-8cc0-eafb33bdf2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d16364fb-7e79-4fa6-8cc0-eafb33bdf2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

