### PR TITLE
chore(ci): enable Turbo remote caching and switch CI builds to `npx turbo run build`

### DIFF
--- a/.github/workflows/ci-cd-enhanced.yml
+++ b/.github/workflows/ci-cd-enhanced.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   type-check:
     runs-on: ubuntu-latest
@@ -13,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - run: npm ci
       - run: npm run type-check
         name: TypeScript Type Checking
@@ -24,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - run: npm ci
       - run: npm audit --audit-level=moderate
         name: Security Audit
@@ -39,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - run: npm ci
       - run: npm run lint
         name: ESLint
@@ -50,9 +54,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - run: npm ci
-      - run: npm run build
+      - run: npx turbo run build
         name: Build
       - run: npm run analyze
         name: Bundle Size Analysis
@@ -67,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - run: npm ci
       - run: npm test
         name: Run Tests
@@ -80,9 +84,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - run: npm ci
-      - run: npm run build
+      - run: npx turbo run build
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v25
         with:

--- a/.github/workflows/ci-with-migrations.yml
+++ b/.github/workflows/ci-with-migrations.yml
@@ -6,15 +6,19 @@ on:
       - main
       - develop
     paths:
-      - 'supabase/migrations/**'
-      - 'packages/web/**'
-      - '.github/workflows/**'
+      - "supabase/migrations/**"
+      - "packages/web/**"
+      - ".github/workflows/**"
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   validate-migrations:
     name: Validate Migrations
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -32,7 +36,7 @@ jobs:
         run: |
           echo "Validating migration syntax (non-blocking)..."
           export PGPASSWORD="$SUPABASE_DB_PASSWORD"
-          
+
           for migration in supabase/migrations/*.sql; do
             if [ -f "$migration" ]; then
               echo "Checking: $(basename $migration)"
@@ -48,7 +52,7 @@ jobs:
   typecheck:
     name: TypeScript Type Check
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,8 +60,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: |
@@ -72,7 +76,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -80,8 +84,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: |
@@ -96,7 +100,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -104,8 +108,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: |
@@ -115,4 +119,4 @@ jobs:
       - name: Build
         run: |
           cd packages/web
-          npm run build
+          npx turbo run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,31 +9,35 @@ on:
 # Only run checks when relevant files change
 # Skip for documentation-only changes, license, etc.
 paths:
-  - 'packages/**'
-  - 'config/**'
-  - 'scripts/**'
-  - 'tests/**'
-  - 'ops/**'
-  - '.github/workflows/**'
-  - '*.json'
-  - '*.js'
-  - '*.ts'
-  - '*.yml'
-  - '*.yaml'
-  - 'tsconfig.json'
-  - '.eslintrc.js'
-  - '.prettierignore'
-  - '.gitignore'
-  - 'vercel.json'
+  - "packages/**"
+  - "config/**"
+  - "scripts/**"
+  - "tests/**"
+  - "ops/**"
+  - ".github/workflows/**"
+  - "*.json"
+  - "*.js"
+  - "*.ts"
+  - "*.yml"
+  - "*.yaml"
+  - "tsconfig.json"
+  - ".eslintrc.js"
+  - ".prettierignore"
+  - ".gitignore"
+  - "vercel.json"
 paths-ignore:
-  - '**/*.md'
-  - 'LICENSE'
-  - 'docs/**'
-  - 'business/**'
-  - 'marketing/**'
-  - 'strategic/**'
-  - 'grafana-dashboards/**'
-  - 'sre/**'
+  - "**/*.md"
+  - "LICENSE"
+  - "docs/**"
+  - "business/**"
+  - "marketing/**"
+  - "strategic/**"
+  - "grafana-dashboards/**"
+  - "sre/**"
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   validate-env:
@@ -43,8 +47,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Validate environment variable schema
         run: |
@@ -73,8 +77,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Run comprehensive repository integrity check
         run: npm run repo-integrity
@@ -90,8 +94,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Validate ESLint config dependencies
         run: npm run validate:eslint-config
@@ -114,8 +118,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Run Settler Doctor
         run: npm run doctor
@@ -186,8 +190,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Run database migrations
         run: |
@@ -228,8 +232,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Run npm audit
         run: |
