### PR TITLE
Add deterministic settler-engine sidecar, schemas, UI flows, fixtures and CI verification

### DIFF
--- a/.github/workflows/release-settler-engine.yml
+++ b/.github/workflows/release-settler-engine.yml
@@ -1,0 +1,49 @@
+name: Release Settler Engine
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
+        exclude:
+          - goos: windows
+            goarch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Build binary
+        run: |
+          mkdir -p dist
+          BIN_NAME="settler-engine"
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            BIN_NAME="settler-engine.exe"
+          fi
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o "dist/${BIN_NAME}" ./tools/settler-engine
+
+      - name: Create checksum
+        run: |
+          cd dist
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum * > checksums.txt
+          else
+            shasum -a 256 * > checksums.txt
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: settler-engine-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/

--- a/.github/workflows/verify-settler-engine.yml
+++ b/.github/workflows/verify-settler-engine.yml
@@ -1,0 +1,35 @@
+name: Verify Settler Engine
+
+on:
+  pull_request:
+    paths:
+      - 'tools/settler-engine/**'
+      - '.github/workflows/verify-settler-engine.yml'
+      - 'templates/settler-engine/**'
+  push:
+    branches: [main]
+    paths:
+      - 'tools/settler-engine/**'
+      - '.github/workflows/verify-settler-engine.yml'
+      - 'templates/settler-engine/**'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run engine tests
+        run: |
+          cd tools/settler-engine
+          go test ./...
+
+      - name: Run fixture verification
+        run: |
+          tools/settler-engine/scripts/run-fixtures.sh

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# Settler Enterprise
+# Settler (OSS-first)
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-blue.svg)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-Proprietary-red.svg)](LICENSE)
 
-**Settler** automates financial reconciliation at $0.01 per transaction. Connect Stripe, Shopify, and other payment systems to automatically match transactions and catch accounting errors.
+**Settler** is an OSS-first reconciliation engine that surfaces discrepancies from local or hosted data sources. Enterprise offerings are optional hosting and support layers that do not change core reconciliation logic.
+
+Settler does not provide compliance or correctness guarantees. It deterministically surfaces discrepancies so operators can review and act.
 
 **Pricing:** 
 - **Free:** 100 transactions/month free, then $0.01 per transaction

--- a/docs/engine/DETERMINISM.md
+++ b/docs/engine/DETERMINISM.md
@@ -1,0 +1,40 @@
+# Determinism in Settler Engine
+
+Settler Engine is designed to be deterministic in local and CI contexts. This means that identical inputs and configuration produce identical outputs, enabling stable diffing and audit-safe evidence bundles.
+
+## Deterministic inputs
+
+The engine output is deterministic when all of the following are unchanged:
+
+- Input files and their content
+- `ruleset.json`
+- `mapping.json` (if provided)
+- `timezone` in `engine_input.json`
+- `rounding_mode` in `engine_input.json`
+
+## Stable ordering
+
+Deterministic ordering rules:
+
+- Normalized records are sorted by: `record_type`, `id`, `source_file`, `source_row`
+- Variances are sorted by: `type`, `transaction_id`, `settlement_id`
+- Evidence manifest input/output entries are sorted by `path`
+
+## Rounding
+
+`rounding_mode` is required. Supported modes:
+
+- `bankers` (half-even)
+- `half-up`
+
+Amounts are converted to integer cents using the configured rounding mode before reconciliation logic runs.
+
+## Timezone rules
+
+- Dates are parsed using the provided IANA timezone.
+- All output dates are normalized to UTC.
+
+## Bounds
+
+Determinism applies to engine outputs, not to external systems or any downstream interpretation of variances. The engine surfaces discrepancies; it does not certify correctness or compliance.
+

--- a/docs/engine/EVIDENCE_BUNDLES.md
+++ b/docs/engine/EVIDENCE_BUNDLES.md
@@ -1,0 +1,27 @@
+# Evidence Bundles
+
+Settler Engine writes an evidence bundle to `output/evidence/` for audit-safe, deterministic record keeping. The bundle is OSS-first and locally generated.
+
+## Contents
+
+- `manifest.json` — hashes of inputs and outputs
+- `normalized.jsonl` — normalized records
+- `variances.jsonl` — discrepancy items
+- `logs/run.log` — deterministic run summary
+
+## Manifest fields
+
+The manifest captures:
+
+- `schema_version`
+- `tool_version`
+- `generated_at` (deterministic timestamp)
+- Input file hashes
+- Output file hashes
+
+## Handling guidance
+
+- Store evidence bundles alongside the exact input files and ruleset.
+- Use the manifest to validate hash integrity when sharing bundles.
+- Evidence bundles surface discrepancies; they do not guarantee correctness or compliance.
+

--- a/docs/engine/QUICKSTART.md
+++ b/docs/engine/QUICKSTART.md
@@ -1,0 +1,54 @@
+# Settler Engine QUICKSTART (≤10 minutes)
+
+Settler Engine is an OSS-first, deterministic reconciliation tool that **surfaces discrepancies** from local files. It does not provide compliance or correctness guarantees.
+
+## 1) Build the binary
+
+```bash
+cd tools/settler-engine
+go build -o bin/settler-engine
+```
+
+## 2) Prepare a run pack
+
+Create a run pack zip in the web UI:
+
+- Navigate to `/engine/create-run-pack`
+- Upload synthetic input files (CSV or JSON)
+- Download the run pack
+
+The zip contains:
+
+- `inputs/` (your files)
+- `ruleset.json`
+- `mapping.json` (optional)
+- `engine_input.json`
+- `README.txt`
+
+## 3) Run the engine locally
+
+```bash
+./tools/settler-engine/bin/settler-engine --input /path/to/engine_input.json
+```
+
+Outputs are written to the `output_dir` configured in `engine_input.json`:
+
+- `output/engine_output.json`
+- `output/evidence/manifest.json`
+- `output/evidence/normalized.jsonl`
+- `output/evidence/variances.jsonl`
+- `output/evidence/logs/`
+
+## 4) Import results into the UI
+
+- Navigate to `/engine/import-results`
+- Upload `engine_output.json`
+- (Optional) upload the evidence bundle zip
+- Review variance summaries and hashes
+
+## Local-only notes
+
+- No telemetry.
+- No network calls.
+- Deterministic sorting, rounding, and timezone handling.
+

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "mirror:dryrun": "tsx scripts/mirror-dryrun.ts",
     "mirror:verify": "tsx scripts/mirror-verify.ts",
     "mirror:publish": "tsx scripts/mirror-publish.ts",
-    "setup:open-core": "bash scripts/setup-open-core.sh"
+    "setup:open-core": "bash scripts/setup-open-core.sh",
+    "settler:run": "node scripts/settler-engine.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -61,6 +61,7 @@
     "critters": "^0.0.20",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.23.24",
+    "fflate": "^0.8.2",
     "gray-matter": "^4.0.3",
     "lenis": "^1.3.15",
     "lucide-react": "^0.555.0",

--- a/packages/web/public/engine-templates/mapping.template.json
+++ b/packages/web/public/engine-templates/mapping.template.json
@@ -1,0 +1,25 @@
+{
+  "record_type_field": "record_type",
+  "record_type_values": {
+    "transaction": "transaction",
+    "settlement": "settlement"
+  },
+  "transactions": {
+    "id": "id",
+    "amount": "amount",
+    "currency": "currency",
+    "date": "date",
+    "reference_id": "reference_id",
+    "provider_transaction_id": "provider_transaction_id",
+    "provider_settlement_id": "provider_settlement_id"
+  },
+  "settlements": {
+    "id": "id",
+    "amount": "amount",
+    "currency": "currency",
+    "date": "date",
+    "reference_id": "reference_id",
+    "provider_transaction_id": "provider_transaction_id",
+    "provider_settlement_id": "provider_settlement_id"
+  }
+}

--- a/packages/web/public/engine-templates/ruleset.template.json
+++ b/packages/web/public/engine-templates/ruleset.template.json
@@ -1,0 +1,50 @@
+{
+  "id": "oss-default-ruleset",
+  "name": "OSS Default Ruleset",
+  "priority": "exact-first",
+  "conflictResolution": "first-wins",
+  "rules": [
+    {
+      "id": "match-reference",
+      "name": "Match on reference ID",
+      "field": "referenceId",
+      "type": "exact",
+      "priority": 1,
+      "enabled": true
+    },
+    {
+      "id": "match-transaction-id",
+      "name": "Match on provider transaction ID",
+      "field": "providerTransactionId",
+      "type": "exact",
+      "priority": 2,
+      "enabled": true
+    },
+    {
+      "id": "match-amount",
+      "name": "Match on amount within tolerance",
+      "field": "amount",
+      "type": "range",
+      "priority": 3,
+      "enabled": true,
+      "tolerance": { "amount": "0.01" }
+    },
+    {
+      "id": "match-date",
+      "name": "Match on date within tolerance",
+      "field": "date",
+      "type": "range",
+      "priority": 4,
+      "enabled": true,
+      "tolerance": { "days": 1 }
+    },
+    {
+      "id": "match-currency",
+      "name": "Match on currency",
+      "field": "currency",
+      "type": "exact",
+      "priority": 5,
+      "enabled": true
+    }
+  ]
+}

