### PR TITLE
Build settler web package

### DIFF
--- a/packages/web/src/app/dashboard/jobs/[jobId]/page.tsx
+++ b/packages/web/src/app/dashboard/jobs/[jobId]/page.tsx
@@ -54,16 +54,16 @@ export default function JobDetailPage() {
 
   useEffect(() => {
     if (jobId) {
-      fetchJobDetail();
+      fetchJobDetail(jobId);
     }
   }, [jobId]);
 
-  const fetchJobDetail = async () => {
+  const fetchJobDetail = async (id: string) => {
     try {
       setIsLoading(true);
-      // In production, fetch from API: `/api/jobs/${jobId}`
+      // In production, fetch from API: `/api/jobs/${id}`
       const mockJob: JobDetail = {
-        id: jobId,
+        id: id,
         name: "Shopify-Stripe Monthly Reconciliation",
         status: "completed",
         source: {


### PR DESCRIPTION
## Description

Resolves a TypeScript error where `jobId` (from `useParams()`) was `string | undefined` but was used in contexts expecting a `string`. The `fetchJobDetail` function now explicitly accepts a `string` ID, and `jobId` is passed to it only after being confirmed as defined. This ensures type safety and prevents potential runtime errors.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

<!-- Any additional information -->

---
<a href="https://cursor.com/background-agent?bcId=bc-fd1f7fc5-e15a-45a5-81d6-5a586e6ee113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd1f7fc5-e15a-45a5-81d6-5a586e6ee113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

