### PR TITLE
fix(repo): stabilize demo data, add deterministic demo scripts, JobForge SDK tests, and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,3 +244,28 @@ These are actionable, repo-specific improvements aligned with current direction:
 ---
 
 **For questions:** See `docs/OPERATIONS.md` or `CONTRIBUTING.md`
+
+## 10. Safe-to-Edit Map (Guardrails)
+
+**Safe zones (preferred for changes):**
+
+- `packages/web/src/app/` (UI + route handlers)
+- `packages/api/src/` (API logic and middleware)
+- `scripts/` (automation, verification, QA)
+- `docs/` (documentation)
+
+**High-risk zones (extra caution):**
+
+- `supabase/` and `prisma/` migrations
+- `packages/*/src/__tests__/` (test correctness gates)
+- `.github/workflows/` (CI gate behavior)
+
+## 11. Standard Command Canon (Copy/Paste)
+
+- Install: `pnpm install`
+- Lint: `pnpm run lint`
+- Typecheck: `pnpm run typecheck`
+- Tests: `pnpm run test`
+- E2E: `pnpm run test:e2e`
+- Build: `pnpm run build`
+- Docs reality: `pnpm run verify:docs`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,46 @@ Include the following details in your report:
 
 Only the `main` branch receives active security updates. If you are running a fork, please keep it current.
 
+## Threat Model (Summary)
+
+**Primary assets**
+
+- Tenant-scoped financial records and reconciliation runs
+- API keys, webhook secrets, and service-role credentials
+- Billing and subscription state
+
+**Key threat vectors**
+
+- Unauthorized tenant access (broken RLS or missing tenant filters)
+- Webhook replay or forgery (Stripe/PayPal/etc.)
+- Abuse of public endpoints (rate-limit bypass, resource exhaustion)
+- Secret leakage in logs, configs, or commits
+
+**Controls in place**
+
+- RLS + tenant-scoped queries
+- Structured error envelopes (no stack leaks in user responses)
+- Auth + billing gates for paid features
+- Runtime validation of external inputs (Zod schemas)
+
+## Webhooks
+
+- **Runtime:** Webhook handlers must use Node.js runtime.
+- **Verification:** Raw body signature verification is required.
+- **Replay protection:** Use event IDs for idempotency; reject duplicate event IDs.
+- **Failure behavior:** Return safe errors with `{ code, message, traceId, retryable }`.
+
+## Rate Limiting
+
+- Public endpoints are rate limited with in-memory limits for OSS/local usage.
+- **Upgrade path:** Use Redis or a managed rate-limit service for production-scale deployments.
+
+## Secrets Hygiene
+
+- Never commit secrets or credentials.
+- Use `.env.example` as the template for required variables.
+- Rotate service-role keys immediately if exposure is suspected.
+
 ## Handling and Disclosure
 
 We acknowledge reports and coordinate fixes as quickly as possible. Please do not publicly disclose vulnerabilities before a fix is available.

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -1,0 +1,63 @@
+# Evidence Log
+
+This log captures commands executed and observed results during the Reality Pass.
+
+## Phase 0 — Baseline (Observed)
+
+### Install
+
+```bash
+pnpm install
+```
+
+**Result:** Success. Prisma generate completed. Warnings about ignored build scripts and npm config keys were emitted.
+
+### Lint
+
+```bash
+pnpm run lint
+```
+
+**Result:** Completed with warnings (no errors). Examples include unused variables in API and web packages, and console usage warnings.
+
+### Typecheck
+
+```bash
+pnpm run typecheck
+```
+
+**Result:** Success. Turbo warned about missing outputs for `@settler/api#typecheck` and `@settler/cli#typecheck`.
+
+### Unit Tests
+
+```bash
+pnpm run test
+```
+
+**Result:** Failed. `@jobforge/sdk-ts` had no test files and exited with code 1.
+
+### Build
+
+```bash
+pnpm run build
+```
+
+**Result:** Success. Next.js build completed with warnings for missing environment variables and a Node 24 requirement note from the Next build output.
+
+### Smoke Test
+
+```bash
+pnpm run test:smoke
+```
+
+**Result:** Failed. Requests to `http://localhost:3000` returned `ECONNREFUSED` because no server was running.
+
+## Remediation Checks (Post-fix)
+
+### JobForge SDK Unit Tests
+
+```bash
+pnpm --filter @jobforge/sdk-ts test
+```
+
+**Result:** Passed (1 test file, 2 tests).