--- a/packages/web/src/app/engine/create-run-pack/page.tsx
+++ b/packages/web/src/app/engine/create-run-pack/page.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { strToU8, zipSync } from 'fflate';
+
+const defaultReadme = (rulesetName: string) => `# Settler Engine Run Pack\n\nThis run pack is OSS-first and designed to run locally or in CI.\n\n## Run\n\n1) Build the engine binary (or download from releases).\n2) Execute:\n\n   settler-engine --input engine_input.json\n\n## Notes\n- This workflow surfaces discrepancies and produces deterministic evidence bundles.\n- No compliance or correctness guarantees are provided.\n\nRuleset: ${rulesetName}\n`;
+
+export default function CreateRunPackPage() {
+  const [inputFiles, setInputFiles] = useState<File[]>([]);
+  const [rulesetTemplate, setRulesetTemplate] = useState<string>('');
+  const [mappingTemplate, setMappingTemplate] = useState<string>('');
+  const [includeMapping, setIncludeMapping] = useState(true);
+  const [status, setStatus] = useState<string>('');
+
+  useEffect(() => {
+    const loadTemplates = async () => {
+      const [rulesetRes, mappingRes] = await Promise.all([
+        fetch('/engine-templates/ruleset.template.json'),
+        fetch('/engine-templates/mapping.template.json'),
+      ]);
+      setRulesetTemplate(await rulesetRes.text());
+      setMappingTemplate(await mappingRes.text());
+    };
+    loadTemplates().catch(() => {
+      setRulesetTemplate('');
+      setMappingTemplate('');
+    });
+  }, []);
+
+  const rulesetName = useMemo(() => {
+    try {
+      const parsed = JSON.parse(rulesetTemplate);
+      return parsed?.name ?? 'OSS Default Ruleset';
+    } catch {
+      return 'OSS Default Ruleset';
+    }
+  }, [rulesetTemplate]);
+
+  const handleCreate = useCallback(async () => {
+    if (inputFiles.length === 0) {
+      setStatus('Select at least one input file.');
+      return;
+    }
+    if (!rulesetTemplate) {
+      setStatus('Ruleset template is unavailable.');
+      return;
+    }
+
+    const files: Record<string, Uint8Array> = {};
+
+    for (const file of inputFiles) {
+      const buffer = await file.arrayBuffer();
+      files[`inputs/${file.name}`] = new Uint8Array(buffer);
+    }
+
+    files['ruleset.json'] = strToU8(rulesetTemplate);
+    if (includeMapping && mappingTemplate) {
+      files['mapping.json'] = strToU8(mappingTemplate);
+    }
+
+    const engineInput = {
+      input_files: inputFiles.map((file) => `inputs/${file.name}`),
+      input_format: 'auto',
+      mapping_config_path: includeMapping ? 'mapping.json' : '',
+      ruleset_path: 'ruleset.json',
+      rounding_mode: 'bankers',
+      timezone: 'UTC',
+      output_dir: './output',
+      mode: 'local',
+      determinism: {
+        sort_keys: ['record_type', 'id', 'source_file', 'source_row'],
+        rounding: 'bankers',
+        timezone: 'UTC',
+      },
+    };
+
+    files['engine_input.json'] = strToU8(JSON.stringify(engineInput, null, 2));
+    files['README.txt'] = strToU8(defaultReadme(rulesetName));
+
+    const zipData = zipSync(files, { level: 9 });
+    const blob = new Blob([zipData], { type: 'application/zip' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'settler-run-pack.zip';
+    link.click();
+    URL.revokeObjectURL(url);
+
+    setStatus('Run pack created.');
+  }, [inputFiles, rulesetTemplate, mappingTemplate, includeMapping, rulesetName]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-6 py-12 text-white">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold">Create Run Pack</h1>
+        <p className="text-white/70">
+          Package inputs, ruleset, and mapping config into a zip you can execute locally or in CI. The engine
+          surfaces discrepancies and produces deterministic evidence bundles without any server dependency.
+        </p>
+        <Link href="/engine" className="text-sm text-blue-200 underline">
+          ← Back to Engine overview
+        </Link>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/5 p-6">
+        <label className="block text-sm font-medium">Input files</label>
+        <input
+          type="file"
+          multiple
+          className="mt-2 w-full rounded border border-white/10 bg-black/30 p-2 text-sm"
+          onChange={(event) => setInputFiles(Array.from(event.target.files ?? []))}
+        />
+        <p className="mt-2 text-xs text-white/60">Supported: CSV or JSON. Use synthetic data only.</p>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/5 p-6">
+        <h2 className="text-lg font-semibold">Ruleset Template</h2>
+        <p className="mt-2 text-sm text-white/70">
+          The default ruleset matches on reference ID, provider IDs, amount tolerance, date tolerance, and
+          currency. You can edit the JSON after downloading the run pack.
+        </p>
+        <pre className="mt-4 max-h-48 overflow-auto rounded bg-black/40 p-3 text-xs text-white/80">
+          {rulesetTemplate || 'Loading ruleset template...'}
+        </pre>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/5 p-6">
+        <label className="flex items-center gap-3 text-sm">
+          <input
+            type="checkbox"
+            checked={includeMapping}
+            onChange={(event) => setIncludeMapping(event.target.checked)}
+          />
+          Include mapping.json
+        </label>
+        <pre className="mt-4 max-h-40 overflow-auto rounded bg-black/40 p-3 text-xs text-white/80">
+          {mappingTemplate || 'Loading mapping template...'}
+        </pre>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleCreate}
+        className="w-fit rounded-lg bg-blue-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-blue-400"
+      >
+        Create Run Pack Zip
+      </button>
+
+      {status ? <p className="text-sm text-emerald-200">{status}</p> : null}
+    </div>
+  );
+}

--- a/packages/web/src/app/engine/import-results/page.tsx
+++ b/packages/web/src/app/engine/import-results/page.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { unzipSync, strFromU8 } from 'fflate';
+import { z } from 'zod';
+
+const varianceCountSchema = z.object({
+  type: z.string(),
+  count: z.number(),
+});
+
+const engineOutputSchema = z.object({
+  schema_version: z.string(),
+  tool_version: z.string(),
+  normalization_summary: z.object({
+    transactions: z.number(),
+    settlements: z.number(),
+    warnings: z.array(z.string()),
+  }),
+  variance_summary: z.object({
+    total: z.number(),
+    by_type: z.array(varianceCountSchema),
+  }),
+  variance_items_path: z.string(),
+  evidence_manifest: z.object({
+    schema_version: z.string(),
+    tool_version: z.string(),
+    generated_at: z.string(),
+    input_files: z.array(z.object({ path: z.string(), sha256: z.string() })),
+    outputs: z.array(z.object({ path: z.string(), sha256: z.string() })),
+  }),
+  deterministic_statement: z.string(),
+});
+
+type EngineOutput = z.infer<typeof engineOutputSchema>;
+
+type VarianceItem = {
+  id: string;
+  type: string;
+  transaction_id?: string;
+  settlement_id?: string;
+  message: string;
+  amount_diff_cents?: number;
+  date_diff_days?: number;
+};
+
+export default function ImportResultsPage() {
+  const [engineOutput, setEngineOutput] = useState<EngineOutput | null>(null);
+  const [variances, setVariances] = useState<VarianceItem[]>([]);
+  const [status, setStatus] = useState<string>('');
+
+  const handleEngineOutput = useCallback(async (file: File) => {
+    const text = await file.text();
+    const parsed = engineOutputSchema.safeParse(JSON.parse(text));
+    if (!parsed.success) {
+      setStatus('engine_output.json failed schema validation.');
+      return;
+    }
+    setEngineOutput(parsed.data);
+    setStatus('engine_output.json loaded.');
+    sessionStorage.setItem('settler-engine-output', JSON.stringify(parsed.data));
+  }, []);
+
+  const handleEvidenceBundle = useCallback(async (file: File) => {
+    const data = new Uint8Array(await file.arrayBuffer());
+    const unzipped = unzipSync(data);
+    const varianceEntry = Object.keys(unzipped).find((key) => key.endsWith('variances.jsonl') || key.endsWith('variances.json'));
+    if (!varianceEntry) {
+      setStatus('Evidence bundle missing variances.jsonl.');
+      return;
+    }
+    const content = strFromU8(unzipped[varianceEntry]);
+    const items: VarianceItem[] = [];
+    if (varianceEntry.endsWith('.jsonl')) {
+      content
+        .split('\n')
+        .filter(Boolean)
+        .forEach((line) => {
+          items.push(JSON.parse(line));
+        });
+    } else {
+      const parsed = JSON.parse(content);
+      if (Array.isArray(parsed)) {
+        items.push(...parsed);
+      }
+    }
+    setVariances(items);
+    sessionStorage.setItem('settler-engine-variances', JSON.stringify(items));
+    setStatus(`Loaded ${items.length} variance items.`);
+  }, []);
+
+  const varianceSummary = useMemo(() => {
+    if (!engineOutput) return [];
+    return engineOutput.variance_summary.by_type;
+  }, [engineOutput]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-6 py-12 text-white">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold">Import Results</h1>
+        <p className="text-white/70">
+          Upload the engine_output.json file and optional evidence bundle zip. The UI remains fully local and
+          surfaces discrepancies without any server dependency.
+        </p>
+        <Link href="/engine" className="text-sm text-blue-200 underline">
+          ← Back to Engine overview
+        </Link>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/5 p-6">
+        <label className="block text-sm font-medium">engine_output.json</label>
+        <input
+          type="file"
+          accept="application/json"
+          className="mt-2 w-full rounded border border-white/10 bg-black/30 p-2 text-sm"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) {
+              void handleEngineOutput(file);
+            }
+          }}
+        />
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/5 p-6">
+        <label className="block text-sm font-medium">Evidence bundle zip (optional)</label>
+        <input
+          type="file"
+          accept="application/zip"
+          className="mt-2 w-full rounded border border-white/10 bg-black/30 p-2 text-sm"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) {
+              void handleEvidenceBundle(file);
+            }
+          }}
+        />
+      </div>
+
+      {status ? <p className="text-sm text-emerald-200">{status}</p> : null}
+
+      {engineOutput ? (
+        <div className="rounded-xl border border-white/10 bg-white/5 p-6">
+          <h2 className="text-lg font-semibold">Variance Summary</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            <div className="rounded-lg bg-black/30 p-3">
+              <p className="text-xs text-white/60">Transactions</p>
+              <p className="text-xl font-semibold">{engineOutput.normalization_summary.transactions}</p>
+            </div>
+            <div className="rounded-lg bg-black/30 p-3">
+              <p className="text-xs text-white/60">Settlements</p>
+              <p className="text-xl font-semibold">{engineOutput.normalization_summary.settlements}</p>
+            </div>
+            <div className="rounded-lg bg-black/30 p-3">
+              <p className="text-xs text-white/60">Variances</p>
+              <p className="text-xl font-semibold">{engineOutput.variance_summary.total}</p>
+            </div>
+          </div>
+          <ul className="mt-4 space-y-2 text-sm text-white/80">
+            {varianceSummary.map((item) => (
+              <li key={item.type}>
+                {item.type}: {item.count}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6 space-y-2 text-sm text-white/70">
+            <p>{engineOutput.deterministic_statement}</p>
+            <p>
+              Evidence manifest includes {engineOutput.evidence_manifest.input_files.length} input hashes and{' '}
+              {engineOutput.evidence_manifest.outputs.length} output hashes.
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {variances.length ? (
+        <div className="rounded-xl border border-white/10 bg-white/5 p-6">
+          <h2 className="text-lg font-semibold">Latest Variances</h2>
+          <p className="mt-2 text-sm text-white/60">
+            Showing the first 20 discrepancy items from the evidence bundle.
+          </p>
+          <ul className="mt-4 space-y-3 text-sm">
+            {variances.slice(0, 20).map((item) => (
+              <li key={item.id} className="rounded-lg bg-black/30 p-3">
+                <p className="text-white">{item.type}</p>
+                <p className="text-xs text-white/60">{item.message}</p>
+              </li>
+            ))}
+          </ul>
+          <Link href="/engine/view-variances" className="mt-4 inline-block text-sm text-blue-200 underline">
+            View full variance list →
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/app/engine/page.tsx
+++ b/packages/web/src/app/engine/page.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+
+export default function EngineLandingPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-6 py-12">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold text-white">Settler Engine (OSS)</h1>
+        <p className="text-base text-white/70">
+          Run deterministic reconciliation locally or in CI, then import results into the OSS UI to surface
+          discrepancies without any server dependency.
+        </p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        <Link
+          href="/engine/create-run-pack"
+          className="rounded-xl border border-white/10 bg-white/5 p-4 text-white transition hover:border-white/20"
+        >
+          <h2 className="text-lg font-semibold">Create Run Pack</h2>
+          <p className="mt-2 text-sm text-white/70">
+            Bundle inputs + ruleset into a portable zip for local or CI runs.
+          </p>
+        </Link>
+        <Link
+          href="/engine/import-results"
+          className="rounded-xl border border-white/10 bg-white/5 p-4 text-white transition hover:border-white/20"
+        >
+          <h2 className="text-lg font-semibold">Import Results</h2>
+          <p className="mt-2 text-sm text-white/70">
+            Upload engine_output.json and evidence bundles to review summaries.
+          </p>
+        </Link>
+        <Link
+          href="/engine/view-variances"
+          className="rounded-xl border border-white/10 bg-white/5 p-4 text-white transition hover:border-white/20"
+        >
+          <h2 className="text-lg font-semibold">View Variances</h2>
+          <p className="mt-2 text-sm text-white/70">
+            Drill into discrepancies captured from your last import.
+          </p>
+        </Link>
+      </div>
+      <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-4 text-sm text-amber-100">
+        Settler OSS surfaces discrepancies and provides audit-safe evidence bundles. It does not guarantee
+        compliance or correctness.
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/engine/view-variances/page.tsx
+++ b/packages/web/src/app/engine/view-variances/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+type VarianceItem = {
+  id: string;
+  type: string;
+  transaction_id?: string;
+  settlement_id?: string;
+  message: string;
+  amount_diff_cents?: number;
+  date_diff_days?: number;
+};
+
+export default function ViewVariancesPage() {
+  const [variances, setVariances] = useState<VarianceItem[]>([]);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem('settler-engine-variances');
+    if (stored) {
+      setVariances(JSON.parse(stored));
+    }
+  }, []);
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-6 py-12 text-white">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold">View Variances</h1>
+        <p className="text-white/70">
+          Variances are loaded from your last import session. If nothing appears, re-import a results bundle.
+        </p>
+        <Link href="/engine/import-results" className="text-sm text-blue-200 underline">
+          ← Back to Import Results
+        </Link>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/5 p-6">
+        {variances.length === 0 ? (
+          <p className="text-sm text-white/70">No variances loaded yet.</p>
+        ) : (
+          <ul className="space-y-3 text-sm">
+            {variances.map((item) => (
+              <li key={item.id} className="rounded-lg bg-black/30 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="text-white">{item.type}</span>
+                  <span className="text-xs text-white/60">{item.id}</span>
+                </div>
+                <p className="mt-2 text-xs text-white/70">{item.message}</p>
+                <div className="mt-2 flex flex-wrap gap-3 text-xs text-white/60">
+                  {item.transaction_id ? <span>Transaction: {item.transaction_id}</span> : null}
+                  {item.settlement_id ? <span>Settlement: {item.settlement_id}</span> : null}
+                  {item.amount_diff_cents !== undefined ? (
+                    <span>Amount diff (cents): {item.amount_diff_cents}</span>
+                  ) : null}
+                  {item.date_diff_days !== undefined ? (
+                    <span>Date diff (days): {item.date_diff_days}</span>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/scripts/settler-engine.mjs
+++ b/scripts/settler-engine.mjs
@@ -1,0 +1,40 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+if (!args.includes('--input')) {
+  console.error('Usage: node scripts/settler-engine.mjs --input <engine_input.json>');
+  process.exit(1);
+}
+
+const platform = process.platform === 'win32' ? 'settler-engine.exe' : 'settler-engine';
+const envBinary = process.env.SETTLER_ENGINE_BIN;
+const binDir = path.join(repoRoot, 'tools', 'settler-engine', 'bin');
+const localBinary = path.join(binDir, platform);
+const candidates = [envBinary, localBinary].filter(Boolean);
+
+let binaryPath = candidates.find((candidate) => candidate && existsSync(candidate));
+
+if (!binaryPath) {
+  mkdirSync(binDir, { recursive: true });
+  const build = spawnSync('go', ['build', '-o', localBinary, './tools/settler-engine'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+  if (build.status !== 0) {
+    console.error('Failed to build settler-engine binary. Set SETTLER_ENGINE_BIN to a prebuilt binary.');
+    process.exit(1);
+  }
+  binaryPath = localBinary;
+}
+
+const run = spawnSync(binaryPath, args, { stdio: 'inherit' });
+if (run.status !== 0) {
+  process.exit(run.status ?? 1);
+}

--- a/templates/settler-engine/mapping.template.json
+++ b/templates/settler-engine/mapping.template.json
@@ -1,0 +1,25 @@
+{
+  "record_type_field": "record_type",
+  "record_type_values": {
+    "transaction": "transaction",
+    "settlement": "settlement"
+  },
+  "transactions": {
+    "id": "id",
+    "amount": "amount",
+    "currency": "currency",
+    "date": "date",
+    "reference_id": "reference_id",
+    "provider_transaction_id": "provider_transaction_id",
+    "provider_settlement_id": "provider_settlement_id"
+  },
+  "settlements": {
+    "id": "id",
+    "amount": "amount",
+    "currency": "currency",
+    "date": "date",
+    "reference_id": "reference_id",
+    "provider_transaction_id": "provider_transaction_id",
+    "provider_settlement_id": "provider_settlement_id"
+  }
+}

--- a/templates/settler-engine/ruleset.template.json
+++ b/templates/settler-engine/ruleset.template.json
@@ -1,0 +1,50 @@
+{
+  "id": "oss-default-ruleset",
+  "name": "OSS Default Ruleset",
+  "priority": "exact-first",
+  "conflictResolution": "first-wins",
+  "rules": [
+    {
+      "id": "match-reference",
+      "name": "Match on reference ID",
+      "field": "referenceId",
+      "type": "exact",
+      "priority": 1,
+      "enabled": true
+    },
+    {
+      "id": "match-transaction-id",
+      "name": "Match on provider transaction ID",
+      "field": "providerTransactionId",
+      "type": "exact",
+      "priority": 2,
+      "enabled": true
+    },
+    {
+      "id": "match-amount",
+      "name": "Match on amount within tolerance",
+      "field": "amount",
+      "type": "range",
+      "priority": 3,
+      "enabled": true,
+      "tolerance": { "amount": "0.01" }
+    },
+    {
+      "id": "match-date",
+      "name": "Match on date within tolerance",
+      "field": "date",
+      "type": "range",
+      "priority": 4,
+      "enabled": true,
+      "tolerance": { "days": 1 }
+    },
+    {
+      "id": "match-currency",
+      "name": "Match on currency",
+      "field": "currency",
+      "type": "exact",
+      "priority": 5,
+      "enabled": true
+    }
+  ]
+}

--- a/tools/settler-engine/fixtures/expected/hashes.json
+++ b/tools/settler-engine/fixtures/expected/hashes.json
@@ -1,0 +1,4 @@
+{
+  "normalized.jsonl": "51a637ab6720cb1d3250b777bab08d0f1638eedc55c3a57a65fbaf503d9fadb3",
+  "variances.jsonl": "9d290085e6ad73c94735295fc201484964cb230d8d76b8b2a28d6675b6afdc7b"
+}

--- a/tools/settler-engine/fixtures/expected/summary.json
+++ b/tools/settler-engine/fixtures/expected/summary.json
@@ -1,0 +1,11 @@
+{
+  "transactions": 3,
+  "settlements": 4,
+  "variances_total": 4,
+  "variance_by_type": {
+    "amount_mismatch": 1,
+    "currency_mismatch": 1,
+    "date_mismatch": 1,
+    "missing_transaction": 1
+  }
+}

--- a/tools/settler-engine/fixtures/input/data.json
+++ b/tools/settler-engine/fixtures/input/data.json
@@ -1,0 +1,62 @@
+{
+  "transactions": [
+    {
+      "id": "txn-1",
+      "amount": "100.00",
+      "currency": "USD",
+      "date": "2024-01-02",
+      "reference_id": "ref-1",
+      "provider_transaction_id": "ptxn-1"
+    },
+    {
+      "id": "txn-2",
+      "amount": "50.00",
+      "currency": "USD",
+      "date": "2024-01-02",
+      "reference_id": "ref-2",
+      "provider_transaction_id": "ptxn-2"
+    },
+    {
+      "id": "txn-3",
+      "amount": "75.00",
+      "currency": "EUR",
+      "date": "2024-01-03",
+      "reference_id": "ref-3",
+      "provider_transaction_id": "ptxn-3"
+    }
+  ],
+  "settlements": [
+    {
+      "id": "set-1",
+      "amount": "100.00",
+      "currency": "USD",
+      "date": "2024-01-02",
+      "reference_id": "ref-1",
+      "provider_transaction_id": "ptxn-1"
+    },
+    {
+      "id": "set-2",
+      "amount": "55.00",
+      "currency": "USD",
+      "date": "2024-01-02",
+      "reference_id": "ref-2",
+      "provider_transaction_id": "ptxn-2"
+    },
+    {
+      "id": "set-3",
+      "amount": "75.00",
+      "currency": "USD",
+      "date": "2024-01-05",
+      "reference_id": "ref-3",
+      "provider_transaction_id": "ptxn-3"
+    },
+    {
+      "id": "set-4",
+      "amount": "20.00",
+      "currency": "USD",
+      "date": "2024-01-04",
+      "reference_id": "ref-4",
+      "provider_transaction_id": "ptxn-4"
+    }
+  ]
+}

--- a/tools/settler-engine/fixtures/input/engine_input.json
+++ b/tools/settler-engine/fixtures/input/engine_input.json
@@ -1,0 +1,14 @@
+{
+  "input_files": ["data.json"],
+  "input_format": "json",
+  "ruleset_path": "ruleset.json",
+  "rounding_mode": "bankers",
+  "timezone": "UTC",
+  "output_dir": "../output",
+  "mode": "ci",
+  "determinism": {
+    "sort_keys": ["record_type", "id", "source_file", "source_row"],
+    "rounding": "bankers",
+    "timezone": "UTC"
+  }
+}

--- a/tools/settler-engine/fixtures/input/ruleset.json
+++ b/tools/settler-engine/fixtures/input/ruleset.json
@@ -1,0 +1,50 @@
+{
+  "id": "oss-default-ruleset",
+  "name": "OSS Default Ruleset",
+  "priority": "exact-first",
+  "conflictResolution": "first-wins",
+  "rules": [
+    {
+      "id": "match-reference",
+      "name": "Match on reference ID",
+      "field": "referenceId",
+      "type": "exact",
+      "priority": 1,
+      "enabled": true
+    },
+    {
+      "id": "match-transaction-id",
+      "name": "Match on provider transaction ID",
+      "field": "providerTransactionId",
+      "type": "exact",
+      "priority": 2,
+      "enabled": true
+    },
+    {
+      "id": "match-amount",
+      "name": "Match on amount within tolerance",
+      "field": "amount",
+      "type": "range",
+      "priority": 3,
+      "enabled": true,
+      "tolerance": { "amount": "0.01" }
+    },
+    {
+      "id": "match-date",
+      "name": "Match on date within tolerance",
+      "field": "date",
+      "type": "range",
+      "priority": 4,
+      "enabled": true,
+      "tolerance": { "days": 1 }
+    },
+    {
+      "id": "match-currency",
+      "name": "Match on currency",
+      "field": "currency",
+      "type": "exact",
+      "priority": 5,
+      "enabled": true
+    }
+  ]
+}

--- a/tools/settler-engine/go.mod
+++ b/tools/settler-engine/go.mod
@@ -1,0 +1,4 @@
+module github.com/settler/settler-engine
+
+go 1.22
+

--- a/tools/settler-engine/internal/engine/engine.go
+++ b/tools/settler-engine/internal/engine/engine.go
@@ -1,0 +1,286 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	SchemaVersion = "1.0.0"
+	ToolVersion   = "0.1.0"
+)
+
+func Run(inputPath string) (EngineOutput, error) {
+	input, err := LoadEngineInput(inputPath)
+	if err != nil {
+		return EngineOutput{}, err
+	}
+	baseDir := filepath.Dir(inputPath)
+	originalInputFiles := append([]string{}, input.InputFiles...)
+	input.InputFiles = resolvePaths(baseDir, input.InputFiles)
+	displayPaths := map[string]string{}
+	for idx, resolved := range input.InputFiles {
+		displayPaths[resolved] = originalInputFiles[idx]
+	}
+	if input.RulesetPath != "" {
+		input.RulesetPath = resolvePath(baseDir, input.RulesetPath)
+	}
+	if input.MappingConfigPath != "" {
+		input.MappingConfigPath = resolvePath(baseDir, input.MappingConfigPath)
+	}
+	if input.OutputDir != "" {
+		input.OutputDir = resolvePath(baseDir, input.OutputDir)
+	}
+
+	if len(input.InputFiles) == 0 {
+		return EngineOutput{}, fmt.Errorf("input_files is required")
+	}
+	if input.RulesetPath == "" {
+		return EngineOutput{}, fmt.Errorf("ruleset_path is required")
+	}
+	if input.OutputDir == "" {
+		return EngineOutput{}, fmt.Errorf("output_dir is required")
+	}
+	if input.Timezone == "" {
+		input.Timezone = "UTC"
+	}
+	if input.RoundingMode == "" {
+		input.RoundingMode = "bankers"
+	}
+
+	location, err := time.LoadLocation(input.Timezone)
+	if err != nil {
+		return EngineOutput{}, fmt.Errorf("invalid timezone: %w", err)
+	}
+
+	mapping, err := LoadMappingConfig(input.MappingConfigPath)
+	if err != nil {
+		return EngineOutput{}, err
+	}
+
+	ruleset, err := LoadRuleset(input.RulesetPath)
+	if err != nil {
+		return EngineOutput{}, err
+	}
+
+	normalized, warnings, err := ParseInputFiles(input, mapping, location, input.RoundingMode, displayPaths)
+	if err != nil {
+		return EngineOutput{}, err
+	}
+
+	transactions, settlements := splitRecords(normalized)
+	matches, variances := MatchRecords(transactions, settlements, ruleset, input.RoundingMode, location)
+
+	varianceSummary := summarizeVariances(variances)
+	normalizationSummary := NormalizationSummary{
+		Transactions: len(transactions),
+		Settlements:  len(settlements),
+		Warnings:     warnings,
+	}
+
+	if err := os.MkdirAll(input.OutputDir, 0o755); err != nil {
+		return EngineOutput{}, fmt.Errorf("create output dir: %w", err)
+	}
+
+	evidenceDir := filepath.Join(input.OutputDir, "evidence")
+	if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
+		return EngineOutput{}, fmt.Errorf("create evidence dir: %w", err)
+	}
+
+	normalizedPath := filepath.Join(evidenceDir, "normalized.jsonl")
+	if err := writeNormalized(normalizedPath, normalized); err != nil {
+		return EngineOutput{}, err
+	}
+
+	variancesPath := filepath.Join(evidenceDir, "variances.jsonl")
+	if err := writeVariances(variancesPath, variances); err != nil {
+		return EngineOutput{}, err
+	}
+
+	logPath := filepath.Join(evidenceDir, "logs")
+	if err := os.MkdirAll(logPath, 0o755); err != nil {
+		return EngineOutput{}, fmt.Errorf("create logs dir: %w", err)
+	}
+
+	if err := writeRunLog(filepath.Join(logPath, "run.log"), input, normalizationSummary, varianceSummary, len(matches)); err != nil {
+		return EngineOutput{}, err
+	}
+
+	output := EngineOutput{
+		SchemaVersion:          SchemaVersion,
+		ToolVersion:            ToolVersion,
+		NormalizationSummary:   normalizationSummary,
+		VarianceSummary:        varianceSummary,
+		VarianceItemsPath:      variancesPath,
+		DeterministicStatement: deterministicStatement(input),
+	}
+
+	manifest, err := buildEvidenceManifest(input, normalizedPath, variancesPath)
+	if err != nil {
+		return EngineOutput{}, err
+	}
+	output.EvidenceManifest = manifest
+
+	outputPath := filepath.Join(input.OutputDir, "engine_output.json")
+	if err := writeJSON(outputPath, output); err != nil {
+		return EngineOutput{}, err
+	}
+
+	manifest.Outputs = append(manifest.Outputs, EvidenceFile{Path: outputPath, Sha256: hashFileOrEmpty(outputPath)})
+	manifestPath := filepath.Join(evidenceDir, "manifest.json")
+	if err := writeJSON(manifestPath, manifest); err != nil {
+		return EngineOutput{}, err
+	}
+
+	return output, nil
+}
+
+func splitRecords(records []NormalizedRecord) ([]NormalizedRecord, []NormalizedRecord) {
+	var transactions []NormalizedRecord
+	var settlements []NormalizedRecord
+	for _, record := range records {
+		switch record.RecordType {
+		case defaultTransactionType:
+			transactions = append(transactions, record)
+		case defaultSettlementType:
+			settlements = append(settlements, record)
+		}
+	}
+	return transactions, settlements
+}
+
+func summarizeVariances(variances []VarianceItem) VarianceSummary {
+	byType := map[string]int{}
+	for _, variance := range variances {
+		byType[variance.Type]++
+	}
+	types := make([]string, 0, len(byType))
+	for varianceType := range byType {
+		types = append(types, varianceType)
+	}
+	sort.Strings(types)
+	counts := make([]VarianceCount, 0, len(types))
+	for _, varianceType := range types {
+		counts = append(counts, VarianceCount{Type: varianceType, Count: byType[varianceType]})
+	}
+	return VarianceSummary{Total: len(variances), ByType: counts}
+}
+
+func writeNormalized(path string, records []NormalizedRecord) error {
+	return writeJSONLines(path, records, func(record NormalizedRecord) NormalizedRecord {
+		record.Date = record.Date.UTC()
+		return record
+	})
+}
+
+func writeVariances(path string, variances []VarianceItem) error {
+	return writeJSONLines(path, variances, func(item VarianceItem) VarianceItem {
+		return item
+	})
+}
+
+func writeRunLog(path string, input EngineInput, normalization NormalizationSummary, variance VarianceSummary, matches int) error {
+	lines := []string{
+		fmt.Sprintf("tool_version=%s", ToolVersion),
+		fmt.Sprintf("input_files=%d", len(input.InputFiles)),
+		fmt.Sprintf("transactions=%d", normalization.Transactions),
+		fmt.Sprintf("settlements=%d", normalization.Settlements),
+		fmt.Sprintf("matches=%d", matches),
+		fmt.Sprintf("variances=%d", variance.Total),
+	}
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
+}
+
+func writeJSON(path string, payload interface{}) error {
+	content, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+	return os.WriteFile(path, append(content, '\n'), 0o644)
+}
+
+func writeJSONLines[T any](path string, entries []T, mapFn func(T) T) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create jsonl: %w", err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	for _, entry := range entries {
+		mapped := mapFn(entry)
+		if err := encoder.Encode(mapped); err != nil {
+			return fmt.Errorf("encode jsonl: %w", err)
+		}
+	}
+	return nil
+}
+
+func buildEvidenceManifest(input EngineInput, normalizedPath string, variancesPath string) (EvidenceManifest, error) {
+	inputs := make([]EvidenceFile, 0, len(input.InputFiles)+1)
+	for _, path := range input.InputFiles {
+		inputs = append(inputs, EvidenceFile{Path: path, Sha256: hashFileOrEmpty(path)})
+	}
+	if input.RulesetPath != "" {
+		inputs = append(inputs, EvidenceFile{Path: input.RulesetPath, Sha256: hashFileOrEmpty(input.RulesetPath)})
+	}
+	if input.MappingConfigPath != "" {
+		inputs = append(inputs, EvidenceFile{Path: input.MappingConfigPath, Sha256: hashFileOrEmpty(input.MappingConfigPath)})
+	}
+
+	outputs := []EvidenceFile{
+		{Path: normalizedPath, Sha256: hashFileOrEmpty(normalizedPath)},
+		{Path: variancesPath, Sha256: hashFileOrEmpty(variancesPath)},
+	}
+
+	sort.Slice(inputs, func(i, j int) bool { return inputs[i].Path < inputs[j].Path })
+	sort.Slice(outputs, func(i, j int) bool { return outputs[i].Path < outputs[j].Path })
+
+	return EvidenceManifest{
+		SchemaVersion: SchemaVersion,
+		ToolVersion:   ToolVersion,
+		GeneratedAt:   deterministicTimestamp(),
+		InputFiles:    inputs,
+		Outputs:       outputs,
+	}, nil
+}
+
+func hashFileOrEmpty(path string) string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return hashBytes(content)
+}
+
+func deterministicStatement(input EngineInput) string {
+	sortKeys := input.Determinism.SortKeys
+	if len(sortKeys) == 0 {
+		sortKeys = []string{"record_type", "id", "source_file", "source_row"}
+	}
+	return fmt.Sprintf("Outputs are deterministic when input files, ruleset, mapping config, timezone (%s), and rounding_mode (%s) are unchanged. Records are sorted by %s and JSON is written with stable ordering. Amounts are rounded using %s.", input.Timezone, input.RoundingMode, strings.Join(sortKeys, ", "), input.RoundingMode)
+}
+
+func deterministicTimestamp() string {
+	return time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+}
+
+func resolvePaths(baseDir string, paths []string) []string {
+	resolved := make([]string, 0, len(paths))
+	for _, path := range paths {
+		resolved = append(resolved, resolvePath(baseDir, path))
+	}
+	return resolved
+}
+
+func resolvePath(baseDir string, path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(baseDir, path)
+}

--- a/tools/settler-engine/internal/engine/engine_test.go
+++ b/tools/settler-engine/internal/engine/engine_test.go
@@ -1,0 +1,61 @@
+package engine
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type expectedSummary struct {
+	Transactions   int            `json:"transactions"`
+	Settlements    int            `json:"settlements"`
+	VariancesTotal int            `json:"variances_total"`
+	VarianceByType map[string]int `json:"variance_by_type"`
+}
+
+func TestFixtureRun(t *testing.T) {
+	root := filepath.Join("..", "..")
+	inputPath := filepath.Join(root, "fixtures", "input", "engine_input.json")
+	outputDir := filepath.Join(root, "fixtures", "output")
+	_ = os.RemoveAll(outputDir)
+
+	output, err := Run(inputPath)
+	if err != nil {
+		t.Fatalf("run engine: %v", err)
+	}
+
+	expectedPath := filepath.Join(root, "fixtures", "expected", "summary.json")
+	content, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read expected summary: %v", err)
+	}
+	var expected expectedSummary
+	if err := json.Unmarshal(content, &expected); err != nil {
+		t.Fatalf("parse expected summary: %v", err)
+	}
+
+	if output.NormalizationSummary.Transactions != expected.Transactions {
+		t.Fatalf("transactions mismatch: got %d want %d", output.NormalizationSummary.Transactions, expected.Transactions)
+	}
+	if output.NormalizationSummary.Settlements != expected.Settlements {
+		t.Fatalf("settlements mismatch: got %d want %d", output.NormalizationSummary.Settlements, expected.Settlements)
+	}
+	if output.VarianceSummary.Total != expected.VariancesTotal {
+		t.Fatalf("variances total mismatch: got %d want %d", output.VarianceSummary.Total, expected.VariancesTotal)
+	}
+
+	counts := map[string]int{}
+	for _, item := range output.VarianceSummary.ByType {
+		counts[item.Type] = item.Count
+	}
+	for varianceType, expectedCount := range expected.VarianceByType {
+		if counts[varianceType] != expectedCount {
+			t.Fatalf("variance %s mismatch: got %d want %d", varianceType, counts[varianceType], expectedCount)
+		}
+	}
+
+	if output.EvidenceManifest.GeneratedAt == "" {
+		t.Fatalf("expected deterministic timestamp")
+	}
+}

--- a/tools/settler-engine/internal/engine/model.go
+++ b/tools/settler-engine/internal/engine/model.go
@@ -1,0 +1,133 @@
+package engine
+
+import (
+	"time"
+)
+
+type EngineInput struct {
+	InputFiles        []string          `json:"input_files"`
+	InputFormat       string            `json:"input_format"`
+	MappingConfigPath string            `json:"mapping_config_path"`
+	RulesetPath       string            `json:"ruleset_path"`
+	Currency          string            `json:"currency"`
+	RoundingMode      string            `json:"rounding_mode"`
+	Timezone          string            `json:"timezone"`
+	OutputDir         string            `json:"output_dir"`
+	Mode              string            `json:"mode"`
+	Determinism       DeterminismConfig `json:"determinism"`
+}
+
+type DeterminismConfig struct {
+	SortKeys []string `json:"sort_keys"`
+	Rounding string   `json:"rounding"`
+	Timezone string   `json:"timezone"`
+}
+
+type MappingConfig struct {
+	RecordTypeField  string           `json:"record_type_field"`
+	RecordTypeValues RecordTypeValues `json:"record_type_values"`
+	Transactions     FieldMapping     `json:"transactions"`
+	Settlements      FieldMapping     `json:"settlements"`
+}
+
+type RecordTypeValues struct {
+	Transaction string `json:"transaction"`
+	Settlement  string `json:"settlement"`
+}
+
+type FieldMapping struct {
+	ID                    string `json:"id"`
+	Amount                string `json:"amount"`
+	Currency              string `json:"currency"`
+	Date                  string `json:"date"`
+	ReferenceID           string `json:"reference_id"`
+	ProviderTransactionID string `json:"provider_transaction_id"`
+	ProviderSettlementID  string `json:"provider_settlement_id"`
+}
+
+type Ruleset struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Rules              []Rule `json:"rules"`
+	Priority           string `json:"priority"`
+	ConflictResolution string `json:"conflictResolution"`
+}
+
+type Rule struct {
+	ID        string        `json:"id"`
+	Name      string        `json:"name"`
+	Field     string        `json:"field"`
+	Type      string        `json:"type"`
+	Tolerance RuleTolerance `json:"tolerance"`
+	Priority  int           `json:"priority"`
+	Enabled   bool          `json:"enabled"`
+}
+
+type RuleTolerance struct {
+	Amount     string  `json:"amount"`
+	Days       int     `json:"days"`
+	Percentage float64 `json:"percentage"`
+	Threshold  float64 `json:"threshold"`
+}
+
+type NormalizedRecord struct {
+	RecordType            string    `json:"record_type"`
+	ID                    string    `json:"id"`
+	AmountCents           int64     `json:"amount_cents"`
+	Currency              string    `json:"currency"`
+	Date                  time.Time `json:"date"`
+	ReferenceID           string    `json:"reference_id,omitempty"`
+	ProviderTransactionID string    `json:"provider_transaction_id,omitempty"`
+	ProviderSettlementID  string    `json:"provider_settlement_id,omitempty"`
+	SourceFile            string    `json:"source_file"`
+	SourceRow             int       `json:"source_row"`
+}
+
+type VarianceItem struct {
+	ID              string `json:"id"`
+	Type            string `json:"type"`
+	TransactionID   string `json:"transaction_id,omitempty"`
+	SettlementID    string `json:"settlement_id,omitempty"`
+	Message         string `json:"message"`
+	AmountDiffCents int64  `json:"amount_diff_cents,omitempty"`
+	DateDiffDays    int    `json:"date_diff_days,omitempty"`
+}
+
+type NormalizationSummary struct {
+	Transactions int      `json:"transactions"`
+	Settlements  int      `json:"settlements"`
+	Warnings     []string `json:"warnings"`
+}
+
+type VarianceSummary struct {
+	Total  int             `json:"total"`
+	ByType []VarianceCount `json:"by_type"`
+}
+
+type VarianceCount struct {
+	Type  string `json:"type"`
+	Count int    `json:"count"`
+}
+
+type EvidenceManifest struct {
+	SchemaVersion string         `json:"schema_version"`
+	ToolVersion   string         `json:"tool_version"`
+	GeneratedAt   string         `json:"generated_at"`
+	InputFiles    []EvidenceFile `json:"input_files"`
+	Outputs       []EvidenceFile `json:"outputs"`
+}
+
+type EvidenceFile struct {
+	Path   string `json:"path"`
+	Sha256 string `json:"sha256"`
+}
+
+type EngineOutput struct {
+	SchemaVersion          string               `json:"schema_version"`
+	ToolVersion            string               `json:"tool_version"`
+	NormalizationSummary   NormalizationSummary `json:"normalization_summary"`
+	VarianceSummary        VarianceSummary      `json:"variance_summary"`
+	VarianceItemsPath      string               `json:"variance_items_path"`
+	EvidenceManifest       EvidenceManifest     `json:"evidence_manifest"`
+	DeterministicStatement string               `json:"deterministic_statement"`
+}

--- a/tools/settler-engine/internal/engine/parser.go
+++ b/tools/settler-engine/internal/engine/parser.go
@@ -1,0 +1,390 @@
+package engine
+
+import (
+	"bufio"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	defaultRecordTypeField = "record_type"
+	defaultTransactionType = "transaction"
+	defaultSettlementType  = "settlement"
+)
+
+func LoadEngineInput(path string) (EngineInput, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return EngineInput{}, fmt.Errorf("open engine input: %w", err)
+	}
+	defer file.Close()
+
+	var input EngineInput
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&input); err != nil {
+		return EngineInput{}, fmt.Errorf("decode engine input: %w", err)
+	}
+	return input, nil
+}
+
+func LoadMappingConfig(path string) (MappingConfig, error) {
+	if path == "" {
+		return defaultMappingConfig(), nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return MappingConfig{}, fmt.Errorf("open mapping config: %w", err)
+	}
+	defer file.Close()
+
+	var cfg MappingConfig
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
+		return MappingConfig{}, fmt.Errorf("decode mapping config: %w", err)
+	}
+	if cfg.RecordTypeField == "" {
+		cfg.RecordTypeField = defaultRecordTypeField
+	}
+	if cfg.RecordTypeValues.Transaction == "" {
+		cfg.RecordTypeValues.Transaction = defaultTransactionType
+	}
+	if cfg.RecordTypeValues.Settlement == "" {
+		cfg.RecordTypeValues.Settlement = defaultSettlementType
+	}
+	cfg.Transactions = withDefaultFieldMapping(cfg.Transactions)
+	cfg.Settlements = withDefaultFieldMapping(cfg.Settlements)
+	return cfg, nil
+}
+
+func LoadRuleset(path string) (Ruleset, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Ruleset{}, fmt.Errorf("open ruleset: %w", err)
+	}
+	defer file.Close()
+
+	var ruleset Ruleset
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&ruleset); err != nil {
+		return Ruleset{}, fmt.Errorf("decode ruleset: %w", err)
+	}
+	if ruleset.Priority == "" {
+		ruleset.Priority = "exact-first"
+	}
+	for i := range ruleset.Rules {
+		if !ruleset.Rules[i].Enabled {
+			ruleset.Rules[i].Enabled = true
+		}
+	}
+	return ruleset, nil
+}
+
+func ParseInputFiles(input EngineInput, mapping MappingConfig, tz *time.Location, roundingMode string, displayPaths map[string]string) ([]NormalizedRecord, []string, error) {
+	var normalized []NormalizedRecord
+	warnings := []string{}
+
+	for _, path := range input.InputFiles {
+		displayPath := displayPaths[path]
+		if displayPath == "" {
+			displayPath = path
+		}
+		records, recordWarnings, err := parseInputFile(path, displayPath, input.InputFormat, mapping, tz, roundingMode)
+		if err != nil {
+			return nil, warnings, err
+		}
+		warnings = append(warnings, recordWarnings...)
+		normalized = append(normalized, records...)
+	}
+
+	sort.Slice(normalized, func(i, j int) bool {
+		if normalized[i].RecordType != normalized[j].RecordType {
+			return normalized[i].RecordType < normalized[j].RecordType
+		}
+		if normalized[i].ID != normalized[j].ID {
+			return normalized[i].ID < normalized[j].ID
+		}
+		if normalized[i].SourceFile != normalized[j].SourceFile {
+			return normalized[i].SourceFile < normalized[j].SourceFile
+		}
+		return normalized[i].SourceRow < normalized[j].SourceRow
+	})
+
+	return normalized, warnings, nil
+}
+
+func parseInputFile(path string, displayPath string, format string, mapping MappingConfig, tz *time.Location, roundingMode string) ([]NormalizedRecord, []string, error) {
+	format = strings.ToLower(strings.TrimSpace(format))
+	if format == "" || format == "auto" {
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".csv":
+			format = "csv"
+		case ".json":
+			format = "json"
+		default:
+			return nil, nil, fmt.Errorf("unsupported input extension %s", ext)
+		}
+	}
+
+	switch format {
+	case "csv":
+		return parseCSV(path, displayPath, mapping, tz, roundingMode)
+	case "json":
+		return parseJSON(path, displayPath, mapping, tz, roundingMode)
+	default:
+		return nil, nil, fmt.Errorf("unsupported input format %s", format)
+	}
+}
+
+func parseCSV(path string, displayPath string, mapping MappingConfig, tz *time.Location, roundingMode string) ([]NormalizedRecord, []string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open csv: %w", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(bufio.NewReader(file))
+	reader.TrimLeadingSpace = true
+	reader.ReuseRecord = false
+	reader.FieldsPerRecord = -1
+
+	headers, err := reader.Read()
+	if err != nil {
+		return nil, nil, fmt.Errorf("read csv header: %w", err)
+	}
+	for i := range headers {
+		headers[i] = strings.TrimSpace(headers[i])
+	}
+
+	var normalized []NormalizedRecord
+	warnings := []string{}
+	row := 1
+	for {
+		row++
+		record, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, warnings, fmt.Errorf("read csv row %d: %w", row, err)
+		}
+		rowMap := map[string]string{}
+		for i, value := range record {
+			if i < len(headers) {
+				rowMap[headers[i]] = strings.TrimSpace(value)
+			}
+		}
+
+		recordType := rowMap[mapping.RecordTypeField]
+		if recordType == "" {
+			warnings = append(warnings, fmt.Sprintf("row %d missing record_type", row))
+			continue
+		}
+
+		var fieldMap FieldMapping
+		switch recordType {
+		case mapping.RecordTypeValues.Transaction:
+			fieldMap = mapping.Transactions
+		case mapping.RecordTypeValues.Settlement:
+			fieldMap = mapping.Settlements
+		default:
+			warnings = append(warnings, fmt.Sprintf("row %d unknown record_type %s", row, recordType))
+			continue
+		}
+
+		normalizedRecord, err := normalizeRow(recordType, fieldMap, rowMap, tz, roundingMode, displayPath, row)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("row %d: %s", row, err.Error()))
+			continue
+		}
+		normalized = append(normalized, normalizedRecord)
+	}
+
+	return normalized, warnings, nil
+}
+
+func parseJSON(path string, displayPath string, mapping MappingConfig, tz *time.Location, roundingMode string) ([]NormalizedRecord, []string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open json: %w", err)
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	decoder.UseNumber()
+
+	var payload interface{}
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, nil, fmt.Errorf("decode json: %w", err)
+	}
+
+	warnings := []string{}
+	var normalized []NormalizedRecord
+	switch value := payload.(type) {
+	case map[string]interface{}:
+		transactions, ok := value["transactions"].([]interface{})
+		if ok {
+			records, warn := parseJSONRecords(transactions, mapping, mapping.RecordTypeValues.Transaction, tz, roundingMode, displayPath)
+			warnings = append(warnings, warn...)
+			normalized = append(normalized, records...)
+		}
+		settlements, ok := value["settlements"].([]interface{})
+		if ok {
+			records, warn := parseJSONRecords(settlements, mapping, mapping.RecordTypeValues.Settlement, tz, roundingMode, displayPath)
+			warnings = append(warnings, warn...)
+			normalized = append(normalized, records...)
+		}
+		if !ok && len(normalized) == 0 {
+			warnings = append(warnings, "json file missing transactions or settlements arrays")
+		}
+	case []interface{}:
+		records, warn := parseJSONRecords(value, mapping, "", tz, roundingMode, displayPath)
+		warnings = append(warnings, warn...)
+		normalized = append(normalized, records...)
+	default:
+		return nil, nil, fmt.Errorf("unsupported json structure")
+	}
+
+	return normalized, warnings, nil
+}
+
+func parseJSONRecords(records []interface{}, mapping MappingConfig, forcedType string, tz *time.Location, roundingMode string, path string) ([]NormalizedRecord, []string) {
+	warnings := []string{}
+	var normalized []NormalizedRecord
+	for idx, item := range records {
+		recordMap, ok := item.(map[string]interface{})
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("record %d not object", idx+1))
+			continue
+		}
+		rowMap := map[string]string{}
+		for key, value := range recordMap {
+			rowMap[key] = fmt.Sprintf("%v", value)
+		}
+		recordType := forcedType
+		if recordType == "" {
+			recordType = rowMap[defaultRecordTypeField]
+		}
+		if recordType == "" {
+			warnings = append(warnings, fmt.Sprintf("record %d missing record_type", idx+1))
+			continue
+		}
+
+		fieldMap := mapping.Transactions
+		if recordType == mapping.RecordTypeValues.Settlement {
+			fieldMap = mapping.Settlements
+		}
+		normalizedRecord, err := normalizeRow(recordType, fieldMap, rowMap, tz, roundingMode, path, idx+1)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("record %d: %s", idx+1, err.Error()))
+			continue
+		}
+		normalized = append(normalized, normalizedRecord)
+	}
+	return normalized, warnings
+}
+
+func normalizeRow(recordType string, mapping FieldMapping, data map[string]string, tz *time.Location, roundingMode string, sourceFile string, row int) (NormalizedRecord, error) {
+	id := strings.TrimSpace(data[mapping.ID])
+	if id == "" {
+		return NormalizedRecord{}, fmt.Errorf("missing id")
+	}
+	amountRaw := strings.TrimSpace(data[mapping.Amount])
+	if amountRaw == "" {
+		return NormalizedRecord{}, fmt.Errorf("missing amount")
+	}
+	amountCents, err := parseAmountToCents(amountRaw, roundingMode)
+	if err != nil {
+		return NormalizedRecord{}, fmt.Errorf("invalid amount: %w", err)
+	}
+	currency := strings.TrimSpace(data[mapping.Currency])
+	if currency == "" {
+		currency = "USD"
+	}
+	dateRaw := strings.TrimSpace(data[mapping.Date])
+	if dateRaw == "" {
+		return NormalizedRecord{}, fmt.Errorf("missing date")
+	}
+	dateValue, err := parseDate(dateRaw, tz)
+	if err != nil {
+		return NormalizedRecord{}, fmt.Errorf("invalid date: %w", err)
+	}
+
+	return NormalizedRecord{
+		RecordType:            recordType,
+		ID:                    id,
+		AmountCents:           amountCents,
+		Currency:              currency,
+		Date:                  dateValue,
+		ReferenceID:           strings.TrimSpace(data[mapping.ReferenceID]),
+		ProviderTransactionID: strings.TrimSpace(data[mapping.ProviderTransactionID]),
+		ProviderSettlementID:  strings.TrimSpace(data[mapping.ProviderSettlementID]),
+		SourceFile:            sourceFile,
+		SourceRow:             row,
+	}, nil
+}
+
+func defaultMappingConfig() MappingConfig {
+	return MappingConfig{
+		RecordTypeField: defaultRecordTypeField,
+		RecordTypeValues: RecordTypeValues{
+			Transaction: defaultTransactionType,
+			Settlement:  defaultSettlementType,
+		},
+		Transactions: FieldMapping{
+			ID:                    "id",
+			Amount:                "amount",
+			Currency:              "currency",
+			Date:                  "date",
+			ReferenceID:           "reference_id",
+			ProviderTransactionID: "provider_transaction_id",
+			ProviderSettlementID:  "provider_settlement_id",
+		},
+		Settlements: FieldMapping{
+			ID:                    "id",
+			Amount:                "amount",
+			Currency:              "currency",
+			Date:                  "date",
+			ReferenceID:           "reference_id",
+			ProviderTransactionID: "provider_transaction_id",
+			ProviderSettlementID:  "provider_settlement_id",
+		},
+	}
+}
+
+func withDefaultFieldMapping(mapping FieldMapping) FieldMapping {
+	defaults := defaultMappingConfig().Transactions
+	if mapping.ID == "" {
+		mapping.ID = defaults.ID
+	}
+	if mapping.Amount == "" {
+		mapping.Amount = defaults.Amount
+	}
+	if mapping.Currency == "" {
+		mapping.Currency = defaults.Currency
+	}
+	if mapping.Date == "" {
+		mapping.Date = defaults.Date
+	}
+	if mapping.ReferenceID == "" {
+		mapping.ReferenceID = defaults.ReferenceID
+	}
+	if mapping.ProviderTransactionID == "" {
+		mapping.ProviderTransactionID = defaults.ProviderTransactionID
+	}
+	if mapping.ProviderSettlementID == "" {
+		mapping.ProviderSettlementID = defaults.ProviderSettlementID
+	}
+	return mapping
+}

