### PR TITLE
fix(web): resolve static content page path in monorepo builds

### DIFF
--- a/packages/web/src/lib/content/pages.ts
+++ b/packages/web/src/lib/content/pages.ts
@@ -1,8 +1,25 @@
-import fs from 'fs';
-import path from 'path';
-import matter from 'gray-matter';
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
 
-const contentDirectory = path.join(process.cwd(), 'content/pages');
+function resolveContentDirectory(): string {
+  const cwd = process.cwd();
+  const directoryCandidates = [
+    path.join(cwd, "content/pages"),
+    path.join(cwd, "packages/web/content/pages"),
+  ];
+
+  for (const directory of directoryCandidates) {
+    if (fs.existsSync(directory)) {
+      return directory;
+    }
+  }
+
+  // Fallback keeps behavior deterministic for environments where content is unavailable.
+  return directoryCandidates[0] ?? path.join(cwd, "content/pages");
+}
+
+const contentDirectory = resolveContentDirectory();
 
 export interface ContentPage {
   slug: string;
@@ -14,13 +31,13 @@ export interface ContentPage {
 export function getContentPage(slug: string): ContentPage | null {
   try {
     const fullPath = path.join(contentDirectory, `${slug}.mdx`);
-    const fileContents = fs.readFileSync(fullPath, 'utf8');
+    const fileContents = fs.readFileSync(fullPath, "utf8");
     const { data, content } = matter(fileContents);
 
     return {
       slug,
       title: (data.title as string) || slug,
-      description: (data.description as string) || '',
+      description: (data.description as string) || "",
       content,
     };
   } catch {


### PR DESCRIPTION
### Motivation
- Top-nav static content pages (e.g. `/product`, `/open-source`, `/integrations`, `/security-and-audit`) were causing Server Component render failures because `getContentPage` only looked in `process.cwd()/content/pages`, which is incorrect when the app is run from the monorepo root where MDX files live under `packages/web/content/pages`.
- Ensure content-backed pages never 500 by making the content lookup robust across monorepo and package-local run contexts.

### Description
- Modified `packages/web/src/lib/content/pages.ts` to add `resolveContentDirectory()` which deterministically checks candidate locations `(<cwd>/content/pages)` and `(<cwd>/packages/web/content/pages)` and returns the first existing path.
- Retained existing `getContentPage` behavior and null-fallback when a page file cannot be read or parsed, avoiding behavioral changes beyond path resolution.

### Testing
- Ran `pnpm --filter @settler/web lint` which completed successfully (26 pre-existing warnings remain, no new errors). 
- Ran `pnpm --filter @settler/web typecheck` which passed with no type errors after the change. 
- Ran `pnpm --filter @settler/web build` (`next build`) which completed and generated the static pages successfully. 
- Ran `pnpm run verify:docs` which passed; pre-commit verification (`verify:fast` / lint-staged / turbo typecheck / typed env / app-router / Python checks) also completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bdd4c70dc832898264f8fbd269ad5)