### PR TITLE
Build project with vercel

### DIFF
--- a/packages/web/src/lib/supabase/server.ts
+++ b/packages/web/src/lib/supabase/server.ts
@@ -15,10 +15,9 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 /**
  * Get Supabase server client for authenticated requests
  * Uses cookies for session management
+ * Gracefully handles errors to prevent page crashes
  */
 export async function createClient(): Promise<ReturnType<typeof createServerClient<Database>>> {
-  const cookieStore = await cookies();
-
   const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
   const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
 
@@ -27,10 +26,31 @@ export async function createClient(): Promise<ReturnType<typeof createServerClie
     console.warn('Supabase environment variables not set - some features may not work');
   }
 
+  // Get cookie store with error handling
+  let cookieStore;
+  try {
+    cookieStore = await cookies();
+  } catch (error) {
+    console.error('Failed to get cookies:', error);
+    // Return a client with empty cookie handlers if cookies() fails
+    return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+      cookies: {
+        get() { return undefined; },
+        set() { /* no-op */ },
+        remove() { /* no-op */ },
+      },
+    });
+  }
+
   return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
     cookies: {
       get(name: string) {
-        return cookieStore.get(name)?.value;
+        try {
+          return cookieStore.get(name)?.value;
+        } catch (error) {
+          console.warn('Failed to get cookie:', error);
+          return undefined;
+        }
       },
       set(name: string, value: string, options: CookieOptions) {
         try {
@@ -57,6 +77,7 @@ export async function createClient(): Promise<ReturnType<typeof createServerClie
 /**
  * Get Supabase admin client (service role)
  * WARNING: Only use in Server Actions/Route Handlers, never expose to client
+ * Gracefully handles errors to prevent crashes
  */
 export async function createAdminClient(): Promise<SupabaseClient<Database>> {
   const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
@@ -67,13 +88,20 @@ export async function createAdminClient(): Promise<SupabaseClient<Database>> {
     console.warn('Supabase admin environment variables not set - admin features may not work');
   }
 
-  // Use regular supabase client with service role key (bypasses RLS)
-  const { createClient: createSupabaseClient } = await import('@supabase/supabase-js');
-  
-  return createSupabaseClient<Database>(supabaseUrl, supabaseServiceRoleKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-  });
+  try {
+    // Use regular supabase client with service role key (bypasses RLS)
+    const { createClient: createSupabaseClient } = await import('@supabase/supabase-js');
+    
+    return createSupabaseClient<Database>(supabaseUrl, supabaseServiceRoleKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to create Supabase admin client:', error);
+    // Return a minimal mock client to prevent crashes
+    // This will fail on actual operations but won't crash the page
+    return {} as SupabaseClient<Database>;
+  }
 }

--- a/packages/web/src/lib/tenant/server.ts
+++ b/packages/web/src/lib/tenant/server.ts
@@ -26,82 +26,113 @@ export interface TenantContext {
 
 /**
  * Get tenant context for server components
+ * Gracefully handles database connection failures and returns default tenant context
  */
 export async function getTenantContext(): Promise<TenantContext> {
-  const headersList = await headers();
-  const host = headersList.get('host') || '';
-  const pathname = headersList.get('x-pathname') || '';
-  
-  // Create a mock Request object for tenant resolution
-  const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
-  const url = `${protocol}://${host}${pathname}`;
-  const request = new Request(url, {
-    headers: {
-      host,
-    },
-  });
-
-  // Get current user if available
-  let userId: string | null = null;
-  try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    userId = user?.id || null;
-  } catch (error) {
-    // Auth not available, continue without user
-  }
-
-  // Resolve tenant
-  const resolution = await resolveTenant(request, userId);
-  
-  if (!resolution.tenantId) {
-    return {
-      tenantId: '',
-      tenantSlug: 'default',
-      theme: null,
-      branding: null,
-      navigation: null,
-    };
-  }
-
-  // Fetch full tenant data with branding and navigation
-  const tenant = await getTenantById(resolution.tenantId);
-  
-  if (!tenant) {
-    return {
-      tenantId: resolution.tenantId,
-      tenantSlug: resolution.tenantSlug,
-      theme: null,
-      branding: null,
-      navigation: null,
-    };
-  }
-
-  // Convert branding to theme
-  const theme = tenant.branding
-    ? brandingToTheme({
-        ...tenant.branding,
-        borderRadiusScale: tenant.branding.borderRadiusScale ? Number(tenant.branding.borderRadiusScale) : null,
-      })
-    : null;
-
-  return {
-    tenantId: tenant.id,
-    tenantSlug: tenant.slug,
-    theme,
-    branding: tenant.branding
-      ? {
-          logoUrl: tenant.branding.logoUrl,
-          faviconUrl: tenant.branding.faviconUrl,
-        }
-      : null,
-    navigation: tenant.navigation
-      ? {
-          navItems: tenant.navigation.navItems as any[],
-          footerItems: tenant.navigation.footerItems as any[],
-        }
-      : null,
+  // Default fallback tenant context
+  const defaultContext: TenantContext = {
+    tenantId: '',
+    tenantSlug: 'default',
+    theme: null,
+    branding: null,
+    navigation: null,
   };
+
+  try {
+    const headersList = await headers();
+    const host = headersList.get('host') || '';
+    const pathname = headersList.get('x-pathname') || '';
+    
+    // Create a mock Request object for tenant resolution
+    const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
+    const url = `${protocol}://${host}${pathname}`;
+    const request = new Request(url, {
+      headers: {
+        host,
+      },
+    });
+
+    // Get current user if available
+    let userId: string | null = null;
+    try {
+      const supabase = await createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      userId = user?.id || null;
+    } catch (error) {
+      // Auth not available, continue without user
+      console.warn('Failed to get user from Supabase:', error);
+    }
+
+    // Resolve tenant - wrap in try-catch to handle database failures
+    let resolution;
+    try {
+      resolution = await resolveTenant(request, userId);
+    } catch (error) {
+      console.error('Failed to resolve tenant:', error);
+      // Return default context if tenant resolution fails
+      return defaultContext;
+    }
+    
+    if (!resolution.tenantId) {
+      return defaultContext;
+    }
+
+    // Fetch full tenant data with branding and navigation
+    let tenant;
+    try {
+      tenant = await getTenantById(resolution.tenantId);
+    } catch (error) {
+      console.error('Failed to fetch tenant by ID:', error);
+      // Return context with tenant ID but no branding/navigation if fetch fails
+      return {
+        tenantId: resolution.tenantId,
+        tenantSlug: resolution.tenantSlug,
+        theme: null,
+        branding: null,
+        navigation: null,
+      };
+    }
+    
+    if (!tenant) {
+      return {
+        tenantId: resolution.tenantId,
+        tenantSlug: resolution.tenantSlug,
+        theme: null,
+        branding: null,
+        navigation: null,
+      };
+    }
+
+    // Convert branding to theme
+    const theme = tenant.branding
+      ? brandingToTheme({
+          ...tenant.branding,
+          borderRadiusScale: tenant.branding.borderRadiusScale ? Number(tenant.branding.borderRadiusScale) : null,
+        })
+      : null;
+
+    return {
+      tenantId: tenant.id,
+      tenantSlug: tenant.slug,
+      theme,
+      branding: tenant.branding
+        ? {
+            logoUrl: tenant.branding.logoUrl,
+            faviconUrl: tenant.branding.faviconUrl,
+          }
+        : null,
+      navigation: tenant.navigation
+        ? {
+            navItems: tenant.navigation.navItems as any[],
+            footerItems: tenant.navigation.footerItems as any[],
+          }
+        : null,
+    };
+  } catch (error) {
+    // Catch any unexpected errors and return default context
+    console.error('Unexpected error in getTenantContext:', error);
+    return defaultContext;
+  }
 }
 
 /**

--- a/packages/web/src/shared/tenant/tenantResolver.ts
+++ b/packages/web/src/shared/tenant/tenantResolver.ts
@@ -33,10 +33,19 @@ function extractSubdomain(host: string): string | null {
   return null;
 }
 
+type TenantSelect = {
+  id: string;
+  slug: string;
+  name: string;
+  primaryDomain: string | null;
+  customDomain: string | null;
+  isActive: boolean;
+};
+
 /**
  * Find tenant by domain (primary or custom)
  */
-async function findTenantByDomain(host: string): Promise<typeof tenant | null> {
+async function findTenantByDomain(host: string): Promise<TenantSelect | null> {
   try {
     const tenant = await prisma.tenant.findFirst({
       where: {
@@ -65,7 +74,7 @@ async function findTenantByDomain(host: string): Promise<typeof tenant | null> {
 /**
  * Find tenant by slug
  */
-async function findTenantBySlug(slug: string): Promise<typeof tenant | null> {
+async function findTenantBySlug(slug: string): Promise<TenantSelect | null> {
   try {
     const tenant = await prisma.tenant.findUnique({
       where: { slug },
@@ -88,7 +97,7 @@ async function findTenantBySlug(slug: string): Promise<typeof tenant | null> {
 /**
  * Get default tenant (slug: "default")
  */
-async function getDefaultTenant(): Promise<typeof tenant | null> {
+async function getDefaultTenant(): Promise<TenantSelect | null> {
   try {
     const tenant = await prisma.tenant.findUnique({
       where: { slug: 'default' },

--- a/packages/web/src/shared/tenant/tenantResolver.ts
+++ b/packages/web/src/shared/tenant/tenantResolver.ts
@@ -37,60 +37,75 @@ function extractSubdomain(host: string): string | null {
  * Find tenant by domain (primary or custom)
  */
 async function findTenantByDomain(host: string): Promise<typeof tenant | null> {
-  const tenant = await prisma.tenant.findFirst({
-    where: {
-      OR: [
-        { primaryDomain: host },
-        { customDomain: host },
-      ],
-      isActive: true,
-    },
-    select: {
-      id: true,
-      slug: true,
-      name: true,
-      primaryDomain: true,
-      customDomain: true,
-      isActive: true,
-    },
-  });
-  return tenant;
+  try {
+    const tenant = await prisma.tenant.findFirst({
+      where: {
+        OR: [
+          { primaryDomain: host },
+          { customDomain: host },
+        ],
+        isActive: true,
+      },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        primaryDomain: true,
+        customDomain: true,
+        isActive: true,
+      },
+    });
+    return tenant;
+  } catch (error) {
+    console.error('Failed to find tenant by domain:', error);
+    return null;
+  }
 }
 
 /**
  * Find tenant by slug
  */
 async function findTenantBySlug(slug: string): Promise<typeof tenant | null> {
-  const tenant = await prisma.tenant.findUnique({
-    where: { slug },
-    select: {
-      id: true,
-      slug: true,
-      name: true,
-      primaryDomain: true,
-      customDomain: true,
-      isActive: true,
-    },
-  });
-  return tenant;
+  try {
+    const tenant = await prisma.tenant.findUnique({
+      where: { slug },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        primaryDomain: true,
+        customDomain: true,
+        isActive: true,
+      },
+    });
+    return tenant;
+  } catch (error) {
+    console.error('Failed to find tenant by slug:', error);
+    return null;
+  }
 }
 
 /**
  * Get default tenant (slug: "default")
  */
 async function getDefaultTenant(): Promise<typeof tenant | null> {
-  const tenant = await prisma.tenant.findUnique({
-    where: { slug: 'default' },
-    select: {
-      id: true,
-      slug: true,
-      name: true,
-      primaryDomain: true,
-      customDomain: true,
-      isActive: true,
-    },
-  });
-  return tenant;
+  try {
+    const tenant = await prisma.tenant.findUnique({
+      where: { slug: 'default' },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        primaryDomain: true,
+        customDomain: true,
+        isActive: true,
+      },
+    });
+    return tenant;
+  } catch (error) {
+    console.error('Failed to get default tenant:', error);
+    return null;
+  }
 }
 
 /**
@@ -102,68 +117,60 @@ async function canAccessTenant(
 ): Promise<boolean> {
   if (!userId) return false;
   
-  // TODO: Implement role-based access check
-  // For now, allow if user has billing account linked to tenant
-  const tenant = await prisma.tenant.findUnique({
-    where: { id: tenantId },
-    include: {
-      billingAccount: {
-        select: { userId: true },
+  try {
+    // TODO: Implement role-based access check
+    // For now, allow if user has billing account linked to tenant
+    const tenant = await prisma.tenant.findUnique({
+      where: { id: tenantId },
+      include: {
+        billingAccount: {
+          select: { userId: true },
+        },
       },
-    },
-  });
-  
-  if (!tenant) return false;
-  
-  // Allow if user owns the billing account
-  if (tenant.billingAccount?.userId === userId) {
-    return true;
+    });
+    
+    if (!tenant) return false;
+    
+    // Allow if user owns the billing account
+    if (tenant.billingAccount?.userId === userId) {
+      return true;
+    }
+    
+    // TODO: Check for SUPER_ADMIN role
+    return false;
+  } catch (error) {
+    console.error('Failed to check tenant access:', error);
+    return false;
   }
-  
-  // TODO: Check for SUPER_ADMIN role
-  return false;
 }
 
 /**
  * Resolve tenant from request
+ * Gracefully handles database connection failures
  */
 export async function resolveTenant(
   request: Request,
   userId?: string | null
 ): Promise<TenantResolutionResult> {
-  const host = request.headers.get('host') || '';
-  const url = new URL(request.url);
-  
-  // 1. Check custom domain or primary domain
-  const tenantByDomain = await findTenantByDomain(host);
-  if (tenantByDomain) {
-    return {
-      tenantId: tenantByDomain.id,
-      tenantSlug: tenantByDomain.slug,
-      tenant: tenantByDomain,
-    };
-  }
-  
-  // 2. Check subdomain
-  const subdomain = extractSubdomain(host);
-  if (subdomain) {
-    const tenantBySlug = await findTenantBySlug(subdomain);
-    if (tenantBySlug && tenantBySlug.isActive) {
+  try {
+    const host = request.headers.get('host') || '';
+    const url = new URL(request.url);
+    
+    // 1. Check custom domain or primary domain
+    const tenantByDomain = await findTenantByDomain(host);
+    if (tenantByDomain) {
       return {
-        tenantId: tenantBySlug.id,
-        tenantSlug: tenantBySlug.slug,
-        tenant: tenantBySlug,
+        tenantId: tenantByDomain.id,
+        tenantSlug: tenantByDomain.slug,
+        tenant: tenantByDomain,
       };
     }
-  }
-  
-  // 3. Check path-based preview (if authenticated)
-  const pathMatch = url.pathname.match(/^\/t\/([^/]+)/);
-  if (pathMatch && userId) {
-    const previewSlug = pathMatch[1];
-    if (previewSlug) {
-      const tenantBySlug = await findTenantBySlug(previewSlug);
-      if (tenantBySlug && await canAccessTenant(userId, tenantBySlug.id)) {
+    
+    // 2. Check subdomain
+    const subdomain = extractSubdomain(host);
+    if (subdomain) {
+      const tenantBySlug = await findTenantBySlug(subdomain);
+      if (tenantBySlug && tenantBySlug.isActive) {
         return {
           tenantId: tenantBySlug.id,
           tenantSlug: tenantBySlug.slug,
@@ -171,19 +178,37 @@ export async function resolveTenant(
         };
       }
     }
+    
+    // 3. Check path-based preview (if authenticated)
+    const pathMatch = url.pathname.match(/^\/t\/([^/]+)/);
+    if (pathMatch && userId) {
+      const previewSlug = pathMatch[1];
+      if (previewSlug) {
+        const tenantBySlug = await findTenantBySlug(previewSlug);
+        if (tenantBySlug && await canAccessTenant(userId, tenantBySlug.id)) {
+          return {
+            tenantId: tenantBySlug.id,
+            tenantSlug: tenantBySlug.slug,
+            tenant: tenantBySlug,
+          };
+        }
+      }
+    }
+    
+    // 4. Default tenant
+    const defaultTenant = await getDefaultTenant();
+    if (defaultTenant) {
+      return {
+        tenantId: defaultTenant.id,
+        tenantSlug: defaultTenant.slug,
+        tenant: defaultTenant,
+      };
+    }
+  } catch (error) {
+    console.error('Error resolving tenant:', error);
   }
   
-  // 4. Default tenant
-  const defaultTenant = await getDefaultTenant();
-  if (defaultTenant) {
-    return {
-      tenantId: defaultTenant.id,
-      tenantSlug: defaultTenant.slug,
-      tenant: defaultTenant,
-    };
-  }
-  
-  // Fallback: return null tenant (should not happen if default tenant exists)
+  // Fallback: return null tenant (used when database is unavailable)
   return {
     tenantId: '',
     tenantSlug: 'default',
@@ -193,26 +218,38 @@ export async function resolveTenant(
 
 /**
  * Get tenant by ID (for server components)
+ * Returns null if database connection fails
  */
 export async function getTenantById(tenantId: string) {
-  return prisma.tenant.findUnique({
-    where: { id: tenantId },
-    include: {
-      branding: true,
-      navigation: true,
-    },
-  });
+  try {
+    return await prisma.tenant.findUnique({
+      where: { id: tenantId },
+      include: {
+        branding: true,
+        navigation: true,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to get tenant by ID:', error);
+    return null;
+  }
 }
 
 /**
  * Get tenant by slug (for server components)
+ * Returns null if database connection fails
  */
 export async function getTenantBySlug(slug: string) {
-  return prisma.tenant.findUnique({
-    where: { slug },
-    include: {
-      branding: true,
-      navigation: true,
-    },
-  });
+  try {
+    return await prisma.tenant.findUnique({
+      where: { slug },
+      include: {
+        branding: true,
+        navigation: true,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to get tenant by slug:', error);
+    return null;
+  }
 }


### PR DESCRIPTION
## Description

This PR introduces comprehensive error handling across critical server-side functions to prevent application crashes when database connections or Supabase client operations fail. Previously, unhandled errors in `getTenantContext()`, `tenantResolver.ts`, and `supabase/server.ts` could lead to the main page displaying a "try again later" message or failing to load entirely, even after successful deployment.

The changes ensure that the application degrades gracefully, returning default contexts or `null` values on failure, allowing the site to load with a fallback experience instead of crashing.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

Error handling was added to:
- `packages/web/src/lib/tenant/server.ts`: `getTenantContext()` now gracefully handles database and Supabase auth failures.
- `packages/web/src/shared/tenant/tenantResolver.ts`: All Prisma queries within tenant resolution functions now include `try-catch` blocks.
- `packages/web/src/lib/supabase/server.ts`: `createClient()` and `createAdminClient()` now handle cookie and import errors gracefully.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d5addd2-500d-4974-a18e-9eb56c4b3832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0d5addd2-500d-4974-a18e-9eb56c4b3832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