--- a/tools/settler-engine/internal/engine/rules.go
+++ b/tools/settler-engine/internal/engine/rules.go
@@ -1,0 +1,258 @@
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+type MatchResult struct {
+	Transaction NormalizedRecord
+	Settlement  NormalizedRecord
+}
+
+func MatchRecords(transactions []NormalizedRecord, settlements []NormalizedRecord, ruleset Ruleset, roundingMode string, tz *time.Location) ([]MatchResult, []VarianceItem) {
+	var matches []MatchResult
+	var variances []VarianceItem
+
+	sort.SliceStable(ruleset.Rules, func(i, j int) bool {
+		return ruleset.Rules[i].Priority < ruleset.Rules[j].Priority
+	})
+
+	settlementMatched := map[string]bool{}
+
+	for _, txn := range transactions {
+		match, found := findMatch(txn, settlements, settlementMatched, ruleset, roundingMode, tz)
+		if found {
+			matches = append(matches, match)
+			settlementMatched[match.Settlement.ID] = true
+			variances = append(variances, compareMatch(match, ruleset, roundingMode, tz)...)
+		} else {
+			variances = append(variances, VarianceItem{
+				ID:            fmt.Sprintf("variance-%s-missing-settlement", txn.ID),
+				Type:          "missing_settlement",
+				TransactionID: txn.ID,
+				Message:       "No settlement matched this transaction; discrepancy surfaced.",
+			})
+		}
+	}
+
+	for _, settlement := range settlements {
+		if settlementMatched[settlement.ID] {
+			continue
+		}
+		variances = append(variances, VarianceItem{
+			ID:           fmt.Sprintf("variance-%s-missing-transaction", settlement.ID),
+			Type:         "missing_transaction",
+			SettlementID: settlement.ID,
+			Message:      "No transaction matched this settlement; discrepancy surfaced.",
+		})
+	}
+
+	sort.SliceStable(variances, func(i, j int) bool {
+		if variances[i].Type != variances[j].Type {
+			return variances[i].Type < variances[j].Type
+		}
+		if variances[i].TransactionID != variances[j].TransactionID {
+			return variances[i].TransactionID < variances[j].TransactionID
+		}
+		return variances[i].SettlementID < variances[j].SettlementID
+	})
+
+	return matches, variances
+}
+
+func findMatch(txn NormalizedRecord, settlements []NormalizedRecord, matched map[string]bool, ruleset Ruleset, roundingMode string, tz *time.Location) (MatchResult, bool) {
+	for _, rule := range ruleset.Rules {
+		if !rule.Enabled {
+			continue
+		}
+		for _, settlement := range settlements {
+			if matched[settlement.ID] {
+				continue
+			}
+			if ruleMatches(rule, txn, settlement, roundingMode, tz) {
+				return MatchResult{Transaction: txn, Settlement: settlement}, true
+			}
+		}
+	}
+	return MatchResult{}, false
+}
+
+func ruleMatches(rule Rule, txn NormalizedRecord, settlement NormalizedRecord, roundingMode string, tz *time.Location) bool {
+	switch rule.Field {
+	case "transactionId", "providerTransactionId":
+		return matchString(rule, txn.ProviderTransactionID, settlement.ProviderTransactionID)
+	case "providerSettlementId":
+		return matchString(rule, txn.ProviderSettlementID, settlement.ProviderSettlementID)
+	case "referenceId":
+		return matchString(rule, txn.ReferenceID, settlement.ReferenceID)
+	case "amount":
+		return matchAmount(rule, txn.AmountCents, settlement.AmountCents)
+	case "date":
+		return matchDate(rule, txn.Date, settlement.Date, tz)
+	case "currency":
+		return matchString(rule, txn.Currency, settlement.Currency)
+	default:
+		return false
+	}
+}
+
+func compareMatch(match MatchResult, ruleset Ruleset, roundingMode string, tz *time.Location) []VarianceItem {
+	variances := []VarianceItem{}
+	amountTolerance := amountToleranceCents(ruleset)
+	dateTolerance := dateToleranceDays(ruleset)
+
+	amountDiff := match.Transaction.AmountCents - match.Settlement.AmountCents
+	if amountDiff < 0 {
+		amountDiff = -amountDiff
+	}
+	if amountDiff > amountTolerance {
+		variances = append(variances, VarianceItem{
+			ID:              fmt.Sprintf("variance-%s-%s-amount", match.Transaction.ID, match.Settlement.ID),
+			Type:            "amount_mismatch",
+			TransactionID:   match.Transaction.ID,
+			SettlementID:    match.Settlement.ID,
+			AmountDiffCents: amountDiff,
+			Message:         "Amounts differ beyond configured tolerance; discrepancy surfaced.",
+		})
+	}
+
+	dateDiff := daysBetween(match.Transaction.Date.In(tz), match.Settlement.Date.In(tz))
+	if dateDiff < 0 {
+		dateDiff = -dateDiff
+	}
+	if dateDiff > dateTolerance {
+		variances = append(variances, VarianceItem{
+			ID:            fmt.Sprintf("variance-%s-%s-date", match.Transaction.ID, match.Settlement.ID),
+			Type:          "date_mismatch",
+			TransactionID: match.Transaction.ID,
+			SettlementID:  match.Settlement.ID,
+			DateDiffDays:  dateDiff,
+			Message:       "Dates differ beyond configured tolerance; discrepancy surfaced.",
+		})
+	}
+
+	if !strings.EqualFold(match.Transaction.Currency, match.Settlement.Currency) {
+		variances = append(variances, VarianceItem{
+			ID:            fmt.Sprintf("variance-%s-%s-currency", match.Transaction.ID, match.Settlement.ID),
+			Type:          "currency_mismatch",
+			TransactionID: match.Transaction.ID,
+			SettlementID:  match.Settlement.ID,
+			Message:       "Currencies differ; discrepancy surfaced.",
+		})
+	}
+
+	return variances
+}
+
+func matchAmount(rule Rule, amount int64, other int64) bool {
+	diff := amount - other
+	if diff < 0 {
+		diff = -diff
+	}
+	switch strings.ToLower(rule.Type) {
+	case "exact", "":
+		return diff == 0
+	case "range":
+		return diff <= amountToleranceCentsFromRule(rule)
+	case "fuzzy":
+		return diff <= amountToleranceCentsFromRule(rule)
+	default:
+		return diff == 0
+	}
+}
+
+func matchDate(rule Rule, a time.Time, b time.Time, tz *time.Location) bool {
+	diff := daysBetween(a.In(tz), b.In(tz))
+	if diff < 0 {
+		diff = -diff
+	}
+	switch strings.ToLower(rule.Type) {
+	case "exact", "":
+		return diff == 0
+	case "range":
+		return diff <= rule.Tolerance.Days
+	case "fuzzy":
+		return diff <= rule.Tolerance.Days
+	default:
+		return diff == 0
+	}
+}
+
+func daysBetween(a time.Time, b time.Time) int {
+	a = time.Date(a.Year(), a.Month(), a.Day(), 0, 0, 0, 0, a.Location())
+	b = time.Date(b.Year(), b.Month(), b.Day(), 0, 0, 0, 0, b.Location())
+	diff := b.Sub(a)
+	return int(diff.Hours() / 24)
+}
+
+func normalizeString(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	value = strings.ReplaceAll(value, " ", "")
+	return value
+}
+
+func matchString(rule Rule, left string, right string) bool {
+	leftNormalized := normalizeString(left)
+	rightNormalized := normalizeString(right)
+	if leftNormalized == "" || rightNormalized == "" {
+		return false
+	}
+	switch strings.ToLower(rule.Type) {
+	case "regex":
+		pattern := strings.TrimSpace(rule.Name)
+		if pattern == "" {
+			return leftNormalized == rightNormalized
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return false
+		}
+		return re.MatchString(left) || re.MatchString(right)
+	case "fuzzy":
+		return leftNormalized == rightNormalized
+	default:
+		return leftNormalized == rightNormalized
+	}
+}
+
+func amountToleranceCents(ruleset Ruleset) int64 {
+	var tolerance int64
+	for _, rule := range ruleset.Rules {
+		if rule.Field == "amount" {
+			if candidate := amountToleranceCentsFromRule(rule); candidate > tolerance {
+				tolerance = candidate
+			}
+		}
+	}
+	return tolerance
+}
+
+func amountToleranceCentsFromRule(rule Rule) int64 {
+	if strings.TrimSpace(rule.Tolerance.Amount) == "" {
+		return 0
+	}
+	amount, err := parseAmountToCents(rule.Tolerance.Amount, "bankers")
+	if err != nil {
+		return 0
+	}
+	if amount < 0 {
+		return -amount
+	}
+	return amount
+}
+
+func dateToleranceDays(ruleset Ruleset) int {
+	var tolerance int
+	for _, rule := range ruleset.Rules {
+		if rule.Field == "date" {
+			if rule.Tolerance.Days > tolerance {
+				tolerance = rule.Tolerance.Days
+			}
+		}
+	}
+	return tolerance
+}

