### PR TITLE
Fix api build error

### DIFF
--- a/packages/api/src/services/predictive/predictive-ops.ts
+++ b/packages/api/src/services/predictive/predictive-ops.ts
@@ -203,8 +203,8 @@ export class PredictiveOps {
       });
 
       const durations = results
-        .filter((r) => r.completedAt !== null && r.startedAt !== null)
-        .map((r) => (r.completedAt!.getTime() - r.startedAt!.getTime()));
+        .filter((r: { completedAt: Date | null; startedAt: Date | null }) => r.completedAt !== null && r.startedAt !== null)
+        .map((r: { completedAt: Date; startedAt: Date }) => (r.completedAt.getTime() - r.startedAt.getTime()));
       
       const avgDuration = durations.length > 0
         ? durations.reduce((a: number, b: number) => a + b, 0) / durations.length


### PR DESCRIPTION
## Description

Fixed TypeScript `noImplicitAny` errors in `src/services/predictive/predictive-ops.ts` by explicitly typing parameters in `filter` and `map` callbacks. This resolves the build failure caused by implicit `any` types.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Verified locally that the type errors are resolved and lint checks pass.)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The errors were `TS7006: Parameter 'r' implicitly has an 'any' type` due to strict TypeScript configuration. Explicit types were added to ensure type safety and allow the build to complete successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-e337c3d1-0283-4154-86e9-07dceb0ed9a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e337c3d1-0283-4154-86e9-07dceb0ed9a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

