### PR TITLE
Fix prisma build error

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "clean:build": "rm -rf .next dist out .next/tsconfig.tsbuildinfo",
-    "prebuild": "npm run validate:prebuild",
+    "prebuild": "cd ../.. && npm run prisma:generate && cd packages/web && npm run validate:prebuild",
     "build": "NODE_OPTIONS='--max-old-space-size=4096' next build",
     "build:vercel": "(test -f ../../scripts/vercel-build-optimizer.js && node ../../scripts/vercel-build-optimizer.js || echo '⚠️  Build optimizer script not available (expected in Vercel)') && NODE_OPTIONS='--max-old-space-size=4096' next build",
     "start": "next start",


### PR DESCRIPTION
## Description

Fixes build failure on Vercel caused by the Prisma Client not being generated before the Next.js build. The `web` package's `prebuild` script now explicitly runs `prisma generate` from the monorepo root, resolving "Cannot find module '.prisma/client/default'" errors.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The existing `postinstall` script explicitly skips `prisma generate` in Vercel environments. This change ensures the Prisma Client is generated as part of the `web` package's build lifecycle by adding `npm run prisma:generate` to its `prebuild` script.

---
<a href="https://cursor.com/background-agent?bcId=bc-73913b15-92ec-498c-8e3f-73088420ca54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73913b15-92ec-498c-8e3f-73088420ca54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

