### PR TITLE
Web package build errors

### DIFF
--- a/packages/web/src/app/api/v1/receipts/route.ts
+++ b/packages/web/src/app/api/v1/receipts/route.ts
@@ -140,7 +140,7 @@ export async function POST(request: NextRequest) {
       logger.info('Receipt parsed from OCR', { correlationId, itemCount: parseResult.receipt.items.length });
 
       // Validate and sanitize receipt data
-      const sanitizedData = sanitizeReceiptData(parseResult.receipt as Record<string, unknown>);
+      const sanitizedData = sanitizeReceiptData(parseResult.receipt as unknown as Record<string, unknown>);
       const validation = validateReceipt(sanitizedData);
 
       if (!validation.valid) {

--- a/packages/web/src/app/api/v1/receipts/route.ts
+++ b/packages/web/src/app/api/v1/receipts/route.ts
@@ -140,13 +140,13 @@ export async function POST(request: NextRequest) {
       logger.info('Receipt parsed from OCR', { correlationId, itemCount: parseResult.receipt.items.length });
 
       // Validate and sanitize receipt data
-      const sanitizedData = sanitizeReceiptData(parseResult.receipt);
+      const sanitizedData = sanitizeReceiptData(parseResult.receipt as Record<string, unknown>);
       const validation = validateReceipt(sanitizedData);
 
       if (!validation.valid) {
         logger.warn('Receipt validation failed', { 
           correlationId, 
-          errors: validation.errors?.errors.map((e: { message: string }) => e.message) || []
+          errors: validation.errors?.issues.map((e) => e.message) || []
         });
         // Continue with sanitized data even if validation fails (graceful degradation)
       }

--- a/packages/web/src/components/console/ErrorBoundary.tsx
+++ b/packages/web/src/components/console/ErrorBoundary.tsx
@@ -33,7 +33,7 @@ export class ConsoleErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     // Log error for monitoring
     console.error('[ConsoleErrorBoundary] Caught error:', {
       error: error.message,
@@ -42,7 +42,7 @@ export class ConsoleErrorBoundary extends Component<Props, State> {
     });
   }
 
-  render() {
+  override render() {
     if (this.state.hasError) {
       // Use custom fallback if provided
       if (this.props.fallback) {


### PR DESCRIPTION
## Description

This PR resolves several TypeScript errors that were preventing the application from building successfully. The changes include:
*   Casting `NormalizedReceipt` to `Record<string, unknown>` to satisfy the `sanitizeReceiptData` function's type requirements.
*   Correcting the access path for Zod validation errors from `errors.errors` to `errors.issues`.
*   Adding `override` modifiers to `componentDidCatch` and `render` methods in `ErrorBoundary.tsx` as required by TypeScript.

These fixes ensure the build passes while maintaining existing functionality.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Integration
- [ ] Infrastructure
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (Verified build passes locally)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] TypeScript types are correct

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots here -->

## Additional Notes

The changes specifically target type-related build failures and do not introduce any new features or alter application logic beyond ensuring type correctness.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e9670ba-b63e-4987-94c5-4a251f41b12d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e9670ba-b63e-4987-94c5-4a251f41b12d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

