### PR TITLE
Fix web build errors

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,6 +25,7 @@
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
     "@next/mdx": "^14.0.4",
+    "@prisma/client": "^7.1.0",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-radio-group": "^1.2.0",
     "@sentry/nextjs": "^7.91.0",

--- a/packages/web/src/app/api/v1/feature-flags/route.ts
+++ b/packages/web/src/app/api/v1/feature-flags/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: NextRequest) {
     });
 
     return NextResponse.json({
-      flags: flags.map((flag: { id: string; key: string; name: string; enabled: boolean; createdAt: Date; updatedAt: Date }) => ({
+      flags: flags.map((flag) => ({
         id: flag.id,
         key: flag.key,
         name: flag.name,

--- a/packages/web/src/app/console/site/navigation/page.tsx
+++ b/packages/web/src/app/console/site/navigation/page.tsx
@@ -94,12 +94,18 @@ export default function NavigationEditorPage() {
   ) {
     if (type === 'nav') {
       const updated = [...navItems];
-      updated[index] = { ...updated[index], ...updates };
-      setNavItems(updated);
+      const existing = updated[index];
+      if (existing) {
+        updated[index] = { ...existing, ...updates } as TenantNavigationItem;
+        setNavItems(updated);
+      }
     } else {
       const updated = [...footerItems];
-      updated[index] = { ...updated[index], ...updates };
-      setFooterItems(updated);
+      const existing = updated[index];
+      if (existing) {
+        updated[index] = { ...existing, ...updates } as TenantNavigationItem;
+        setFooterItems(updated);
+      }
     }
   }
 
@@ -111,23 +117,7 @@ export default function NavigationEditorPage() {
     }
   }
 
-  function _handleMoveItem(
-    type: 'nav' | 'footer',
-    fromIndex: number,
-    toIndex: number
-  ) {
-    if (type === 'nav') {
-      const updated = [...navItems];
-      const [moved] = updated.splice(fromIndex, 1);
-      updated.splice(toIndex, 0, moved);
-      setNavItems(updated);
-    } else {
-      const updated = [...footerItems];
-      const [moved] = updated.splice(fromIndex, 1);
-      updated.splice(toIndex, 0, moved);
-      setFooterItems(updated);
-    }
-  }
+  // Removed unused function _handleMoveItem
 
   function renderItemEditor(
     item: TenantNavigationItem,

--- a/packages/web/src/app/console/site/pages/[id]/page.tsx
+++ b/packages/web/src/app/console/site/pages/[id]/page.tsx
@@ -132,8 +132,10 @@ export default function PageEditorPage() {
   function handleMoveBlock(fromIndex: number, toIndex: number) {
     const newBlocks = [...blocks];
     const [moved] = newBlocks.splice(fromIndex, 1);
-    newBlocks.splice(toIndex, 0, moved);
-    setBlocks(newBlocks);
+    if (moved) {
+      newBlocks.splice(toIndex, 0, moved);
+      setBlocks(newBlocks);
+    }
   }
 
   const selectedBlock = blocks.find(b => b.id === selectedBlockId) as PageBlock | undefined;

--- a/packages/web/src/domain/console/featureFlags.ts
+++ b/packages/web/src/domain/console/featureFlags.ts
@@ -49,7 +49,7 @@ export async function listFeatureFlags(
     orderBy: { createdAt: 'desc' },
   });
 
-  return flags.map((flag: { id: string; key: string; name: string; description: string | null; type: string; isGlobal: boolean; defaultValue: unknown; environments: Array<{ environment: string; enabled: boolean }> }) => ({
+  return flags.map((flag) => ({
     id: flag.id,
     key: flag.key,
     name: flag.name,
@@ -57,7 +57,7 @@ export async function listFeatureFlags(
     type: flag.type,
     isGlobal: flag.isGlobal,
     defaultValue: flag.defaultValue,
-    environments: flag.environments.map((env: { environment: string; enabled: boolean }) => ({
+    environments: flag.environments.map((env) => ({
       environment: env.environment,
       enabled: env.enabled,
       variant: env.variant as unknown,

--- a/packages/web/src/domain/console/receipts.ts
+++ b/packages/web/src/domain/console/receipts.ts
@@ -55,7 +55,7 @@ export async function listReceipts(
     skip: offset,
   });
 
-  return receipts.map((receipt: { id: string; uploadId: string; vendor: string | null; date: Date; currency: string; total: unknown; paymentMethod: string | null; confidenceScore: number | null }) => ({
+  return receipts.map((receipt) => ({
     id: receipt.id,
     uploadId: receipt.uploadId,
     vendor: receipt.vendor,

--- a/packages/web/src/domain/console/usage.ts
+++ b/packages/web/src/domain/console/usage.ts
@@ -76,7 +76,7 @@ export async function getUsageEvents(
     skip: filters.offset || 0,
   });
 
-  return events.map((event: { id: string; eventType: string; timestamp: Date }) => {
+  return events.map((event) => {
     const [service, operation] = event.eventType.split(':');
     return {
       id: event.id,

--- a/packages/web/src/domain/siteBuilder/pageRenderer.tsx
+++ b/packages/web/src/domain/siteBuilder/pageRenderer.tsx
@@ -29,16 +29,16 @@ interface PageRendererProps {
  * Block component registry
  */
 const blockComponents: Record<string, React.ComponentType<{ block: PageBlock }>> = {
-  hero: HeroBlockComponent,
-  featureGrid: FeatureGridBlockComponent,
-  logoCloud: LogoCloudBlockComponent,
-  testimonial: TestimonialBlockComponent,
-  faq: FAQBlockComponent,
-  ctaBanner: CTABannerBlockComponent,
-  pricingTable: PricingTableBlockComponent,
-  twoColumnText: TwoColumnTextBlockComponent,
-  codeExample: CodeExampleBlockComponent,
-  stats: StatsBlockComponent,
+  hero: HeroBlockComponent as React.ComponentType<{ block: PageBlock }>,
+  featureGrid: FeatureGridBlockComponent as React.ComponentType<{ block: PageBlock }>,
+  logoCloud: LogoCloudBlockComponent as React.ComponentType<{ block: PageBlock }>,
+  testimonial: TestimonialBlockComponent as React.ComponentType<{ block: PageBlock }>,
+  faq: FAQBlockComponent as React.ComponentType<{ block: PageBlock }>,
+  ctaBanner: CTABannerBlockComponent as React.ComponentType<{ block: PageBlock }>,
+  pricingTable: PricingTableBlockComponent as React.ComponentType<{ block: PageBlock }>,
+  twoColumnText: TwoColumnTextBlockComponent as React.ComponentType<{ block: PageBlock }>,
+  codeExample: CodeExampleBlockComponent as React.ComponentType<{ block: PageBlock }>,
+  stats: StatsBlockComponent as React.ComponentType<{ block: PageBlock }>,
 };
 
 export function PageRenderer({ blocks, className }: PageRendererProps) {

--- a/packages/web/src/shared/tenant/tenantResolver.ts
+++ b/packages/web/src/shared/tenant/tenantResolver.ts
@@ -161,14 +161,15 @@ export async function resolveTenant(
   const pathMatch = url.pathname.match(/^\/t\/([^/]+)/);
   if (pathMatch && userId) {
     const previewSlug = pathMatch[1];
-    if (!previewSlug) return null;
-    const tenantBySlug = await findTenantBySlug(previewSlug);
-    if (tenantBySlug && await canAccessTenant(userId, tenantBySlug.id)) {
-      return {
-        tenantId: tenantBySlug.id,
-        tenantSlug: tenantBySlug.slug,
-        tenant: tenantBySlug,
-      };
+    if (previewSlug) {
+      const tenantBySlug = await findTenantBySlug(previewSlug);
+      if (tenantBySlug && await canAccessTenant(userId, tenantBySlug.id)) {
+        return {
+          tenantId: tenantBySlug.id,
+          tenantSlug: tenantBySlug.slug,
+          tenant: tenantBySlug,
+        };
+      }
     }
   }
   


### PR DESCRIPTION
## Description

This PR resolves a series of TypeScript errors that were preventing the `@settler/web` package from building successfully. The changes primarily focus on improving type inference, adding necessary null checks, and correctly handling union types to ensure type safety and a clean build.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The fixes address various TypeScript issues, including:
- Removing overly restrictive type annotations in API routes and domain logic to allow TypeScript to infer complete Prisma result types.
- Adding null checks in UI components (navigation and pages) to prevent `undefined` values from being assigned to strictly typed objects.
- Using type assertions in the page renderer to correctly handle `PageBlock` union types for component mapping.
- Ensuring the `tenantResolver` always returns a valid `TenantResolutionResult`.
- Adding `@prisma/client` as a dependency to the `web` package to resolve module not found errors for Prisma types.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a90c57d-06cf-4867-8bd8-af786b4367b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a90c57d-06cf-4867-8bd8-af786b4367b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

