### PR TITLE
Secure Builder.io webhook validation

### DIFF
--- a/packages/web/src/app/api/builder/revalidate/route.ts
+++ b/packages/web/src/app/api/builder/revalidate/route.ts
@@ -3,20 +3,42 @@
  * Revalidates pages when content is published in Builder.io
  */
 
+import { createHmac, timingSafeEqual } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
 
+function normalizeSignature(signature: string): string {
+  return signature.startsWith('sha256=') ? signature.slice('sha256='.length) : signature;
+}
+
+function isValidSignature(secret: string, payload: string, signature: string): boolean {
+  const expected = createHmac('sha256', secret).update(payload, 'utf8').digest('hex');
+  const provided = normalizeSignature(signature);
+
+  if (expected.length !== provided.length) {
+    return false;
+  }
+
+  return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(provided, 'hex'));
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const rawBody = await request.text();
 
     // Verify webhook signature (optional but recommended)
     const webhookSecret = process.env.BUILDER_WEBHOOK_SECRET;
     if (webhookSecret) {
-      const _signature = request.headers.get('x-builder-signature');
-      // TODO: Implement signature verification
-      // For now, we'll trust the webhook
+      const signature = request.headers.get('x-builder-signature');
+      if (!signature || !isValidSignature(webhookSecret, rawBody, signature)) {
+        return NextResponse.json(
+          { error: 'Invalid webhook signature' },
+          { status: 401 }
+        );
+      }
     }
+
+    const body = JSON.parse(rawBody);
 
     // Extract the model and URL from the webhook payload
     const { model, url } = body;


### PR DESCRIPTION
### Motivation
- Prevent unauthorized Builder.io webhooks from triggering `revalidatePath` by verifying the webhook signature with HMAC-SHA256 and avoid signature mismatches by parsing the raw request body once.

### Description
- Added HMAC-SHA256 signature verification using `crypto.createHmac` and constant-time comparison with `timingSafeEqual` in `packages/web/src/app/api/builder/revalidate/route.ts`.
- Read the raw request body with `request.text()` and validate the `x-builder-signature`, returning a `401` when the signature is missing or invalid.
- Preserved existing behavior: parse payload, require `url`, call `revalidatePath(url)` (and `/` when appropriate), and keep the `GET` health endpoint.

### Testing
- Ran `npx tsx scripts/validate-eslint-config.ts` which completed successfully.
- Ran `npx tsx scripts/validate-build-safety.ts` which reported no build-safety issues and completed successfully.
- Ran `npx tsx scripts/validate-lint-config.ts` which completed successfully.
- Attempted `npm run typecheck` and `npm run lint -- --filter=web` but they failed due to the Turborepo binary not being available in the environment (installation error), so full repo-wide typecheck/lint could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727a4d12bc8328a075ecb8c9076e7e)