--- a/tools/settler-engine/internal/engine/util.go
+++ b/tools/settler-engine/internal/engine/util.go
@@ -1,0 +1,120 @@
+package engine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+)
+
+func parseDate(value string, tz *time.Location) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02",
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+	}
+	var parsed time.Time
+	var err error
+	for _, layout := range layouts {
+		parsed, err = time.ParseInLocation(layout, value, tz)
+		if err == nil {
+			return parsed.In(tz), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unsupported date format")
+}
+
+func parseAmountToCents(value string, roundingMode string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, errors.New("empty amount")
+	}
+	value = strings.ReplaceAll(value, ",", "")
+
+	rat, ok := new(big.Rat).SetString(value)
+	if !ok {
+		return 0, fmt.Errorf("invalid number %s", value)
+	}
+
+	multiplier := big.NewRat(100, 1)
+	rat.Mul(rat, multiplier)
+
+	return roundRatToInt64(rat, roundingMode)
+}
+
+func roundRatToInt64(rat *big.Rat, roundingMode string) (int64, error) {
+	if roundingMode == "" {
+		roundingMode = "bankers"
+	}
+	sign := rat.Sign()
+	absRat := new(big.Rat).Set(rat)
+	if sign < 0 {
+		absRat.Neg(absRat)
+	}
+
+	floor := new(big.Int)
+	floor.Div(absRat.Num(), absRat.Denom())
+
+	fraction := new(big.Rat).Sub(absRat, new(big.Rat).SetInt(floor))
+	if fraction.Sign() == 0 {
+		if sign < 0 {
+			return -floor.Int64(), nil
+		}
+		return floor.Int64(), nil
+	}
+
+	switch strings.ToLower(roundingMode) {
+	case "bankers", "banker", "half-even":
+		cmpHalf := fraction.Cmp(big.NewRat(1, 2))
+		if cmpHalf < 0 {
+			if sign < 0 {
+				return -floor.Int64(), nil
+			}
+			return floor.Int64(), nil
+		}
+		if cmpHalf > 0 {
+			floor.Add(floor, big.NewInt(1))
+			if sign < 0 {
+				return -floor.Int64(), nil
+			}
+			return floor.Int64(), nil
+		}
+		if floor.Bit(0) == 0 {
+			if sign < 0 {
+				return -floor.Int64(), nil
+			}
+			return floor.Int64(), nil
+		}
+		floor.Add(floor, big.NewInt(1))
+		if sign < 0 {
+			return -floor.Int64(), nil
+		}
+		return floor.Int64(), nil
+	case "half-up", "half_up", "halfup":
+		cmpHalf := fraction.Cmp(big.NewRat(1, 2))
+		if cmpHalf >= 0 {
+			floor.Add(floor, big.NewInt(1))
+			if sign < 0 {
+				return -floor.Int64(), nil
+			}
+			return floor.Int64(), nil
+		}
+		if sign < 0 {
+			return -floor.Int64(), nil
+		}
+		return floor.Int64(), nil
+	default:
+		return 0, fmt.Errorf("unsupported rounding mode %s", roundingMode)
+	}
+}
+
+func hashBytes(content []byte) string {
+	hasher := sha256.New()
+	_, _ = hasher.Write(content)
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/tools/settler-engine/main.go
+++ b/tools/settler-engine/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/settler/settler-engine/internal/engine"
+)
+
+func main() {
+	inputPath := flag.String("input", "", "Path to engine_input.json")
+	flag.Parse()
+
+	if *inputPath == "" {
+		fmt.Fprintln(os.Stderr, "--input is required")
+		os.Exit(1)
+	}
+
+	output, err := engine.Run(*inputPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Settler engine run completed. Variances: %d. Output: %s\n", output.VarianceSummary.Total, output.VarianceItemsPath)
+}

--- a/tools/settler-engine/schemas/engine_input.schema.json
+++ b/tools/settler-engine/schemas/engine_input.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://settler.dev/schemas/engine_input.schema.json",
+  "title": "Settler Engine Input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "input_files",
+    "input_format",
+    "ruleset_path",
+    "rounding_mode",
+    "timezone",
+    "output_dir",
+    "mode",
+    "determinism"
+  ],
+  "properties": {
+    "input_files": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "input_format": {
+      "type": "string",
+      "enum": ["csv", "json", "auto"]
+    },
+    "mapping_config_path": {
+      "type": "string"
+    },
+    "ruleset_path": {
+      "type": "string"
+    },
+    "currency": {
+      "type": "string"
+    },
+    "rounding_mode": {
+      "type": "string",
+      "enum": ["bankers", "half-up", "half_up", "halfup", "half-even", "banker"]
+    },
+    "timezone": {
+      "type": "string",
+      "default": "UTC"
+    },
+    "output_dir": {
+      "type": "string"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["local", "ci"]
+    },
+    "determinism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sort_keys", "rounding", "timezone"],
+      "properties": {
+        "sort_keys": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "rounding": { "type": "string" },
+        "timezone": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tools/settler-engine/schemas/engine_output.schema.json
+++ b/tools/settler-engine/schemas/engine_output.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://settler.dev/schemas/engine_output.schema.json",
+  "title": "Settler Engine Output",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "tool_version",
+    "normalization_summary",
+    "variance_summary",
+    "variance_items_path",
+    "evidence_manifest",
+    "deterministic_statement"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "tool_version": { "type": "string" },
+    "normalization_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transactions", "settlements", "warnings"],
+      "properties": {
+        "transactions": { "type": "integer" },
+        "settlements": { "type": "integer" },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "variance_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "by_type"],
+      "properties": {
+        "total": { "type": "integer" },
+        "by_type": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "count"],
+            "properties": {
+              "type": { "type": "string" },
+              "count": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "variance_items_path": { "type": "string" },
+    "evidence_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "tool_version", "generated_at", "input_files", "outputs"],
+      "properties": {
+        "schema_version": { "type": "string" },
+        "tool_version": { "type": "string" },
+        "generated_at": { "type": "string" },
+        "input_files": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "sha256"],
+            "properties": {
+              "path": { "type": "string" },
+              "sha256": { "type": "string" }
+            }
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "sha256"],
+            "properties": {
+              "path": { "type": "string" },
+              "sha256": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "deterministic_statement": { "type": "string" }
+  }
+}