--- a/docs/REALITY_MAP.md
+++ b/docs/REALITY_MAP.md
@@ -1,0 +1,87 @@
+# Reality Map
+
+**Scope:** Settler end-to-end flows mapped to routes, data stores, external dependencies, and invariants.
+
+## Stack Snapshot
+
+- **Web:** Next.js App Router (`packages/web`)
+- **API:** Express + TypeScript (`packages/api`)
+- **Workers:** JobForge (Node) + Workhorse (Python)
+- **Data:** Supabase/Postgres (RLS enforced), Redis
+- **SDKs:** TypeScript, Python, Go, Ruby, C#, Java
+
+## Primary Flows
+
+### 1) Console Sign-in → Tenant Context → Console APIs
+
+- **Routes**
+  - Web UI: `/console/*` (App Router)
+  - APIs: `/api/console/*`
+- **Data stores**
+  - `billing_accounts`, `subscriptions`, `tenants`, `usage_events`
+- **External deps**
+  - Supabase Auth (user context), Stripe (entitlements)
+- **Invariants**
+  - Tenant isolation enforced by RLS and `tenant_id` filters.
+  - Errors use `{ code, message, traceId, retryable }` envelope.
+
+### 2) Reconciliation Workflow (Create → Run → Results)
+
+- **Routes**
+  - Create job: `/api/v1/recon/jobs`
+  - Read results: `/api/console/reconciliation`, `/console/reconciliation/[runId]`
+- **Data stores**
+  - `normalized_transactions`, `reconciliation_runs`, `reconciliation_matches`
+- **External deps**
+  - Adapters (Stripe, Shopify, PayPal) via `packages/adapters`
+- **Invariants**
+  - Deterministic matching logic; no hidden side effects.
+  - No hard 500s on user routes; fail closed for entitlements.
+
+### 3) Billing & Webhooks (Checkout → Webhook → Entitlements)
+
+- **Routes**
+  - Checkout: `/api/stripe/checkout`
+  - Webhook: `/api/stripe/webhook`
+- **Data stores**
+  - `billing_accounts`, `subscriptions`
+- **External deps**
+  - Stripe (signature verification + idempotency)
+- **Invariants**
+  - Webhooks must use **Node runtime**, verify raw body, and reject replays.
+  - Entitlements are enforced server-side; demo mode returns safe fallback.
+
+### 4) Demo Mode (Deterministic Sandbox)
+
+- **Routes**
+  - Playground dataset: `/playground/demo-dataset`
+  - Playground run: `/playground/demo-run`
+  - Web demo: `/demo/*`
+- **Data stores**
+  - `demo/data/*.json` (seeded deterministic files)
+- **External deps**
+  - None (all demo data is local and deterministic)
+- **Invariants**
+  - No external calls in demo mode.
+  - Resettable via `npm run demo:reset`.
+
+## External Dependencies
+
+- **Stripe** (billing + webhooks)
+- **Supabase** (Postgres + Auth + RLS)
+- **Redis** (job queues, caching)
+- **OpenAI** (optional; gated)
+
+## Error & Safety Guarantees
+
+- **Error envelope:** `{ code, message, traceId, retryable }`
+- **No hard 500s:** user routes must return graceful fallback responses.
+- **Tenant isolation:** RLS + tenant-scoped queries.
+- **Rate limits:** public endpoints are rate limited (in-memory; Redis upgrade path documented).
+
+## Verification Commands (Reality Gates)
+
+- `pnpm run verify:fast`
+- `pnpm run verify:docs`
+- `pnpm run test:smoke`
+- `pnpm run test:e2e`

