### PR TITLE
Fix TypeScript build deps and add Builder.io Fusion deployment guide

### DIFF
--- a/docs/builder-io-fusion.md
+++ b/docs/builder-io-fusion.md
@@ -1,0 +1,67 @@
+# Builder.io Fusion Deployment Guide
+
+This guide documents the exact settings required to compile and deploy the Settler monorepo with Builder.io Fusion.
+
+## App Root
+
+Set the **App Root Directory** to the repository root:
+
+```
+/
+```
+
+The build relies on Turbo at the repo root to compile shared packages before the Next.js app.
+
+## Commands
+
+### Setup (Install) Command
+
+```bash
+npm install
+```
+
+### Development Command
+
+```bash
+npm run dev
+```
+
+### Build Command
+
+```bash
+npm run build
+```
+
+### Output Directory
+
+Use the default Next.js output:
+
+```
+.next
+```
+
+## Required Environment Variables
+
+Set these variables for **Production** and **Preview** environments in Builder.io Fusion:
+
+### Public (Browser) Variables
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `NEXT_PUBLIC_SETTLER_API_KEY` (used by the SDK demo flows)
+
+### Server Variables
+
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `DATABASE_URL`
+- `SETTLER_API_KEY`
+
+### Build Behavior
+
+- `NODE_ENV=production`
+- `SENTRY_SKIP_AUTO_INSTALL=1` (prevents build-time Sentry CLI installs)
+
+## Notes
+
+- The build compiles TypeScript packages in the monorepo. Ensure the install step includes dependencies (do **not** omit them).
+- If you only want to run the Next.js app locally, you can use `cd packages/web && npm run dev`, but Fusion should use the root commands above so Turbo can build shared packages first.

--- a/packages/edge-ai-core/package.json
+++ b/packages/edge-ai-core/package.json
@@ -18,11 +18,12 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.3.3",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",
-    "@types/node": "^24.0.0",
     "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
@@ -31,8 +32,7 @@
     "jest": "^29.7.0",
     "prettier": "^3.1.1",
     "ts-jest": "^29.1.1",
-    "tsx": "^4.7.0",
-    "typescript": "^5.3.3"
+    "tsx": "^4.7.0"
   },
   "keywords": [
     "edge-ai",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -22,6 +22,10 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
+  "dependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.3.3"
+  },
   "keywords": [
     "reconciliation",
     "payments",
@@ -35,8 +39,5 @@
     "url": "https://github.com/settler/react-settler.git",
     "directory": "packages/protocol"
   },
-  "devDependencies": {
-    "@types/node": "^24.0.0",
-    "typescript": "^5.3.3"
-  }
+  "devDependencies": {}
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -51,16 +51,17 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.3.3"
+  },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.11",
-    "@types/node": "^24.0.0",
     "eslint-config-prettier": "^10.1.8",
     "jest": "^29.7.0",
     "msw": "^2.0.0",
-    "ts-jest": "^29.1.1",
-    "typescript": "^5.3.3"
+    "ts-jest": "^29.1.1"
   },
   "peerDependencies": {
     "typescript": ">=5.0.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,9 +17,10 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
-  "devDependencies": {
+  "dependencies": {
     "@types/node": "^24.0.0",
     "typescript": "^5.3.3"
   },
+  "devDependencies": {},
   "license": "MIT"
 }


### PR DESCRIPTION
### Motivation

- The monorepo build failed in CI because `tsc` was not available when TypeScript tooling lived only in `devDependencies` and the installer omitted dev deps in the build environment.
- Builder.io Fusion users need explicit app-root, build/dev commands, and environment-variable guidance so Turbo-driven monorepo builds succeed.

### Description

- Promote `typescript` and `@types/node` from dev-only to runtime `dependencies` in the buildable packages `packages/protocol`, `packages/types`, `packages/sdk`, and `packages/edge-ai-core` so `tsc` is present during install/build phases.
- Remove duplicated TypeScript tooling from package `devDependencies` where moved to `dependencies` to avoid redundancy.
- Add `docs/builder-io-fusion.md` describing required Builder.io Fusion settings: App Root (`/`), install (`npm install`), dev (`npm run dev`) and build (`npm run build`) commands, output directory (`.next`), required public and server environment variables, and recommended build env flags (`NODE_ENV=production`, `SENTRY_SKIP_AUTO_INSTALL=1`).
- Keep package scripts unchanged; this change only ensures the TypeScript compiler is available in environments that omit `devDependencies` during install.

### Testing

- Ran `npm install --package-lock-only` to validate dependency resolution and update `package-lock.json`, which completed with engine warnings but produced an updated lockfile.
- No full `build` or test pipeline was executed in this change set, so `turbo`/`npm run build` and automated test suites were not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969413ca1508328849fb9980b8c2f85)