### PR TITLE
Add idempotency integration test and enforce idempotency-after-auth ordering

### DIFF
--- a/packages/api/src/__tests__/integration/idempotency.test.ts
+++ b/packages/api/src/__tests__/integration/idempotency.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Integration Tests: Idempotency
+ * Validates idempotency cache behavior for authenticated POST requests.
+ */
+
+import request from "supertest";
+import crypto from "crypto";
+import app from "../../index";
+import { query } from "../../db";
+import { generateApiKey, hashApiKey } from "../../utils/hash";
+
+const shouldRunDbTests = process.env.RUN_DB_TESTS === "true";
+const describeIdempotency = shouldRunDbTests ? describe : describe.skip;
+
+describeIdempotency("Idempotency Integration", () => {
+  const idempotencyKey = "idem-test-key";
+  const testEmail = "idempotency-test@example.com";
+  let testUserId: string;
+  let apiKeyId: string;
+  let apiKey: string;
+
+  beforeAll(async () => {
+    const users = await query<{ id: string }>(
+      `INSERT INTO users (email, password_hash, role)
+       VALUES ($1, $2, $3)
+       RETURNING id`,
+      [testEmail, "$2b$10$test", "developer"]
+    );
+    testUserId = users[0]?.id || "";
+
+    const { key, prefix } = generateApiKey();
+    apiKey = key;
+    const keyHash = await hashApiKey(apiKey);
+    apiKeyId = crypto.randomUUID();
+
+    await query(
+      `INSERT INTO api_keys (id, user_id, key_prefix, key_hash, name, scopes, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, NOW())`,
+      [apiKeyId, testUserId, prefix, keyHash, "idempotency-test", []]
+    );
+  });
+
+  afterAll(async () => {
+    if (apiKeyId) {
+      await query("DELETE FROM api_keys WHERE id = $1", [apiKeyId]);
+    }
+    if (testUserId) {
+      await query("DELETE FROM idempotency_keys WHERE user_id = $1", [testUserId]);
+      await query("DELETE FROM users WHERE id = $1", [testUserId]);
+    }
+  });
+
+  it("should return cached response for repeated idempotency key", async () => {
+    const firstResponse = await request(app)
+      .post("/api/v1/batch/jobs")
+      .set("X-API-Key", apiKey)
+      .set("Idempotency-Key", idempotencyKey)
+      .send({ jobs: [{ type: "reconcile" }] });
+
+    expect(firstResponse.status).toBe(200);
+    expect(firstResponse.body.batchId).toBeDefined();
+
+    const cachedEntries = await query<{ total: string }>(
+      `SELECT COUNT(*)::text as total
+       FROM idempotency_keys
+       WHERE user_id = $1 AND key = $2`,
+      [testUserId, idempotencyKey]
+    );
+
+    expect(Number(cachedEntries[0]?.total || "0")).toBe(1);
+
+    const secondResponse = await request(app)
+      .post("/api/v1/batch/jobs")
+      .set("X-API-Key", apiKey)
+      .set("Idempotency-Key", idempotencyKey)
+      .send({ jobs: [{ type: "reconcile" }] });
+
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.body.batchId).toBe(firstResponse.body.batchId);
+  });
+});

--- a/packages/api/src/__tests__/route-inventory.test.ts
+++ b/packages/api/src/__tests__/route-inventory.test.ts
@@ -1,58 +1,128 @@
 /**
  * Route Inventory Test
- * 
+ *
  * Ensures all exported routes have handlers and no dead routes exist.
  * This test imports the router tree and verifies handlers mount correctly.
  */
 
-import app from '../index';
+import app from "../index";
+import { authMiddleware } from "../middleware/auth";
 
