### PR TITLE
ci(workflows): add dedicated conflict-markers fast-fail job to primary pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,30 @@ on:
       - "vercel.json"
 
 jobs:
+  conflict-markers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+      - name: Deterministic install
+        run: pnpm run pnpm:ci:install
+
+      - name: Detect unresolved conflict markers
+        run: pnpm run verify:conflict-markers
+
   parity:
+    needs: conflict-markers
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -66,6 +89,7 @@ jobs:
 
 
   api-tests-serial:
+    needs: conflict-markers
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -11,7 +11,26 @@ env:
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
+  conflict-markers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Detect unresolved conflict markers
+        run: npm run verify:conflict-markers
+
   verify:
+    needs: conflict-markers
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Motivation
- `verify:conflict-markers` was only enforced in the `quality.yml` workflow, so other primary pipelines could continue into expensive lint/typecheck/build stages before failing on unresolved merge conflict markers.

### Description
- Add a `conflict-markers` job and make primary jobs depend on it in `.github/workflows/ci.yml` and `.github/workflows/verify-build.yml`, so `verify:conflict-markers` runs and fast-fails before heavier CI stages.

### Testing
- Ran `pnpm run verify:conflict-markers` locally and it completed successfully with `✅ No unresolved merge conflict markers found.`
- Executed the repo verification (`pnpm run verify`) which exercised lint, typecheck, docs parity and build steps; the verification completed (lint produced warnings only) indicating the added gating does not block the primary pipeline when checks pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951c7c8da083288bd2e1d1b629094e)