### PR TITLE
Web package build error

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -22,10 +22,10 @@ node_modules/
 # Documentation
 *.md
 !README.md
-docs/
-business/
-marketing/
-strategic/
+/docs/
+/business/
+/marketing/
+/strategic/
 
 # Test files
 tests/


### PR DESCRIPTION
## Description

Fixes a Vercel build failure where the `@settler/web` package could not resolve imports for `@/components/marketing`. This was caused by an unanchored `marketing/` pattern in `.vercelignore`, which inadvertently excluded the `packages/web/src/components/marketing` directory from the build.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The `.vercelignore` file was updated to anchor documentation-related ignore patterns (e.g., `marketing/` changed to `/marketing/`) to the repository root. This ensures that only top-level documentation folders are ignored, allowing the `src/components/marketing` directory within the `packages/web` workspace to be included in Vercel builds, resolving the TypeScript import errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2dbbdaa-ecd1-415d-b261-68b3b7831005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c2dbbdaa-ecd1-415d-b261-68b3b7831005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

