### PR TITLE
feat(benchmarks): add deterministic reconciliation regression harness

### DIFF
--- a/benchmarks/reconciliationBenchmark.ts
+++ b/benchmarks/reconciliationBenchmark.ts
@@ -1,0 +1,176 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+type ReconDataRecord = {
+  id: string;
+  amount: number;
+  currency: string;
+  occurredAt: string;
+  externalId?: string;
+  description?: string;
+  type?: string;
+};
+
+const SNAPSHOT_PATH = path.join(process.cwd(), "benchmarks", "snapshots.json");
+
+const sourceData: ReconDataRecord[] = [
+  {
+    id: "src_001",
+    amount: 120.5,
+    currency: "USD",
+    occurredAt: "2026-01-01T10:00:00.000Z",
+    externalId: "pay_001",
+    description: "Payout pay_001",
+    type: "PAYOUT",
+  },
+  {
+    id: "src_002",
+    amount: 49.99,
+    currency: "USD",
+    occurredAt: "2026-01-03T12:00:00.000Z",
+    externalId: "sale_002",
+    description: "Order 1002",
+    type: "CHARGE",
+  },
+  {
+    id: "src_003",
+    amount: 89.25,
+    currency: "USD",
+    occurredAt: "2026-01-04T12:00:00.000Z",
+    externalId: "sale_003",
+    description: "Order 1003",
+    type: "CHARGE",
+  },
+];
+
+const targetData: ReconDataRecord[] = [
+  {
+    id: "tgt_001",
+    amount: 120.5,
+    currency: "USD",
+    occurredAt: "2026-01-01T11:00:00.000Z",
+    externalId: "pay_001",
+    description: "Settlement for pay_001",
+    type: "TRANSFER",
+  },
+  {
+    id: "tgt_002",
+    amount: 49.99,
+    currency: "USD",
+    occurredAt: "2026-01-03T13:00:00.000Z",
+    externalId: "bank_2002",
+    description: "Deposit Order 1002",
+    type: "TRANSFER",
+  },
+  {
+    id: "tgt_003",
+    amount: 89.25,
+    currency: "USD",
+    occurredAt: "2026-01-06T12:00:00.000Z",
+    externalId: "bank_2003",
+    description: "Deposit Order 1003",
+    type: "TRANSFER",
+  },
+];
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  const body = entries
+    .map(([key, nestedValue]) => `${JSON.stringify(key)}:${stableStringify(nestedValue)}`)
+    .join(",");
+
+  return `{${body}}`;
+}
+
+function hashContent(value: unknown): string {
+  return crypto.createHash("sha256").update(stableStringify(value)).digest("hex");
+}
+
+function loadSnapshot(): { datasetChecksum: string; expectedOutputHash: string } {
+  const raw = fs.readFileSync(SNAPSHOT_PATH, "utf-8");
+  return JSON.parse(raw) as { datasetChecksum: string; expectedOutputHash: string };
+}
+
+function saveSnapshot(snapshot: { datasetChecksum: string; expectedOutputHash: string }): void {
+  fs.writeFileSync(SNAPSHOT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`, "utf-8");
+}
+
+async function main(): Promise<void> {
+  process.env.DB_PASSWORD ??= "benchmark-db-password";
+  process.env.ENCRYPTION_KEY ??= "12345678901234567890123456789012";
+  process.env.JWT_SECRET ??= "benchmark-jwt-secret";
+  process.env.JWT_REFRESH_SECRET ??= "benchmark-refresh-secret";
+
+  const { ReconCoreEngine } = await import("../packages/api/src/services/recon-core");
+
+  const dataset = { sourceData, targetData };
+  const datasetChecksum = hashContent(dataset);
+
+  const engine = new ReconCoreEngine({} as never);
+  const startNs = process.hrtime.bigint();
+  const output = await engine.performReconciliation(
+    sourceData,
+    targetData,
+    "deterministic",
+    {} as never
+  );
+  const endNs = process.hrtime.bigint();
+
+  const durationMs = Number(endNs - startNs) / 1_000_000;
+  const outputHash = hashContent(output);
+  const memory = typeof process.memoryUsage === "function" ? process.memoryUsage() : undefined;
+
+  console.log(`runtimeMs=${durationMs.toFixed(3)}`);
+  console.log(`outputHash=${outputHash}`);
+  if (memory) {
+    console.log(`memory.rss=${memory.rss}`);
+    console.log(`memory.heapUsed=${memory.heapUsed}`);
+  }
+
+  const writeSnapshot = process.argv.includes("--write-snapshot");
+  const snapshot = { datasetChecksum, expectedOutputHash: outputHash };
+
+  if (writeSnapshot) {
+    saveSnapshot(snapshot);
+    console.log(`snapshotUpdated=${SNAPSHOT_PATH}`);
+    return;
+  }
+
+  const expected = loadSnapshot();
+  if (expected.datasetChecksum !== datasetChecksum || expected.expectedOutputHash !== outputHash) {
+    console.error("Benchmark regression detected.");
+    console.error(
+      JSON.stringify(
+        {
+          expected,
+          actual: snapshot,
+          outputPreview: output.map((match) => ({
+            id: match.id,
+            sourceId: match.sourceId,
+            targetId: match.targetId,
+            confidence: match.confidence,
+          })),
+        },
+        null,
+        2
+      )
+    );
+    process.exit(1);
+  }
+
+  console.log("snapshotCheck=passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/benchmarks/snapshots.json
+++ b/benchmarks/snapshots.json
@@ -1,0 +1,4 @@
+{
+  "datasetChecksum": "2c5150d452aa7cf7de6dd6f53fd4e4c0c135b21af5b4bb546364c8be8992501f",
+  "expectedOutputHash": "2b6e8c2d2a9368ee0741f80401cc395f9876b7e462a5f25f1a225f56f2745913"
+}

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "validate:env": "tsx scripts/check-env.ts production",
     "validate:env:build": "npx tsx scripts/validate-env-build.ts --build",
     "validate:env:runtime": "npx tsx scripts/validate-env-build.ts --runtime",
-    "validate:eslint-config": "test -f scripts/validate-eslint-config.ts && npx tsx scripts/validate-eslint-config.ts || (echo '\u26a0\ufe0f  ESLint config validation script not found (expected in Vercel builds), skipping...' && exit 0)",
+    "validate:eslint-config": "test -f scripts/validate-eslint-config.ts && npx tsx scripts/validate-eslint-config.ts || (echo '⚠️  ESLint config validation script not found (expected in Vercel builds), skipping...' && exit 0)",
     "validate:build-safety": "npx tsx scripts/validate-build-safety.ts",
     "validate:nextjs": "npx tsx scripts/validate-nextjs-build.ts",
     "validate:lint-config": "npx tsx scripts/validate-lint-config.ts",
@@ -119,8 +119,8 @@
     "prisma:status": "prisma migrate status",
     "preinstall": "export SENTRY_SKIP_AUTO_INSTALL=1 || set SENTRY_SKIP_AUTO_INSTALL=1 || true",
     "postinstall": "test -f scripts/vercel-prisma-postinstall.js && node scripts/vercel-prisma-postinstall.js || echo 'Skipping postinstall: script not found (expected in Vercel builds)'",
-    "verify:build": "test -f scripts/verify-build-setup.sh && bash scripts/verify-build-setup.sh || echo '\u26a0\ufe0f  Build verification script not available'",
-    "setup:turbo": "test -f scripts/setup-vercel-turbo-cache.sh && bash scripts/setup-vercel-turbo-cache.sh || echo '\u26a0\ufe0f  Turbo setup script not available'",
+    "verify:build": "test -f scripts/verify-build-setup.sh && bash scripts/verify-build-setup.sh || echo '⚠️  Build verification script not available'",
+    "setup:turbo": "test -f scripts/setup-vercel-turbo-cache.sh && bash scripts/setup-vercel-turbo-cache.sh || echo '⚠️  Turbo setup script not available'",
     "demo:setup": "tsx scripts/generate-demo-data.ts",
     "demo:reset": "tsx scripts/generate-demo-data.ts",
     "demo:start": "pnpm run demo:setup && turbo run dev --filter @settler/web",
@@ -170,7 +170,8 @@
     "test:web:offline-harness": "pnpm --filter @settler/web test -- offline-prerender-compat.test.ts offline-render-harness.test.tsx",
     "verify:route-boundaries": "node scripts/verify-route-boundaries.mjs",
     "test:web:middleware-gating": "pnpm --filter @settler/web test -- app-auth-gating.test.ts",
-    "test:e2e:marketing:prod": "pnpm --filter @settler/web build && playwright test -c playwright.prod.config.ts tests/e2e/marketing-crawl.spec.ts"
+    "test:e2e:marketing:prod": "pnpm --filter @settler/web build && playwright test -c playwright.prod.config.ts tests/e2e/marketing-crawl.spec.ts",
+    "benchmark:check": "tsx benchmarks/reconciliationBenchmark.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
### Motivation
- Add a lightweight, deterministic benchmark and regression guard to detect output or performance drift in the reconciliation engine.
- Ensure CI/local workflows can validate reconciliation output deterministically without external services or secrets.

### Description
- Added `benchmarks/reconciliationBenchmark.ts` which loads an in-file fixed dataset, invokes `ReconCoreEngine.performReconciliation`, records runtime and memory, computes a stable SHA-256 hash of the output, and fails with diff context when the snapshot differs; it supports `--write-snapshot` to refresh baselines.
- Added `benchmarks/snapshots.json` to store the baseline `datasetChecksum` and `expectedOutputHash` used for regression detection.
- Added a root `package.json` script `benchmark:check` which runs the benchmark via `tsx` as `tsx benchmarks/reconciliationBenchmark.ts`.

### Testing
- Ran `pnpm install` which completed successfully.
- Ran `pnpm run lint` and `pnpm run typecheck` which completed successfully (existing lint warnings predated this change and were not introduced by this PR).
- Ran `pnpm run test` which executed the repository test suites (most suites passed; some existing Jest teardown/open-handle warnings were observed and are unrelated to the new benchmark harness).
- Ran `pnpm run build` which completed successfully.
- Executed `pnpm exec tsx benchmarks/reconciliationBenchmark.ts --write-snapshot` to generate/update the baseline snapshot and it completed successfully and wrote `benchmarks/snapshots.json`.
- Executed `pnpm run benchmark:check` which ran the benchmark and returned `snapshotCheck=passed` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e218db008328b37b0bfe9b0a6972)