@@ -268,8 +272,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Generate route registry
         run: npm run qa:routes
@@ -296,15 +300,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Verify backend contract (schema-only mode)
         run: |
           echo "🔍 Running backend contract verification..."
           echo "Note: This runs in schema-only mode without live DB connection"
           echo "For full verification, run locally with SUPABASE_SERVICE_ROLE_KEY set"
-          
+
           # Check if verification script exists and is valid TypeScript
           if [ -f "scripts/verify-backend-contract.ts" ]; then
             echo "✅ Verification script found"
@@ -314,7 +318,7 @@ jobs:
             echo "❌ Verification script not found"
             exit 1
           fi
-          
+
           # Check if smoke test script exists
           if [ -f "scripts/smoke-test-backend.ts" ]; then
             echo "✅ Smoke test script found"
@@ -323,7 +327,7 @@ jobs:
             echo "❌ Smoke test script not found"
             exit 1
           fi
-          
+
           # Check if RLS test script exists
           if [ -f "scripts/test-rls-policies.ts" ]; then
             echo "✅ RLS test script found"
@@ -332,7 +336,7 @@ jobs:
             echo "❌ RLS test script not found"
             exit 1
           fi
-          
+
           echo "✅ All backend verification scripts are present and valid"
         continue-on-error: true
       - name: Verify healthcheck endpoint exists
@@ -358,19 +362,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
       - run: npm ci
       - name: Build application
-        run: npm run build --workspace=packages/web
+        run: npx turbo run build --filter @settler/web...
         env:
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
           NEXT_PUBLIC_SUPABASE_URL: https://dummy.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-key
           SKIP_ENV_VALIDATION: true
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
       - name: Start production server
         run: |
           cd packages/web
@@ -379,7 +383,7 @@ jobs:
         env:
           PORT: 3000
           NODE_ENV: production
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
         continue-on-error: true
       - name: Run reality gates tests
         run: npx playwright test tests/e2e/reality-gates.spec.ts
@@ -401,22 +405,22 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
       - run: npm ci
       - name: Build application
-        run: npm run build --workspace=packages/web
+        run: npx turbo run build --filter @settler/web...
         env:
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
           NEXT_PUBLIC_SUPABASE_URL: https://dummy.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-key
           SKIP_ENV_VALIDATION: true
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
       - name: Start production server
         run: |
           cd packages/web
@@ -425,7 +429,7 @@ jobs:
         env:
           PORT: 3000
           NODE_ENV: production
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
         continue-on-error: true
       - name: Run smoke tests
         run: npm run qa:smoke
@@ -453,19 +457,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
       - run: npm ci
       - name: Build application
-        run: npm run build --workspace=packages/web
+        run: npx turbo run build --filter @settler/web...
         env:
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
           NEXT_PUBLIC_SUPABASE_URL: https://dummy.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-key
           SKIP_ENV_VALIDATION: true
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
       - name: Start production server
         run: |
           cd packages/web
@@ -474,7 +478,7 @@ jobs:
         env:
           PORT: 3000
           NODE_ENV: production
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
         continue-on-error: true
       - name: Run visual regression tests
         run: npm run qa:visual
@@ -496,19 +500,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
       - run: npm ci
       - name: Build application
-        run: npm run build --workspace=packages/web
+        run: npx turbo run build --filter @settler/web...
         env:
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
           NEXT_PUBLIC_SUPABASE_URL: https://dummy.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-key
           SKIP_ENV_VALIDATION: true
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
       - name: Start production server
         run: |
           cd packages/web
@@ -517,7 +521,7 @@ jobs:
         env:
           PORT: 3000
           NODE_ENV: production
-          SAFE_MODE: '1'
+          SAFE_MODE: "1"
         continue-on-error: true
       - name: Run accessibility tests
         run: npm run qa:a11y
@@ -539,10 +543,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
-      - run: npm run build
+      - run: npx turbo run build
       - name: Check build artifacts
         run: |
           test -d packages/api/dist || (echo "❌ packages/api/dist not found" && exit 1)
@@ -559,8 +563,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Run canonical production check
         run: npm run check:production
@@ -577,8 +581,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Run smoke tests
         run: npm run test:smoke
