### PR TITLE
fix(web): remove vulnerable next-mdx-remote dependency

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "next dev",
     "clean:build": "rm -rf .next dist out .next/tsconfig.tsbuildinfo",
-    "validate:api-routes": "test -f ../../scripts/validate-api-routes.ts && tsx ../../scripts/validate-api-routes.ts || echo '⚠️  API route validation skipped (script not found)'",
+    "validate:api-routes": "test -f ../../scripts/validate-api-routes.ts && tsx ../../scripts/validate-api-routes.ts || echo '\u26a0\ufe0f  API route validation skipped (script not found)'",
     "build": "next build --webpack",
     "build:vercel": "next build --webpack",
     "postinstall": "export SENTRY_SKIP_AUTO_INSTALL=1 || set SENTRY_SKIP_AUTO_INSTALL=1 || true",
@@ -21,9 +21,9 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "analyze": "ANALYZE=true next build",
-    "analyze:bundle": "ANALYZE=true next build && echo '\n📦 Bundle analysis complete. Open the generated HTML report to view details.'",
+    "analyze:bundle": "ANALYZE=true next build && echo '\n\ud83d\udce6 Bundle analysis complete. Open the generated HTML report to view details.'",
     "bundle:size": "next build && du -sh .next && du -sh .next/static && du -sh .next/static/chunks",
-    "bundle:check": "echo '⚠️  Run \"pnpm build\" first, then \"pnpm bundle:size\" to check bundle sizes'",
+    "bundle:check": "echo '\u26a0\ufe0f  Run \"pnpm build\" first, then \"pnpm bundle:size\" to check bundle sizes'",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
@@ -71,7 +71,6 @@
     "lenis": "^1.3.15",
     "lucide-react": "^0.555.0",
     "next": "16.1.6",
-    "next-mdx-remote": "^5.0.0",
     "openai": "^4.28.0",
     "postcss": "^8.4.32",
     "react": "^18.2.0",

--- a/packages/web/src/app/changelog/[slug]/page.tsx
+++ b/packages/web/src/app/changelog/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { AnimatedPageWrapper } from '@/components/AnimatedPageWrapper';
 import { Breadcrumbs } from '@/components/Breadcrumbs';
 import { getChangelogPost, getAllChangelogPosts } from '@/lib/changelog';
 import { notFound } from 'next/navigation';
