### PR TITLE
Web package build failure

### DIFF
--- a/packages/web/src/components/ui/SpotlightCard.tsx
+++ b/packages/web/src/components/ui/SpotlightCard.tsx
@@ -52,10 +52,11 @@ export function SpotlightCard({
     } else if (onClick && (e.key === 'Enter' || e.key === ' ')) {
       e.preventDefault();
       // Create a synthetic mouse event for keyboard activation
+      // Using 'unknown' as intermediate type to satisfy TypeScript's type checking
       const syntheticEvent = {
         ...e,
         type: 'click',
-      } as React.MouseEvent<HTMLDivElement>;
+      } as unknown as React.MouseEvent<HTMLDivElement>;
       onClick(syntheticEvent);
     }
   };


### PR DESCRIPTION
## Description

Fixes a TypeScript error (`TS2352`) in `SpotlightCard.tsx` where a `KeyboardEvent` was being incorrectly cast to a `MouseEvent`. The change adds `unknown` as an intermediate type in the type assertion to satisfy TypeScript's strict type checking, allowing keyboard events (Enter/Space) to correctly trigger the `onClick` handler.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (verified with `tsc --noEmit --skipLibCheck`)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally (type check)
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The synthetic event is used only to trigger the `onClick` handler when Enter or Space is pressed, so the missing mouse-specific properties from the original `KeyboardEvent` should not affect functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-746731bd-26db-4a90-97a9-090749bfce32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-746731bd-26db-4a90-97a9-090749bfce32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

