### PR TITLE
chore(ci): install with pnpm and cache pnpm store

### DIFF
--- a/.github/workflows/auto-sync-oss.yml
+++ b/.github/workflows/auto-sync-oss.yml
@@ -6,15 +6,15 @@ on:
       - main
       - master
     paths-ignore:
-      - '**.md'
-      - '.github/**'
-      - 'docs/**'
+      - "**.md"
+      - ".github/**"
+      - "docs/**"
   workflow_dispatch:
     inputs:
       force_sync:
-        description: 'Force sync all OSS content (ignores changes)'
+        description: "Force sync all OSS content (ignores changes)"
         required: false
-        default: 'false'
+        default: "false"
         type: boolean
 
 env:
@@ -29,40 +29,52 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    
+
     steps:
       - name: Checkout private repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-      
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+
       - name: Install dependencies
         run: |
           if [ -f "package.json" ]; then
-            npm ci || npm install
+            pnpm install --frozen-lockfile
           fi
-      
+
       - name: Classify OSS_PUBLIC content
         id: classify
         run: |
           echo "🔍 Classifying OSS_PUBLIC content..."
-          
+
           # Create classification script if it doesn't exist
           if [ ! -f "scripts/classify-oss.sh" ]; then
             mkdir -p scripts
             cat > scripts/classify-oss.sh << 'SCRIPT'
           #!/bin/bash
           # Classify files as OSS_PUBLIC or private
-          
+
           OSS_FILES=""
-          
+
           # Find all files marked as OSS_PUBLIC
           find . -type f \( -name "OSS_PUBLIC" -o -name ".oss-public" \) | while read marker; do
             dir=$(dirname "$marker")
@@ -70,7 +82,7 @@ jobs:
               echo "$file"
             done
           done
-          
+
           # Also check for explicit OSS_PUBLIC directories
           for dir in packages/sdk packages/sdk-python packages/sdk-go packages/sdk-ruby packages/api-client packages/protocol packages/react-settler packages/cli examples docs; do
             if [ -d "$dir" ] && [ ! -f "$dir/.private" ]; then
@@ -82,16 +94,16 @@ jobs:
           SCRIPT
             chmod +x scripts/classify-oss.sh
           fi
-          
+
           # Run classification
           OSS_FILES=$(./scripts/classify-oss.sh | sort -u)
           echo "$OSS_FILES" > /tmp/oss_files.txt
-          
+
           # Count files
           FILE_COUNT=$(echo "$OSS_FILES" | grep -v '^$' | wc -l)
           echo "file_count=$FILE_COUNT" >> $GITHUB_OUTPUT
           echo "Found $FILE_COUNT OSS_PUBLIC files"
-      
+
       - name: Check for changes
         id: changes
         run: |
@@ -127,7 +139,7 @@ jobs:
               echo "has_oss_changes=false" >> $GITHUB_OUTPUT
             fi
           fi
-      
+
       - name: Sync to OSS repository
         if: steps.changes.outputs.has_oss_changes == 'true' || steps.changes.outputs.force_sync == 'true'
         env:
@@ -137,18 +149,18 @@ jobs:
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: |
           echo "🚀 Syncing to OSS repository..."
-          
+
           # Clone OSS repo
           git clone --depth 1 "https://${{ env.OSS_REPO_USERNAME }}:${{ env.OSS_REPO_TOKEN }}@github.com/shardie-github/settler-oss.git" /tmp/oss-repo
           cd /tmp/oss-repo
-          
+
           # Configure git
           git config user.name "${{ env.OSS_REPO_USERNAME }}"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          
+
           # Get OSS files list
           OSS_FILES=$(cat /tmp/oss_files.txt)
-          
+
           # Copy OSS files
           echo "📋 Copying OSS_PUBLIC files..."
           echo "$OSS_FILES" | while read file; do
@@ -162,7 +174,7 @@ jobs:
               echo "  ✓ $file"
             fi
           done
-          
+
           # Copy common OSS files
           for file in LICENSE README.public.md CONTRIBUTING.md SECURITY.md; do
             if [ -f "${{ github.workspace }}/$file" ]; then
@@ -172,7 +184,7 @@ jobs:
               fi
             fi
           done
