### PR TITLE
Fix web type error

### DIFF
--- a/packages/web/src/app/dashboard/addons/page.tsx
+++ b/packages/web/src/app/dashboard/addons/page.tsx
@@ -225,7 +225,7 @@ export default function AddOnsMarketplacePage() {
             isPurchased={addOn.is_purchased}
             isStandard={addOn.is_standard}
             features={addOn.features}
-            onPurchase={() => {
+            onPurchase={async (_id) => {
               openPurchaseModal(addOn);
             }}
             onCancel={() => handleCancel(addOn.id)}


### PR DESCRIPTION
## Description

Fixes a TypeScript error (`TS6133: 'id' is declared but its value is never read.`) in `src/app/dashboard/addons/page.tsx`. The `onPurchase` callback for `AddOnCard` now correctly matches the expected `(id: string) => Promise<void>` signature.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Verified build passes after fix)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The `onPurchase` prop of `AddOnCard` expects a function `(id: string) => Promise<void>`. The provided callback was updated to `async (_id) => { ... }` to match this signature. The `_id` parameter is prefixed with an underscore to indicate it's intentionally unused, resolving the `TS6133` error, and the function is made `async` to match the `Promise<void>` return type.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebd7bc05-282a-482c-9ca7-ac7616d186cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebd7bc05-282a-482c-9ca7-ac7616d186cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

