### PR TITLE
fix(web): harden app gating, webhook runtime safety, and smoke CI coverage

### DIFF
--- a/.github/workflows/playwright-route-protection-smoke.yml
+++ b/.github/workflows/playwright-route-protection-smoke.yml
@@ -1,0 +1,40 @@
+name: Playwright Route Protection Smoke
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'packages/web/**'
+      - 'tests/e2e/**'
+      - 'playwright.config.ts'
+      - '.github/workflows/playwright-route-protection-smoke.yml'
+  push:
+    branches: [main]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.13.1
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run route-protection smoke suite
+        run: pnpm exec playwright test tests/e2e/route-protection-smoke.spec.ts --project=chromium
+        env:
+          NEXT_PUBLIC_SITE_URL: http://localhost:3000
+          NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: anon-key-for-ci

--- a/packages/web/src/__tests__/api/stripe-webhook-runtime.test.ts
+++ b/packages/web/src/__tests__/api/stripe-webhook-runtime.test.ts
@@ -3,8 +3,8 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-describe('stripe webhook runtime invariants', () => {
-  it('keeps node runtime and raw body verification path', () => {
+describe('webhook runtime invariants', () => {
+  it('keeps stripe webhook runtime and raw body verification path', () => {
     const source = readFileSync(
       resolve(process.cwd(), 'src/app/api/stripe/webhook/route.ts'),
       'utf-8'
@@ -13,5 +13,16 @@ describe('stripe webhook runtime invariants', () => {
     expect(source).toContain('export const runtime = "nodejs"');
     expect(source).toContain('const body = await request.text();');
     expect(source).toContain('stripe.webhooks.constructEvent(body, signature, webhookSecret)');
+  });
+
+  it('keeps builder webhook on node runtime for crypto signature verification', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/app/api/builder/revalidate/route.ts'),
+      'utf-8'
+    );
+
+    expect(source).toContain("export const runtime = 'nodejs'");
+    expect(source).toContain('const rawBody = await request.text();');
+    expect(source).toContain("createHmac('sha256'");
   });
 });

--- a/packages/web/src/__tests__/env/runtime-access.test.ts
+++ b/packages/web/src/__tests__/env/runtime-access.test.ts
@@ -1,0 +1,37 @@
+/** @jest-environment node */
+
+import { getAppEnvStatus } from '@/lib/env/runtime-access';
+
+describe('runtime env access contract', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    delete process.env.SUPABASE_ANON_KEY;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('accepts server-prefixed fallbacks for app required env keys', () => {
+    process.env.SUPABASE_URL = 'https://fallback.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'fallback-anon';
+
+    const status = getAppEnvStatus();
+
+    expect(status.ok).toBe(true);
+    expect(status.missing).toEqual([]);
+  });
+
+  it('reports missing grouped requirements when both variants are absent', () => {
+    const status = getAppEnvStatus();
+
+    expect(status.ok).toBe(false);
+    expect(status.missing).toContain('NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL');
+    expect(status.missing).toContain('NEXT_PUBLIC_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY');
+  });
+});

--- a/packages/web/src/__tests__/middleware/app-auth-gating.test.ts
+++ b/packages/web/src/__tests__/middleware/app-auth-gating.test.ts
@@ -15,6 +15,14 @@ describe('middleware /app-only auth gating', () => {
     expect(isAppAuthRequiredRoute('/dashboard')).toBe(false);
   });
 
+
+  it('keeps middleware matcher scoped to /app and /api only', () => {
+    const middlewareSource = readFileSync(resolve(process.cwd(), 'middleware.ts'), 'utf-8');
+
+    expect(middlewareSource).toContain('"/app/:path*"');
+    expect(middlewareSource).toContain('"/api/:path*"');
+  });
+
   it('keeps /app unauthenticated redirects targeting /login with next param', () => {
     const middlewareSource = readFileSync(resolve(process.cwd(), 'middleware.ts'), 'utf-8');
 

--- a/packages/web/src/app/api/builder/revalidate/route.ts
+++ b/packages/web/src/app/api/builder/revalidate/route.ts
@@ -7,6 +7,8 @@ import { createHmac, timingSafeEqual } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
 
+export const runtime = 'nodejs';
+
 function normalizeSignature(signature: string): string {
   return signature.startsWith('sha256=') ? signature.slice('sha256='.length) : signature;
 }
@@ -38,7 +40,12 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const body = JSON.parse(rawBody);
+    let body: { model?: string; url?: string };
+    try {
+      body = JSON.parse(rawBody) as { model?: string; url?: string };
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    }
 
     // Extract the model and URL from the webhook payload
     const { model, url } = body;
@@ -69,12 +76,11 @@ export async function POST(request: NextRequest) {
       },
       { status: 200 }
     );
-   
-      } catch (error) {
+  } catch (error) {
     console.error('Error processing Builder.io webhook:', error);
     return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
+      { error: 'Failed to process webhook' },
+      { status: 503 }
     );
   }
 }

--- a/packages/web/src/lib/env/runtime-access.ts
+++ b/packages/web/src/lib/env/runtime-access.ts
@@ -1,19 +1,27 @@
 export const MARKETING_OPTIONAL_ENV_KEYS = [
-  'NEXT_PUBLIC_SUPABASE_URL',
-  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-  'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+  ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_URL'],
+  ['NEXT_PUBLIC_SUPABASE_ANON_KEY', 'SUPABASE_ANON_KEY'],
+  ['NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY'],
 ] as const;
 
 export const APP_REQUIRED_ENV_KEYS = [
-  'NEXT_PUBLIC_SUPABASE_URL',
-  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_URL'],
+  ['NEXT_PUBLIC_SUPABASE_ANON_KEY', 'SUPABASE_ANON_KEY'],
 ] as const;
 
-function findMissing(keys: readonly string[]): string[] {
-  return keys.filter((key) => {
+type EnvKeyGroup = readonly string[];
+
+function isConfigured(keys: EnvKeyGroup): boolean {
+  return keys.some((key) => {
     const value = process.env[key];
-    return !value || value.trim().length === 0;
+    return Boolean(value && value.trim().length > 0);
   });
+}
+
+function findMissing(keyGroups: readonly EnvKeyGroup[]): string[] {
+  return keyGroups
+    .filter((keys) => !isConfigured(keys))
+    .map((keys) => keys.join(' or '));
 }
 
 export function getMarketingEnvStatus(): { ok: boolean; missing: string[] } {

--- a/tests/e2e/route-protection-smoke.spec.ts
+++ b/tests/e2e/route-protection-smoke.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+
+const MARKETING_ROUTES = ['/', '/pricing', '/trust', '/contact'] as const;
+
+test.describe('route protection smoke', () => {
+  for (const route of MARKETING_ROUTES) {
+    test(`marketing route ${route} renders without 500 or hydration errors`, async ({ page }) => {
+      const consoleErrors: string[] = [];
+
+      page.on('console', (message) => {
+        const text = message.text();
+        if (message.type() === 'error' || /hydration/i.test(text)) {
+          consoleErrors.push(text);
+        }
+      });
+
+      const response = await page.goto(route, { waitUntil: 'networkidle' });
+
+      expect(response, `expected HTTP response for ${route}`).not.toBeNull();
+      expect(response!.status(), `${route} should not 500`).toBeLessThan(500);
+      await expect(page.locator('body')).toBeVisible();
+      expect(consoleErrors).toEqual([]);
+    });
+  }
+
+  test('/app redirects unauthenticated users to login with next param', async ({ page }) => {
+    const response = await page.goto('/app', { waitUntil: 'networkidle' });
+
+    expect(response, 'expected HTTP response for /app').not.toBeNull();
+    expect(response!.status(), '/app should not 500').toBeLessThan(500);
+    await expect(page).toHaveURL(/\/login\?next=%2Fapp/);
+  });
+});


### PR DESCRIPTION
### Motivation

- Public-facing marketing routes must never assume auth/env and must render safely even when server envs are absent.  
- Webhook handlers that rely on raw-body signature verification must be explicitly pinned to Node runtimes to avoid runtime mismatches and silent failures.  
- There was no focused Playwright smoke guard that ensures marketing pages and the /app auth-gate behave correctly on PRs, so regressions could slip through.

### Description

- Made env contract support grouped key fallbacks so app-required keys accept `NEXT_PUBLIC_*` OR server-side variants by introducing grouped key logic in `packages/web/src/lib/env/runtime-access.ts`.  
- Pinned Builder.io webhook handler to Node runtime and hardened parsing/error modes in `packages/web/src/app/api/builder/revalidate/route.ts` by adding `export const runtime = 'nodejs'`, validating JSON with a `400` on bad payloads, and returning `503` for processing failures.  
- Extended webhook/runtime invariants test to include Builder webhook expectations in `packages/web/src/__tests__/api/stripe-webhook-runtime.test.ts`.  
- Strengthened middleware gating tests to assert the middleware matcher remains scoped to `/app` and `/api` in `packages/web/src/__tests__/middleware/app-auth-gating.test.ts`.  
- Added unit tests for the env-access contract (server-key fallback + grouped missing reporting) at `packages/web/src/__tests__/env/runtime-access.test.ts`.  
- Added a focused Playwright smoke test `tests/e2e/route-protection-smoke.spec.ts` that checks marketing routes render without 500s/hydration errors and that unauthenticated `/app` redirects to `/login?next=/app`.  
- Added a GitHub Actions workflow `.github/workflows/playwright-route-protection-smoke.yml` to run the Playwright smoke suite on PRs and on main push so browser-based regressions are caught in CI.

### Testing

- Ran the focused Jest suites: `pnpm --filter @settler/web test -- src/__tests__/middleware/app-auth-gating.test.ts src/__tests__/api/stripe-webhook-runtime.test.ts src/__tests__/env/runtime-access.test.ts` which passed (`3 suites, 7 tests` passed).  
- Linting succeeded via `pnpm run lint` (warnings only, no blocking errors).  
- Type-check succeeded via `pnpm run typecheck`.  
- Build succeeded via `pnpm run build` for the web package and full monorepo build filter used in verification.  
- Docs verification succeeded via `pnpm run verify:docs`.  
- Attempted local Playwright run `pnpm exec playwright test tests/e2e/route-protection-smoke.spec.ts --project=chromium` and browser install `pnpm exec playwright install chromium`, but local Playwright runs in this environment failed due to missing browser binary and remote CDN download returning `403 Forbidden`; to ensure CI coverage the workflow added will install browsers and run the smoke suite on GitHub Actions.

Commands run during verification (representative):  
- `pnpm --filter @settler/web test -- src/__tests__/middleware/app-auth-gating.test.ts src/__tests__/api/stripe-webhook-runtime.test.ts src/__tests__/env/runtime-access.test.ts`  
- `pnpm run lint`  
- `pnpm run typecheck`  
- `pnpm run build`  
- `pnpm run verify:docs`  
- (Playwright attempt) `pnpm exec playwright test tests/e2e/route-protection-smoke.spec.ts --project=chromium` — blocked locally due to Playwright browser binary issues (see notes above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993dbea6f8c83289c57b9dd840ca9e6)