### PR TITLE
Web package build failure

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -66,6 +66,13 @@ const nextConfig = {
         ...originalResolve.alias,
         '@': require('path').resolve(__dirname, 'src'),
       },
+      extensions: [
+        ...(originalResolve.extensions || []),
+        '.ts',
+        '.tsx',
+        '.js',
+        '.jsx',
+      ],
     };
     return config;
   },

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -26,16 +26,17 @@ const AnimatedCodeBlock = dynamic(() => import("@/components/AnimatedCodeBlock")
 const AnimatedStatCard = dynamic(() => import("@/components/AnimatedStatCard").then(mod => ({ default: mod.AnimatedStatCard })), { ssr: true });
 const TrustSignalBanner = dynamic(() => import("@/components/TrustSignalBanner").then(mod => ({ default: mod.TrustSignalBanner })), { ssr: true });
 const EnhancedConversionCTA = dynamic(() => import("@/components/EnhancedConversionCTA").then(mod => ({ default: mod.EnhancedConversionCTA })), { ssr: true });
-const InvestorMetrics = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.InvestorMetrics })), { ssr: true });
-const LiveMetricsCounter = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.LiveMetricsCounter })), { ssr: false });
-const ValueProposition = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.ValueProposition })), { ssr: true });
-const SocialProofCounter = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.SocialProofCounter })), { ssr: true });
-const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
-const InvestorPitch = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.InvestorPitch })), { ssr: true });
-const TestimonialCarousel = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.TestimonialCarousel })), { ssr: true });
+// Dynamic imports for marketing components - using individual files for better TypeScript/webpack resolution
+const InvestorMetrics = dynamic(() => import("@/components/marketing/InvestorMetrics").then(mod => ({ default: mod.InvestorMetrics })), { ssr: true });
+const LiveMetricsCounter = dynamic(() => import("@/components/marketing/LiveMetricsCounter").then(mod => ({ default: mod.LiveMetricsCounter })), { ssr: false });
+const ValueProposition = dynamic(() => import("@/components/marketing/ValueProposition").then(mod => ({ default: mod.ValueProposition })), { ssr: true });
+const SocialProofCounter = dynamic(() => import("@/components/marketing/SocialProofCounter").then(mod => ({ default: mod.SocialProofCounter })), { ssr: true });
+const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing/UrgencyBanner").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
+const InvestorPitch = dynamic(() => import("@/components/marketing/InvestorPitch").then(mod => ({ default: mod.InvestorPitch })), { ssr: true });
+const TestimonialCarousel = dynamic(() => import("@/components/marketing/TestimonialCarousel").then(mod => ({ default: mod.TestimonialCarousel })), { ssr: true });
 const IntegrationLogos = dynamic(() => import("@/components/IntegrationLogos").then(mod => ({ default: mod.IntegrationLogos })), { ssr: true });
 const EnhancedTrustBadges = dynamic(() => import("@/components/EnhancedTrustBadges").then(mod => ({ default: mod.EnhancedTrustBadges })), { ssr: true });