-import { MDXRemote } from 'next-mdx-remote/rsc';
+import { MdxPlainRenderer } from '@/components/content/MdxPlainRenderer';
 import { Metadata } from 'next';
 
 interface Props {
@@ -55,7 +55,7 @@ export default function ChangelogPostPage({ params }: Props) {
         </header>
         
         <div className="prose prose-slate dark:prose-invert max-w-none">
-          <MDXRemote source={post.content} />
+          <MdxPlainRenderer source={post.content} />
         </div>
       </article>
       <Footer />

--- a/packages/web/src/app/integrations/page.tsx
+++ b/packages/web/src/app/integrations/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { MDXRemote } from 'next-mdx-remote/rsc';
+import { MdxPlainRenderer } from '@/components/content/MdxPlainRenderer';
 import { PageLayout } from '@/components/content/PageLayout';
 import { getContentPage } from '@/lib/content/pages';
 
@@ -25,7 +25,7 @@ export default function IntegrationsPage() {
 
   return (
     <PageLayout title={page.title} description={page.description}>
-      <MDXRemote source={page.content} />
+      <MdxPlainRenderer source={page.content} />
     </PageLayout>
   );
 }

--- a/packages/web/src/app/open-source/page.tsx
+++ b/packages/web/src/app/open-source/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { MDXRemote } from 'next-mdx-remote/rsc';
+import { MdxPlainRenderer } from '@/components/content/MdxPlainRenderer';
 import { PageLayout } from '@/components/content/PageLayout';
 import { getContentPage } from '@/lib/content/pages';
 
@@ -25,7 +25,7 @@ export default function OpenSourcePage() {
 
   return (
     <PageLayout title={page.title} description={page.description}>
-      <MDXRemote source={page.content} />
+      <MdxPlainRenderer source={page.content} />
     </PageLayout>
   );
 }

--- a/packages/web/src/app/product/page.tsx
+++ b/packages/web/src/app/product/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { MDXRemote } from 'next-mdx-remote/rsc';
+import { MdxPlainRenderer } from '@/components/content/MdxPlainRenderer';
 import { PageLayout } from '@/components/content/PageLayout';
 import { getContentPage } from '@/lib/content/pages';
 
@@ -25,7 +25,7 @@ export default function ProductPage() {
 
   return (
     <PageLayout title={page.title} description={page.description}>
-      <MDXRemote source={page.content} />
+      <MdxPlainRenderer source={page.content} />
     </PageLayout>
   );
 }

--- a/packages/web/src/app/security-and-audit/page.tsx
+++ b/packages/web/src/app/security-and-audit/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { MDXRemote } from 'next-mdx-remote/rsc';
+import { MdxPlainRenderer } from '@/components/content/MdxPlainRenderer';
 import { PageLayout } from '@/components/content/PageLayout';
 import { getContentPage } from '@/lib/content/pages';
 
@@ -25,7 +25,7 @@ export default function SecurityAndAuditPage() {
 
   return (
     <PageLayout title={page.title} description={page.description}>
-      <MDXRemote source={page.content} />
+      <MdxPlainRenderer source={page.content} />
     </PageLayout>
   );
 }

--- a/packages/web/src/components/content/MdxPlainRenderer.tsx
+++ b/packages/web/src/components/content/MdxPlainRenderer.tsx
@@ -1,0 +1,109 @@
+interface MdxPlainRendererProps {
+  source: string;
+}
+
+export function MdxPlainRenderer({ source }: MdxPlainRendererProps) {
+  const lines = source.split('\n');
+  const blocks: Array<{ type: 'h1' | 'h2' | 'h3' | 'li' | 'p' | 'code'; content: string }> = [];
+
+  let inCodeBlock = false;
+  let codeBuffer: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith('```')) {
+      if (inCodeBlock) {
+        blocks.push({ type: 'code', content: codeBuffer.join('\n') });
+        codeBuffer = [];
+      }
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeBuffer.push(line);
+      continue;
+    }
+
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    if (trimmed.startsWith('### ')) {
+      blocks.push({ type: 'h3', content: trimmed.replace(/^###\s+/, '') });
+      continue;
+    }
+
+    if (trimmed.startsWith('## ')) {
+      blocks.push({ type: 'h2', content: trimmed.replace(/^##\s+/, '') });
+      continue;
+    }
+
+    if (trimmed.startsWith('# ')) {
+      blocks.push({ type: 'h1', content: trimmed.replace(/^#\s+/, '') });
+      continue;
+    }
+
+    if (trimmed.startsWith('- ')) {
+      blocks.push({ type: 'li', content: trimmed.replace(/^-\s+/, '') });
+      continue;
+    }
+
+    blocks.push({ type: 'p', content: trimmed });
+  }
+
+  return (
+    <div className="space-y-4">
+      {blocks.map((block, index) => {
+        if (block.type === 'h1') {
+          return (
+            <h1 key={`${block.type}-${index}`} className="text-3xl font-bold text-slate-900 dark:text-white">
+              {block.content}
+            </h1>
+          );
+        }
+
+        if (block.type === 'h2') {
+          return (
+            <h2 key={`${block.type}-${index}`} className="text-2xl font-semibold text-slate-900 dark:text-white">
+              {block.content}
+            </h2>
+          );
+        }
+
+        if (block.type === 'h3') {
+          return (
+            <h3 key={`${block.type}-${index}`} className="text-xl font-semibold text-slate-900 dark:text-white">
+              {block.content}
+            </h3>
+          );
+        }
+
+        if (block.type === 'li') {
+          return (
+            <li key={`${block.type}-${index}`} className="ml-5 list-disc text-slate-700 dark:text-slate-300">
+              {block.content}
+            </li>
+          );
+        }
+
+        if (block.type === 'code') {
+          return (
+            <pre
+              key={`${block.type}-${index}`}
+              className="overflow-x-auto rounded-md bg-slate-900 p-4 text-sm text-slate-100 dark:bg-slate-950"
+            >
+              <code>{block.content}</code>
+            </pre>
+          );
+        }
+
+        return (
+          <p key={`${block.type}-${index}`} className="text-slate-700 dark:text-slate-300">
+            {block.content}
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -803,9 +803,6 @@ importers:
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      next-mdx-remote:
-        specifier: ^5.0.0
-        version: 5.0.0(@types/react@18.3.27)(react@18.3.1)
       openai:
         specifier: ^4.28.0
         version: 4.104.0(ws@8.19.0)(zod@4.3.6)


### PR DESCRIPTION
### Motivation
- Vercel builds blocked by a security advisory for `next-mdx-remote@5.0.0` (CVE-2026-0969) and the environment could not fetch registry upgrades, so the web package must stop depending on the vulnerable package to unblock deploys.
- Provide a minimal, local renderer so content pages continue to render without adding an external MDX dependency that is blocked by the security gate.

### Description
- Removed `next-mdx-remote` from `packages/web/package.json` and cleared its importer entry from `pnpm-lock.yaml` so it is no longer a direct dependency of `@settler/web` (affected files: `packages/web/package.json`, `pnpm-lock.yaml`).
- Replaced usages of `MDXRemote` with a local renderer `MdxPlainRenderer` in content routes at `packages/web/src/app/changelog/[slug]/page.tsx`, `packages/web/src/app/integrations/page.tsx`, `packages/web/src/app/open-source/page.tsx`, `packages/web/src/app/product/page.tsx`, and `packages/web/src/app/security-and-audit/page.tsx`.
- Added `packages/web/src/components/content/MdxPlainRenderer.tsx`, a small server component that renders basic markdown-like content (headings, lists, paragraphs, fenced code blocks) without external MDX packages.
- Kept change minimal and reversible so full MDX support can be reintroduced later when a safe upgrade is available.

### Testing
- Ran `pnpm --filter @settler/web typecheck` which completed successfully with no blocking errors.
- Built the frontend with `pnpm --filter @settler/web build` and the Next.js production build completed successfully (static prerendering and route generation succeeded with previously unrelated non-fatal warnings).
- Executed repository verification pipeline triggered during the change which ran `lint`, globals CSS import order check, route boundary smoke, offline prerender harness tests, middleware gating tests, typecheck across packages, `verify:docs`, and the monorepo `build`, all of which passed in this environment; `pnpm audit` returned a 403 from the npm audit endpoint and was treated as a warning by the tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eca51634083289aca78d583614d8b)