--- a/package.json
+++ b/package.json
@@ -119,6 +119,9 @@
     "postinstall": "test -f scripts/vercel-prisma-postinstall.js && node scripts/vercel-prisma-postinstall.js || echo 'Skipping postinstall: script not found (expected in Vercel builds)'",
     "verify:build": "test -f scripts/verify-build-setup.sh && bash scripts/verify-build-setup.sh || echo '⚠️  Build verification script not available'",
     "setup:turbo": "test -f scripts/setup-vercel-turbo-cache.sh && bash scripts/setup-vercel-turbo-cache.sh || echo '⚠️  Turbo setup script not available'",
+    "demo:setup": "tsx scripts/generate-demo-data.ts",
+    "demo:reset": "tsx scripts/generate-demo-data.ts",
+    "demo:start": "npm run demo:setup && turbo run dev --filter @settler/web",
     "agents:deploy": "bash scripts/deploy-autonomous-agents.sh",
     "agents:setup": "tsx scripts/setup-autonomous-agents.ts",
     "agents:monitor": "bash scripts/monitor-agents.sh",
@@ -157,9 +160,6 @@
     "workhorse:verify": "npm run workhorse:format:check && npm run workhorse:lint && npm run workhorse:typecheck",
     "worker:py": "cd packages/workhorse && python -m settler_workhorse.cli worker",
     "jobs:smoke": "tsx scripts/worker-smoke-test.ts",
-    "workhorse:test": "cd packages/workhorse && pytest tests/ -v",
-    "workhorse:lint": "cd packages/workhorse && black --check src/ tests/ && ruff check src/ tests/ && mypy src/",
-    "workhorse:format": "cd packages/workhorse && black src/ tests/ && ruff fix src/ tests/",
     "workhorse:dev": "cd packages/workhorse && python -m settler_workhorse.cli worker --poll-interval 2"
   },
   "lint-staged": {

--- a/packages/jobforge-sdk-ts/test/client.test.ts
+++ b/packages/jobforge-sdk-ts/test/client.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { JobForgeClient } from "../src/client";
+
+const tenantId = "00000000-0000-0000-0000-000000000000";
+
+function createClient(rpcImpl: ReturnType<typeof vi.fn>) {
+  const supabaseClient = { rpc: rpcImpl } as unknown;
+  return new JobForgeClient({
+    supabaseUrl: "http://localhost:54321",
+    supabaseKey: "test-key",
+    supabaseClient: supabaseClient as never,
+  });
+}
+
+describe("JobForgeClient", () => {
+  it("enqueueJob returns data from RPC", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: { id: "job-1" }, error: null });
+    const client = createClient(rpc);
+
+    const result = await client.enqueueJob({
+      tenant_id: tenantId,
+      type: "demo.job",
+      payload: { ok: true },
+    });
+
+    expect(rpc).toHaveBeenCalledWith(
+      "jobforge_enqueue_job",
+      expect.objectContaining({
+        p_tenant_id: tenantId,
+        p_type: "demo.job",
+      })
+    );
+    expect(result).toEqual({ id: "job-1" });
+  });
+
+  it("enqueueJob surfaces RPC errors", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: { message: "boom" } });
+    const client = createClient(rpc);
+
+    await expect(
+      client.enqueueJob({
+        tenant_id: tenantId,
+        type: "demo.job",
+        payload: { ok: true },
+      })
+    ).rejects.toThrow("Failed to enqueue job: boom");
+  });
+});

