### PR TITLE
Build project with vercel

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -39,6 +39,8 @@ tests/
 
 # Scripts (not needed in deployment)
 scripts/
+# But include build-time scripts
+!scripts/vercel-prisma-postinstall.js
 
 # Other
 .DS_Store


### PR DESCRIPTION
## Description

Updates `.vercelignore` to explicitly include `scripts/vercel-prisma-postinstall.js`. This resolves a "script not found" message during Vercel builds, which occurred because the entire `scripts/` directory was being ignored. The script is designed to skip execution in Vercel environments, but this change ensures its presence for consistency.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Vercel build log reviewed)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated (resolves existing warning)
- [x] Tests pass locally
- [ ] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The `vercel-prisma-postinstall.js` script is intentionally designed to skip execution in Vercel builds (as Prisma generation is handled in a `prebuild` step). This change simply ensures the script file itself is available in the build environment, preventing the "script not found" message.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e702793-42d1-4f5d-b4ce-2f72c283aefe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e702793-42d1-4f5d-b4ce-2f72c283aefe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

