### PR TITLE
fix(web): harden headers, error boundaries, and server logging

### DIFF
--- a/.github/workflows/playwright-route-protection-smoke.yml
+++ b/.github/workflows/playwright-route-protection-smoke.yml
@@ -38,3 +38,10 @@ jobs:
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
           NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: anon-key-for-ci
+
+      - name: Run security headers smoke check
+        run: pnpm exec playwright test tests/e2e/security-headers-smoke.spec.ts --project=chromium
+        env:
+          NEXT_PUBLIC_SITE_URL: http://localhost:3000
+          NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: anon-key-for-ci

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -13,6 +13,7 @@ import { addSecurityHeaders } from "./src/middleware/security-headers";
 import { generateTraceId } from "./src/lib/observability/trace";
 import { isAppAuthRequiredRoute } from "./src/lib/auth/route-gating";
 import { getAppEnvStatus } from "./src/lib/env/runtime-access";
+import { serverLogger } from "./src/lib/observability/server-logger";
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   // CRITICAL: Wrap entire middleware in try-catch to prevent any 500 errors
@@ -29,6 +30,12 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
       maxAge: 60 * 60 * 24 * 7,
       path: "/",
     };
+    serverLogger.info("middleware.request", {
+      trace_id: traceId,
+      method: request.method,
+      path: pathname,
+    });
+
     const applyTraceContext = (nextResponse: NextResponse): NextResponse => {
       nextResponse.headers.set("x-trace-id", traceId);
       nextResponse.headers.set("x-request-id", traceId);
@@ -144,10 +151,11 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
         }
       } catch (authError) {
         // Log but don't fail - let the route handler deal with auth
-        console.warn(
-          "[Middleware] Auth refresh failed (non-fatal):",
-          authError instanceof Error ? authError.message : "Unknown error"
-        );
+        serverLogger.warn("middleware.auth_refresh_failed", {
+          trace_id: traceId,
+          path: pathname,
+          error: authError instanceof Error ? authError.message : "Unknown error",
+        });
         if (isAuthRequiredRoute) {
           const redirectUrl = new URL('/login', request.url);
           redirectUrl.searchParams.set('next', pathname);
@@ -160,10 +168,11 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     } catch (error) {
       // If Supabase client creation fails, log but continue
       // Routes will handle auth errors themselves
-      console.error(
-        "[Middleware] Failed to create Supabase client (non-fatal):",
-        error instanceof Error ? error.message : "Unknown error"
-      );
+      serverLogger.error("middleware.supabase_client_failed", {
+        trace_id: traceId,
+        path: pathname,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
       if (isAuthRequiredRoute) {
         const redirectUrl = new URL('/login', request.url);
         redirectUrl.searchParams.set('next', pathname);
@@ -187,9 +196,10 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   } catch (error) {
     // CRITICAL: Middleware must NEVER throw - always return a valid response
     // Log error but continue with basic response
-    console.error('[Middleware] Unexpected error (non-fatal):',
-      error instanceof Error ? error.message : 'Unknown error'
-    );
+    serverLogger.error("middleware.unexpected_error", {
+      error: error instanceof Error ? error.message : "Unknown error",
+      path: request.nextUrl.pathname,
+    });
 
     // Return a basic response with security headers
     const fallbackResponse = NextResponse.next({

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -235,7 +235,7 @@ const nextConfig = {
             value: "geolocation=(), microphone=(), camera=()",
           },
           {
-            key: "Content-Security-Policy",
+            key: "Content-Security-Policy-Report-Only",
             value: [
               "default-src 'self'",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval'",

--- a/packages/web/src/app/api/stripe/webhook/route.ts
+++ b/packages/web/src/app/api/stripe/webhook/route.ts
@@ -22,6 +22,7 @@ import { logger } from "@/lib/observability/logger";
 import { emitLifecycleEventSafe, LifecycleEventType } from "@/lib/ops/lifecycle-events";
 import { safeLogger } from "@/lib/observability/safe-logger";
 import { safeJsonParseWithDefault } from "@/lib/utils/safe-parse";
+import { serverLogger } from "@/lib/observability/server-logger";
 // NOTE: Webhooks don't use billing gates - they're authenticated via Stripe signature
 
 export const dynamic = "force-dynamic";
@@ -181,6 +182,12 @@ function extractBillingAccountId(event: Stripe.Event): string | null {
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
   const traceId = await getTraceId(request);
+
+  serverLogger.info("stripe_webhook.received", {
+    trace_id: traceId,
+    method: request.method,
+    path: request.nextUrl.pathname,
+  });
 
   // Check request size (max 500KB for webhooks)
   const sizeCheck = requestSizeLimits.webhook(request);
@@ -522,6 +529,7 @@ export async function POST(request: NextRequest) {
 
     const response = NextResponse.json({ received: true, trace_id: traceId });
     response.headers.set("x-trace-id", traceId);
+    serverLogger.info("stripe_webhook.processed", { trace_id: traceId, eventId: event.id, eventType: event.type, duration_ms: Date.now() - startTime });
     return response;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error";

--- a/packages/web/src/app/app/error.tsx
+++ b/packages/web/src/app/app/error.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('App route error', {
+      message: error.message,
+      digest: error.digest,
+    });
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center p-6 bg-slate-50 dark:bg-slate-900">
+      <Card className="max-w-md w-full">
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-amber-600" />
+            <CardTitle>Unable to load app view</CardTitle>
+          </div>
+          <CardDescription>
+            Something went wrong while loading this page. Your data is safe.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error.digest ? (
+            <p className="text-xs text-slate-500 dark:text-slate-400 font-mono">Error ID: {error.digest}</p>
+          ) : null}
+          <div className="flex gap-2">
+            <Button onClick={reset}>Try again</Button>
+            <Button asChild variant="outline">
+              <Link href="/app">Back to app</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/app/error.tsx
+++ b/packages/web/src/app/error.tsx
@@ -49,7 +49,7 @@ export default function GlobalError({
             </CardHeader>
             <CardContent className="space-y-4">
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                {error.message || 'An unexpected error occurred. Please try again.'}
+                An unexpected error occurred. Please try again.
               </p>
               {error.digest && (
                 <p className="text-xs text-slate-500 dark:text-slate-500 font-mono">

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -7,7 +7,6 @@
 'use client';
 
 import { useEffect } from 'react';
-import { logger } from '@/lib/logging/logger';
 
 export default function GlobalError({
   error,
@@ -17,14 +16,7 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Log critical error
-    logger.critical('Global error handler caught error', error, {
-      digest: error.digest,
-      name: error.name,
-      message: error.message,
-      stack: error.stack,
-    });
-
+    console.error('Global error handler caught error', { digest: error.digest, name: error.name });
   }, [error]);
 
   return (

--- a/packages/web/src/lib/observability/server-logger.ts
+++ b/packages/web/src/lib/observability/server-logger.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+type LogLevel = "info" | "warn" | "error";
+
+const REDACTED = "[REDACTED]";
+const SECRET_KEY_PATTERN = /(secret|token|password|key|authorization|cookie)/i;
+
+function redactValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(redactValue);
+  }
+
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).reduce<Record<string, unknown>>(
+      (acc, [key, nested]) => {
+        acc[key] = SECRET_KEY_PATTERN.test(key) ? REDACTED : redactValue(nested);
+        return acc;
+      },
+      {}
+    );
+  }
+
+  return value;
+}
+
+function writeLog(level: LogLevel, message: string, context: Record<string, unknown> = {}): void {
+  const sanitizedContext = redactValue(context) as Record<string, unknown>;
+  const entry = {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...sanitizedContext,
+  };
+
+  const payload = JSON.stringify(entry);
+  if (level === "error") {
+    console.error(payload);
+    return;
+  }
+
+  if (level === "warn") {
+    console.warn(payload);
+    return;
+  }
+
+  console.warn(payload);
+}
+
+export const serverLogger = {
+  info: (message: string, context?: Record<string, unknown>) => writeLog("info", message, context),
+  warn: (message: string, context?: Record<string, unknown>) => writeLog("warn", message, context),
+  error: (message: string, context?: Record<string, unknown>) => writeLog("error", message, context),
+};
+

--- a/packages/web/src/middleware/security-headers.ts
+++ b/packages/web/src/middleware/security-headers.ts
@@ -1,25 +1,24 @@
 /**
  * Security Headers Middleware
- * 
+ *
  * Adds security headers to all responses.
  */
 
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 
 /**
  * Add security headers to response
  */
 export function addSecurityHeaders(response: NextResponse): NextResponse {
-  // Content Security Policy
-  const csp = [
+  const cspReportOnly = [
     "default-src 'self'",
     "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https:",
     "font-src 'self' data:",
     "connect-src 'self' https://*.supabase.co https://*.upstash.io https://vercel.live https://status.settler.dev wss://*.supabase.co",
-    "frame-src 'self' https://vercel.live",
+    "frame-src 'self' https://vercel.live https://js.stripe.com",
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
@@ -27,15 +26,13 @@ export function addSecurityHeaders(response: NextResponse): NextResponse {
     "upgrade-insecure-requests",
   ].join('; ');
 
-  // Security headers
   response.headers.set('X-DNS-Prefetch-Control', 'on');
   response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
   response.headers.set('X-Frame-Options', 'DENY');
   response.headers.set('X-Content-Type-Options', 'nosniff');
-  response.headers.set('X-XSS-Protection', '1; mode=block');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-  response.headers.set('Content-Security-Policy', csp);
+  response.headers.set('Content-Security-Policy-Report-Only', cspReportOnly);
 
   return response;
 }

--- a/tests/e2e/security-headers-smoke.spec.ts
+++ b/tests/e2e/security-headers-smoke.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+test('security headers are present on marketing route', async ({ request }) => {
+  const response = await request.get('/');
+
+  expect(response.status()).toBeLessThan(500);
+  expect(response.headers()['x-content-type-options']).toBe('nosniff');
+  expect(response.headers()['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  expect(response.headers()['permissions-policy']).toContain('camera=()');
+  expect(response.headers()['x-frame-options']).toBe('DENY');
+  expect(response.headers()['content-security-policy-report-only']).toContain("default-src 'self'");
+});


### PR DESCRIPTION
### Motivation

- Operational hardening gaps left CSP enforced by default and logging paths that could leak secrets or cause secondary failures. 
- Marketing and `/app` routes needed guaranteed graceful fallbacks when optional envs (Supabase) are missing to avoid hard 500s. 
- Minimal structured server logging with redaction was required to add trace context and avoid printing raw secrets (while preserving Stripe webhook raw-body verification).

### Description

- Stage CSP as report-only and keep safe headers (`X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, `X-Frame-Options`) by switching to `Content-Security-Policy-Report-Only` in both runtime middleware and `next.config.js`. 
- Add a server-only structured logger with key-based redaction and wire middleware to emit `middleware.request`, `middleware.auth_refresh_failed`, `middleware.supabase_client_failed`, and `middleware.unexpected_error` events including `trace_id` context. 
- Harden error handling and UX by adding an `/app` segment error boundary and removing raw exception text from the root error UI to prevent leaking details and avoid secondary failures. 
- Preserve Stripe webhook invariants (keeps `runtime = "nodejs"` and raw-body signature verification) while adding structured `stripe_webhook.received` / `stripe_webhook.processed` events for observability without logging raw bodies. 
- Add an automated Playwright smoke test for header sanity and extend the existing smoke workflow to run it.

Files changed: `packages/web/middleware.ts`, `packages/web/next.config.js`, `packages/web/src/middleware/security-headers.ts`, `packages/web/src/lib/observability/server-logger.ts`, `packages/web/src/app/app/error.tsx`, `packages/web/src/app/error.tsx`, `packages/web/src/app/global-error.tsx`, `packages/web/src/app/api/stripe/webhook/route.ts`, `.github/workflows/playwright-route-protection-smoke.yml`, `tests/e2e/security-headers-smoke.spec.ts`.

### Testing

- Ran `pnpm install` which completed successfully. 
- Ran `pnpm run lint` which completed successfully (no new lint errors introduced). 
- Ran `pnpm run typecheck` which completed successfully across workspaces. 
- Ran `pnpm run test` where the web package test suites passed but existing API test failures remained (baseline failures in unrelated `packages/api` suites and TypeScript/test contract issues that were not introduced by this change). 
- Ran `pnpm run build` which completed successfully for the web build. 
- Ran `pnpm exec playwright test tests/e2e/security-headers-smoke.spec.ts --project=chromium` which passed and validated header presence. 
- Attempted `pnpm exec playwright test tests/e2e/route-protection-smoke.spec.ts tests/e2e/security-headers-smoke.spec.ts --project=chromium` but the route-protection suite was blocked by missing Chromium binaries in this environment (Playwright browser download failed with upstream 403); header smoke still passed in isolation. 

All automated checks relevant to these changes (install, lint, typecheck, web build, header smoke test) passed; pre-existing API test failures were observed but are out of scope for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e18ac6e083289bbab0f4b73af505)