-const InfographicSection = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.InfographicSection })), { ssr: true });
+const InfographicSection = dynamic(() => import("@/components/marketing/InfographicSection").then(mod => ({ default: mod.InfographicSection })), { ssr: true });
 
 export default function Home() {
   const trackCTA = useTrackCTA();

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -26,24 +26,16 @@ const AnimatedCodeBlock = dynamic(() => import("@/components/AnimatedCodeBlock")
 const AnimatedStatCard = dynamic(() => import("@/components/AnimatedStatCard").then(mod => ({ default: mod.AnimatedStatCard })), { ssr: true });
 const TrustSignalBanner = dynamic(() => import("@/components/TrustSignalBanner").then(mod => ({ default: mod.TrustSignalBanner })), { ssr: true });
 const EnhancedConversionCTA = dynamic(() => import("@/components/EnhancedConversionCTA").then(mod => ({ default: mod.EnhancedConversionCTA })), { ssr: true });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const InvestorMetrics = dynamic(() => import("@/components/marketing/InvestorMetrics").then(mod => ({ default: mod.InvestorMetrics })), { ssr: true });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const LiveMetricsCounter = dynamic(() => import("@/components/marketing/LiveMetricsCounter").then(mod => ({ default: mod.LiveMetricsCounter })), { ssr: false });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const ValueProposition = dynamic(() => import("@/components/marketing/ValueProposition").then(mod => ({ default: mod.ValueProposition })), { ssr: true });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const SocialProofCounter = dynamic(() => import("@/components/marketing/SocialProofCounter").then(mod => ({ default: mod.SocialProofCounter })), { ssr: true });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing/UrgencyBanner").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const InvestorPitch = dynamic(() => import("@/components/marketing/InvestorPitch").then(mod => ({ default: mod.InvestorPitch })), { ssr: true });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const TestimonialCarousel = dynamic(() => import("@/components/marketing/TestimonialCarousel").then(mod => ({ default: mod.TestimonialCarousel })), { ssr: true });
+const InvestorMetrics = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.InvestorMetrics })), { ssr: true });
+const LiveMetricsCounter = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.LiveMetricsCounter })), { ssr: false });
+const ValueProposition = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.ValueProposition })), { ssr: true });
+const SocialProofCounter = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.SocialProofCounter })), { ssr: true });
+const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
+const InvestorPitch = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.InvestorPitch })), { ssr: true });
+const TestimonialCarousel = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.TestimonialCarousel })), { ssr: true });
 const IntegrationLogos = dynamic(() => import("@/components/IntegrationLogos").then(mod => ({ default: mod.IntegrationLogos })), { ssr: true });
 const EnhancedTrustBadges = dynamic(() => import("@/components/EnhancedTrustBadges").then(mod => ({ default: mod.EnhancedTrustBadges })), { ssr: true });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const InfographicSection = dynamic(() => import("@/components/marketing/InfographicSection").then(mod => ({ default: mod.InfographicSection })), { ssr: true });
+const InfographicSection = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.InfographicSection })), { ssr: true });
 
 export default function Home() {
   const trackCTA = useTrackCTA();

--- a/packages/web/src/app/pricing/page.tsx
+++ b/packages/web/src/app/pricing/page.tsx
@@ -16,9 +16,9 @@ import { AnimatedFAQ } from "@/components/AnimatedFAQ";
 import { FAQSchema } from "@/components/StructuredData";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 
-const ROICalculator = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.ROICalculator })), { ssr: true });
-const ComparisonTable = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.ComparisonTable })), { ssr: true });
-const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
+const ROICalculator = dynamic(() => import("@/components/marketing/ROICalculator").then(mod => ({ default: mod.ROICalculator })), { ssr: true });
+const ComparisonTable = dynamic(() => import("@/components/marketing/ComparisonTable").then(mod => ({ default: mod.ComparisonTable })), { ssr: true });
+const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing/UrgencyBanner").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
 
 export default function Pricing() {
   const [billingCycle, setBillingCycle] = useState<'monthly' | 'annual'>('monthly');

--- a/packages/web/src/app/pricing/page.tsx
+++ b/packages/web/src/app/pricing/page.tsx
@@ -16,12 +16,9 @@ import { AnimatedFAQ } from "@/components/AnimatedFAQ";
 import { FAQSchema } from "@/components/StructuredData";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const ROICalculator = dynamic(() => import("@/components/marketing/ROICalculator").then(mod => ({ default: mod.ROICalculator })), { ssr: true });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const ComparisonTable = dynamic(() => import("@/components/marketing/ComparisonTable").then(mod => ({ default: mod.ComparisonTable })), { ssr: true });
-// @ts-expect-error - TypeScript can't resolve dynamic imports for marketing components, but Next.js/webpack handles them correctly at runtime
-const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing/UrgencyBanner").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
+const ROICalculator = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.ROICalculator })), { ssr: true });
+const ComparisonTable = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.ComparisonTable })), { ssr: true });
+const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
 
 export default function Pricing() {
   const [billingCycle, setBillingCycle] = useState<'monthly' | 'annual'>('monthly');


### PR DESCRIPTION
## Description

Resolves a Vercel build failure where webpack could not resolve dynamic imports for marketing components. The previous imports directly referenced individual component files (e.g., `@/components/marketing/InvestorMetrics`), leading to "Module not found" errors. This change updates the dynamic imports to use the barrel export from `@/components/marketing`, allowing webpack to correctly resolve the components during the build process.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (build verification)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The dynamic imports in `packages/web/src/app/page.tsx` and `packages/web/src/app/pricing/page.tsx` were updated to use the barrel export. This also allowed for the removal of `@ts-expect-error` comments.

---
<a href="https://cursor.com/background-agent?bcId=bc-02619d0e-0875-4dbf-9767-209239422adf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02619d0e-0875-4dbf-9767-209239422adf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