-          
+
           # Handle deletions - check what was deleted
           if [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
             DELETED_FILES=$(git diff --name-only --diff-filter=D ${{ github.event.before }} ${{ github.sha }} || true)
@@ -185,10 +197,10 @@ jobs:
               fi
             done
           fi
-          
+
           # Stage all changes
           git add -A
-          
+
           # Check if there are changes
           if git diff --staged --quiet; then
             echo "ℹ️  No changes to sync"
@@ -198,7 +210,7 @@ jobs:
 
           Auto-synced from: ${{ github.repository }}@${{ github.sha }}
           Commit: ${{ github.event.head_commit.message || 'Auto-sync' }}
-          
+
           [skip ci]"
             
             git commit -m "$COMMIT_MSG" || exit 0
@@ -208,7 +220,7 @@ jobs:
             
             echo "✅ Successfully synced to OSS repository"
           fi
-      
+
       - name: Summary
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,31 +9,31 @@ on:
 # Only run checks when relevant files change
 # Skip for documentation-only changes, license, etc.
 paths:
-  - 'packages/**'
-  - 'config/**'
-  - 'scripts/**'
-  - 'tests/**'
-  - 'ops/**'
-  - '.github/workflows/**'
-  - '*.json'
-  - '*.js'
-  - '*.ts'
-  - '*.yml'
-  - '*.yaml'
-  - 'tsconfig.json'
-  - '.eslintrc.js'
-  - '.prettierignore'
-  - '.gitignore'
-  - 'vercel.json'
+  - "packages/**"
+  - "config/**"
+  - "scripts/**"
+  - "tests/**"
+  - "ops/**"
+  - ".github/workflows/**"
+  - "*.json"
+  - "*.js"
+  - "*.ts"
+  - "*.yml"
+  - "*.yaml"
+  - "tsconfig.json"
+  - ".eslintrc.js"
+  - ".prettierignore"
+  - ".gitignore"
+  - "vercel.json"
 paths-ignore:
-  - '**/*.md'
-  - 'LICENSE'
-  - 'docs/**'
-  - 'business/**'
-  - 'marketing/**'
-  - 'strategic/**'
-  - 'grafana-dashboards/**'
-  - 'sre/**'
+  - "**/*.md"
+  - "LICENSE"
+  - "docs/**"
+  - "business/**"
+  - "marketing/**"
+  - "strategic/**"
+  - "grafana-dashboards/**"
+  - "sre/**"
 
 jobs:
   validate-env:
@@ -43,14 +43,24 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Validate environment variable schema
         run: |
           # Check that env schema compiles and is valid
           # tsx is available via npx or can be installed
-          npx --yes tsx --check config/env.schema.ts || npm install -g tsx && tsx --check config/env.schema.ts
+          npx --yes tsx --check config/env.schema.ts || pnpm add -g tsx && tsx --check config/env.schema.ts
           echo "✅ Environment schema is valid"
       - name: Check for missing required env vars (dry-run)
         run: |
@@ -73,9 +83,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Run comprehensive repository integrity check
         run: npm run repo-integrity
       - name: Check workspace integrity (legacy)
@@ -90,9 +110,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Validate ESLint config dependencies
         run: npm run validate:eslint-config
       - name: Validate build safety
@@ -114,9 +144,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Run Settler Doctor
         run: npm run doctor
         continue-on-error: true
@@ -186,9 +226,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Run database migrations
         run: |
           cd packages/api
@@ -228,9 +278,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Run npm audit
         run: |
           npm audit --audit-level=moderate --json > npm-audit.json || true
@@ -268,9 +328,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Generate route registry
         run: npm run qa:routes
       - name: Extract links
@@ -296,15 +366,25 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Verify backend contract (schema-only mode)
         run: |
           echo "🔍 Running backend contract verification..."
           echo "Note: This runs in schema-only mode without live DB connection"
           echo "For full verification, run locally with SUPABASE_SERVICE_ROLE_KEY set"
-          
+
           # Check if verification script exists and is valid TypeScript
           if [ -f "scripts/verify-backend-contract.ts" ]; then
             echo "✅ Verification script found"
@@ -314,7 +394,7 @@ jobs:
             echo "❌ Verification script not found"
             exit 1
           fi
-          
+
           # Check if smoke test script exists
           if [ -f "scripts/smoke-test-backend.ts" ]; then
             echo "✅ Smoke test script found"
@@ -323,7 +403,7 @@ jobs:
             echo "❌ Smoke test script not found"
             exit 1
           fi
-          
+
           # Check if RLS test script exists
           if [ -f "scripts/test-rls-policies.ts" ]; then
             echo "✅ RLS test script found"
@@ -332,7 +412,7 @@ jobs:
             echo "❌ RLS test script not found"
             exit 1
           fi
-          
+
           echo "✅ All backend verification scripts are present and valid"
         continue-on-error: true
       - name: Verify healthcheck endpoint exists
@@ -358,11 +438,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
-      - run: npm ci
+      - run: pnpm install --frozen-lockfile
       - name: Build application
         run: npm run build --workspace=packages/web
         env:
@@ -370,7 +460,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: https://dummy.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-key
           SKIP_ENV_VALIDATION: true
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
       - name: Start production server
         run: |
           cd packages/web
@@ -379,7 +469,7 @@ jobs:
         env:
           PORT: 3000
           NODE_ENV: production
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
         continue-on-error: true
       - name: Run reality gates tests
         run: npx playwright test tests/e2e/reality-gates.spec.ts
@@ -401,14 +491,24 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
-      - run: npm ci
+      - run: pnpm install --frozen-lockfile
       - name: Build application
         run: npm run build --workspace=packages/web
         env:
@@ -416,7 +516,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: https://dummy.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-key
           SKIP_ENV_VALIDATION: true
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
       - name: Start production server
         run: |
           cd packages/web
@@ -425,7 +525,7 @@ jobs:
         env:
           PORT: 3000
           NODE_ENV: production
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
         continue-on-error: true
       - name: Run smoke tests
         run: npm run qa:smoke
@@ -453,11 +553,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
-      - run: npm ci
+      - run: pnpm install --frozen-lockfile
       - name: Build application
         run: npm run build --workspace=packages/web
         env:
@@ -465,7 +575,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: https://dummy.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-key
           SKIP_ENV_VALIDATION: true
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
       - name: Start production server
         run: |
           cd packages/web
@@ -474,7 +584,7 @@ jobs:
         env:
           PORT: 3000
           NODE_ENV: production
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
         continue-on-error: true
       - name: Run visual regression tests
         run: npm run qa:visual
@@ -496,11 +606,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
-      - run: npm ci
+      - run: pnpm install --frozen-lockfile
       - name: Build application
         run: npm run build --workspace=packages/web
         env:
@@ -508,7 +628,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: https://dummy.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-key
           SKIP_ENV_VALIDATION: true
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
       - name: Start production server
         run: |
           cd packages/web
@@ -517,7 +637,7 @@ jobs:
         env:
           PORT: 3000
           NODE_ENV: production
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
         continue-on-error: true
       - name: Run accessibility tests
         run: npm run qa:a11y
@@ -539,9 +659,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - run: npm run build
       - name: Check build artifacts
         run: |
@@ -559,9 +689,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Run canonical production check
         run: npm run check:production
       - name: Verify build artifacts exist
@@ -577,9 +717,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Run smoke tests
         run: npm run test:smoke
         continue-on-error: true
@@ -590,7 +740,7 @@ jobs:
 
   # Note: E2E tests moved to separate workflow (e2e.yml) for faster CI feedback
   # E2E tests run in parallel and don't block the main CI pipeline
-  
+
   # Classification check runs in separate workflow (classify.yml) for parallel execution
   # Full smoke tests against live deployment run in separate workflow (smoke.yml)
 
@@ -626,9 +776,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
-      - run: npm ci
+          node-version: "24"
+          cache: "pnpm"
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
       - name: Run database migrations
         run: |
           cd packages/api

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -6,20 +6,20 @@ on:
       - main
       - develop
     paths:
-      - 'supabase/migrations/**'
-      - '.github/workflows/migrations.yml'
+      - "supabase/migrations/**"
+      - ".github/workflows/migrations.yml"
   pull_request:
     branches:
       - main
       - develop
     paths:
-      - 'supabase/migrations/**'
+      - "supabase/migrations/**"
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to apply migrations'
+        description: "Environment to apply migrations"
         required: true
-        default: 'staging'
+        default: "staging"
         type: choice
         options:
           - staging
@@ -30,7 +30,7 @@ jobs:
     name: Apply Migrations
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'staging' }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,12 +38,24 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
 
       - name: Install Supabase CLI
         run: |