@@ -590,7 +594,7 @@ jobs:
 
   # Note: E2E tests moved to separate workflow (e2e.yml) for faster CI feedback
   # E2E tests run in parallel and don't block the main CI pipeline
-  
+
   # Classification check runs in separate workflow (classify.yml) for parallel execution
   # Full smoke tests against live deployment run in separate workflow (smoke.yml)
 
@@ -626,8 +630,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
       - run: npm ci
       - name: Run database migrations
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'packages/**'
-      - 'config/**'
-      - 'scripts/**'
-      - '.github/workflows/deploy-preview.yml'
+      - "packages/**"
+      - "config/**"
+      - "scripts/**"
+      - ".github/workflows/deploy-preview.yml"
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   deploy-preview:
@@ -17,11 +21,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm ci
       - name: Build application
-        run: npm run build
+        run: npx turbo run build
       - name: Verify build artifacts
         run: |
           test -d packages/api/dist || (echo "❌ API dist missing" && exit 1)
@@ -33,7 +37,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--yes'
+          vercel-args: "--yes"
           working-directory: ./packages/web
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PREVIEW || secrets.DATABASE_URL }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,25 +7,27 @@ on:
     branches:
       - main
     paths:
-      - 'packages/**'
-      - 'config/**'
-      - 'scripts/**'
-      - '.github/workflows/deploy-production.yml'
+      - "packages/**"
+      - "config/**"
+      - "scripts/**"
+      - ".github/workflows/deploy-production.yml"
   workflow_dispatch:
     inputs:
       skip_tests:
-        description: 'Skip tests (use with caution)'
+        description: "Skip tests (use with caution)"
         required: false
         default: false
         type: boolean
       skip_migrations:
-        description: 'Skip migrations (migrations handled by migration-guardian)'
+        description: "Skip migrations (migrations handled by migration-guardian)"
         required: false
         default: true
         type: boolean
 
 env:
   NODE_ENV: production
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   validate:
@@ -35,8 +37,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm ci
       - name: Validate environment schema
         run: npx --yes tsx --check config/env.schema.ts
@@ -56,8 +58,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm ci
       - name: Run tests
         run: npm run test -- --coverage
@@ -83,11 +85,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm ci
       - name: Build all packages
-        run: npm run build
+        run: npx turbo run build
       - name: Verify build artifacts
         run: |
           test -d packages/api/dist || (echo "❌ API dist missing" && exit 1)
@@ -111,8 +113,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,17 +9,21 @@ on:
 
 # Only run when relevant files change
 paths:
-  - 'packages/**'
-  - 'tests/**'
-  - 'playwright.config.ts'
-  - '.github/workflows/e2e.yml'
+  - "packages/**"
+  - "tests/**"
+  - "playwright.config.ts"
+  - ".github/workflows/e2e.yml"
 paths-ignore:
-  - '**/*.md'
-  - 'LICENSE'
-  - 'docs/**'
-  - 'business/**'
-  - 'marketing/**'
-  - 'strategic/**'
+  - "**/*.md"
+  - "LICENSE"
+  - "docs/**"
+  - "business/**"
+  - "marketing/**"
+  - "strategic/**"
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   e2e:
@@ -51,21 +55,21 @@ jobs:
           - 6379:6379
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
-      
+
       - name: Build application
-        run: npm run build
-      
+        run: npx turbo run build
+
       - name: Run database migrations
         run: |
           cd packages/api
@@ -76,7 +80,7 @@ jobs:
           JWT_SECRET: test-secret-min-32-chars-long-for-testing
           ENCRYPTION_KEY: test-encryption-key-32-chars-long!!
         continue-on-error: true
-      
+
       - name: Seed test data
         run: |
           # Seed test data for E2E tests
@@ -86,7 +90,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/settler_test
           NODE_ENV: test
         continue-on-error: true
-      
+
       - name: Start API server
         run: |
           cd packages/api
@@ -102,13 +106,13 @@ jobs:
           REDIS_URL: redis://localhost:6379
           JWT_SECRET: test-secret-min-32-chars-long-for-testing
           ENCRYPTION_KEY: test-encryption-key-32-chars-long!!
-      
+
       - name: Run E2E tests
         run: npm run test:e2e
         env:
           E2E_API_KEY: test-api-key
           E2E_BASE_URL: http://localhost:3000