--- a/scripts/generate-demo-data.ts
+++ b/scripts/generate-demo-data.ts
@@ -1,20 +1,69 @@
-import fs from 'fs';
-import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
-import { NormalizedRecord, RecordDirection, RecordType } from '../packages/api/src/services/recon-core/normalized-types';
+import fs from "fs";
+import path from "path";
+enum RecordType {
+  CHARGE = "CHARGE",
+  REFUND = "REFUND",
+  PAYOUT = "PAYOUT",
+  FEE = "FEE",
+  TRANSFER = "TRANSFER",
+  ADJUSTMENT = "ADJUSTMENT",
+}
 
-const DEMO_DIR = path.join(process.cwd(), 'demo/data');
+enum RecordDirection {
+  INCOMING = "INCOMING",
+  OUTGOING = "OUTGOING",
+}
+
+interface NormalizedRecord {
+  id: string;
+  externalId: string;
+  source: string;
+  occurredAt: Date;
+  amount: number;
+  currency: string;
+  direction: RecordDirection;
+  type: RecordType;
+  status: string;
+  description?: string;
+  customerEmail?: string;
+  customerName?: string;
+  orderId?: string;
+  payoutId?: string;
+  feeAmount?: number;
+  netAmount?: number;
+  raw: Record<string, unknown>;
+}
+
+const DEMO_DIR = path.join(process.cwd(), "demo/data");
 if (!fs.existsSync(DEMO_DIR)) {
   fs.mkdirSync(DEMO_DIR, { recursive: true });
 }
 
-const START_DATE = new Date('2025-01-01T00:00:00Z');
+const START_DATE = new Date("2025-01-01T00:00:00Z");
 const DAYS = 30;
