### PR TITLE
fix(api): enforce and verify multi-tenant isolation boundaries

### DIFF
--- a/packages/api/src/__tests__/multi-tenancy/rls-simulation.test.ts
+++ b/packages/api/src/__tests__/multi-tenancy/rls-simulation.test.ts
@@ -1,0 +1,88 @@
+import { query, assertTenantScoped } from "../../db";
+import { buildReconciliationExport } from "../../services/reconciliation/export-contract";
+import { appendRunIntegrityEntry } from "../../services/reconciliation/integrity";
+
+jest.mock("../../db", () => {
+  const actual = jest.requireActual("../../db");
+  return {
+    ...actual,
+    query: jest.fn(),
+  };
+});
+
+const queryMock = query as jest.MockedFunction<typeof query>;
+
+describe("RLS simulation attack tests", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it("prevents access to another tenant's reconciliation", async () => {
+    queryMock.mockResolvedValueOnce([]);
+
+    const result = await buildReconciliationExport(
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222"
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("fails hard when export query returns cross-tenant run data", async () => {
+    queryMock.mockResolvedValueOnce([
+      {
+        id: "run-1",
+        tenant_id: "99999999-9999-4999-8999-999999999999",
+        ingestion_id: null,
+        status: "completed",
+        source_count: 1,
+        target_count: 1,
+        matched_count: 1,
+        unmatched_source_count: 0,
+        unmatched_target_count: 0,
+        confidence_avg: 1,
+        started_at: new Date().toISOString(),
+        completed_at: new Date().toISOString(),
+      },
+    ]);
+
+    await expect(
+      buildReconciliationExport(
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222"
+      )
+    ).rejects.toThrow("TENANT ISOLATION VIOLATION");
+  });
+
+  it("fails hard on replay attempt across tenant boundary", async () => {
+    queryMock.mockResolvedValueOnce([
+      {
+        id: "run-1",
+        tenant_id: "99999999-9999-4999-8999-999999999999",
+        ingestion_id: null,
+        status: "completed",
+        source_count: 1,
+        target_count: 1,
+        matched_count: 1,
+        unmatched_source_count: 0,
+        unmatched_target_count: 0,
+        confidence_avg: 1,
+        started_at: new Date().toISOString(),
+        completed_at: new Date().toISOString(),
+      },
+    ]);
+
+    await expect(
+      appendRunIntegrityEntry(
+        "22222222-2222-4222-8222-222222222222",
+        "11111111-1111-4111-8111-111111111111"
+      )
+    ).rejects.toThrow("TENANT ISOLATION VIOLATION");
+  });
+
+  it("fails hard on mixed-tenant batch injection query shape", () => {
+    expect(() =>
+      assertTenantScoped("SELECT * FROM reconciliation_matches WHERE run_id = ANY($1)")
+    ).toThrow("TENANT ISOLATION VIOLATION");
+  });
+});

--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -80,6 +80,9 @@ export async function queryWithTenant<T = Record<string, unknown>>(
     throw new Error(`[TENANT ISOLATION VIOLATION] Invalid or missing tenantId: ${tenantId}`);
   }
 
+  // Runtime assertion to prevent unscoped tenant-table access.
+  assertTenantScoped(text);
+
   const client = await pool.connect();
   try {
     // Set tenant context for RLS

--- a/packages/api/src/routes/tenant-data.ts
+++ b/packages/api/src/routes/tenant-data.ts
@@ -16,6 +16,8 @@ import { query, transaction } from "../db";
 import { logInfo, logError } from "../utils/logger";
 import { handleRouteError } from "../utils/error-handler";
 import { UserRole } from "../domain/entities/User";
+import { validateTenantId } from "../infrastructure/tenancy/TenantEnforcement";
+import { verifyTenantIntegrityChain } from "../services/reconciliation/integrity";
 
 const router: Router = Router();
 
@@ -214,6 +216,125 @@ router.get(
         userId: req.userId 
       });
       return;
+    }
+  }
+);
+
+
+
+async function tableExists(tableName: string): Promise<boolean> {
+  const rows = await query<{ exists: string | null }>(
+    `SELECT to_regclass($1) as exists`,
+    [`public.${tableName}`]
+  );
+
+  return Boolean(rows[0]?.exists);
+}
+
+async function countIfTableExists(tableName: string, sql: string, params: (string | number)[]): Promise<number> {
+  if (!(await tableExists(tableName))) {
+    return 0;
+  }
+
+  const rows = await query<{ count: string }>(sql, params);
+  return Number(rows[0]?.count ?? 0);
+}
+
+router.get(
+  "/integrity-check",
+  requirePermission(Permission.TENANT_READ),
+  async (req: TenantRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId!;
+      validateTenantId(tenantId, "tenant-data integrity-check");
+
+      const rlsRows = await query<{ table_name: string; relrowsecurity: boolean; policy_count: string }>(
+        `SELECT c.relname as table_name,
+                c.relrowsecurity,
+                COUNT(p.polname)::text as policy_count
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         LEFT JOIN pg_policy p ON p.polrelid = c.oid
+         WHERE n.nspname = 'public'
+           AND c.relname IN ('users', 'jobs', 'reconciliation_runs', 'reconciliation_matches', 'audit_logs')
+         GROUP BY c.relname, c.relrowsecurity`,
+      );
+
+      const allTablesProtected =
+        rlsRows.length >= 5 &&
+        rlsRows.every((row) => row.relrowsecurity && Number(row.policy_count) > 0);
+
+      const orphanJobs = await countIfTableExists(
+        "jobs",
+        `SELECT COUNT(*)::text as count
+         FROM jobs j
+         LEFT JOIN users u ON j.user_id = u.id
+         WHERE j.tenant_id = $1
+           AND (u.id IS NULL OR u.tenant_id <> j.tenant_id)`,
+        [tenantId]
+      );
+
+      const orphanMatches = await countIfTableExists(
+        "reconciliation_matches",
+        `SELECT COUNT(*)::text as count
+         FROM reconciliation_matches m
+         LEFT JOIN reconciliation_runs r ON m.run_id = r.id
+         WHERE m.tenant_id = $1
+           AND (r.id IS NULL OR r.tenant_id <> m.tenant_id)`,
+        [tenantId]
+      );
+
+      const crossTenantJobRefs = await countIfTableExists(
+        "jobs",
+        `SELECT COUNT(*)::text as count
+         FROM jobs j
+         JOIN users u ON j.user_id = u.id
+         WHERE j.tenant_id = $1
+           AND u.tenant_id <> j.tenant_id`,
+        [tenantId]
+      );
+
+      const crossTenantMatchRefs = await countIfTableExists(
+        "reconciliation_matches",
+        `SELECT COUNT(*)::text as count
+         FROM reconciliation_matches m
+         JOIN reconciliation_runs r ON m.run_id = r.id
+         WHERE m.tenant_id = $1
+           AND r.tenant_id <> m.tenant_id`,
+        [tenantId]
+      );
+
+      const chainIntegrity = await verifyTenantIntegrityChain(tenantId);
+
+      return res.status(200).json({
+        tenantId,
+        checkedAt: new Date().toISOString(),
+        isolationRulesActive: allTablesProtected,
+        noOrphanRecords: orphanJobs + orphanMatches === 0,
+        noCrossTenantReferences: crossTenantJobRefs + crossTenantMatchRefs === 0,
+        details: {
+          rlsTables: rlsRows.map((row) => ({
+            tableName: row.table_name,
+            rowLevelSecurity: row.relrowsecurity,
+            policyCount: Number(row.policy_count),
+          })),
+          orphanRecords: {
+            jobs: orphanJobs,
+            reconciliationMatches: orphanMatches,
+          },
+          crossTenantReferences: {
+            jobsToUsers: crossTenantJobRefs,
+            matchesToRuns: crossTenantMatchRefs,
+          },
+          reconciliationIntegrity: chainIntegrity,
+        },
+      });
+    } catch (error: unknown) {
+      logError('Failed to run tenant integrity check', error, { tenantId: req.tenantId, userId: req.userId });
+      return handleRouteError(res, error, 'Failed to run tenant integrity check', 500, {
+        tenantId: req.tenantId,
+        userId: req.userId,
+      });
     }
   }
 );