--- a/tools/settler-engine/scripts/run-fixtures.sh
+++ b/tools/settler-engine/scripts/run-fixtures.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INPUT_PATH="$ROOT_DIR/fixtures/input/engine_input.json"
+EXPECTED_PATH="$ROOT_DIR/fixtures/expected/hashes.json"
+OUTPUT_DIR="$ROOT_DIR/fixtures/output"
+
+rm -rf "$OUTPUT_DIR"
+
+(
+  cd "$ROOT_DIR"
+  go run . --input "$INPUT_PATH"
+)
+
+ROOT_DIR="$ROOT_DIR" python3 - <<'PY'
+import json
+import hashlib
+import os
+from pathlib import Path
+
+root = Path(os.environ["ROOT_DIR"]).resolve()
+output_dir = root / 'fixtures' / 'output' / 'evidence'
+expected_path = root / 'fixtures' / 'expected' / 'hashes.json'
+
+files = {
+    'normalized.jsonl': output_dir / 'normalized.jsonl',
+    'variances.jsonl': output_dir / 'variances.jsonl',
+}
+
+hashes = {}
+for key, path in files.items():
+    content = path.read_bytes()
+    hashes[key] = hashlib.sha256(content).hexdigest()
+
+expected = json.loads(expected_path.read_text())
+if hashes != expected:
+    raise SystemExit(f"Fixture hashes mismatch. Expected {expected} got {hashes}")
+
+print("Fixture hashes match expected.")
+PY