+const DEFAULT_SEED = 42;
+let seed = Number(process.env.DEMO_SEED ?? DEFAULT_SEED);
+
+function seededRandom() {
+  seed = (seed * 1664525 + 1013904223) % 4294967296;
+  return seed / 4294967296;
+}
+
+function seededUuid() {
+  const hex = Array.from({ length: 32 }, () => Math.floor(seededRandom() * 16).toString(16)).join(
+    ""
+  );
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
 
 function randomDate(start: Date, days: number) {
   const date = new Date(start);
-  date.setDate(date.getDate() + Math.floor(Math.random() * days));
-  date.setHours(Math.floor(Math.random() * 24), Math.floor(Math.random() * 60), Math.floor(Math.random() * 60));
+  date.setDate(date.getDate() + Math.floor(seededRandom() * days));
+  date.setHours(
+    Math.floor(seededRandom() * 24),
+    Math.floor(seededRandom() * 60),
+    Math.floor(seededRandom() * 60)
+  );
   return date;
 }
 
@@ -25,42 +74,42 @@ function generateDataset() {
 
   // 1. Generate Charges (incoming to Stripe)
   for (let i = 0; i < 50; i++) {
-    const amount = Number((Math.random() * 100 + 10).toFixed(2));
-    const fee = Number((amount * 0.029 + 0.30).toFixed(2));
+    const amount = Number((seededRandom() * 100 + 10).toFixed(2));
+    const fee = Number((amount * 0.029 + 0.3).toFixed(2));
     const net = Number((amount - fee).toFixed(2));
     const date = randomDate(START_DATE, DAYS);
-    const orderId = `ord_${Math.floor(Math.random() * 10000)}`;
+    const orderId = `ord_${Math.floor(seededRandom() * 10000)}`;
     const payoutId = `po_${Math.floor(i / 10)}`; // Group 10 charges per payout
 
     const stripeCharge: NormalizedRecord = {
-      id: uuidv4(),
-      externalId: `ch_${uuidv4().substring(0, 8)}`,
-      source: 'Stripe',
+      id: seededUuid(),
+      externalId: `ch_${seededUuid().substring(0, 8)}`,
+      source: "Stripe",
       occurredAt: date,
       amount: amount,
-      currency: 'USD',
+      currency: "USD",
       direction: RecordDirection.INCOMING,
       type: RecordType.CHARGE,
-      status: 'succeeded',
+      status: "succeeded",
       orderId: orderId,
       payoutId: payoutId,
       feeAmount: fee,
       netAmount: net,
       description: `Charge for ${orderId}`,
-      raw: { id: 'raw_stripe' }
+      raw: { id: "raw_stripe" },
     };
     stripeRecords.push(stripeCharge);
   }
 
   // 2. Generate Payouts (outgoing from Stripe, incoming to Bank)
   // Group by payoutId
-  const payouts = new Map<string, { amount: number, fee: number, date: Date, count: number }>();
-  
-  stripeRecords.forEach(r => {
+  const payouts = new Map<string, { amount: number; fee: number; date: Date; count: number }>();
+
+  stripeRecords.forEach((r) => {
     if (r.payoutId) {
       const p = payouts.get(r.payoutId) || { amount: 0, fee: 0, date: r.occurredAt, count: 0 };
       p.amount += r.amount;
-      p.fee += (r.feeAmount || 0);
+      p.fee += r.feeAmount || 0;
       p.count++;
       // Payout happens 2 days after the latest charge in the batch
       if (r.occurredAt > p.date) p.date = r.occurredAt;
@@ -76,79 +125,94 @@ function generateDataset() {
 
     // Stripe Payout Record
     const stripePayout: NormalizedRecord = {
-      id: uuidv4(),
+      id: seededUuid(),
       externalId: payoutId,
-      source: 'Stripe',
+      source: "Stripe",
       occurredAt: payoutDate,
       amount: netAmount,
-      currency: 'USD',
+      currency: "USD",
       direction: RecordDirection.OUTGOING,
       type: RecordType.PAYOUT,
-      status: 'paid',
+      status: "paid",
       description: `Payout ${payoutId}`,
-      raw: { id: 'raw_payout' }
+      raw: { id: "raw_payout" },
     };
     stripeRecords.push(stripePayout);
 
     // Bank Deposit Record (Matches Stripe Payout)
     const bankDeposit: NormalizedRecord = {
-      id: uuidv4(),
-      externalId: `txn_${uuidv4().substring(0, 8)}`,
-      source: 'Bank',
+      id: seededUuid(),
+      externalId: `txn_${seededUuid().substring(0, 8)}`,
+      source: "Bank",
       occurredAt: payoutDate, // Same day
       amount: netAmount,
-      currency: 'USD',
+      currency: "USD",
       direction: RecordDirection.INCOMING,
       type: RecordType.TRANSFER,
-      status: 'posted',
+      status: "posted",
       description: `STRIPE TRANSFER ${payoutId}`,
-      raw: { id: 'raw_bank' }
+      raw: { id: "raw_bank" },
     };
     bankRecords.push(bankDeposit);
 
-    expectedMatches.push({ stripeId: stripePayout.id, bankId: bankDeposit.id, type: 'PAYOUT_MATCH' });
+    expectedMatches.push({
+      stripeId: stripePayout.id,
+      bankId: bankDeposit.id,
+      type: "PAYOUT_MATCH",
+    });
   });
 
   // 3. Generate some Unmatched Records (Anomalies)
-  
+
   // A. Stripe Charge missing in Bank (not possible usually, but maybe missing payout)
   // B. Bank Fee not in Stripe
   bankRecords.push({
-    id: uuidv4(),
-    externalId: `txn_fee_${uuidv4().substring(0, 8)}`,
-    source: 'Bank',
+    id: seededUuid(),
+    externalId: `txn_fee_${seededUuid().substring(0, 8)}`,
+    source: "Bank",
     occurredAt: randomDate(START_DATE, DAYS),
-    amount: 15.00,
-    currency: 'USD',
+    amount: 15.0,
+    currency: "USD",
     direction: RecordDirection.OUTGOING,
     type: RecordType.FEE,
-    status: 'posted',
-    description: 'MONTHLY SERVICE FEE',
-    raw: {}
+    status: "posted",
+    description: "MONTHLY SERVICE FEE",
+    raw: {},
   });
 
   // C. Stripe Refund
-  const refundAmount = 50.00;
+  const refundAmount = 50.0;
   stripeRecords.push({
-    id: uuidv4(),
-    externalId: `re_${uuidv4().substring(0, 8)}`,
-    source: 'Stripe',
+    id: seededUuid(),
+    externalId: `re_${seededUuid().substring(0, 8)}`,
+    source: "Stripe",
     occurredAt: randomDate(START_DATE, DAYS),
     amount: refundAmount,
-    currency: 'USD',
+    currency: "USD",
     direction: RecordDirection.OUTGOING,
     type: RecordType.REFUND,
-    status: 'succeeded',
-    description: 'Refund for item',
-    raw: {}
+    status: "succeeded",
+    description: "Refund for item",
+    raw: {},
   });
 
   // Write to files
-  fs.writeFileSync(path.join(DEMO_DIR, 'stripe_normalized.json'), JSON.stringify(stripeRecords, null, 2));
-  fs.writeFileSync(path.join(DEMO_DIR, 'bank_normalized.json'), JSON.stringify(bankRecords, null, 2));
-  fs.writeFileSync(path.join(DEMO_DIR, 'expected_matches.json'), JSON.stringify(expectedMatches, null, 2));
+  fs.writeFileSync(
+    path.join(DEMO_DIR, "stripe_normalized.json"),
+    JSON.stringify(stripeRecords, null, 2)
+  );
+  fs.writeFileSync(
+    path.join(DEMO_DIR, "bank_normalized.json"),
+    JSON.stringify(bankRecords, null, 2)
+  );
+  fs.writeFileSync(
+    path.join(DEMO_DIR, "expected_matches.json"),
+    JSON.stringify(expectedMatches, null, 2)
+  );
 
-  console.log(`Generated ${stripeRecords.length} Stripe records and ${bankRecords.length} Bank records.`);
+  console.warn(
+    `Generated ${stripeRecords.length} Stripe records and ${bankRecords.length} Bank records.`
+  );
 }
 
 generateDataset();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsx": "react-jsx",
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "commonjs",


### PR DESCRIPTION
### Motivation

- Demo data generation was nondeterministic and imported from package src paths, causing CI flakiness and unreproducible sandbox runs. 
- The `@jobforge/sdk-ts` workspace lacked unit tests which caused monorepo test gates to fail. 
- Documentation and governance (reality map, evidence, security, agent guardrails) needed explicit, copy-paste runnable artifacts to support Reality Pass objectives.

### Description

- Make demo dataset deterministic by adding a seeded RNG and seeded UUID generator and by removing direct imports from package source files in `scripts/generate-demo-data.ts`, and switch output to `console.warn` for informational logs. 
- Add demo lifecycle npm scripts (`demo:setup`, `demo:reset`, `demo:start`) to `package.json` to enable reproducible demo setup and reset. 
- Add unit tests for `@jobforge/sdk-ts` at `packages/jobforge-sdk-ts/test/client.test.ts` covering `enqueueJob` success and RPC-error paths. 
- Add documentation and governance artifacts: `docs/REALITY_MAP.md`, `docs/EVIDENCE.md`, extend `SECURITY.md` with webhook/rate-limit guidance, and update `AGENTS.md` with a safe-to-edit map and command canon; also remove duplicate `jsx` entry in `tsconfig.json`.

### Testing

- Ran `pnpm --filter @jobforge/sdk-ts test` and it passed (1 test file, 2 tests). 
- Executed the repo fast verification `node scripts/verify.mjs --fast --changed` which passed staged checks (lint-staged, typecheck, python checks) on the modified files. 
- `pnpm install` was executed during discovery and completed successfully (Prisma client generation observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69856af1c68083288ff869084155e633)