-      
+
       - name: Upload E2E test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -150,21 +154,21 @@ jobs:
           - 6379:6379
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
-      
+
       - name: Build application
-        run: npm run build
-      
+        run: npx turbo run build
+
       - name: Run database migrations
         run: |
           cd packages/api
@@ -175,7 +179,7 @@ jobs:
           JWT_SECRET: test-secret-min-32-chars-long-for-testing
           ENCRYPTION_KEY: test-encryption-key-32-chars-long!!
         continue-on-error: true
-      
+
       - name: Seed test data
         run: |
           cd packages/api
@@ -184,7 +188,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/settler_test
           NODE_ENV: test
         continue-on-error: true
-      
+
       - name: Start API server
         run: |
           cd packages/api
@@ -200,12 +204,12 @@ jobs:
           REDIS_URL: redis://localhost:6379
           JWT_SECRET: test-secret-min-32-chars-long-for-testing
           ENCRYPTION_KEY: test-encryption-key-32-chars-long!!
-      
+
       - name: Start web server (if web package exists)
         run: |
           if [ -d "packages/web" ]; then
             cd packages/web
-            npm run build
+            npx turbo run build --filter @settler/web...
             npm start &
             echo "Waiting for web server to start..."
             sleep 15
@@ -217,7 +221,7 @@ jobs:
         env:
           NODE_ENV: test
           PORT: 3001
-      
+
       - name: Run visual regression tests
         run: npm run test:visual || echo "⚠️  Visual tests not configured yet"
         continue-on-error: true
@@ -225,7 +229,7 @@ jobs:
           E2E_API_KEY: test-api-key
           E2E_BASE_URL: http://localhost:3000
           WEB_BASE_URL: http://localhost:3001
-      
+
       - name: Upload visual test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/migration-guardian.yml
+++ b/.github/workflows/migration-guardian.yml
@@ -3,19 +3,19 @@ name: Migration Guardian
 on:
   schedule:
     # Run every hour to check for pending migrations
-    - cron: '0 * * * *'
+    - cron: "0 * * * *"
   workflow_dispatch: # Allow manual trigger
     inputs:
       environment:
-        description: 'Environment to migrate'
+        description: "Environment to migrate"
         required: false
-        default: 'staging'
+        default: "staging"
         type: choice
         options:
           - staging
           - production
       force:
-        description: 'Force migration even if checks fail'
+        description: "Force migration even if checks fail"
         required: false
         default: false
         type: boolean
@@ -23,10 +23,10 @@ on:
     branches:
       - main
     paths:
-      - 'prisma/migrations/**'
-      - 'prisma/schema.prisma'
-      - 'supabase/migrations/**'
-      - 'scripts/migration-guardian.ts'
+      - "prisma/migrations/**"
+      - "prisma/schema.prisma"
+      - "supabase/migrations/**"
+      - "scripts/migration-guardian.ts"
   pull_request:
     types: [closed]
     branches:
@@ -39,6 +39,8 @@ env:
   SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
   UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
   UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   detect-migrations:
@@ -58,11 +60,11 @@ jobs:
         id: check
         run: |
           echo "🔍 Detecting migration changes..."
-          
+
           # Determine migration type and files
           MIGRATION_TYPE="none"
           MIGRATION_FILES=""
-          
+
           # Check for Prisma migrations
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_SHA="${{ github.event.pull_request.base.sha }}"
@@ -73,14 +75,14 @@ jobs:
             PRISMA_MIGRATIONS=$(git diff --name-only HEAD~1 HEAD | grep -E "prisma/migrations/.*\.sql$" || true)
             SCHEMA_CHANGES=$(git diff --name-only HEAD~1 HEAD | grep "prisma/schema.prisma" || true)
           fi
-          
+
           # Check for Supabase migrations
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             SUPABASE_MIGRATIONS=$(git diff --name-only $BASE_SHA $HEAD_SHA | grep -E "supabase/migrations/.*\.sql$" || true)
           else
             SUPABASE_MIGRATIONS=$(git diff --name-only HEAD~1 HEAD | grep -E "supabase/migrations/.*\.sql$" || true)
           fi
