### PR TITLE
fix(web): harden trust page reality data fallback

### DIFF
--- a/packages/web/src/app/api/public/reality/route.ts
+++ b/packages/web/src/app/api/public/reality/route.ts
@@ -6,10 +6,9 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
 import { publicRoute } from '@/middleware/billing-gate-universal';
-import { appLogger } from '@/lib/utils/logger';
 import { withSecurity } from '@/lib/middleware/api-security';
+import { getPublicRealityData } from '@/lib/public/reality-data';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -19,92 +18,8 @@ export const runtime = 'nodejs';
  */
 export const GET = withSecurity(
   publicRoute(async function GET(_request: NextRequest) {
-  try {
-    const supabase = await createClient();
-    
-    // Get public-facing metrics only
-    const { data: metrics, error: metricsError } = await supabase
-      .from('reality_metrics')
-      .select('category, name, value, status, last_updated')
-      .in('category', ['failure', 'deployment']) // Only show failure and deployment metrics publicly
-      .order('category', { ascending: true });
-
-    if (metricsError) {
-      appLogger.error('Error fetching public reality metrics', metricsError);
-      // Return safe defaults instead of error
-      return NextResponse.json({
-        uptime_proxy: null,
-        last_incident: null,
-        hard_500_count: 0,
-        status: 'assumed',
-        timestamp: new Date().toISOString(),
-      });
-    }
-
-    // Extract key metrics
-     
-    const metricsArray = (metrics || []) as Array<{ name: string; value: any; status: string }>; // value can be any type from database
-    const hard500Metric = metricsArray.find((m) => m.name === 'hard_500_count');
-    const { data: lastIncidentData } = await supabase
-      .from('reality_events')
-      .select('created_at, event_name, severity')
-      .eq('category', 'failure')
-      .eq('severity', 'critical')
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    const lastIncident = lastIncidentData as {
-      created_at?: string;
-      event_name?: string;
-      severity?: string;
-    } | null;
-
-    // Calculate uptime proxy (inverse of failure rate)
-    // This is simplified - real uptime would come from monitoring
-    const hard500Value = hard500Metric?.value;
-    const uptimeProxy = typeof hard500Value === 'number' && hard500Value === 0 ? 99.9 : null;
-
-    const response = {
-      uptime_proxy: uptimeProxy,
-      last_incident: lastIncident && lastIncident.created_at && lastIncident.event_name ? {
-        timestamp: lastIncident.created_at,
-        event: lastIncident.event_name,
-      } : null,
-      hard_500_count: typeof hard500Value === 'number' ? hard500Value : 0,
-      status: hard500Metric?.status ?? 'assumed',
-      data_isolation: {
-        model: 'Row Level Security (RLS)',
-        enforced_at: 'database',
-        status: 'proven',
-      },
-      compliance_actions: {
-        data_deletion: 'supported',
-        data_export: 'supported',
-        access_revocation: 'supported',
-        status: 'assumed', // Will be proven once tested
-      },
-      deployment_maturity: {
-        multi_region: false,
-        multi_platform: false,
-        status: 'assumed',
-      },
-      timestamp: new Date().toISOString(),
-    };
-
-    return NextResponse.json(response);
-  } catch (error) {
-    appLogger.error('Error in public reality API', error);
-    // Return safe defaults
-    return NextResponse.json({
-      uptime_proxy: null,
-      last_incident: null,
-      hard_500_count: 0,
-      status: 'assumed',
-      error: 'Failed to fetch reality data',
-      timestamp: new Date().toISOString(),
-    }, { status: 200 }); // Return 200 to prevent page crash
-  }
+    const data = await getPublicRealityData();
+    return NextResponse.json(data);
 }),
   { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: false }
 );

--- a/packages/web/src/app/trust/page.tsx
+++ b/packages/web/src/app/trust/page.tsx
@@ -5,6 +5,7 @@ import { Breadcrumbs } from '@/components/Breadcrumbs';
 import { Shield, Clock, Database, GitBranch, CheckCircle, AlertCircle } from 'lucide-react';
 import { Metadata } from 'next';
 import { Badge } from '@/components/ui/badge';
+import { getPublicRealityData } from '@/lib/public/reality-data';
 
 export const metadata: Metadata = {
   title: 'Trust & Reliability',
@@ -15,43 +16,8 @@ export const metadata: Metadata = {
   },
 };
 
