### PR TITLE
fix: decouple typecheck from build in turbo task graph

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -176,12 +176,9 @@
     },
     "lint": {
       "outputs": [],
-      "env": [
-        "NODE_ENV"
-      ]
+      "env": ["NODE_ENV"]
     },
     "typecheck": {
-      "dependsOn": ["^build"],
       "outputs": [".next/tsconfig.tsbuildinfo", "tsconfig.tsbuildinfo"],
       "cache": true,
       "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig.json", "package.json"],


### PR DESCRIPTION
### Motivation
- Prevent `turbo run typecheck` from triggering package `build` tasks so typechecking can run faster and without side-effects in CI and local workflows.

### Description
- Removed the `dependsOn: ["^build"]` entry from the `typecheck` task in `turbo.json`, making `typecheck` independent of `build`.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran `npm run typecheck` which executed `tsc --noEmit` in most packages but overall failed due to `@settler/cli` type errors (missing `@settler/sdk` types and implicit `any` issues).
- Ran `npm run test` which executed package tests; several API integration tests failed (health/route validation and Jest teardown issues).
- Ran `npm run build` which attempted package builds and failed due to a TypeScript error in `@settler/web` (`NewExperimentForm.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69795a997850832886e36acd96bcc989)