-          
+
           if [ -n "$PRISMA_MIGRATIONS" ] || [ -n "$SCHEMA_CHANGES" ]; then
             MIGRATION_TYPE="prisma"
             MIGRATION_FILES="$PRISMA_MIGRATIONS"
@@ -122,8 +124,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -208,31 +210,31 @@ jobs:
             } catch (error) {
               logContent = 'Migration log not available';
             }
-            
+
             const title = `🚨 Migration Guardian Failed - ${new Date().toISOString()}`;
             const body = `## Migration Guardian Failure
-            
+
             **Workflow Run:** [View Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
             **Commit:** \`${{ github.sha }}\`
             **Branch:** \`${{ github.ref }}\`
-            
+
             ### Migration Log
             <details>
             <summary>View Full Log</summary>
-            
+
             \`\`\`
             ${logContent.substring(0, 10000)}
             \`\`\`
-            
+
             </details>
-            
+
             ### Next Steps
             1. Review the migration log above
             2. Check database connectivity
             3. Verify Prisma migrations are valid
             4. Re-run the workflow once issues are resolved
             `;
-            
+
             github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -261,11 +263,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm ci
       - name: Build application
-        run: npm run build
+        run: npx turbo run build
       - name: Apply staging migrations
         env:
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
@@ -304,11 +306,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm ci
       - name: Build application
-        run: npm run build
+        run: npx turbo run build
       - name: Apply production migrations
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/operator-mode-daily.yml
+++ b/.github/workflows/operator-mode-daily.yml
@@ -3,24 +3,28 @@ name: Operator Mode Daily Job
 on:
   schedule:
     # Run daily at 2 AM UTC
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to run job in'
+        description: "Environment to run job in"
         required: true
-        default: 'production'
+        default: "production"
         type: choice
         options:
           - production
           - staging
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   operator-mode-daily:
     name: Operator Mode Daily Job
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || 'production' }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,8 +32,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -37,7 +41,7 @@ jobs:
       - name: Build API package
         run: |
           cd packages/api
-          npm run build
+          npx turbo run build
 
       - name: Run Operator Mode Daily Job
         env:

--- a/.github/workflows/operator-mode-setup-alerts.yml
+++ b/.github/workflows/operator-mode-setup-alerts.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to setup alerts in'
+        description: "Environment to setup alerts in"
         required: true
-        default: 'production'
+        default: "production"
         type: choice
         options:
           - production
@@ -15,15 +15,19 @@ on:
     branches:
       - main
     paths:
-      - 'scripts/setup-operator-mode-alerts.ts'
-      - '.github/workflows/operator-mode-setup-alerts.yml'
+      - "scripts/setup-operator-mode-alerts.ts"
+      - ".github/workflows/operator-mode-setup-alerts.yml"
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   setup-alerts:
     name: Setup Default Alert Rules
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || 'production' }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,8 +35,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -40,7 +44,7 @@ jobs:
       - name: Build API package
         run: |
           cd packages/api
-          npm run build
+          npx turbo run build
 
       - name: Setup Default Alert Rules
         env:

--- a/.github/workflows/operator-mode-verification.yml
+++ b/.github/workflows/operator-mode-verification.yml
@@ -4,32 +4,36 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to run tests in'
+        description: "Environment to run tests in"
         required: true
-        default: 'staging'
+        default: "staging"
         type: choice
         options:
           - production
           - staging
   pull_request:
     paths:
-      - 'packages/api/src/services/operator-mode/**'
-      - 'packages/api/src/__tests__/operator-mode-verification.ts'
-      - '.github/workflows/operator-mode-verification.yml'
+      - "packages/api/src/services/operator-mode/**"
+      - "packages/api/src/__tests__/operator-mode-verification.ts"
+      - ".github/workflows/operator-mode-verification.yml"
   push:
     branches:
       - main
     paths:
-      - 'packages/api/src/services/operator-mode/**'
-      - 'packages/api/src/__tests__/operator-mode-verification.ts'
-      - '.github/workflows/operator-mode-verification.yml'
+      - "packages/api/src/services/operator-mode/**"
+      - "packages/api/src/__tests__/operator-mode-verification.ts"
+      - ".github/workflows/operator-mode-verification.yml"
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   verify-operator-mode:
     name: Verify Operator Mode
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || 'staging' }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -37,8 +41,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -51,7 +55,7 @@ jobs:
       - name: Build API package
         run: |
           cd packages/api
