### PR TITLE
Fix prisma schema build

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -620,7 +620,7 @@ model FeatureFlagOverride {
 
 model Tenant {
   id                String    @id @default(uuid())
-  billingAccountId  String?   @db.Uuid // Optional: link to billing account
+  billingAccountId  String?   @unique @db.Uuid // Optional: link to billing account
   slug               String    @unique // e.g., "default", "partner-x"
   primaryDomain      String?   // e.g., "settler.dev"
   customDomain       String?   // e.g., "api.partnerx.com"


### PR DESCRIPTION
## Description

Adds the `@unique` attribute to the `billingAccountId` field in the `Tenant` model to resolve a Prisma schema validation error. This ensures that the one-to-one relation between `Tenant` and `BillingAccount` is correctly defined, as Prisma requires unique fields on the defining side of a one-to-one relation.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Prisma schema validation)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The previous build failed with `Error parsing attribute "@relation": A one-to-one relation must use unique fields on the defining side. Either add an @unique attribute to the field billingAccountId, or change the relation to one-to-many.` This change directly addresses that error. A redundant `@@index([billingAccountId])` exists but does not cause an error.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5b86e9f-8c6e-4114-a617-f652da21fa0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c5b86e9f-8c6e-4114-a617-f652da21fa0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

