### PR TITLE
Web package build failure

### DIFF
--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import dynamic from "next/dynamic";
-import React, { useEffect, Suspense } from "react";
+import React, { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/Navigation";

--- a/packages/web/src/app/pricing/page.tsx
+++ b/packages/web/src/app/pricing/page.tsx
@@ -16,9 +16,9 @@ import { AnimatedFAQ } from "@/components/AnimatedFAQ";
 import { FAQSchema } from "@/components/StructuredData";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 
-const ROICalculator = dynamic(() => import("@/components/marketing/ROICalculator").then(mod => ({ default: mod.ROICalculator })), { ssr: true });
-const ComparisonTable = dynamic(() => import("@/components/marketing/ComparisonTable").then(mod => ({ default: mod.ComparisonTable })), { ssr: true });
-const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing/UrgencyBanner").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
+const ROICalculator = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.ROICalculator })), { ssr: true });
+const ComparisonTable = dynamic(() => import("@/components/marketing").then(mod => ({ default: mod.ComparisonTable })), { ssr: true });
+const UrgencyBanner = dynamic<{ variant?: 'default' | 'minimal' | 'prominent'; className?: string }>(() => import("@/components/marketing").then(mod => ({ default: mod.UrgencyBanner })), { ssr: true });
 
 export default function Pricing() {
   const [billingCycle, setBillingCycle] = useState<'monthly' | 'annual'>('monthly');


### PR DESCRIPTION
## Description

Resolves TypeScript build errors by removing an unused `Suspense` import and correcting module resolution for marketing components. Marketing components are now imported via the `@/components/marketing` alias, which correctly points to their `index.ts` barrel file, rather than directly from individual component files.

## Type of Change

- [x] Bug Fix
- [ ] Feature
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Verified `tsc --noEmit --skipLibCheck` passes)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

<!-- Any additional information -->

---
<a href="https://cursor.com/background-agent?bcId=bc-9f737520-9276-4075-99c1-caba928f8449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f737520-9276-4075-99c1-caba928f8449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