-          npm run build
+          npx turbo run build
 
       - name: Run Operator Mode Verification Tests
         env:

--- a/.github/workflows/production-migrations.yml
+++ b/.github/workflows/production-migrations.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch: # Allow manual trigger
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   run-production-migrations:
     name: Run Production Migrations
@@ -19,11 +23,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm ci
       - name: Build application
-        run: npm run build
+        run: npx turbo run build
       - name: Run production migrations
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,7 +28,7 @@ jobs:
         run: cd packages/web && npm run lint
 
       - name: Typecheck
-        run: cd packages/web && npm run type-check || npx turbo run build --filter @settler/web... -- --no-lint # build often includes typecheck
+        run: cd packages/web && npm run typecheck
 
       - name: Security Audit
         run: npm audit --audit-level=high

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   quality:
     runs-on: ubuntu-latest
@@ -24,7 +28,7 @@ jobs:
         run: cd packages/web && npm run lint
 
       - name: Typecheck
-        run: cd packages/web && npm run type-check || npm run build -- --no-lint # build often includes typecheck
+        run: cd packages/web && npm run type-check || npx turbo run build --filter @settler/web... -- --no-lint # build often includes typecheck
 
       - name: Security Audit
         run: npm audit --audit-level=high

--- a/.github/workflows/receipt-console-ci.yml
+++ b/.github/workflows/receipt-console-ci.yml
@@ -4,32 +4,34 @@ on:
   push:
     branches: [main, develop]
     paths:
-      - 'packages/web/src/app/api/v1/receipts/**'
-      - 'packages/web/src/app/api/console/receipts/**'
-      - 'packages/web/src/app/console/receipts/**'
-      - 'packages/web/src/domain/console/receipts.ts'
-      - 'packages/web/src/domain/receipts/**'
-      - 'supabase/migrations/**receipt*'
-      - '.github/workflows/receipt-console-ci.yml'
+      - "packages/web/src/app/api/v1/receipts/**"
+      - "packages/web/src/app/api/console/receipts/**"
+      - "packages/web/src/app/console/receipts/**"
+      - "packages/web/src/domain/console/receipts.ts"
+      - "packages/web/src/domain/receipts/**"
+      - "supabase/migrations/**receipt*"
+      - ".github/workflows/receipt-console-ci.yml"
   pull_request:
     branches: [main, develop]
     paths:
-      - 'packages/web/src/app/api/v1/receipts/**'
-      - 'packages/web/src/app/api/console/receipts/**'
-      - 'packages/web/src/app/console/receipts/**'
-      - 'packages/web/src/domain/console/receipts.ts'
-      - 'packages/web/src/domain/receipts/**'
-      - 'supabase/migrations/**receipt*'
-      - '.github/workflows/receipt-console-ci.yml'
+      - "packages/web/src/app/api/v1/receipts/**"
+      - "packages/web/src/app/api/console/receipts/**"
+      - "packages/web/src/app/console/receipts/**"
+      - "packages/web/src/domain/console/receipts.ts"
+      - "packages/web/src/domain/receipts/**"
+      - "supabase/migrations/**receipt*"
+      - ".github/workflows/receipt-console-ci.yml"
 
 env:
-  NODE_VERSION: '24'
+  NODE_VERSION: "24"
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
   SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
   SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
   NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
   NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   typecheck:
@@ -37,16 +39,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run typecheck
         run: npm run typecheck
         env:
@@ -57,16 +59,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run lint
         run: npm run lint
 
@@ -75,16 +77,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run receipt smoke test
         run: npx tsx scripts/smoke-receipts.ts
         env:
@@ -97,19 +99,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
-      
+
       - name: Run E2E tests
         run: npm run test:e2e -- tests/e2e/receipt-console.spec.ts
         env:
@@ -120,7 +122,7 @@ jobs:
           E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
           E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
           E2E_TEST_API_KEY: ${{ secrets.E2E_TEST_API_KEY }}