-          npm install -g supabase@latest
+          pnpm add -g supabase@latest
           supabase --version
 
       - name: Verify Supabase CLI installation
@@ -58,7 +70,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
           echo "Applying migrations to staging environment..."
-          
+
           # Use psql directly if SUPABASE_DB_URL is provided
           if [ -n "$SUPABASE_DB_URL" ]; then
             echo "Using direct PostgreSQL connection..."
@@ -94,7 +106,7 @@ jobs:
         run: |
           echo "⚠️  Applying migrations to PRODUCTION environment..."
           echo "This requires manual approval..."
-          
+
           # Use psql directly if SUPABASE_DB_URL is provided
           if [ -n "$SUPABASE_DB_URL" ]; then
             echo "Using direct PostgreSQL connection..."
@@ -127,7 +139,7 @@ jobs:
         run: |
           echo "Verifying migrations..."
           export PGPASSWORD="$SUPABASE_DB_PASSWORD"
-          
+
           # Check if key tables exist
           psql "$SUPABASE_DB_URL" -c "
             SELECT 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,8 +17,20 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+
       - name: Install Dependencies
-        run: cd packages/web && npm install # Assuming npm, adjust if pnpm/yarn detected
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: cd packages/web && npm run lint

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, develop]
   schedule:
     # Run daily security scans at 2 AM UTC
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
 
 jobs:
   # SAST - Static Application Security Testing
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Run Semgrep SAST
         uses: returntocorp/semgrep-action@v1
         with:
@@ -27,7 +27,7 @@ jobs:
             p/typescript
           generateSarif: "1"
         continue-on-error: true
-      
+
       - name: Upload SARIF results
         uses: github/codeql-action/upload-sarif@v2
         if: always()
@@ -43,18 +43,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run npm audit
         run: |
           npm audit --audit-level=moderate --json > npm-audit.json || true
           npm audit --audit-level=moderate
         continue-on-error: true
-      
+
       - name: Run Snyk security scan
         uses: snyk/actions/node@master
         env:
@@ -62,7 +62,7 @@ jobs:
         with:
           args: --severity-threshold=high --json-file-output=snyk-results.json
         continue-on-error: true
-      
+
       - name: Upload Snyk results
         uses: actions/upload-artifact@v3
         if: always()
@@ -70,7 +70,7 @@ jobs:
           name: snyk-results
           path: snyk-results.json
         continue-on-error: true
-      
+
       - name: Check for critical vulnerabilities
         run: |
           if [ -f snyk-results.json ]; then
@@ -89,14 +89,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Full history for better detection
-      
+          fetch-depth: 0 # Full history for better detection
+
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
-      
+
       - name: Run TruffleHog
         uses: trufflesecurity/trufflehog@main
         with:
@@ -112,22 +112,22 @@ jobs:
     if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Build Docker image
         run: |
           if [ -f Dockerfile ]; then
             docker build -t settler-api:test -f Dockerfile .
           fi
         continue-on-error: true
-      
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: settler-api:test
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          format: "sarif"
+          output: "trivy-results.sarif"
         continue-on-error: true
-      
+
       - name: Upload Trivy results
         uses: github/codeql-action/upload-sarif@v2
         if: always()
@@ -143,18 +143,30 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+
       - name: Install dependencies
-        run: npm ci
-      
+        run: pnpm install --frozen-lockfile
+
       - name: Run license-checker
         run: |
-          npm install -g license-checker
+          pnpm add -g license-checker
           license-checker --json > license-report.json || true
         continue-on-error: true
-      
+
       - name: Check for problematic licenses
         run: |
           if [ -f license-report.json ]; then
@@ -173,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Check security headers
         run: |
           # Verify security headers are configured
@@ -189,7 +201,7 @@ jobs:
             echo "✅ Security headers configured"
           fi
         continue-on-error: true
-      
+
       - name: Check for hardcoded secrets
         run: |
           # Check for common secret patterns
@@ -211,7 +223,7 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Generate security summary
         run: |
           echo "# Security Scan Report" > security-report.md
@@ -226,7 +238,7 @@ jobs:
           echo "- Container Scan: ${{ needs.container-scan.result }}" >> security-report.md
           echo "- License Scan: ${{ needs.license-scan.result }}" >> security-report.md
           echo "- Security Policy: ${{ needs.security-policy.result }}" >> security-report.md
-      
+
       - name: Upload security report
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
### Motivation
- Align CI with repository `packageManager` by switching CI workflows from `npm` installs to `pnpm` to preserve lockfile parity and deterministic installs. 
- Speed up CI and reduce network usage by caching the pnpm store directories across jobs. 
- Ensure CI uses the pinned `pnpm` version declared in the repo via Corepack so global tools and installs are reproducible.

### Description
- Replaced `npm ci` / `npm install` calls with `pnpm install --frozen-lockfile` in CI jobs and added `corepack prepare pnpm@10.13.1 --activate` to pin `pnpm` in CI. 
- Added pnpm store caching (`~/.pnpm-store` and `~/.local/share/pnpm/store`) using `actions/cache@v4` and a keyed restore tied to `pnpm-lock.yaml`. 
- Converted global tool installs from `npm install -g` to `pnpm add -g` for tools used in workflows (examples: `tsx`, `supabase`, `license-checker`). 
- Updated the following workflow files: `.github/workflows/ci.yml`, `.github/workflows/quality.yml`, `.github/workflows/auto-sync-oss.yml`, `.github/workflows/migrations.yml`, and `.github/workflows/security-scan.yml` to include `pnpm` setup, caching, and the `pnpm install --frozen-lockfile` step.

### Testing
- Ran `npm run validate:eslint-config` and it completed successfully. 
- Ran `npm run validate:build-safety` and it completed successfully. 
- Ran `npm run validate:lint-config` and `npm run typecheck` and both succeeded (typecheck ran via Turbo across workspace packages).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69795a9baebc832887074ddfd0191c35)