-describe('Route Inventory', () => {
-  it('should have app instance', () => {
+type Layer = {
+  handle?: any;
+  stack?: Layer[];
+  route?: { path?: string };
+  regexp?: RegExp;
+};
+
+const flattenLayers = (layers: Layer[]): Layer[] => {
+  const collected: Layer[] = [];
+  const seen = new Set<any>();
+  const walk = (layerList: Layer[]) => {
+    layerList.forEach((layer) => {
+      collected.push(layer);
+      const handleAny = layer.handle as any;
+      if (handleAny?.stack && !seen.has(handleAny)) {
+        seen.add(handleAny);
+        walk(handleAny.stack as Layer[]);
+      }
+    });
+  };
+  walk(layers);
+  return collected;
+};
+
+const countAuthMiddleware = (layers: Layer[]): number => {
+  const seen = new Set<any>();
+  const countLayers = (layerList: Layer[]): number =>
+    layerList.reduce((acc, layer) => {
+      if (layer.handle === authMiddleware) {
+        acc += 1;
+      }
+      const handleAny = layer.handle as any;
+      if (handleAny?.stack && !seen.has(handleAny)) {
+        seen.add(handleAny);
+        acc += countLayers(handleAny.stack as Layer[]);
+      }
+      return acc;
+    }, 0);
+
+  return countLayers(layers);
+};
+
+const hasRoutePrefix = (layers: Layer[], prefix: string): boolean => {
+  const flattened = flattenLayers(layers);
+  return flattened.some((layer) => {
+    const regexText = layer?.regexp?.toString()?.replace(/\\\//g, "/");
+    return layer?.route?.path?.includes(prefix) || regexText?.includes(prefix);
+  });
+};
+
+const findMiddlewareIndices = (layers: Layer[], name: string): number[] => {
+  return flattenLayers(layers)
+    .map((layer) => layer?.handle?.name)
+    .reduce<number[]>((indices, handleName, index) => {
+      if (handleName === name) {
+        indices.push(index);
+      }
+      return indices;
+    }, []);
+};
+
+describe("Route Inventory", () => {
+  it("should have app instance", () => {
     expect(app).toBeDefined();
-    expect(typeof app).toBe('function');
+    expect(typeof app).toBe("function");
   });
 
-  it('should have health routes mounted', () => {
+  it("should have health routes mounted", () => {
     // Health routes should be accessible
-    const routes = (app)._router?.stack || [];
-    const healthRoutes = routes.filter((layer: any) => 
-      layer?.route?.path?.includes('/health') || 
-      layer?.regexp?.toString().includes('health')
+    const routes = app._router?.stack || [];
+    const healthRoutes = routes.filter(
+      (layer: any) =>
+        layer?.route?.path?.includes("/health") || layer?.regexp?.toString().includes("health")
     );
     expect(healthRoutes.length).toBeGreaterThan(0);
   });
 
-  it('should have API v1 routes mounted', () => {
-    const routes = (app)._router?.stack || [];
-    const v1Routes = routes.filter((layer: any) => 
-      layer?.route?.path?.includes('/api/v1') || 
-      layer?.regexp?.toString().includes('api/v1')
-    );
-    expect(v1Routes.length).toBeGreaterThan(0);
+  it("should have API v1 routes mounted", () => {
+    const routes = app._router?.stack || [];
+    expect(hasRoutePrefix(routes, "api/v1")).toBe(true);
   });
 
-  it('should have API v2 routes mounted', () => {
-    const routes = (app)._router?.stack || [];
-    const v2Routes = routes.filter((layer: any) => 
-      layer?.route?.path?.includes('/api/v2') || 
-      layer?.regexp?.toString().includes('api/v2')
-    );
-    expect(v2Routes.length).toBeGreaterThan(0);
+  it("should have API v2 routes mounted", () => {
+    const routes = app._router?.stack || [];
+    expect(hasRoutePrefix(routes, "api/v2")).toBe(true);
   });
 
-  it('should have 404 handler for unknown routes', () => {
-    const routes = (app)._router?.stack || [];
+  it("should have 404 handler for unknown routes", () => {
+    const routes = app._router?.stack || [];
     // The 404 handler should be the last middleware
     const lastLayer = routes[routes.length - 1];
     expect(lastLayer).toBeDefined();
   });
 
-  it('should have error handler middleware', () => {
-    const routes = (app)._router?.stack || [];
-    const errorHandlers = routes.filter((layer: any) => 
-      layer?.handle?.length === 4 // Error handlers have 4 parameters (err, req, res, next)
+  it("should have error handler middleware", () => {
+    const routes = app._router?.stack || [];
+    const errorHandlers = routes.filter(
+      (layer: any) => layer?.handle?.length === 4 // Error handlers have 4 parameters (err, req, res, next)
     );
     expect(errorHandlers.length).toBeGreaterThan(0);
+  });
+
+  it("should only register auth middleware once per API version", () => {
+    const routes = app._router?.stack || [];
+    expect(countAuthMiddleware(routes)).toBeLessThanOrEqual(2);
+  });
+
+  it("should mount idempotency middleware after auth per API version", () => {
+    const routes = app._router?.stack || [];
+    const authIndices = findMiddlewareIndices(routes, "authMiddleware");
+    const idempotencyIndices = findMiddlewareIndices(routes, "idempotencyHandler");
+    expect(authIndices).toHaveLength(2);
+    expect(idempotencyIndices).toHaveLength(2);
+    authIndices.forEach((authIndex, position) => {
+      expect(authIndex).toBeLessThan(idempotencyIndices[position] ?? Number.MAX_SAFE_INTEGER);
+    });
   });
 });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -207,67 +207,74 @@ app.use("/api/v1", openApiRouter);
 // API versioning middleware
 app.use("/api", versionMiddleware);
 
-// Idempotency middleware for state-changing operations
-app.use("/api/v1", idempotencyMiddleware());
-app.use("/api/v2", idempotencyMiddleware());
+const v1ProtectedRouter = express.Router();
+const v2ProtectedRouter = express.Router();
+
+// Auth required routes (apply auth middleware once per request)
+v1ProtectedRouter.use(authMiddleware);
+v2ProtectedRouter.use(authMiddleware);
+
+// Idempotency middleware for state-changing operations (requires auth)
+v1ProtectedRouter.use(idempotencyMiddleware());
+v2ProtectedRouter.use(idempotencyMiddleware());
 
 // Rate limiting per API key
-app.use("/api/v1", authMiddleware, rateLimitMiddleware());
-app.use("/api/v2", authMiddleware, rateLimitMiddleware());
+v1ProtectedRouter.use(rateLimitMiddleware());
+v2ProtectedRouter.use(rateLimitMiddleware());
 
 // Test mode middleware (after auth, before routes)
-app.use("/api/v1", authMiddleware, testModeMiddleware);
-app.use("/api/v2", authMiddleware, testModeMiddleware);
-app.use("/api/v1", authMiddleware, validateTestMode);
-app.use("/api/v2", authMiddleware, validateTestMode);
+v1ProtectedRouter.use(testModeMiddleware);
+v2ProtectedRouter.use(testModeMiddleware);
+v1ProtectedRouter.use(validateTestMode);
+v2ProtectedRouter.use(validateTestMode);
 
 // Auth routes (no auth required for login/refresh)
 app.use("/api/v1/auth", authRouter);
 app.use("/api/v2/auth", authRouter);
 
 // API Keys routes (requires auth)
-app.use("/api/v1", authMiddleware, apiKeysRouter);
-app.use("/api/v2", authMiddleware, apiKeysRouter);
+v1ProtectedRouter.use(apiKeysRouter);
+v2ProtectedRouter.use(apiKeysRouter);
 
 // Exceptions routes (requires auth)
-app.use("/api/v1", authMiddleware, exceptionsRouter);
-app.use("/api/v2", authMiddleware, exceptionsRouter);
+v1ProtectedRouter.use(exceptionsRouter);
+v2ProtectedRouter.use(exceptionsRouter);
 
 // Test mode routes (requires auth)
-app.use("/api/v1", authMiddleware, testModeRouter);
-app.use("/api/v2", authMiddleware, testModeRouter);
+v1ProtectedRouter.use(testModeRouter);
+v2ProtectedRouter.use(testModeRouter);
 
 // Dashboard routes (requires auth)
-app.use("/api/v1", authMiddleware, dashboardsRouter);
-app.use("/api/v2", authMiddleware, dashboardsRouter);
+v1ProtectedRouter.use(dashboardsRouter);
+v2ProtectedRouter.use(dashboardsRouter);
 
 // Feedback routes (requires auth)
-app.use("/api/v1", authMiddleware, feedbackRouter);
-app.use("/api/v2", authMiddleware, feedbackRouter);
+v1ProtectedRouter.use(feedbackRouter);
+v2ProtectedRouter.use(feedbackRouter);
 
 // Alert routes (requires auth)
-app.use("/api/v1", authMiddleware, alertsRouter);
-app.use("/api/v2", authMiddleware, alertsRouter);
+v1ProtectedRouter.use(alertsRouter);
+v2ProtectedRouter.use(alertsRouter);
 
 // Adapter test routes (requires auth)
-app.use("/api/v1", authMiddleware, adapterTestRouter);
-app.use("/api/v2", authMiddleware, adapterTestRouter);
+v1ProtectedRouter.use(adapterTestRouter);
+v2ProtectedRouter.use(adapterTestRouter);
 
 // Enhanced reports routes (requires auth)
-app.use("/api/v1", authMiddleware, reportsEnhancedRouter);
-app.use("/api/v2", authMiddleware, reportsEnhancedRouter);
+v1ProtectedRouter.use(reportsEnhancedRouter);
+v2ProtectedRouter.use(reportsEnhancedRouter);
 
 // Confidence score routes (requires auth)
-app.use("/api/v1", authMiddleware, confidenceRouter);
-app.use("/api/v2", authMiddleware, confidenceRouter);
+v1ProtectedRouter.use(confidenceRouter);
+v2ProtectedRouter.use(confidenceRouter);
 
 // Reconciliation status routes (requires auth)
-app.use("/api/v1", authMiddleware, reconciliationStatusRouter);
-app.use("/api/v2", authMiddleware, reconciliationStatusRouter);
+v1ProtectedRouter.use(reconciliationStatusRouter);
+v2ProtectedRouter.use(reconciliationStatusRouter);
 
 // Rules editor routes (requires auth)
-app.use("/api/v1", authMiddleware, rulesEditorRouter);
-app.use("/api/v2", authMiddleware, rulesEditorRouter);
+v1ProtectedRouter.use(rulesEditorRouter);
+v2ProtectedRouter.use(rulesEditorRouter);
 
 // Playground routes (no auth, rate-limited)
 app.use("/api/v1/playground", playgroundRouter);
@@ -277,51 +284,54 @@ app.use("/api/v2/playground", playgroundRouter);
 app.get("/api/csrf-token", getCsrfToken);
 
 // CLI wizard routes (requires auth)
-app.use("/api/v1", authMiddleware, cliWizardRouter);
-app.use("/api/v2", authMiddleware, cliWizardRouter);
+v1ProtectedRouter.use(cliWizardRouter);
+v2ProtectedRouter.use(cliWizardRouter);
 
 // Enhanced export routes (requires auth)
-app.use("/api/v1", authMiddleware, exportEnhancedRouter);
-app.use("/api/v2", authMiddleware, exportEnhancedRouter);
+v1ProtectedRouter.use(exportEnhancedRouter);
+v2ProtectedRouter.use(exportEnhancedRouter);
 
 // AI assistant routes (requires auth)
-app.use("/api/v1", authMiddleware, aiAssistantRouter);
-app.use("/api/v2", authMiddleware, aiAssistantRouter);
+v1ProtectedRouter.use(aiAssistantRouter);
+v2ProtectedRouter.use(aiAssistantRouter);
 
 // Audit trail routes (requires auth)
-app.use("/api/v1", authMiddleware, auditTrailRouter);
-app.use("/api/v2", authMiddleware, auditTrailRouter);
+v1ProtectedRouter.use(auditTrailRouter);
+v2ProtectedRouter.use(auditTrailRouter);
 
 // Tenant data management routes (requires auth + tenant context)
-app.use("/api/v1/tenant", authMiddleware, tenantMiddleware, tenantDataRouter);
-app.use("/api/v2/tenant", authMiddleware, tenantMiddleware, tenantDataRouter);
+v1ProtectedRouter.use("/tenant", tenantMiddleware, tenantDataRouter);
+v2ProtectedRouter.use("/tenant", tenantMiddleware, tenantDataRouter);
 
 // Webhook management routes (requires auth)
-app.use("/api/v1/webhooks", authMiddleware, webhookManagementRouter);
-app.use("/api/v2/webhooks", authMiddleware, webhookManagementRouter);
+v1ProtectedRouter.use("/webhooks", webhookManagementRouter);
+v2ProtectedRouter.use("/webhooks", webhookManagementRouter);
 
 // Notification routes (requires auth)
-app.use("/api/v1/notifications", authMiddleware, notificationsRouter);
-app.use("/api/v2/notifications", authMiddleware, notificationsRouter);
+v1ProtectedRouter.use("/notifications", notificationsRouter);
+v2ProtectedRouter.use("/notifications", notificationsRouter);
 
 // Usage tracking routes (requires auth)
-app.use("/api/v1/usage", authMiddleware, usageRouter);
-app.use("/api/v2/usage", authMiddleware, usageRouter);
+v1ProtectedRouter.use("/usage", usageRouter);
+v2ProtectedRouter.use("/usage", usageRouter);
 
 // Batch processing routes (requires auth)
-app.use("/api/v1/batch", authMiddleware, batchRouter);
-app.use("/api/v2/batch", authMiddleware, batchRouter);
+v1ProtectedRouter.use("/batch", batchRouter);
+v2ProtectedRouter.use("/batch", batchRouter);
 
 // Export routes (requires auth)
-app.use("/api/v1/exports", authMiddleware, exportsRouter);
-app.use("/api/v2/exports", authMiddleware, exportsRouter);
+v1ProtectedRouter.use("/exports", exportsRouter);
+v2ProtectedRouter.use("/exports", exportsRouter);
 
 // Versioned API routes
-app.use("/api/v1", authMiddleware, v1Router);
-app.use("/api/v2", authMiddleware, v2Router);
+v1ProtectedRouter.use(v1Router);
+v2ProtectedRouter.use(v2Router);
 
 // Optimized reconciliation summary endpoint
-app.use("/api/v1/reconciliations", authMiddleware, reconciliationSummaryRouter);
+v1ProtectedRouter.use("/reconciliations", reconciliationSummaryRouter);
+
+app.use("/api/v1", v1ProtectedRouter);
+app.use("/api/v2", v2ProtectedRouter);
 
 // Sentry error handler (before custom error handler)
 app.use(sentryErrorHandler());

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -5,9 +5,13 @@ import { v4 as uuidv4 } from "uuid";
 import { logError } from "../utils/logger";
 
 export function idempotencyMiddleware() {
-  return async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
+  const middleware = async function idempotencyHandler(
+    req: AuthRequest,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
     // Only apply to state-changing methods
-    if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+    if (!["POST", "PUT", "PATCH", "DELETE"].includes(req.method)) {
       return next();
     }
 
@@ -16,10 +20,13 @@ export function idempotencyMiddleware() {
     }
 
     // Get idempotency key from header or generate one
-    const idempotencyKey = (req.headers['idempotency-key'] as string) || uuidv4();
-    
+    const idempotencyKey = (req.headers["idempotency-key"] as string) || uuidv4();
+
     // Check if we've seen this request
-    const cached = await query<{ response: { statusCode?: number; data: unknown }; created_at: Date }>(
+    const cached = await query<{
+      response: { statusCode?: number; data: unknown };
+      created_at: Date;
+    }>(
       `SELECT response, created_at
        FROM idempotency_keys
        WHERE user_id = $1 AND key = $2 AND expires_at > NOW()`,
@@ -41,12 +48,12 @@ export function idempotencyMiddleware() {
     let responseData: unknown;
 
     // Override json to capture response
-    res.json = function(data: unknown) {
+    res.json = function (data: unknown) {
       responseData = data;
       return originalJson(data);
     };
 
-    res.status = function(code: number) {
+    res.status = function (code: number) {
       statusCode = code;
       return originalStatus(code);
     };
@@ -54,23 +61,19 @@ export function idempotencyMiddleware() {
     // Call next middleware
     await new Promise<void>((resolve) => {
       const originalEnd = res.end.bind(res);
-      res.end = function(chunk?: unknown, encoding?: BufferEncoding, cb?: () => void) {
+      res.end = function (chunk?: unknown, encoding?: BufferEncoding, cb?: () => void) {
         // Cache successful responses (2xx)
         if (statusCode >= 200 && statusCode < 300) {
           query(
             `INSERT INTO idempotency_keys (user_id, key, response, expires_at)
              VALUES ($1, $2, $3, NOW() + INTERVAL '24 hours')
              ON CONFLICT (user_id, key) DO NOTHING`,
-            [
-              req.userId || null,
-              idempotencyKey,
-              JSON.stringify({ statusCode, data: responseData }),
-            ]
-          ).catch(err => {
-            logError('Failed to cache idempotency key', err);
+            [req.userId || null, idempotencyKey, JSON.stringify({ statusCode, data: responseData })]
+          ).catch((err) => {
+            logError("Failed to cache idempotency key", err);
           });
         }
-        if (encoding !== undefined && typeof encoding === 'string') {
+        if (encoding !== undefined && typeof encoding === "string") {
           originalEnd(chunk, encoding, cb);
         } else if (cb !== undefined) {
           originalEnd(chunk, cb);
@@ -82,4 +85,6 @@ export function idempotencyMiddleware() {
       next();
     });
   };
+
+  return middleware;
 }


### PR DESCRIPTION
### Motivation
- Ensure idempotency middleware executes after authentication so it can observe `req.userId` and cache authenticated state-changing requests.
- Add an end-to-end integration test that exercises an authenticated POST with an `Idempotency-Key` to validate DB-backed caching once test DB fixtures are available.

### Description
- Reworked routing to mount authenticated routes via per-version protected routers and apply `authMiddleware` once per version, then apply `idempotencyMiddleware`, rate limiting, and other post-auth middleware (changes primarily in `packages/api/src/index.ts`).
- Converted the idempotency middleware into a named handler (`idempotencyHandler`) by returning a middleware function from `packages/api/src/middleware/idempotency.ts` so tests can deterministically inspect middleware order and behavior.
- Hardened the route inventory test (`packages/api/src/__tests__/route-inventory.test.ts`) by flattening router layers, adding helpers to locate middleware indices, asserting auth is registered at most once per API version, and asserting `idempotencyHandler` is mounted after `authMiddleware` for each API version.
- Added a DB-gated integration test `packages/api/src/__tests__/integration/idempotency.test.ts` which creates a test user and API key, performs a `POST /api/v1/batch/jobs` with an `Idempotency-Key`, asserts an entry appears in `idempotency_keys`, and verifies the second request returns the cached response (test is skipped unless `RUN_DB_TESTS=true`).

### Testing
- Ran the idempotency integration test with `pnpm --filter @settler/api test -- idempotency.test.ts`, which is skipped in this environment because `RUN_DB_TESTS` is not set; Jest printed the usual open-handles message in this environment but the test gating behaved as expected.
- Executed the repository verification pipeline that runs lint, typecheck, build-safety and python checks during commit (`verify`/pre-commit), and all verification checks passed (lint, typecheck, build-safety, python format/lint).
- Note: to validate end-to-end DB caching locally or in CI, run the integration test with `RUN_DB_TESTS=true pnpm --filter @settler/api test -- idempotency.test.ts` against a test database seeded with the repo migrations and fixtures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698392257d248328bb14e67b8965b62e)