### PR TITLE
Web package build failure

### DIFF
--- a/packages/web/src/app/api/exports/route.ts
+++ b/packages/web/src/app/api/exports/route.ts
@@ -49,26 +49,35 @@ export const POST = withUniversalBillingGate(async function POST(request: NextRe
         userId = auth.userId || null;
       } else {
         // Try Supabase auth as fallback (graceful degradation)
-      try {
-        const supabase = await createClient();
-        const { data: { user } } = await supabase.auth.getUser();
-        if (user) {
-          userId = user.id;
-          const billingAccount = await prisma.billingAccount.findFirst({
-            where: { userId: user.id },
-            select: { tenantId: true },
-          });
-          tenantId = billingAccount?.tenantId || null;
+        try {
+          const supabase = await createClient();
+          const { data: { user } } = await supabase.auth.getUser();
+          if (user) {
+            userId = user.id;
+            const billingAccount = await prisma.billingAccount.findFirst({
+              where: { userId: user.id },
+              select: { tenantId: true },
+            });
+            tenantId = billingAccount?.tenantId || null;
+          }
+        } catch (supabaseError) {
+          return NextResponse.json(
+            {
+              error: 'Unauthorized',
+              message: 'Authentication required',
+            },
+            { status: 401 }
+          );
         }
-      } catch (supabaseError) {
-        return NextResponse.json(
-          {
-            error: 'Unauthorized',
-            message: 'Authentication required',
-          },
-          { status: 401 }
-        );
       }
+    } catch (authError) {
+      return NextResponse.json(
+        {
+          error: 'Unauthorized',
+          message: 'Authentication required',
+        },
+        { status: 401 }
+      );
     }
 
     if (!tenantId || !userId) {

--- a/packages/web/src/app/api/jobs/[jobId]/exceptions/[exceptionId]/route.ts
+++ b/packages/web/src/app/api/jobs/[jobId]/exceptions/[exceptionId]/route.ts
@@ -96,27 +96,36 @@ export const PATCH = withUniversalBillingGate(async function PATCH(
         userId = auth.userId || null;
       } else {
         // Try Supabase auth as fallback (graceful degradation)
-      try {
-        const supabase = await createClient();
-        const { data: { user } } = await supabase.auth.getUser();
-        if (user) {
-          userId = user.id;
-          // Get tenant from billing account
-          const billingAccount = await prisma.billingAccount.findFirst({
-            where: { userId: user.id },
-            select: { tenantId: true },
-          });
-          tenantId = billingAccount?.tenantId || null;
+        try {
+          const supabase = await createClient();
+          const { data: { user } } = await supabase.auth.getUser();
+          if (user) {
+            userId = user.id;
+            // Get tenant from billing account
+            const billingAccount = await prisma.billingAccount.findFirst({
+              where: { userId: user.id },
+              select: { tenantId: true },
+            });
+            tenantId = billingAccount?.tenantId || null;
+          }
+        } catch (supabaseError) {
+          return NextResponse.json(
+            {
+              error: 'Unauthorized',
+              message: 'Authentication required',
+            },
+            { status: 401 }
+          );
         }
-      } catch (supabaseError) {
-        return NextResponse.json(
-          {
-            error: 'Unauthorized',
-            message: 'Authentication required',
-          },
-          { status: 401 }
-        );
       }
+    } catch (authError) {
+      return NextResponse.json(
+        {
+          error: 'Unauthorized',
+          message: 'Authentication required',
+        },
+        { status: 401 }
+      );
     }
 
     if (!tenantId || !userId) {

--- a/packages/web/src/app/api/jobs/[jobId]/exceptions/route.ts
+++ b/packages/web/src/app/api/jobs/[jobId]/exceptions/route.ts
@@ -152,27 +152,36 @@ export const GET = withUniversalBillingGate(async function GET(
         userId = auth.userId || null;
       } else {
         // Try Supabase auth as fallback (graceful degradation)
-      try {
-        const supabase = await createClient();
-        const { data: { user } } = await supabase.auth.getUser();
-        if (user) {
-          userId = user.id;
-          // Get tenant from billing account
-          const billingAccount = await prisma.billingAccount.findFirst({
-            where: { userId: user.id },
-            select: { tenantId: true },
-          });
-          tenantId = billingAccount?.tenantId || null;
+        try {
+          const supabase = await createClient();
+          const { data: { user } } = await supabase.auth.getUser();
+          if (user) {
+            userId = user.id;
+            // Get tenant from billing account
+            const billingAccount = await prisma.billingAccount.findFirst({
+              where: { userId: user.id },
+              select: { tenantId: true },
+            });
+            tenantId = billingAccount?.tenantId || null;
+          }
+        } catch (supabaseError) {
+          return NextResponse.json(
+            {
+              error: 'Unauthorized',
+              message: 'Authentication required',
+            },
+            { status: 401 }
+          );
         }
-      } catch (supabaseError) {
-        return NextResponse.json(
-          {
-            error: 'Unauthorized',
-            message: 'Authentication required',
-          },
-          { status: 401 }
-        );
       }
+    } catch (authError) {
+      return NextResponse.json(
+        {
+          error: 'Unauthorized',
+          message: 'Authentication required',
+        },
+        { status: 401 }
+      );
     }
 
     if (!tenantId || !userId) {

--- a/packages/web/src/app/api/jobs/[jobId]/route.ts
+++ b/packages/web/src/app/api/jobs/[jobId]/route.ts
@@ -127,28 +127,37 @@ export const GET = withUniversalBillingGate(async function GET(
         userId = auth.userId || null;
       } else {
         // Try Supabase auth as fallback (graceful degradation)
-      try {
-        const supabase = await createClient();
-        const { data: { user } } = await supabase.auth.getUser();
-        if (user) {
-          userId = user.id;
-          // Get tenant from billing account
-          const billingAccount = await prisma.billingAccount.findFirst({
-            where: { userId: user.id },
-            select: { tenantId: true },
-          });
-          tenantId = billingAccount?.tenantId || null;
+        try {
+          const supabase = await createClient();
+          const { data: { user } } = await supabase.auth.getUser();
+          if (user) {
+            userId = user.id;
+            // Get tenant from billing account
+            const billingAccount = await prisma.billingAccount.findFirst({
+              where: { userId: user.id },
+              select: { tenantId: true },
+            });
+            tenantId = billingAccount?.tenantId || null;
+          }
+        } catch (supabaseError) {
+          // Both auth methods failed
+          return NextResponse.json(
+            {
+              error: 'Unauthorized',
+              message: 'Authentication required',
+            },
+            { status: 401 }
+          );
         }
-      } catch (supabaseError) {
-        // Both auth methods failed
-        return NextResponse.json(
-          {
-            error: 'Unauthorized',
-            message: 'Authentication required',
-          },
-          { status: 401 }
-        );
       }
+    } catch (authError) {
+      return NextResponse.json(
+        {
+          error: 'Unauthorized',
+          message: 'Authentication required',
+        },
+        { status: 401 }
+      );
     }
 
     if (!tenantId || !userId) {

--- a/packages/web/src/app/api/jobs/bulk/route.ts
+++ b/packages/web/src/app/api/jobs/bulk/route.ts
@@ -47,26 +47,35 @@ export const POST = withUniversalBillingGate(async function POST(request: NextRe
         userId = auth.userId || null;
       } else {
         // Try Supabase auth as fallback (graceful degradation)
-      try {
-        const supabase = await createClient();
-        const { data: { user } } = await supabase.auth.getUser();
-        if (user) {
-          userId = user.id;
-          const billingAccount = await prisma.billingAccount.findFirst({
-            where: { userId: user.id },
-            select: { tenantId: true },
-          });
-          tenantId = billingAccount?.tenantId || null;
+        try {
+          const supabase = await createClient();
+          const { data: { user } } = await supabase.auth.getUser();
+          if (user) {
+            userId = user.id;
+            const billingAccount = await prisma.billingAccount.findFirst({
+              where: { userId: user.id },
+              select: { tenantId: true },
+            });
+            tenantId = billingAccount?.tenantId || null;
+          }
+        } catch (supabaseError) {
+          return NextResponse.json(
+            {
+              error: 'Unauthorized',
+              message: 'Authentication required',
+            },
+            { status: 401 }
+          );
         }
-      } catch (supabaseError) {
-        return NextResponse.json(
-          {
-            error: 'Unauthorized',
-            message: 'Authentication required',
-          },
-          { status: 401 }
-        );
       }
+    } catch (authError) {
+      return NextResponse.json(
+        {
+          error: 'Unauthorized',
+          message: 'Authentication required',
+        },
+        { status: 401 }
+      );
     }
 
     if (!tenantId || !userId) {

--- a/packages/web/src/app/api/ops/performance/route.ts
+++ b/packages/web/src/app/api/ops/performance/route.ts
@@ -5,7 +5,6 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { safeLogger } from '@/lib/observability/safe-logger';
 import { prisma } from '@/shared/db/prismaClient';
 import { logger } from '@/lib/observability/logger';
 

--- a/packages/web/src/lib/security/entitlement-checks.ts
+++ b/packages/web/src/lib/security/entitlement-checks.ts
@@ -6,6 +6,7 @@
 
 import { NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
+import { safeLogger } from '@/lib/observability/safe-logger';
 
 // Import billing hardening functions - handle both direct import and dynamic import
 let checkEntitlements: any;

--- a/packages/web/src/lib/server/settler/ai-tokens.ts
+++ b/packages/web/src/lib/server/settler/ai-tokens.ts
@@ -9,6 +9,7 @@ import type { TenantId } from "@/lib/domain/types";
 import type { Database } from "@/types/database.types";
 import { prisma } from "@/shared/db/prismaClient";
 import { determineSubscriptionTier, type SubscriptionTier } from "@/lib/subscription-access";
+import { safeLogger } from "@/lib/observability/safe-logger";
 
 export interface TokenUsage {
   used: number;

--- a/packages/web/src/lib/server/settler/alerts.ts
+++ b/packages/web/src/lib/server/settler/alerts.ts
@@ -8,6 +8,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Alert, TenantId } from "@/lib/domain/types";
 import { generateExplanation } from "@/lib/judgment/rules";
 import type { Database } from "@/types/database.types";
+import { safeLogger } from "@/lib/observability/safe-logger";
 
 /**
  * List alerts for a tenant

--- a/packages/web/src/lib/server/settler/feature-flags.ts
+++ b/packages/web/src/lib/server/settler/feature-flags.ts
@@ -8,6 +8,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { FlagKey, FlagValue, TenantId } from "@/lib/domain/types";
 import { FLAG_REGISTRY } from "@/lib/flags/registry";
 import type { Database } from "@/types/database.types";
+import { safeLogger } from "@/lib/observability/safe-logger";
 
 /**
  * Get feature flags for a tenant

--- a/packages/web/src/lib/server/settler/meaningful-changes.ts
+++ b/packages/web/src/lib/server/settler/meaningful-changes.ts
@@ -13,6 +13,7 @@ import {
   getSourceReliabilityScore,
 } from "@/lib/judgment/rules";
 import type { Database } from "@/types/database.types";
+import { safeLogger } from "@/lib/observability/safe-logger";
 
 export interface MeaningfulChangesFilters {
   severity?: "info" | "warning" | "critical";

--- a/packages/web/src/lib/server/settler/receipts.ts
+++ b/packages/web/src/lib/server/settler/receipts.ts
@@ -8,6 +8,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createHash } from "crypto";
 import type { Receipt, TenantId, Evidence } from "@/lib/domain/types";
 import type { Database } from "@/types/database.types";
+import { safeLogger } from "@/lib/observability/safe-logger";
 
 /**
  * Canonicalize JSON for stable hashing

--- a/packages/web/src/lib/supabase/client.ts
+++ b/packages/web/src/lib/supabase/client.ts
@@ -11,6 +11,7 @@
 import { createBrowserClient } from '@supabase/ssr';
 import { Database } from '@/types/database.types';
 import { validateSupabaseEnv } from '@/lib/env/validator';
+import { safeLogger } from '@/lib/observability/safe-logger';
 
 /**
  * Get Supabase browser client for client-side operations

--- a/packages/web/src/lib/supabase/safe-query.ts
+++ b/packages/web/src/lib/supabase/safe-query.ts
@@ -44,7 +44,7 @@ export async function safeQuery<T>(
         errorMessage.includes('does not exist') ||
         errorMessage.includes('relation') && errorMessage.includes('does not exist')
       ) {
-        await safeLogger.debug('[SafeQuery] Table does not exist, returning empty result', { table });
+        await safeLogger.debug('[SafeQuery] Table does not exist, returning empty result', { errorCode, errorMessage });
         return {
           data: defaultValue,
           error: null, // Don't treat missing table as error
@@ -59,7 +59,7 @@ export async function safeQuery<T>(
         errorMessage.includes('permission denied') ||
         errorMessage.includes('RLS')
       ) {
-        await safeLogger.debug('[SafeQuery] Permission denied by RLS, returning empty result', { table });
+        await safeLogger.debug('[SafeQuery] Permission denied by RLS, returning empty result', { errorCode, errorMessage });
         return {
           data: defaultValue,
           error: null, // RLS blocks are expected, not errors
@@ -106,7 +106,6 @@ export async function safeQuery<T>(
     // Unexpected error - log but don't throw
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     await safeLogger.error('[SafeQuery] Unexpected error', {
-      table,
       error: errorMessage,
       stack: error instanceof Error ? error.stack : undefined,
     });


### PR DESCRIPTION
# Pull Request

## Description

Fixed TypeScript errors (`TS1472`, `TS1128`) in several API route files. The build was failing because an outer `try` block was missing its corresponding `catch` statement. A `catch` block has been added to handle authentication errors, and indentation has been corrected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Security fix

## CI Verification Checklist

**⚠️ CI MUST PASS BEFORE MERGE**

- [ ] CI link: [View CI run](https://github.com/YOUR_REPO/actions/runs/YOUR_RUN_ID)
- [ ] ✅ Repository integrity check passed (`repo-integrity`)
- [ ] ✅ Lint and typecheck passed
- [ ] ✅ Tests passed
- [ ] ✅ Build succeeded
- [ ] ✅ Vercel parity check passed (`vercel:parity`)
- [ ] ✅ Canonical production check passed (`check:production`)
- [ ] ✅ No workspace drift detected
- [ ] ✅ No phantom package references
- [ ] ✅ All scripts reference valid files

## Testing

<!-- Describe how you tested your changes -->

- [x] Local testing completed
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [ ] Manual testing completed

## Deployment Notes

<!-- Any special considerations for deployment? -->

- [ ] Environment variables documented (if new ones added)
- [ ] Database migrations included (if applicable)
- [ ] Breaking changes documented
- [ ] Rollback plan considered

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [ ] No console.logs or debug code left behind
- [ ] No secrets or sensitive data committed

## Related Issues

<!-- Link related issues -->

Closes #

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

---

**Remember:** 
- CI green = merge allowed ✅
- CI red = merge impossible ❌
- Never merge with failing CI checks

---
<a href="https://cursor.com/background-agent?bcId=bc-4b4a63df-de5f-4dc2-8077-18800925c6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b4a63df-de5f-4dc2-8077-18800925c6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

