### PR TITLE
Web package build failure

### DIFF
--- a/packages/web/src/lib/api/cors.ts
+++ b/packages/web/src/lib/api/cors.ts
@@ -41,7 +41,7 @@ export function getCorsHeaders(
   options: CorsOptions = {}
 ): Record<string, string> {
   const allowedOrigins = options.origin || ALLOWED_ORIGINS;
-  const originHeader = (origin && allowedOrigins.includes(origin) ? origin : allowedOrigins[0]) || allowedOrigins[0];
+  const originHeader = (origin && allowedOrigins.includes(origin) ? origin : allowedOrigins[0]) || allowedOrigins[0] || '*';
 
   return {
     'Access-Control-Allow-Origin': originHeader,

--- a/packages/web/src/lib/api/idempotency.ts
+++ b/packages/web/src/lib/api/idempotency.ts
@@ -87,6 +87,7 @@ export async function recordIdempotency(
 ): Promise<void> {
   try {
     const responseJson = response ? (typeof response === 'string' ? JSON.parse(response) : response) : null;
+    const expiresAt = new Date(Date.now() + IDEMPOTENCY_TTL);
     
     await prisma.idempotencyKey.upsert({
       where: { key },
@@ -95,6 +96,7 @@ export async function recordIdempotency(
         status,
         response: responseJson as any,
         completedAt: status !== 'pending' ? new Date() : null,
+        expiresAt,
       },
       update: {
         status,

--- a/packages/web/src/lib/middleware/apply-middleware.ts
+++ b/packages/web/src/lib/middleware/apply-middleware.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { withRateLimit, getRateLimitTypeForRoute } from './rate-limit-wrapper';
+import { withRateLimit } from './rate-limit-wrapper';
 import { addCorsHeaders, handleCors } from '@/lib/api/cors';
 import { withCircuitBreaker } from '@/lib/resilience/circuit-breaker';
 import { withIdempotency } from '@/lib/api/idempotency';


### PR DESCRIPTION
## Description

This PR resolves a build failure caused by several TypeScript errors in the `@settler/web` package.

The following issues have been addressed:
- Ensured `originHeader` in `cors.ts` always resolves to a string by adding a fallback `'*'`.
- Added the required `expiresAt` field to `IdempotencyKeyCreateInput` in `idempotency.ts`, setting it to 24 hours from creation.
- Removed the unused import `getRateLimitTypeForRoute` from `apply-middleware.ts`.

These changes ensure the project passes TypeScript type checking and builds successfully.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Verified `tsc --noEmit` passes)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

<!-- Any additional information -->

---
<a href="https://cursor.com/background-agent?bcId=bc-6621d586-c061-4265-9ea9-4ebc5d03fc77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6621d586-c061-4265-9ea9-4ebc5d03fc77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