### PR DESCRIPTION
### Motivation

- Provide an OSS-first, deterministic reconciliation sidecar that can be run locally or in CI to surface discrepancies and produce audit-safe evidence bundles. 
- Enable the Next.js UI to work without a backend by packaging run packs and allowing local import of engine results for review and investigation. 
- Establish schema-first contracts for inputs/outputs so runs are reproducible and verifiable in CI. 
- Add fixture-driven verification and release automation to keep the engine reproducible and testable across platforms.

### Description

- Implement a Go engine at `tools/settler-engine/` (canonical model, deterministic parsing/normalization, matching rules, evidence manifest, JSONL outputs, stable sorting and deterministic timestamps). 
- Add input/output JSON schemas at `tools/settler-engine/schemas/engine_input.schema.json` and `tools/settler-engine/schemas/engine_output.schema.json` and a `main.go` + node wrapper `scripts/settler-engine.mjs` with a repo-level `settler:run` npm script. 
- Wire three OSS UI flows in the Next.js app under `packages/web/src/app/engine/`: `Create Run Pack`, `Import Results`, and `View Variances`, plus public templates in `packages/web/public/engine-templates/` for ruleset/mapping. 
- Add synthetic fixtures and expected outputs in `tools/settler-engine/fixtures/`, a fixture-run helper `tools/settler-engine/scripts/run-fixtures.sh`, and cross-platform release and verification workflows `.github/workflows/release-settler-engine.yml` and `.github/workflows/verify-settler-engine.yml`. 
- Add docs under `docs/engine/` (QUICKSTART, DETERMINISM, EVIDENCE_BUNDLES) and update the top-level README to state OSS-first posture and conservative language about guarantees.

### Testing

- Ran `cd tools/settler-engine && go test ./...` and unit/package tests in the engine package completed successfully. 
- Executed the fixture verification `tools/settler-engine/scripts/run-fixtures.sh`, which runs the engine against synthetic fixtures and validated SHA256 hashes against expected values (hashes matched). 
- Applied `gofmt -w` to engine sources during the rollout to ensure formatted Go code (no formatting errors remained).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69758cb053308328bb7781fbc272ce63)