--- a/packages/api/src/services/reconciliation/export-contract.ts
+++ b/packages/api/src/services/reconciliation/export-contract.ts
@@ -1,4 +1,5 @@
 import { query } from "../../db";
+import { assertTenantOwnership, validateTenantId } from "../../infrastructure/tenancy/TenantEnforcement";
 import {
   computeReconciliationHash,
   verifyIntegrityChain,
@@ -34,6 +35,7 @@ export async function buildReconciliationExport(
   tenantId: string,
   runId: string
 ): Promise<ReconciliationExportDocument | null> {
+  validateTenantId(tenantId, "buildReconciliationExport");
   const runRows = await query<Record<string, unknown>>(
     `SELECT id, tenant_id, ingestion_id, status, source_count, target_count,
             matched_count, unmatched_source_count, unmatched_target_count,
@@ -52,6 +54,8 @@ export async function buildReconciliationExport(
   if (!runRow) {
     return null;
   }
+
+  assertTenantOwnership(runRow as { tenant_id?: string | null }, tenantId, "reconciliation_runs");
   const run: ReconciliationRunForIntegrity = {
     id: String(runRow.id),
     tenantId: String(runRow.tenant_id),
@@ -68,12 +72,14 @@ export async function buildReconciliationExport(
   };
 
   const matchRows = await query<Record<string, unknown>>(
-    `SELECT id, source_transaction_id, target_transaction_id, match_type, confidence, amount_diff, date_diff
+    `SELECT id, tenant_id, source_transaction_id, target_transaction_id, match_type, confidence, amount_diff, date_diff
      FROM reconciliation_matches
      WHERE run_id = $1 AND tenant_id = $2
      ORDER BY id ASC`,
     [runId, tenantId]
   );
+
+  assertTenantOwnership(matchRows as Array<{ tenant_id?: string | null }>, tenantId, "reconciliation_matches");
 
   const matches: ReconciliationMatchForIntegrity[] = matchRows.map((row) => ({
     id: String(row.id),

--- a/packages/api/src/services/reconciliation/integrity.ts
+++ b/packages/api/src/services/reconciliation/integrity.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { query } from "../../db";
+import { assertTenantOwnership, validateTenantId } from "../../infrastructure/tenancy/TenantEnforcement";
 import { logError, logInfo } from "../../utils/logger";
 
 export interface ReconciliationRunForIntegrity {
@@ -101,6 +102,7 @@ export function verifyIntegrityChain(
 }
 
 async function loadRun(runId: string, tenantId: string): Promise<ReconciliationRunForIntegrity | null> {
+  validateTenantId(tenantId, "loadRun");
   const rows = await query<Record<string, unknown>>(
     `SELECT id, tenant_id, ingestion_id, status, source_count, target_count,
             matched_count, unmatched_source_count, unmatched_target_count,
@@ -120,6 +122,8 @@ async function loadRun(runId: string, tenantId: string): Promise<ReconciliationR
     return null;
   }
 
+  assertTenantOwnership(row as { tenant_id?: string | null }, tenantId, "reconciliation_runs");
+
   return {
     id: String(row.id),
     tenantId: String(row.tenant_id),
@@ -137,13 +141,16 @@ async function loadRun(runId: string, tenantId: string): Promise<ReconciliationR
 }
 
 async function loadMatches(runId: string, tenantId: string): Promise<ReconciliationMatchForIntegrity[]> {
+  validateTenantId(tenantId, "loadMatches");
   const rows = await query<Record<string, unknown>>(
-    `SELECT id, source_transaction_id, target_transaction_id,
+    `SELECT id, tenant_id, source_transaction_id, target_transaction_id,
             match_type, confidence, amount_diff, date_diff
      FROM reconciliation_matches
      WHERE run_id = $1 AND tenant_id = $2`,
     [runId, tenantId]
   );
+
+  assertTenantOwnership(rows as Array<{ tenant_id?: string | null }>, tenantId, "reconciliation_matches");
 
   return rows.map((row) => ({
     id: String(row.id),
@@ -160,6 +167,7 @@ export async function appendRunIntegrityEntry(
   runId: string,
   tenantId: string
 ): Promise<IntegrityMetadata | null> {
+  validateTenantId(tenantId, "appendRunIntegrityEntry");
   const run = await loadRun(runId, tenantId);
   if (!run) {
     return null;
@@ -214,6 +222,8 @@ export async function verifyTenantIntegrityChain(tenantId: string): Promise<{
   checkedRuns: number;
   brokenRunId: string | null;
 }> {
+  validateTenantId(tenantId, "verifyTenantIntegrityChain");
+
   const rows = await query<Record<string, unknown>>(
     `SELECT id, metadata
      FROM reconciliation_runs

--- a/packages/cli/src/commands/tenant-check.ts
+++ b/packages/cli/src/commands/tenant-check.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import chalk from "chalk";
+
+interface TenantIntegrityResponse {
+  tenantId: string;
+  checkedAt: string;
+  isolationRulesActive: boolean;
+  noOrphanRecords: boolean;
+  noCrossTenantReferences: boolean;
+  details: {
+    rlsTables: Array<{ tableName: string; rowLevelSecurity: boolean; policyCount: number }>;
+    orphanRecords: { jobs: number; reconciliationMatches: number };
+    crossTenantReferences: { jobsToUsers: number; matchesToRuns: number };
+    reconciliationIntegrity: {
+      valid: boolean;
+      checkedRuns: number;
+      brokenRunId: string | null;
+    };
+  };
+}
+
+export const tenantCheckCommand = new Command("tenant-check")
+  .description("Verify tenant isolation integrity constraints")
+  .action(async (options) => {
+    const apiKey = process.env.SETTLER_API_KEY || options.parent.apiKey;
+    if (!apiKey) {
+      console.error(chalk.red("Error: API key required"));
+      process.exit(1);
+    }
+
+    const baseUrl = (options.parent.baseUrl || "https://api.settler.io").replace(/\/$/, "");
+    const response = await fetch(`${baseUrl}/api/v1/tenant/integrity-check`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      console.error(
+        chalk.red(`Error: tenant integrity check failed (${response.status}) ${body}`)
+      );
+      process.exit(1);
+    }
+
+    const report = (await response.json()) as TenantIntegrityResponse;
+
+    const checks = [
+      ["Isolation rules active", report.isolationRulesActive],
+      ["No orphan records", report.noOrphanRecords],
+      ["No cross-tenant references", report.noCrossTenantReferences],
+      ["Reconciliation chain valid", report.details.reconciliationIntegrity.valid],
+    ] as const;
+
+    console.log(chalk.bold(`Tenant integrity report for ${report.tenantId}`));
+    console.log(`Checked at: ${report.checkedAt}`);
+
+    for (const [label, ok] of checks) {
+      const prefix = ok ? chalk.green("PASS") : chalk.red("FAIL");
+      console.log(`${prefix} ${label}`);
+    }
+
+    if (!checks.every(([, ok]) => ok)) {
+      console.log(chalk.yellow("\nDetails:"));
+      console.log(JSON.stringify(report.details, null, 2));
+      process.exit(1);
+    }
+
+    console.log(chalk.green("\nAll tenant integrity checks passed."));
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -89,6 +89,13 @@ const commandRegistry: Record<
       return { command: mcpCommand };
     },
   },
+  "tenant-check": {
+    description: "Run multi-tenant isolation integrity checks",
+    load: async () => {
+      const { tenantCheckCommand } = await import("./commands/tenant-check");
+      return { command: tenantCheckCommand };
+    },
+  },
 };
 
 const aliasMap = new Map<string, string>();


### PR DESCRIPTION
### Motivation

- Root cause: tenant isolation checks were not consistently enforced at runtime boundaries, leaving export/replay paths trusting query results and `queryWithTenant` not asserting tenant filters in SQL text.
- Goal: harden runtime guards, add ownership assertions for reconciliation/export/integrity flows, simulate attack vectors, and provide an operator-facing integrity check CLI.

### Description

- Added a runtime tenant-scope guard: call `assertTenantScoped(text)` inside `queryWithTenant` so tenant-table queries without a `tenant_id` filter fail fast (`packages/api/src/db/index.ts`).
- Hardened reconciliation export/integrity flows by validating `tenantId` at service entry points and asserting ownership of fetched rows with `assertTenantOwnership`, and included `tenant_id` in select lists where needed (`packages/api/src/services/reconciliation/export-contract.ts`, `packages/api/src/services/reconciliation/integrity.ts`).
- Added a permission-gated tenant integrity API endpoint `GET /tenant/integrity-check` that reports RLS posture, orphan record counts, cross-tenant reference counts, and reconciliation chain integrity (`packages/api/src/routes/tenant-data.ts`).
- Added an attack-simulation test suite that verifies cross-tenant read/export/replay/batch-injection failures and a CLI command `settler tenant-check` to call the integrity endpoint and print PASS/FAIL (`packages/api/src/__tests__/multi-tenancy/rls-simulation.test.ts`, `packages/cli/src/commands/tenant-check.ts`, `packages/cli/src/index.ts`).

### Testing

- Ran `pnpm install`, `pnpm run lint`, `pnpm run typecheck`, `pnpm run build`, and `pnpm run verify:docs` and they all completed successfully.
- Ran `pnpm --filter @settler/cli typecheck` (succeeded) and the targeted isolation suite `pnpm --filter @settler/api test -- rls-simulation` (new `rls-simulation` tests) and it passed: 4 tests, 4 passed.
- Ran full workspace `pnpm run test`; the new isolation tests are included and passed, but the overall run exited non-zero due to existing repository-wide teardown/open-handle issues unrelated to these changes (existing suites logged async open-handle warnings and lifecycle messages).
- Verification commands used: `pnpm run lint`, `pnpm run typecheck`, `pnpm run build`, `pnpm run verify:docs`, `pnpm --filter @settler/cli typecheck`, `pnpm --filter @settler/api test -- rls-simulation` (all succeeded for the changes introduced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952163c6d88328b56eccb87d5dbe6f)