### PR TITLE
Validate currency endpoint inputs (dates and numeric values)

### DIFF
--- a/packages/api/src/routes/v1/currency.ts
+++ b/packages/api/src/routes/v1/currency.ts
@@ -31,6 +31,13 @@ router.get("/rates", async (req: AuthRequest, res: Response) => {
     }
 
     const rateDate = date ? new Date(date as string) : new Date();
+    if (Number.isNaN(rateDate.getTime())) {
+      return res.status(400).json({
+        error: "Bad Request",
+        message: "date must be a valid ISO-8601 date string",
+        traceId: req.traceId,
+      });
+    }
     const rate = await getExchangeRate(
       fromCurrency as string,
       toCurrency as string,
@@ -78,7 +85,22 @@ router.post("/rates", async (req: AuthRequest, res: Response) => {
       });
     }
 
+    if (typeof rate !== "number" || !Number.isFinite(rate)) {
+      return res.status(400).json({
+        error: "Bad Request",
+        message: "rate must be a finite number",
+        traceId: req.traceId,
+      });
+    }
+
     const rateDate = date ? new Date(date) : new Date();
+    if (Number.isNaN(rateDate.getTime())) {
+      return res.status(400).json({
+        error: "Bad Request",
+        message: "date must be a valid ISO-8601 date string",
+        traceId: req.traceId,
+      });
+    }
     const rateId = await addExchangeRate(
       fromCurrency,
       toCurrency,
@@ -119,7 +141,7 @@ router.post("/convert", async (req: AuthRequest, res: Response) => {
     const { amount, fromCurrency, toCurrency, date, reconciliationRunId, transactionId } =
       req.body;
 
-    if (!amount || !fromCurrency || !toCurrency) {
+    if (amount === undefined || amount === null || !fromCurrency || !toCurrency) {
       return res.status(400).json({
         error: "Bad Request",
         message: "amount, fromCurrency, and toCurrency are required",
@@ -127,7 +149,22 @@ router.post("/convert", async (req: AuthRequest, res: Response) => {
       });
     }
 
+    if (typeof amount !== "number" || !Number.isFinite(amount)) {
+      return res.status(400).json({
+        error: "Bad Request",
+        message: "amount must be a finite number",
+        traceId: req.traceId,
+      });
+    }
+
     const conversionDate = date ? new Date(date) : new Date();
+    if (Number.isNaN(conversionDate.getTime())) {
+      return res.status(400).json({
+        error: "Bad Request",
+        message: "date must be a valid ISO-8601 date string",
+        traceId: req.traceId,
+      });
+    }
     const result = await convertCurrency(
       tenantId,
       amount,


### PR DESCRIPTION
### Motivation
- Prevent invalid or malformed input from causing silent failures or bad data when looking up, creating, or converting exchange rates. 
- Enforce clear input invariants (valid ISO-8601 dates and finite numeric values) to reduce error surface and improve observability/tracing on bad requests.

### Description
- Added date validation for `GET /api/v1/currency/rates` to return `400` when `date` is not a valid ISO-8601 date string in `packages/api/src/routes/v1/currency.ts`.
- Added validation in `POST /api/v1/currency/rates` to require `rate` to be a finite number and to validate `date` before calling `addExchangeRate`.
- Strengthened `POST /api/v1/currency/convert` input checks to allow zero amounts (rejecting only `undefined`/`null`), require `amount` to be a finite number, and validate `date` before calling `convertCurrency`.
- All new validation responses include consistent `400` error payloads with `traceId` for easier debugging.

### Testing
- No automated tests were executed against these changes in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69725dce7a60832881386744db4b70d5)