### PR TITLE
feat(recon): add overlay contracts, explainers, PR detector, and enterprise adapter

### DIFF
--- a/contracts/recon.ts
+++ b/contracts/recon.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+export const ReconReasonCategorySchema = z.enum([
+  "match",
+  "missing",
+  "drift",
+  "mismatch",
+  "unclassified",
+]);
+
+export type ReconReasonCategory = z.infer<typeof ReconReasonCategorySchema>;
+
+export const SourceTraceSchema = z
+  .object({
+    source: z.string(),
+    recordId: z.string().optional(),
+    line: z.number().int().nonnegative().optional(),
+    column: z.string().optional(),
+    field: z.string().optional(),
+    path: z.string().optional(),
+    note: z.string().optional(),
+  })
+  .passthrough();
+
+export type SourceTrace = z.infer<typeof SourceTraceSchema>;
+
+export const ReconItemSchema = z
+  .object({
+    id: z.string(),
+    status: z.enum(["match", "missing", "drift", "mismatch"]),
+    reasonCategory: ReconReasonCategorySchema.optional().default("unclassified"),
+    reason: z.string().optional(),
+    amount: z.number().optional(),
+    currency: z.string().optional(),
+    sourceTrace: SourceTraceSchema.optional(),
+    targetTrace: SourceTraceSchema.optional(),
+    fields: z.record(z.string(), z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+export type ReconItem = z.infer<typeof ReconItemSchema>;
+
+export const ReconRunSchema = z
+  .object({
+    runId: z.string(),
+    status: z.enum(["completed", "running", "failed"]),
+    startedAt: z.string(),
+    completedAt: z.string().optional(),
+    summary: z
+      .object({
+        totalItems: z.number().int().nonnegative().optional(),
+        matched: z.number().int().nonnegative().optional(),
+        missing: z.number().int().nonnegative().optional(),
+        drift: z.number().int().nonnegative().optional(),
+        mismatched: z.number().int().nonnegative().optional(),
+      })
+      .partial()
+      .optional(),
+    items: z.array(ReconItemSchema).default([]),
+    raw: z
+      .object({
+        json: z.unknown().optional(),
+        csv: z.string().optional(),
+        log: z.string().optional(),
+      })
+      .partial()
+      .optional(),
+  })
+  .passthrough();
+
+export type ReconRun = z.infer<typeof ReconRunSchema>;
+
+export const coerceReconRun = (raw: unknown): ReconRun | null => {
+  const parsed = ReconRunSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+};

--- a/enterprise/adapter.ts
+++ b/enterprise/adapter.ts
@@ -1,0 +1,35 @@
+export type ReviewResult = {
+  discrepancyId: string;
+  reviewedAt: string;
+  note?: string;
+};
+
+export type EvidenceExport = {
+  runId: string;
+  exportedAt: string;
+  format: "json" | "csv" | "log" | "bundle";
+  payload: string;
+};
+
+export interface EnterpriseReviewAdapter {
+  markReviewed: (discrepancyId: string, note?: string) => Promise<ReviewResult>;
+  exportEvidence: (runId: string) => Promise<EvidenceExport | null>;
+}
+
+export const NoopEnterpriseAdapter: EnterpriseReviewAdapter = {
+  async markReviewed(discrepancyId, note) {
+    return {
+      discrepancyId,
+      reviewedAt: new Date(0).toISOString(),
+      note,
+    };
+  },
+  async exportEvidence(runId) {
+    return {
+      runId,
+      exportedAt: new Date(0).toISOString(),
+      format: "json",
+      payload: "{}",
+    };
+  },
+};

--- a/fixtures/demo-recon-after.json
+++ b/fixtures/demo-recon-after.json
@@ -1,0 +1,43 @@
+{
+  "runId": "fixture-after",
+  "status": "completed",
+  "startedAt": "2024-09-02T08:00:00Z",
+  "completedAt": "2024-09-02T08:01:00Z",
+  "summary": {
+    "totalItems": 2,
+    "matched": 2,
+    "missing": 0,
+    "drift": 0,
+    "mismatched": 0
+  },
+  "items": [
+    {
+      "id": "after-1",
+      "status": "match",
+      "reasonCategory": "match",
+      "reason": "Invoices reconciled.",
+      "amount": 120,
+      "currency": "USD",
+      "sourceTrace": {
+        "source": "after.csv",
+        "recordId": "inv_01",
+        "line": 2,
+        "column": "amount"
+      }
+    },
+    {
+      "id": "after-2",
+      "status": "match",
+      "reasonCategory": "match",
+      "reason": "New rule resolved missing settlement.",
+      "amount": 75,
+      "currency": "USD",
+      "sourceTrace": {
+        "source": "after.csv",
+        "recordId": "inv_02",
+        "line": 3,
+        "column": "reference"
+      }
+    }
+  ]
+}

--- a/fixtures/demo-recon-before.json
+++ b/fixtures/demo-recon-before.json
@@ -1,0 +1,43 @@
+{
+  "runId": "fixture-before",
+  "status": "completed",
+  "startedAt": "2024-09-01T08:00:00Z",
+  "completedAt": "2024-09-01T08:01:00Z",
+  "summary": {
+    "totalItems": 2,
+    "matched": 1,
+    "missing": 1,
+    "drift": 0,
+    "mismatched": 0
+  },
+  "items": [
+    {
+      "id": "before-1",
+      "status": "match",
+      "reasonCategory": "match",
+      "reason": "Invoices reconciled.",
+      "amount": 120,
+      "currency": "USD",
+      "sourceTrace": {
+        "source": "before.csv",
+        "recordId": "inv_01",
+        "line": 2,
+        "column": "amount"
+      }
+    },
+    {
+      "id": "before-2",
+      "status": "missing",
+      "reasonCategory": "missing",
+      "reason": "Missing settlement reference.",
+      "amount": 75,
+      "currency": "USD",
+      "sourceTrace": {
+        "source": "before.csv",
+        "recordId": "inv_02",
+        "line": 3,
+        "column": "reference"
+      }
+    }
+  ]
+}

--- a/fixtures/demo-recon-run.json
+++ b/fixtures/demo-recon-run.json
@@ -1,0 +1,60 @@
+{
+  "runId": "demo-run-2024-09-14",
+  "status": "completed",
+  "startedAt": "2024-09-14T10:00:00Z",
+  "completedAt": "2024-09-14T10:02:15Z",
+  "summary": {
+    "totalItems": 3,
+    "matched": 1,
+    "missing": 1,
+    "drift": 1,
+    "mismatched": 0
+  },
+  "items": [
+    {
+      "id": "item-1001",
+      "status": "match",
+      "reasonCategory": "match",
+      "reason": "Payment and ledger entry line up exactly.",
+      "amount": 125.5,
+      "currency": "USD",
+      "sourceTrace": {
+        "source": "payments.csv",
+        "recordId": "pay_1001",
+        "line": 2,
+        "column": "amount"
+      }
+    },
+    {
+      "id": "item-1002",
+      "status": "missing",
+      "reasonCategory": "missing",
+      "reason": "Ledger entry missing for payment reference.",
+      "amount": 80,
+      "currency": "USD",
+      "sourceTrace": {
+        "source": "payments.csv",
+        "recordId": "pay_1002",
+        "line": 3,
+        "column": "reference"
+      }
+    },
+    {
+      "id": "item-1003",
+      "status": "drift",
+      "reasonCategory": "drift",
+      "reason": "Amount differs by settlement fee.",
+      "amount": 99.2,
+      "currency": "USD",
+      "sourceTrace": {
+        "source": "payments.csv",
+        "recordId": "pay_1003",
+        "line": 4,
+        "column": "amount"
+      }
+    }
+  ],
+  "raw": {
+    "log": "Recon run demo-run-2024-09-14 completed with 3 items."
+  }
+}

--- a/fixtures/demo-recon.csv
+++ b/fixtures/demo-recon.csv
@@ -1,0 +1,4 @@
+reference,amount,currency,status
+pay_1001,125.50,USD,matched
+pay_1002,80.00,USD,missing
+pay_1003,99.20,USD,drift

--- a/packages/web/src/__tests__/contracts/recon-contracts.test.ts
+++ b/packages/web/src/__tests__/contracts/recon-contracts.test.ts
@@ -1,0 +1,15 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ReconRunSchema } from "../../../../../contracts/recon";
+
+describe("recon contracts", () => {
+  it("parses the demo reconciliation run", () => {
+    const fixturePath = path.join(process.cwd(), "..", "..", "fixtures", "demo-recon-run.json");
+    const parsed = ReconRunSchema.parse(JSON.parse(fs.readFileSync(fixturePath, "utf8")));
+
+    expect(parsed.runId).toBe("demo-run-2024-09-14");
+    expect(parsed.items).toHaveLength(3);
+    expect(parsed.summary?.matched).toBe(1);
+  });
+});

--- a/packages/web/src/__tests__/pr-overlay/recon-change-detector.test.ts
+++ b/packages/web/src/__tests__/pr-overlay/recon-change-detector.test.ts
@@ -1,0 +1,20 @@
+import { detectReconChange } from "../../../../../pr-overlay/ReconChangeDetector";
+
+describe("detectReconChange", () => {
+  it("flags rule file updates", () => {
+    const result = detectReconChange([
+      "packages/api/src/recon/rules.ts",
+      "packages/web/src/app/page.tsx",
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(result.matchedFiles).toContain("packages/api/src/recon/rules.ts");
+  });
+
+  it("ignores unrelated changes", () => {
+    const result = detectReconChange(["packages/web/src/app/page.tsx"]);
+
+    expect(result.changed).toBe(false);
+    expect(result.matchedFiles).toHaveLength(0);
+  });
+});

--- a/packages/web/src/__tests__/ui/recon-explainer.test.tsx
+++ b/packages/web/src/__tests__/ui/recon-explainer.test.tsx
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { ReconRunSchema } from "../../../../../contracts/recon";
+import { ReconResultExplainer } from "../../../../../ui/explainers/ReconResultExplainer";
+
+describe("ReconResultExplainer", () => {
+  it("renders the demo report with CSV overlay", () => {
+    const csvPath = path.join(process.cwd(), "..", "..", "fixtures", "demo-recon.csv");
+    const jsonPath = path.join(process.cwd(), "..", "..", "fixtures", "demo-recon-run.json");
+    const csv = fs.readFileSync(csvPath, "utf8");
+    const run = ReconRunSchema.parse(JSON.parse(fs.readFileSync(jsonPath, "utf8")));
+
+    render(<ReconResultExplainer run={run} rawCsv={csv} />);
+
+    expect(screen.getByText("Reconciliation result")).toBeInTheDocument();
+    expect(screen.getByText(/demo-run-2024-09-14/)).toBeInTheDocument();
+    expect(screen.getByText("CSV overlay annotations")).toBeInTheDocument();
+    expect(screen.getByText(/Payment and ledger entry line up exactly/)).toBeInTheDocument();
+  });
+});

--- a/pr-overlay/ReconChangeDetector.ts
+++ b/pr-overlay/ReconChangeDetector.ts
@@ -1,0 +1,66 @@
+const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const globToRegex = (pattern: string) => {
+  const normalized = pattern.replace(/\\/g, "/");
+  const regexBody = normalized
+    .split("**")
+    .map((segment) =>
+      segment
+        .split("*")
+        .map((part) => escapeRegex(part))
+        .join("[^/]*")
+    )
+    .join(".*")
+    .replace(/\?/g, ".");
+
+  return new RegExp(`^${regexBody}$`);
+};
+
+export type ReconChangeDetectorOptions = {
+  patterns?: string[];
+  excludedPatterns?: string[];
+};
+
+export type ReconChangeResult = {
+  changed: boolean;
+  matchedFiles: string[];
+  reason: string;
+};
+
+export const defaultReconPatterns = [
+  "contracts/recon.ts",
+  "**/recon/**",
+  "**/reconciliation/**",
+  "**/rules/**",
+  "**/*.recon.*",
+  "**/*.rules.*",
+  "**/*reconcile*",
+];
+
+export const detectReconChange = (
+  changedFiles: string[],
+  { patterns = defaultReconPatterns, excludedPatterns = [] }: ReconChangeDetectorOptions = {}
+): ReconChangeResult => {
+  const matcher = patterns.map(globToRegex);
+  const excludedMatcher = excludedPatterns.map(globToRegex);
+  const matches: string[] = [];
+
+  changedFiles.forEach((file) => {
+    const normalized = file.replace(/\\/g, "/");
+    if (excludedMatcher.some((regex) => regex.test(normalized))) {
+      return;
+    }
+    if (matcher.some((regex) => regex.test(normalized))) {
+      matches.push(normalized);
+    }
+  });
+
+  return {
+    changed: matches.length > 0,
+    matchedFiles: matches,
+    reason:
+      matches.length > 0
+        ? "Reconciliation logic changed"
+        : "No reconciliation logic changes detected",
+  };
+};

--- a/pr-overlay/SampleBeforeAfterPanel.tsx
+++ b/pr-overlay/SampleBeforeAfterPanel.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+
+import { ReconRun } from "../contracts/recon";
+
+export type SampleBeforeAfterPanelProps = {
+  before: ReconRun;
+  after: ReconRun;
+  title?: string;
+  description?: string;
+};
+
+const computeCounts = (run: ReconRun) => {
+  const base = run.summary ?? {};
+  const items = run.items ?? [];
+  if (Object.keys(base).length > 0) {
+    return base;
+  }
+
+  const counts = { matched: 0, missing: 0, drift: 0, mismatched: 0 };
+  items.forEach((item) => {
+    if (item.status === "match") counts.matched += 1;
+    if (item.status === "missing") counts.missing += 1;
+    if (item.status === "drift") counts.drift += 1;
+    if (item.status === "mismatch") counts.mismatched += 1;
+  });
+  return counts;
+};
+
+const formatValue = (value?: number) => (typeof value === "number" ? value.toString() : "—");
+
+export const SampleBeforeAfterPanel = ({
+  before,
+  after,
+  title = "Reconciliation change preview",
+  description = "Sample output derived from fixtures to show how rule changes affect reconciliation.",
+}: SampleBeforeAfterPanelProps) => {
+  const beforeCounts = computeCounts(before);
+  const afterCounts = computeCounts(after);
+
+  return (
+    <section
+      style={{
+        border: "1px solid #e2e8f0",
+        borderRadius: 12,
+        padding: 16,
+        backgroundColor: "#ffffff",
+        boxShadow: "0 1px 3px rgba(15, 23, 42, 0.08)",
+      }}
+    >
+      <header style={{ marginBottom: 12 }}>
+        <h3 style={{ margin: 0, fontSize: 18 }}>{title}</h3>
+        <p style={{ margin: 0, color: "#475569", fontSize: 13 }}>{description}</p>
+      </header>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+          gap: 12,
+        }}
+      >
+        {[
+          { label: "Matched", before: beforeCounts.matched, after: afterCounts.matched },
+          { label: "Missing", before: beforeCounts.missing, after: afterCounts.missing },
+          { label: "Drift", before: beforeCounts.drift, after: afterCounts.drift },
+          { label: "Mismatched", before: beforeCounts.mismatched, after: afterCounts.mismatched },
+        ].map((row) => (
+          <div
+            key={row.label}
+            style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 12 }}
+          >
+            <strong style={{ display: "block", marginBottom: 6 }}>{row.label}</strong>
+            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13 }}>
+              <span>Before: {formatValue(row.before)}</span>
+              <span>After: {formatValue(row.after)}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/pr-overlay/host/github.ts
+++ b/pr-overlay/host/github.ts
@@ -1,0 +1,43 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+import { ReconRun } from "../../contracts/recon";
+import { detectReconChange, ReconChangeDetectorOptions } from "../ReconChangeDetector";
+import { SampleBeforeAfterPanel } from "../SampleBeforeAfterPanel";
+
+type GithubOverlayOptions = ReconChangeDetectorOptions & {
+  changedFiles: string[];
+  before: ReconRun;
+  after: ReconRun;
+  mountId?: string;
+};
+
+export const mountGithubOverlay = ({
+  changedFiles,
+  before,
+  after,
+  mountId = "settler-recon-overlay",
+  ...detectorOptions
+}: GithubOverlayOptions) => {
+  if (typeof document === "undefined") {
+    return { mounted: false, ...detectReconChange(changedFiles, detectorOptions) };
+  }
+
+  const detection = detectReconChange(changedFiles, detectorOptions);
+  if (!detection.changed) {
+    return { mounted: false, ...detection };
+  }
+
+  const container = document.getElementById(mountId) ?? document.createElement("div");
+  container.id = mountId;
+  container.style.margin = "16px 0";
+
+  if (!container.parentElement) {
+    document.body.prepend(container);
+  }
+
+  const root = createRoot(container);
+  root.render(React.createElement(SampleBeforeAfterPanel, { before, after }));
+
+  return { mounted: true, ...detection };
+};

--- a/pr-overlay/host/gitlab.ts
+++ b/pr-overlay/host/gitlab.ts
@@ -1,0 +1,45 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+import { ReconRun } from "../../contracts/recon";
+import { detectReconChange, ReconChangeDetectorOptions } from "../ReconChangeDetector";
+import { SampleBeforeAfterPanel } from "../SampleBeforeAfterPanel";
+
+type GitlabOverlayOptions = ReconChangeDetectorOptions & {
+  changedFiles: string[];
+  before: ReconRun;
+  after: ReconRun;
+  mountId?: string;
+};
+
+export const mountGitlabOverlay = ({
+  changedFiles,
+  before,
+  after,
+  mountId = "settler-recon-overlay",
+  ...detectorOptions
+}: GitlabOverlayOptions) => {
+  if (typeof document === "undefined") {
+    return { mounted: false, ...detectReconChange(changedFiles, detectorOptions) };
+  }
+
+  const detection = detectReconChange(changedFiles, detectorOptions);
+  if (!detection.changed) {
+    return { mounted: false, ...detection };
+  }
+
+  const container = document.getElementById(mountId) ?? document.createElement("div");
+  container.id = mountId;
+  container.style.margin = "16px 0";
+
+  if (!container.parentElement) {
+    const target =
+      document.querySelector("#merge-requests, .merge-request-details") ?? document.body;
+    target.prepend(container);
+  }
+
+  const root = createRoot(container);
+  root.render(React.createElement(SampleBeforeAfterPanel, { before, after }));
+
+  return { mounted: true, ...detection };
+};

--- a/ui/explainers/CsvOverlayTable.tsx
+++ b/ui/explainers/CsvOverlayTable.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+
+export type CsvOverlayStatus = "match" | "missing" | "drift" | "mismatch";
+
+export type CsvOverlayAnnotation = {
+  rowIndex: number;
+  column?: string;
+  status: CsvOverlayStatus;
+  message?: string;
+};
+
+type CsvOverlayTableProps = {
+  headers: string[];
+  rows: string[][];
+  annotations?: CsvOverlayAnnotation[];
+  caption?: string;
+};
+
+const statusStyles: Record<CsvOverlayStatus, React.CSSProperties> = {
+  match: { backgroundColor: "#e8f7ee", borderColor: "#21a366" },
+  missing: { backgroundColor: "#fff3e0", borderColor: "#ff9800" },
+  drift: { backgroundColor: "#e3f2fd", borderColor: "#1e88e5" },
+  mismatch: { backgroundColor: "#fdecea", borderColor: "#d32f2f" },
+};
+
+const resolveAnnotation = (
+  annotations: CsvOverlayAnnotation[] | undefined,
+  rowIndex: number,
+  column: string
+) =>
+  annotations?.find(
+    (annotation) =>
+      annotation.rowIndex === rowIndex &&
+      (annotation.column === undefined || annotation.column === column)
+  );
+
+export const CsvOverlayTable = ({
+  headers,
+  rows,
+  annotations = [],
+  caption = "CSV annotation overlay",
+}: CsvOverlayTableProps) => (
+  <div style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 8 }}>
+    <table style={{ width: "100%", borderCollapse: "collapse" }}>
+      <caption style={{ textAlign: "left", padding: "8px 12px", color: "#475569" }}>
+        {caption}
+      </caption>
+      <thead style={{ backgroundColor: "#f8fafc" }}>
+        <tr>
+          {headers.map((header) => (
+            <th
+              key={header}
+              style={{
+                textAlign: "left",
+                fontWeight: 600,
+                fontSize: 12,
+                padding: "8px 12px",
+                borderBottom: "1px solid #e2e8f0",
+              }}
+            >
+              {header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, rowIndex) => (
+          <tr key={`row-${rowIndex}`}>
+            {row.map((cell, cellIndex) => {
+              const column = headers[cellIndex] ?? `Column ${cellIndex + 1}`;
+              const annotation = resolveAnnotation(annotations, rowIndex, column);
+              const style = annotation ? statusStyles[annotation.status] : undefined;
+
+              return (
+                <td
+                  key={`${rowIndex}-${column}`}
+                  style={{
+                    padding: "8px 12px",
+                    borderBottom: "1px solid #e2e8f0",
+                    borderLeft: cellIndex === 0 ? "none" : "1px solid #e2e8f0",
+                    backgroundColor: style?.backgroundColor,
+                    borderTop: annotation ? `2px solid ${style?.borderColor}` : undefined,
+                  }}
+                >
+                  <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                    <span>{cell || "—"}</span>
+                    {annotation?.message ? (
+                      <span style={{ fontSize: 11, color: "#475569" }}>{annotation.message}</span>
+                    ) : null}
+                  </div>
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);

--- a/ui/explainers/ReconResultExplainer.tsx
+++ b/ui/explainers/ReconResultExplainer.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+
+import { coerceReconRun, ReconItem, ReconRun } from "../../contracts/recon";
+import { CsvOverlayAnnotation, CsvOverlayTable } from "./CsvOverlayTable";
+
+export type ReconResultExplainerProps = {
+  run?: ReconRun;
+  rawJson?: unknown;
+  rawCsv?: string;
+  rawLog?: string;
+  title?: string;
+};
+
+type ParsedCsv = {
+  headers: string[];
+  rows: string[][];
+};
+
+const parseCsv = (csv?: string): ParsedCsv | null => {
+  if (!csv) {
+    return null;
+  }
+
+  const lines = csv
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const rows = lines.map((line) => line.split(",").map((cell) => cell.trim()));
+  const [headers, ...dataRows] = rows;
+
+  return {
+    headers: headers ?? [],
+    rows: dataRows,
+  };
+};
+
+const buildAnnotations = (items: ReconItem[]): CsvOverlayAnnotation[] =>
+  items
+    .map((item) => {
+      const trace = item.sourceTrace;
+      if (!trace || typeof trace.line !== "number") {
+        return null;
+      }
+
+      const rowIndex = Math.max(trace.line - 2, 0);
+      const column = trace.column;
+
+      return {
+        rowIndex,
+        column,
+        status: item.status,
+        message: item.reason ?? item.reasonCategory,
+      } satisfies CsvOverlayAnnotation;
+    })
+    .filter((annotation): annotation is CsvOverlayAnnotation => Boolean(annotation));
+
+const formatCount = (value?: number) => (typeof value === "number" ? value.toString() : "—");
+
+const summarizeItems = (items: ReconItem[]) => {
+  const summary = { match: 0, missing: 0, drift: 0, mismatch: 0 } as const;
+  const counts = { ...summary } as Record<keyof typeof summary, number>;
+
+  items.forEach((item) => {
+    if (counts[item.status] !== undefined) {
+      counts[item.status] += 1;
+    }
+  });
+
+  return counts;
+};
+
+export const ReconResultExplainer = ({
+  run,
+  rawJson,
+  rawCsv,
+  rawLog,
+  title = "Reconciliation result",
+}: ReconResultExplainerProps) => {
+  const parsedRun = run ?? coerceReconRun(rawJson);
+  const items = parsedRun?.items ?? [];
+  const summaryCounts = parsedRun?.summary ?? summarizeItems(items);
+  const summary = summaryCounts as Record<string, number | undefined>;
+  const parsedCsv = parseCsv(rawCsv ?? parsedRun?.raw?.csv);
+  const annotations = buildAnnotations(items);
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <header>
+        <h2 style={{ fontSize: 20, fontWeight: 600, marginBottom: 4 }}>{title}</h2>
+        <p style={{ color: "#475569", margin: 0 }}>Run ID: {parsedRun?.runId ?? "Unknown"}</p>
+      </header>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+          gap: 12,
+        }}
+      >
+        <div style={{ padding: 12, border: "1px solid #e2e8f0", borderRadius: 8 }}>
+          <strong>Matched</strong>
+          <div>{formatCount(summary.matched ?? summary.match)}</div>
+        </div>
+        <div style={{ padding: 12, border: "1px solid #e2e8f0", borderRadius: 8 }}>
+          <strong>Missing</strong>
+          <div>{formatCount(summary.missing)}</div>
+        </div>
+        <div style={{ padding: 12, border: "1px solid #e2e8f0", borderRadius: 8 }}>
+          <strong>Drift</strong>
+          <div>{formatCount(summary.drift)}</div>
+        </div>
+        <div style={{ padding: 12, border: "1px solid #e2e8f0", borderRadius: 8 }}>
+          <strong>Mismatched</strong>
+          <div>{formatCount(summary.mismatched ?? summary.mismatch)}</div>
+        </div>
+      </div>
+
+      <div style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 12 }}>
+        <h3 style={{ fontSize: 16, marginTop: 0 }}>Item explanations</h3>
+        {items.length === 0 ? (
+          <p style={{ margin: 0, color: "#64748b" }}>No reconciliation items available.</p>
+        ) : (
+          <ul
+            style={{ margin: 0, paddingLeft: 20, display: "flex", flexDirection: "column", gap: 8 }}
+          >
+            {items.map((item) => (
+              <li key={item.id}>
+                <strong>{item.status.toUpperCase()}</strong> —{" "}
+                {item.reason ?? "No reason provided."}
+                <div style={{ fontSize: 12, color: "#64748b" }}>
+                  Category: {item.reasonCategory ?? "unclassified"} · Amount: {item.amount ?? "—"}{" "}
+                  {item.currency ?? ""}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {parsedCsv ? (
+        <CsvOverlayTable
+          headers={parsedCsv.headers}
+          rows={parsedCsv.rows}
+          annotations={annotations}
+          caption="CSV overlay annotations"
+        />
+      ) : null}
+
+      {(rawLog ?? parsedRun?.raw?.log) ? (
+        <details style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 12 }}>
+          <summary style={{ cursor: "pointer", fontWeight: 600 }}>Run log</summary>
+          <pre style={{ whiteSpace: "pre-wrap", marginTop: 8 }}>
+            {rawLog ?? parsedRun?.raw?.log ?? ""}
+          </pre>
+        </details>
+      ) : null}
+    </section>
+  );
+};


### PR DESCRIPTION
### Motivation
- Provide concrete contracts and UI building blocks so reconciliation runs can be explained and CSVs annotated for OSS users. 
- Detect changes to reconciliation logic in PRs and show sample before/after using local fixtures to make reviews safer. 
- Offer a pluggable enterprise adapter surface (default noop) for review/exports.

### Description
- Added a TypeScript contract at `contracts/recon.ts` defining `ReconRun`, `ReconItem`, `ReconReasonCategory`, `SourceTrace`, and a `coerceReconRun` helper. 
- Implemented UI explainer components under `ui/explainers/`: `ReconResultExplainer.tsx` (renders summaries, item explanations, run log) and `CsvOverlayTable.tsx` (annotates CSV rows/cells with match/missing/drift/mismatch states). 
- Added PR overlay utilities under `pr-overlay/`: `ReconChangeDetector.ts` (glob-based detection of rule/recon file changes), `SampleBeforeAfterPanel.tsx` (fixture-based before/after summary), and host mounts `host/github.ts` and `host/gitlab.ts` to mount the panel into pages. 
- Added `enterprise/adapter.ts` defining `EnterpriseReviewAdapter` and a `NoopEnterpriseAdapter` default. 
- Included demo fixtures (`fixtures/demo-recon*.json` and `fixtures/demo-recon.csv`) and three tests: contract parsing, UI render of the explainer (render + CSV overlay), and the recon change detector unit test.

### Testing
- Ran `pnpm run lint` which passed (repo has pre-existing warnings not introduced by this change). ✅
- Ran `pnpm run typecheck` (turbo orchestrated); TypeScript checks passed across packages. ✅
- Ran `pnpm run build` (filtered `@settler/web`); build completed with repository environment/Node warnings (expected in local env). ✅
- Ran `pnpm run test`: new unit/UI tests were added and exercised locally, but full monorepo `pnpm run test` shows unrelated failures in `@settler/api` and `@settler/web` suites due to existing environment and harness issues (DB/Supabase env, Request polyfill, and some test expectations); the created tests for recon passed in their scope. ❌


Files changed (new):
- `contracts/recon.ts`
- `ui/explainers/CsvOverlayTable.tsx`
- `ui/explainers/ReconResultExplainer.tsx`
- `pr-overlay/ReconChangeDetector.ts`
- `pr-overlay/SampleBeforeAfterPanel.tsx`
- `pr-overlay/host/github.ts`
- `pr-overlay/host/gitlab.ts`
- `enterprise/adapter.ts`
- `fixtures/demo-recon-run.json`
- `fixtures/demo-recon.csv`
- `fixtures/demo-recon-before.json`
- `fixtures/demo-recon-after.json`
- `packages/web/src/__tests__/contracts/recon-contracts.test.ts`
- `packages/web/src/__tests__/ui/recon-explainer.test.tsx`
- `packages/web/src/__tests__/pr-overlay/recon-change-detector.test.ts`

Verification commands to reproduce locally:
- `pnpm install`
- `pnpm run lint` (will show repo warnings but no new lint errors from this change)
- `pnpm run typecheck`
- `pnpm run build` (may warn about missing runtime env vars and Node version)
- `pnpm run test` (note: full test run surfaces unrelated existing failures; unit tests added for recon run and PR detector are present under `packages/web/src/__tests__`)

Notes / Risks / Followups:
- The explainer and overlay are self-contained UI components but not wired into an actual console route; next step is to mount a demo page in `packages/web` or a Storybook story. 
- Some repository test failures remain unrelated to these changes (environmental/test harness issues). Recommended follow-ups: polyfill `Request` for Jest, stabilize DB/Supabase test setup, and run visual snapshot checks for the explainer. 
- Rollback is straightforward by reverting the added files if needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857045204c83288d375efe58787f67)