### PR TITLE
Fix prisma build error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "build": {
     "env": {
       "NODE_OPTIONS": "--max-old-space-size=4096",
-      "PRISMA_CLIENT_ENGINE_TYPE": "library",
+      "PRISMA_CLIENT_ENGINE_TYPE": "binary",
       "NEXT_TELEMETRY_DISABLED": "1",
       "NODE_VERSION": "24",
       "TURBO_TOKEN": "",


### PR DESCRIPTION
## Description

Fixes a Vercel build error by correcting the Prisma client engine type. The `PRISMA_CLIENT_ENGINE_TYPE` was set to `library`, which is intended for edge environments and requires an adapter or accelerateUrl. This application runs in a standard Node.js environment, so the engine type has been changed to `binary` to resolve the `PrismaClientConstructorValidationError`.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (verified by successful Vercel build)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The `library` engine type is specifically for Prisma Edge or Prisma Accelerate. For standard Node.js environments, the `binary` engine type is the correct choice and does not require additional adapter or accelerateUrl configurations.

---
<a href="https://cursor.com/background-agent?bcId=bc-b200ddda-86d9-4ddd-a946-045cc3184987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b200ddda-86d9-4ddd-a946-045cc3184987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

