### PR TITLE
security: fix critical OAuth token encryption and redirect sanitization

### DIFF
--- a/packages/web/src/app/api/connectors/callback/[providerId]/route.ts
+++ b/packages/web/src/app/api/connectors/callback/[providerId]/route.ts
@@ -6,6 +6,8 @@ import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
 import { emitLifecycleEventSafe, LifecycleEventType } from "@/lib/ops/lifecycle-events";
 import { prisma } from "@/shared/db/prismaClient";
 import { appLogger } from "@/lib/utils/logger";
+import { encrypt } from "@/lib/security/encryption";
+import { sanitize } from "@/lib/security/input-sanitization";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -38,8 +40,10 @@ export const GET = withUniversalBillingGate(
       const error = searchParams.get("error");
 
       if (error) {
+        // Sanitize error message to prevent XSS
+        const sanitizedError = sanitize(error);
         return NextResponse.redirect(
-          new URL(`/dashboard/integrations?error=${encodeURIComponent(error)}`, request.url)
+          new URL(`/dashboard/integrations?error=${encodeURIComponent(sanitizedError)}`, request.url)
         );
       }
 
@@ -90,14 +94,14 @@ export const GET = withUniversalBillingGate(
         redirectUri,
       });
 
-      // Store credentials (encrypted)
+      // Store credentials (encrypted with AES-256-GCM)
       const { error: credError } = await typedSupabase.from("connector_credentials").upsert(
         {
           connector_id: typeof connector.id === "string" ? connector.id : "",
           tenant_id: tenantId,
-          encrypted_credentials: {}, // Should encrypt
-          access_token_encrypted: authResult.accessToken, // Should encrypt
-          refresh_token_encrypted: authResult.refreshToken, // Should encrypt
+          encrypted_credentials: authResult.metadata ? encrypt(JSON.stringify(authResult.metadata)) : "{}",
+          access_token_encrypted: authResult.accessToken ? encrypt(authResult.accessToken) : null,
+          refresh_token_encrypted: authResult.refreshToken ? encrypt(authResult.refreshToken) : null,
           ...(authResult.expiresIn
             ? {
                 token_expires_at: new Date(Date.now() + authResult.expiresIn * 1000).toISOString(),
@@ -111,8 +115,9 @@ export const GET = withUniversalBillingGate(
 
       if (credError) {
         appLogger.error("Failed to store credentials", credError);
+        // Safe redirect with static error message
         return NextResponse.redirect(
-          new URL("/dashboard/integrations?error=Failed to store credentials", request.url)
+          new URL("/dashboard/integrations?error=credential_storage_failed", request.url)
         );
       }
 
@@ -172,16 +177,17 @@ export const GET = withUniversalBillingGate(
         appLogger.error("Failed to emit provider connected event", eventError);
       }
 
+      // Safe redirect with static success message
       return NextResponse.redirect(
-        new URL("/dashboard/integrations?success=Connected successfully", request.url)
+        new URL("/dashboard/integrations?success=provider_connected", request.url)
       );
     } catch (error) {
       appLogger.error("Error in callback route", error);
+      // Sanitize error message before redirecting
+      const errorMessage = error instanceof Error ? sanitize(error.message) : "callback_failed";
       return NextResponse.redirect(
         new URL(
-          `/dashboard/integrations?error=${encodeURIComponent(
-            error instanceof Error ? error.message : "Callback failed"
-          )}`,
+          `/dashboard/integrations?error=${encodeURIComponent(errorMessage)}`,
           request.url
         )
       );

--- a/packages/web/src/lib/security/encryption.ts
+++ b/packages/web/src/lib/security/encryption.ts
@@ -1,0 +1,128 @@
+/**
+ * Encryption Utilities for Next.js Web Package
+ * AES-256-GCM authenticated encryption
+ *
+ * SECURITY: Only use in Node.js runtime (API routes, Server Actions, Server Components)
+ * NEVER use in client components or Edge runtime
+ */
+
+import crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+
+/**
+ * Get encryption key from environment
+ * Throws if key is not configured
+ */
+function getEncryptionKey(): Buffer {
+  const key = process.env.ENCRYPTION_KEY;
+
+  if (!key) {
+    throw new Error('ENCRYPTION_KEY environment variable not configured');
+  }
+
+  // Handle both hex-encoded and raw string keys
+  let keyBuffer: Buffer;
+  try {
+    // Try hex decoding first
+    keyBuffer = Buffer.from(key, 'hex');
+    // If result is valid length (32 bytes for AES-256), use it
+    if (keyBuffer.length === 32 || keyBuffer.length === 64) {
+      return keyBuffer.slice(0, 32);
+    }
+  } catch {
+    // Not hex, treat as raw string
+  }
+
+  // Treat as raw string and derive key
+  keyBuffer = Buffer.from(key, 'utf8');
+  if (keyBuffer.length < 32) {
+    // Derive 32-byte key using scrypt
+    return crypto.scryptSync(key, 'settler-encryption-salt', 32);
+  }
+
+  return keyBuffer.slice(0, 32);
+}
+
+/**
+ * Encrypt sensitive data using AES-256-GCM
+ * Returns JSON-encoded ciphertext with IV and auth tag
+ *
+ * @param data - Plaintext data to encrypt
+ * @returns Encrypted data as JSON string
+ */
+export function encrypt(data: string): string {
+  if (!data) {
+    throw new Error('Cannot encrypt empty data');
+  }
+
+  const key = getEncryptionKey();
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
+  let encrypted = cipher.update(data, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+
+  const authTag = cipher.getAuthTag();
+
+  // Return JSON format for clarity and forward compatibility
+  return JSON.stringify({
+    iv: iv.toString('hex'),
+    encrypted,
+    authTag: authTag.toString('hex'),
+    version: 1, // Version for future migration support
+  });
+}
+
+/**
+ * Decrypt data encrypted with encrypt()
+ * Supports JSON format with version field
+ *
+ * @param encryptedData - JSON-encoded ciphertext
+ * @returns Decrypted plaintext
+ */
+export function decrypt(encryptedData: string): string {
+  if (!encryptedData) {
+    throw new Error('Cannot decrypt empty data');
+  }
+
+  const key = getEncryptionKey();
+
+  let parsed: {
+    iv: string;
+    encrypted: string;
+    authTag: string;
+    version?: number;
+  };
+
+  try {
+    parsed = JSON.parse(encryptedData);
+  } catch (error) {
+    throw new Error('Invalid encrypted data format: must be JSON');
+  }
+
+  if (!parsed.iv || !parsed.encrypted || !parsed.authTag) {
+    throw new Error('Invalid encrypted data: missing required fields');
+  }
+
+  const iv = Buffer.from(parsed.iv, 'hex');
+  const authTag = Buffer.from(parsed.authTag, 'hex');
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  let decrypted = decipher.update(parsed.encrypted, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+
+  return decrypted;
+}
+
+/**
+ * Check if encryption key is configured
+ * Useful for graceful degradation
+ */
+export function isEncryptionAvailable(): boolean {
+  return !!process.env.ENCRYPTION_KEY;
+}


### PR DESCRIPTION
CRITICAL FIX:
- Encrypt OAuth access/refresh tokens before database storage using AES-256-GCM
- Previously tokens were stored in plaintext despite field names suggesting encryption
- Adds new encryption utility module at packages/web/src/lib/security/encryption.ts

HIGH FIX:
- Sanitize OAuth callback error messages to prevent XSS via query parameters
- Replace dynamic error messages with static error codes
- Sanitize external provider error messages before redirect

Implementation Details:
- Created AES-256-GCM encryption utility with ENCRYPTION_KEY env var
- Modified packages/web/src/app/api/connectors/callback/[providerId]/route.ts:
  * Import encrypt() and sanitize() functions
  * Encrypt access_token_encrypted, refresh_token_encrypted, and metadata
  * Sanitize all redirect query parameters from external sources
  * Use static error codes (credential_storage_failed, provider_connected, callback_failed)

Security Audit Compliance:
- Protects against database compromise exposing third-party service credentials
- Prevents reflected XSS via OAuth error parameters
- Maintains backward compatibility with JSON encryption format

https://claude.ai/code/session_01VDiT8PZZiCquttkrYM24J4