### PR TITLE
Fix web package type error

### DIFF
--- a/packages/web/src/app/edge-ai/nodes/[nodeId]/page.tsx
+++ b/packages/web/src/app/edge-ai/nodes/[nodeId]/page.tsx
@@ -35,16 +35,16 @@ export default function NodeDetailPage() {
 
   useEffect(() => {
     if (nodeId) {
-      fetchNodeDetail();
+      fetchNodeDetail(nodeId);
     }
   }, [nodeId]);
 
-  const fetchNodeDetail = async () => {
+  const fetchNodeDetail = async (id: string) => {
     try {
       setIsLoading(true);
-      // In production, fetch from API: `/api/edge-ai/nodes/${nodeId}`
+      // In production, fetch from API: `/api/edge-ai/nodes/${id}`
       const mockNode: NodeDetail = {
-        id: nodeId,
+        id: id,
         name: "US-East Edge Node",
         status: "active",
         region: "us-east-1",
@@ -56,7 +56,7 @@ export default function NodeDetailPage() {
         config: {
           model: "settler-reconciliation-v2",
           version: "2.1.0",
-          endpoint: `https://edge-${nodeId}.settler.dev`,
+          endpoint: `https://edge-${id}.settler.dev`,
         },
       };
       setNode(mockNode);


### PR DESCRIPTION
## Description

Fixes a TypeScript error where `nodeId` (from `useParams`) was typed as `string | undefined` but used in contexts expecting `string`. The `fetchNodeDetail` function now explicitly accepts a `string` ID, and is only called when `nodeId` is defined, ensuring type safety and resolving the build failure.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Build passes locally)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

<!-- Any additional information -->

---
<a href="https://cursor.com/background-agent?bcId=bc-1baa3226-05f1-4ac7-9726-de18ec6aedd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1baa3226-05f1-4ac7-9726-de18ec6aedd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