-async function getRealityData() {
-  // CRITICAL: Never throw - always return null on failure
-  try {
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
-    
-    // Use timeout to prevent hanging
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
-    
-    try {
-      const response = await fetch(`${baseUrl}/api/public/reality`, {
-        cache: 'no-store',
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-      
-      if (response.ok) {
-        return await response.json();
-      }
-    } catch (fetchError) {
-      clearTimeout(timeoutId);
-      // If fetch fails (network error, timeout, etc.), return null
-      console.warn('[Trust] Failed to fetch reality data (non-fatal):', 
-        fetchError instanceof Error ? fetchError.message : 'Unknown error'
-      );
-    }
-  } catch (error) {
-    // Catch any other errors
-    console.warn('[Trust] Error in getRealityData (non-fatal):', 
-      error instanceof Error ? error.message : 'Unknown error'
-    );
-  }
-  return null;
-}
-
 export default async function TrustPage() {
-  const realityData = await getRealityData();
+  const realityData = await getPublicRealityData();
   return (
     <AnimatedPageWrapper aria-label="Trust page">
       <Navigation />

--- a/packages/web/src/lib/public/reality-data.ts
+++ b/packages/web/src/lib/public/reality-data.ts
@@ -1,0 +1,118 @@
+import { createClient } from '@/lib/supabase/server';
+import { getAppEnvStatus } from '@/lib/env/runtime-access';
+import { appLogger } from '@/lib/utils/logger';
+
+export type PublicRealityResponse = {
+  uptime_proxy: number | null;
+  last_incident: { timestamp: string; event: string } | null;
+  hard_500_count: number;
+  status: string;
+  data_isolation?: {
+    model: string;
+    enforced_at: string;
+    status: string;
+  };
+  compliance_actions?: {
+    data_deletion: string;
+    data_export: string;
+    access_revocation: string;
+    status: string;
+  };
+  deployment_maturity?: {
+    multi_region: boolean;
+    multi_platform: boolean;
+    status: string;
+  };
+  timestamp: string;
+};
+
+export const DEFAULT_PUBLIC_REALITY_RESPONSE: PublicRealityResponse = {
+  uptime_proxy: null,
+  last_incident: null,
+  hard_500_count: 0,
+  status: 'assumed',
+  timestamp: new Date().toISOString(),
+};
+
+export async function getPublicRealityData(): Promise<PublicRealityResponse> {
+  if (!getAppEnvStatus().ok) {
+    return {
+      ...DEFAULT_PUBLIC_REALITY_RESPONSE,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  try {
+    const supabase = await createClient();
+
+    const { data: metrics, error: metricsError } = await supabase
+      .from('reality_metrics')
+      .select('category, name, value, status, last_updated')
+      .in('category', ['failure', 'deployment'])
+      .order('category', { ascending: true });
+
+    if (metricsError) {
+      appLogger.error('Error fetching public reality metrics', metricsError);
+      return {
+        ...DEFAULT_PUBLIC_REALITY_RESPONSE,
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    const metricsArray = (metrics || []) as Array<{ name: string; value: unknown; status: string }>;
+    const hard500Metric = metricsArray.find((metric) => metric.name === 'hard_500_count');
+
+    const { data: lastIncidentData } = await supabase
+      .from('reality_events')
+      .select('created_at, event_name, severity')
+      .eq('category', 'failure')
+      .eq('severity', 'critical')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const lastIncident = lastIncidentData as {
+      created_at?: string;
+      event_name?: string;
+    } | null;
+
+    const hard500Value = hard500Metric?.value;
+    const uptimeProxy = typeof hard500Value === 'number' && hard500Value === 0 ? 99.9 : null;
+
+    return {
+      uptime_proxy: uptimeProxy,
+      last_incident:
+        lastIncident && lastIncident.created_at && lastIncident.event_name
+          ? {
+              timestamp: lastIncident.created_at,
+              event: lastIncident.event_name,
+            }
+          : null,
+      hard_500_count: typeof hard500Value === 'number' ? hard500Value : 0,
+      status: hard500Metric?.status ?? 'assumed',
+      data_isolation: {
+        model: 'Row Level Security (RLS)',
+        enforced_at: 'database',
+        status: 'proven',
+      },
+      compliance_actions: {
+        data_deletion: 'supported',
+        data_export: 'supported',
+        access_revocation: 'supported',
+        status: 'assumed',
+      },
+      deployment_maturity: {
+        multi_region: false,
+        multi_platform: false,
+        status: 'assumed',
+      },
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
+    appLogger.error('Error in public reality data service', error);
+    return {
+      ...DEFAULT_PUBLIC_REALITY_RESPONSE,
+      timestamp: new Date().toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
### Motivation
- The `/trust` marketing page performed an internal HTTP fetch to `/api/public/reality` during server rendering, which made marketing rendering brittle in build/preview environments and exposed the page to missing Supabase envs and dynamic-origin failures. 
- The change aims to ensure public marketing routes never hard-500, remove runtime origin dependencies during build, and provide safe defaults when telemetry/datastore envs are absent.

### Description
- Introduced a shared server-side accessor `getPublicRealityData()` that returns a safe default payload when required Supabase env is missing and gracefully handles query errors (`packages/web/src/lib/public/reality-data.ts`).
- Updated the public API route `GET /api/public/reality` to delegate to the shared service instead of inlining Supabase logic (`packages/web/src/app/api/public/reality/route.ts`).
- Changed the `/trust` page to call the server-side service directly instead of doing an internal HTTP fetch, removing build-time cross-request dependency (`packages/web/src/app/trust/page.tsx`).
- The service uses `getAppEnvStatus()` to short-circuit when app env is not configured and logs failures without throwing, preserving marketing route availability and `/app` auth boundaries.

### Testing
- Ran workspace setup and verification: `pnpm install` completed successfully and pre-commit fast-verify (`pnpm run verify:fast`) passed.
- Ran lint and typecheck with `pnpm run lint` and `pnpm run typecheck`; both completed (lint produced only pre-existing warnings, no new errors).
- Executed targeted web tests and gating checks: `pnpm --filter @settler/web test -- offline-prerender-compat.test.ts offline-render-harness.test.tsx` passed and `pnpm run verify:route-boundaries` passed.
- Built the web package with `pnpm --filter @settler/web build` and the build completed successfully; the `@settler/web` build now generates static content for marketing routes without depending on local origin fetch.
- Note: running the full repo `pnpm run test` reflects unrelated pre-existing failures/flakiness in other packages and was not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994bb5fab1083289cc04ead056149cf)