### PR TITLE
fix(web): await trace id in workspace APIs

### DIFF
--- a/packages/web/src/app/api/invite/[token]/route.ts
+++ b/packages/web/src/app/api/invite/[token]/route.ts
@@ -24,7 +24,7 @@ export const GET = withSecurity(
   request: NextRequest,
   { params }: { params: { token: string } }
 ) {
-  const traceId = getTraceId(request);
+  const traceId = await getTraceId(request);
   
   try {
     const invite = await prisma.workspaceInvite.findUnique({
@@ -95,7 +95,7 @@ export const POST = withSecurity(
   request: NextRequest,
   { params }: { params: { token: string } }
 ) {
-  const traceId = getTraceId(request);
+  const traceId = await getTraceId(request);
   
   try {
     const supabase = await createClient();

--- a/packages/web/src/app/api/workspaces/[workspaceId]/invites/route.ts
+++ b/packages/web/src/app/api/workspaces/[workspaceId]/invites/route.ts
@@ -31,7 +31,7 @@ export const POST = withSecurity(
   request: NextRequest,
   { params }: { params: { workspaceId: string } }
 ) {
-  const traceId = getTraceId(request);
+  const traceId = await getTraceId(request);
   
   try {
     const supabase = await createClient();
@@ -135,7 +135,7 @@ export const GET = withSecurity(
   request: NextRequest,
   { params }: { params: { workspaceId: string } }
 ) {
-  const traceId = getTraceId(request);
+  const traceId = await getTraceId(request);
   
   try {
     const supabase = await createClient();

--- a/packages/web/src/app/api/workspaces/[workspaceId]/onboarding/route.ts
+++ b/packages/web/src/app/api/workspaces/[workspaceId]/onboarding/route.ts
@@ -29,7 +29,7 @@ export const GET = withSecurity(
   request: NextRequest,
   { params }: { params: { workspaceId: string } }
 ) {
-  const traceId = getTraceId(request);
+  const traceId = await getTraceId(request);
   
   try {
     const supabase = await createClient();
@@ -182,7 +182,7 @@ export const POST = withSecurity(
   request: NextRequest,
   { params }: { params: { workspaceId: string } }
 ) {
-  const traceId = getTraceId(request);
+  const traceId = await getTraceId(request);
   
   try {
     const supabase = await createClient();

--- a/packages/web/src/app/api/workspaces/route.ts
+++ b/packages/web/src/app/api/workspaces/route.ts
@@ -28,7 +28,7 @@ const createWorkspaceSchema = z.object({
  */
 export const POST = withSecurity(
   withUniversalBillingGate(async function POST(request: NextRequest) {
-  const traceId = getTraceId(request);
+  const traceId = await getTraceId(request);
   
   try {
     const supabase = await createClient();
@@ -220,7 +220,7 @@ export const POST = withSecurity(
  */
 export const GET = withSecurity(
   withUniversalBillingGate(async function GET(request: NextRequest) {
-  const traceId = getTraceId(request);
+  const traceId = await getTraceId(request);
   
   try {
     const supabase = await createClient();


### PR DESCRIPTION
### Motivation
- `getTraceId` is asynchronous and was previously used without `await`, risking unresolved Promise values being serialized into responses and RPCs and breaking traceability for requests and logs.

### Description
- Await `getTraceId(request)` before use in the affected API handlers to ensure `trace_id` is a resolved string; change applied to these files: `packages/web/src/app/api/invite/[token]/route.ts`, `packages/web/src/app/api/workspaces/route.ts`, `packages/web/src/app/api/workspaces/[workspaceId]/invites/route.ts`, and `packages/web/src/app/api/workspaces/[workspaceId]/onboarding/route.ts`.

### Testing
- Ran `pnpm lint` which executed but failed due to existing ESLint parsing errors and warnings unrelated to this change (stitch_export files and other warnings).
- Ran `pnpm typecheck` which failed with existing TypeScript errors in `@settler/web` and dependency packages (prebuild/typecheck errors), not introduced by this change.
- Ran `pnpm test` which exercised package tests but the overall run failed because `@settler/web` prebuild/typecheck step failed.
- Ran `pnpm build` which failed for the same `@settler/web` prebuild/typecheck errors; all failures are due to pre-existing repo issues rather than the awaited `getTraceId` updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979edaebcf48328b724629af4c3bc0a)