-      
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -134,16 +136,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Verify Supabase migrations
         run: npm run db:verify
         env:
@@ -157,23 +159,23 @@ jobs:
     needs: [typecheck, lint]
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Generate Prisma client
         run: npm run prisma:generate
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      
+
       - name: Build packages
-        run: npm run build
+        run: npx turbo run build
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -188,16 +190,16 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Deploy Supabase migrations
         run: npm run db:push
         env:

--- a/.github/workflows/receipt-console-deploy.yml
+++ b/.github/workflows/receipt-console-deploy.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Deployment environment'
+        description: "Deployment environment"
         required: true
-        default: 'staging'
+        default: "staging"
         type: choice
         options:
           - staging
@@ -14,15 +14,15 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/web/src/app/api/v1/receipts/**'
-      - 'packages/web/src/app/api/console/receipts/**'
-      - 'packages/web/src/app/console/receipts/**'
-      - 'packages/web/src/domain/console/receipts.ts'
-      - 'packages/web/src/domain/receipts/**'
-      - 'supabase/migrations/**receipt*'
+      - "packages/web/src/app/api/v1/receipts/**"
+      - "packages/web/src/app/api/console/receipts/**"
+      - "packages/web/src/app/console/receipts/**"
+      - "packages/web/src/domain/console/receipts.ts"
+      - "packages/web/src/domain/receipts/**"
+      - "supabase/migrations/**receipt*"
 
 env:
-  NODE_VERSION: '24'
+  NODE_VERSION: "24"
   # Database password injected from GitHub secrets
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   # Supabase credentials from secrets
@@ -31,37 +31,39 @@ env:
   SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
   NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
   NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   deploy:
     name: Deploy Receipt Console
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || 'staging' }}
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Generate Prisma client
         run: npm run prisma:generate
         env:
           # Database password auto-injected from GitHub secrets
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      
+
       - name: Verify database connection
         run: npm run db:check
         env:
           # Database password auto-injected from GitHub secrets
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      
+
       - name: Run database migrations
         run: npm run db:migrate:prod
         env:
@@ -71,7 +73,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-      
+
       - name: Verify receipt tables exist
         run: |
           npx tsx -e "
@@ -93,9 +95,9 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-      
+
       - name: Build application
-        run: npm run build
+        run: npx turbo run build
         env:
           # Database password auto-injected from GitHub secrets
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
@@ -103,7 +105,7 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-      
+
       - name: Run smoke tests
         run: npx tsx scripts/smoke-receipts.ts
         env:
@@ -111,7 +113,7 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-      
+
       - name: Deploy to Vercel (if configured)
         if: env.VERCEL_TOKEN != ''
         uses: amondnet/vercel-action@v25
@@ -119,7 +121,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prod'
+          vercel-args: "--prod"
         env:
           # Database password auto-injected from GitHub secrets
           DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,17 @@ on:
   push:
     branches: [main]
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 1.2.3)'
+        description: "Version to release (e.g., 1.2.3)"
         required: true
         type: string
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   release:
@@ -21,40 +25,40 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run doctor
         run: npm run doctor
-      
+
       - name: Run tests
         run: npm test
-      
+
       - name: Run build
-        run: npm run build
-      
+        run: npx turbo run build
+
       - name: Generate changelog
         id: changelog
         run: |
           TAG=${GITHUB_REF#refs/tags/}
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          
+
           if [ -z "$PREVIOUS_TAG" ]; then
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" $TAG)
           else
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" $PREVIOUS_TAG..$TAG)
           fi
-          
+
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      
+
       - name: Create Release
         uses: actions/create-release@v1
         env:
@@ -64,17 +68,17 @@ jobs:
           release_name: Release ${{ github.ref }}
           body: |
             ## Changes
-            
+
             ${{ steps.changelog.outputs.changelog }}
-            
+
             ## Verification
-            
+
             - ✅ All tests passed
             - ✅ Build successful
             - ✅ Doctor checks passed
           draft: false
           prerelease: false
-      
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -92,22 +96,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      
+
       - name: Bump version
         run: |
           VERSION=${{ github.event.inputs.version }}
           npm version $VERSION --no-git-tag-version
-          
+
           # Update CHANGELOG.md
           echo "# Changelog" > CHANGELOG.md
           echo "" >> CHANGELOG.md
@@ -115,7 +119,7 @@ jobs:
           echo "" >> CHANGELOG.md
           echo "### Changed" >> CHANGELOG.md
           echo "- Version bump to $VERSION" >> CHANGELOG.md
-      
+
       - name: Commit and tag
         run: |
           git add package.json CHANGELOG.md

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,6 +8,10 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   smoke:
     name: Smoke Tests
@@ -16,11 +20,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm ci
       - name: Build application
-        run: npm run build
+        run: npx turbo run build
         env:
           # Use dummy values for build (smoke tests will use actual deployment URL)
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
@@ -40,7 +44,7 @@ jobs:
           # Try to get preview URL from Vercel deployment comment
           # This is a best-effort attempt
           PREVIEW_URL=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.author.login == "vercel[bot]") | .body' | grep -oP 'https://[^/]+-.*\.vercel\.app' | head -1 || echo "")
-          
+
           if [ -n "$PREVIEW_URL" ]; then
             echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
             echo "✅ Found Vercel preview URL: $PREVIEW_URL"
@@ -51,14 +55,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
-      
+
       - name: Run smoke tests against preview
         if: github.event_name == 'pull_request' && steps.vercel-preview.outputs.preview_url != ''
         run: npm run qa:smoke
         env:
           BASE_URL: ${{ steps.vercel-preview.outputs.preview_url }}
         continue-on-error: true
-      
+
       - name: Skip smoke tests (no preview URL)
         if: github.event_name == 'pull_request' && steps.vercel-preview.outputs.preview_url == ''
         run: |

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -16,8 +20,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -38,7 +42,7 @@ jobs:
         run: npm run typecheck
 
       - name: Build
-        run: npm run build
+        run: npx turbo run build
 
       - name: Test
         run: npm test -- --passWithNoTests

--- a/turbo.json
+++ b/turbo.json
@@ -176,13 +176,11 @@
     },
     "lint": {
       "outputs": [],
-      "env": [
-        "NODE_ENV"
-      ]
+      "env": ["NODE_ENV"]
     },
     "typecheck": {
       "dependsOn": ["^build"],
-      "outputs": [".next/tsconfig.tsbuildinfo", "tsconfig.tsbuildinfo"],
+      "outputs": [],
       "cache": true,
       "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig.json", "package.json"],
       "env": [


### PR DESCRIPTION
### Motivation

- Enable Turbo remote caching in CI by provisioning `TURBO_TOKEN` and `TURBO_TEAM` so CI can reuse cached task outputs and speed up builds. 
- Ensure CI build steps consistently invoke Turbo rather than package-level `npm` build scripts to take advantage of monorepo-aware caching and correct task graph scheduling. 
- Fix Turbo cache noise by aligning the `typecheck` task `outputs` with what the packages actually emit so Turbo stops warning about missing outputs.

### Description

- Added `TURBO_TOKEN` and `TURBO_TEAM` environment variables to CI workflows (multiple files under `.github/workflows/`) so Turbo remote caching can authenticate and attribute cache entries. 
- Replaced `npm run build` / workspace-specific `npm run build` invocations with `npx turbo run build` (and `--filter @settler/web...` where appropriate) across CI workflows to use Turbo's task runner and remote cache. 
- Updated `turbo.json` `typecheck` task to use an empty `outputs` array to reflect that these steps do not produce persistent files for caching and to remove Turbo missing-output warnings. 
- Minor CI workflow formatting/consistency updates (consistent quoting, Node version formatting) for readability and stability.

### Testing

- Ran `pnpm install` to validate dependency installation (succeeded). 
- Ran `pnpm lint` to validate linting across packages (succeeded). 
- Ran `pnpm typecheck` (Turbo typecheck pipeline executed, succeeded). 
- Ran `pnpm test` (executed the monorepo test pipeline via Turbo; observed failing API tests and a web build type error in `NewExperimentForm.tsx`, so test run reported failures). 
- Ran `pnpm build` (invoked Turbo build; web build failed due to an existing TypeScript error in `packages/web`, so build is failing and CI will remain red until those pre-existing issues are fixed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69795a9671748328be170acff8d9fd17)