### PR TITLE
Normalize line endings to prevent CRLF script failures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,9 @@
 # Files in INVESTOR-RELATIONS-PRIVATE will be encrypted
 # NOTE: Run 'git crypt init' and 'git crypt add-gpg-user <email>' before committing
 INVESTOR-RELATIONS-PRIVATE/** filter=git-crypt diff=git-crypt
+
+# Normalize line endings to prevent CRLF-sensitive scripts from breaking in CI.
+* text=auto eol=lf
+*.sh text eol=lf
+*.bash text eol=lf
+*.zsh text eol=lf


### PR DESCRIPTION
### Motivation
- Prevent CRLF (`^M`) line-ending issues that caused shell setup scripts to fail (e.g. `/workspace/Settler^M` path errors) by enforcing LF normalization.

### Description
- Update `.gitattributes` to preserve existing `git-crypt` rules and add `* text=auto eol=lf` plus `*.sh`, `*.bash`, and `*.zsh` entries to normalize line endings to LF for CI-sensitive scripts.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967b39fc6908328982ec0a1800f776d)