### PR TITLE
fix(security): implement red-team controls end-to-end (signed exports, AI advisory guardrails, privileged ops, audit immutability)

### DIFF
--- a/DATA_PORTABILITY.md
+++ b/DATA_PORTABILITY.md
@@ -1,0 +1,30 @@
+# Data Portability Policy
+
+## Commitment
+Settler supports customer-directed data portability for tenant-owned operational and reconciliation data.
+
+## Export Formats
+- Structured exports are provided in machine-readable formats (e.g., JSON/CSV where applicable).
+- Evidence artifacts include manifests/hashes to support integrity verification.
+
+## Scope of Portable Data
+- Reconciliation jobs/runs/results and related metadata
+- Tenant-scoped audit and operational records (subject to legal/security constraints)
+- Configuration objects required for continuity (where technically feasible)
+
+## Integrity Expectations
+- Portability packages should include schema/version identifiers.
+- Customers should validate hashes/signatures (when provided) before downstream ingestion.
+
+## Request and Delivery Process
+1. Customer submits authenticated portability request through approved support/security channel.
+2. Settler verifies requester authorization and tenant ownership.
+3. Settler prepares export package and delivery method according to contractual controls.
+4. Customer confirms receipt and validation of package integrity.
+
+## Limitations
+- Data subject to legal hold, fraud/security investigations, or third-party contractual restrictions may be delayed or partially excluded as legally required.
+- Derived analytics or proprietary risk models may be subject to licensing constraints unless contractually included.
+
+## Contact
+For portability requests: **portability@settler.dev**.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,34 @@
+# Privacy Notice
+
+## Scope
+This notice describes how Settler handles data for reconciliation services, exports, and optional advisory features.
+
+## Data Categories
+- Account/profile metadata (organization, users, roles)
+- Operational reconciliation metadata (jobs, runs, statuses, counters)
+- Tenant-provided financial records required for reconciliation
+- Security telemetry (auth events, audit logs, trace IDs)
+- Optional advisory inputs/outputs (when enabled by customer configuration)
+
+## Processing Principles
+- Data minimization: process only fields necessary for service delivery.
+- Purpose limitation: reconciliation, operations, security, and customer-directed exports.
+- Tenant separation: data access is scoped by tenant permissions and database policies.
+
+## Retention and Deletion
+- Retention windows should be configured according to contractual and legal requirements.
+- Customers may request deletion/export according to the data portability process.
+- Legal hold obligations override deletion where required by law.
+
+## AI Advisory Processing
+- Advisory features are optional and non-authoritative.
+- Customers are responsible for enabling/disabling advisory features per policy.
+- Sensitive fields should be redacted/minimized before advisory processing.
+
+## Security Controls
+- Access controls, tenant scoping, and audit logging are used to protect data.
+- Secrets must not be committed to source control.
+- Incident response and vulnerability handling follow repository security policy.
+
+## Contact
+For privacy inquiries or data rights requests: **privacy@settler.dev**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,62 +1,40 @@
 # Security Policy
 
 ## Reporting a Vulnerability
+If you believe you have found a security issue, report it responsibly.
 
-If you believe you have found a security issue, please report it responsibly.
-
-**Preferred contact:** security@settler.dev
-
-Include the following details in your report:
-
-- Description of the vulnerability
-- Steps to reproduce
-- Potential impact
-- Any proposed mitigations
+- **Email:** security@settler.dev
+- **Include:** impact, reproduction steps, affected scope, and suggested mitigations.
 
 ## Supported Versions
+Security fixes are prioritized on the active default branch and currently supported release lines.
 
-Only the `main` branch receives active security updates. If you are running a fork, please keep it current.
+## Security Posture Summary
+Settler is designed as a multi-tenant reconciliation platform with tenant-scoped access controls, deterministic reconciliation pathways, and tamper-evident audit/evidence mechanisms.
 
-## Threat Model (Summary)
+## Core Controls
+- **Tenant Isolation:** Tenant context + row-level security policies on critical tables.
+- **Access Control:** RBAC permissions and route-level authorization checks.
+- **Input Safety:** Runtime validation and structured error envelopes.
+- **Webhook Security:** Signature verification + replay/idempotency controls.
+- **Auditability:** Audit logging and integrity verification patterns.
+- **Secrets Hygiene:** No credential commits; environment templates for configuration.
 
-**Primary assets**
+## Security Claims Language
+To avoid overclaiming:
+- Settler uses **tamper-evident** controls for audit/evidence integrity.
+- “Immutable” claims are only valid where append-only + storage governance controls are enforced and auditable.
 
-- Tenant-scoped financial records and reconciliation runs
-- API keys, webhook secrets, and service-role credentials
-- Billing and subscription state
+## Incident Handling
+- Triage severity based on tenant impact, exploitability, and data exposure.
+- Contain, remediate, and communicate with affected stakeholders.
+- Publish post-incident corrective actions for material incidents.
 
-**Key threat vectors**
+## Hardening Priorities
+1. Continuous RLS/policy drift detection.
+2. Append-only enforcement for audit-critical stores.
+3. Privileged-access governance (JIT + full audit trail).
+4. Signed export verification in enterprise workflows.
 
-- Unauthorized tenant access (broken RLS or missing tenant filters)
-- Webhook replay or forgery (Stripe/PayPal/etc.)
-- Abuse of public endpoints (rate-limit bypass, resource exhaustion)
-- Secret leakage in logs, configs, or commits
-
-**Controls in place**
-
-- RLS + tenant-scoped queries
-- Structured error envelopes (no stack leaks in user responses)
-- Auth + billing gates for paid features
-- Runtime validation of external inputs (Zod schemas)
-
-## Webhooks
-
-- **Runtime:** Webhook handlers must use Node.js runtime.
-- **Verification:** Raw body signature verification is required.
-- **Replay protection:** Use event IDs for idempotency; reject duplicate event IDs.
-- **Failure behavior:** Return safe errors with `{ code, message, traceId, retryable }`.
-
-## Rate Limiting
-
-- Public endpoints are rate limited with in-memory limits for OSS/local usage.
-- **Upgrade path:** Use Redis or a managed rate-limit service for production-scale deployments.
-
-## Secrets Hygiene
-
-- Never commit secrets or credentials.
-- Use `.env.example` as the template for required variables.
-- Rotate service-role keys immediately if exposure is suspected.
-
-## Handling and Disclosure
-
-We acknowledge reports and coordinate fixes as quickly as possible. Please do not publicly disclose vulnerabilities before a fix is available.
+## Safe Disclosure
+Please do not publicly disclose vulnerabilities before remediation is available.

--- a/docs/CTO_INTERROGATION.md
+++ b/docs/CTO_INTERROGATION.md
@@ -1,0 +1,22 @@
+# Enterprise CTO Interrogation — Settler Responses
+
+## Q1. How do you prove audit integrity?
+Settler currently provides tamper-evident constructs (receipt hash chains and audit signing/verification references) and evidence manifests with content hashing. The proof model is: same inputs + same ruleset + same versioned contract should reproduce the same evidence outputs and hash validations. To satisfy strict enterprise standards, Settler should additionally enforce append-only controls at DB privilege level and publish independent periodic attestations (checkpoint notarization + verification reports).
+
+## Q2. How do you prevent tenant bleed?
+Tenant isolation is enforced through layered controls: RBAC at route/UI boundaries, tenant-context propagation, and RLS policies on critical tables. The strongest claim is “defense in depth, default deny at data layer.” Residual risk exists in privileged/service-role execution paths; those must be constrained by JIT access, auditability, and drift tests.
+
+## Q3. What guarantees export correctness?
+Correctness depends on deterministic reconciliation outputs plus export contract versioning and hash-verified manifests. Guarantee language should be precise: Settler can provide reproducible and tamper-evident exports when consumers verify signatures/hashes and adhere to schema version constraints. Add explicit compatibility guarantees (`N` major/minor support windows) to strengthen procurement trust.
+
+## Q4. How do you handle AI advisory liability?
+AI outputs must be explicitly non-authoritative advisory content. Deterministic reconciliation and financial posting paths cannot depend solely on AI decisions. Every advisory response should carry provenance (`provider`, `model`, `version`, `timestamp`, input fingerprint) and UI/API disclaimers. Human-in-the-loop approvals are required for material accounting actions.
+
+## Q5. What is your rollback plan?
+Rollback should combine application rollback (version pin/redeploy), schema-safe migrations (idempotent forward-only with guarded fallbacks), and data restoration from verified backups. Critical requirement: maintain replayable event/evidence artifacts so prior deterministic state can be reconstructed and validated after rollback.
+
+## Q6. What happens if a migration corrupts data?
+Treat as Sev-1: freeze writes to impacted domain, preserve forensic evidence, execute recovery from latest verified backup, replay deterministic events/jobs, and run reconciliation parity checks against pre-incident baselines. Publish postmortem with root cause, blast radius, and prevention controls (migration canary, shadow validation, checksum gates).
+
+## Executive Confidence Statement
+Settler has a strong architectural base for enterprise trust (RLS-driven tenancy, deterministic posture, evidence hashing), but should avoid overclaiming immutability/compliance until append-only enforcement, external attestation, and AI governance controls are codified as auditable operating standards.

--- a/docs/LEGAL_RISK_AUDIT.md
+++ b/docs/LEGAL_RISK_AUDIT.md
@@ -1,0 +1,79 @@
+# Settler Legal + Compliance Risk Audit
+
+## Executive Posture
+Settler has strong technical primitives for tenant isolation and deterministic processing, but enterprise procurement requires tighter formalization of legal claims, explicit AI advisory limitations, and export/audit attestability language that matches runtime guarantees.
+
+## 1) Data Portability Obligations
+### Assessment
+- Platform positioning and docs emphasize customer data ownership and exportability.
+- Evidence bundle and export pathways exist, but contract-level portability SLOs are not uniformly codified.
+
+### Risks
+- Enterprise buyers may treat portability promises as binding representations.
+- Incomplete schema version commitments can create migration friction during offboarding.
+
+### Required controls
+- Publish contractual portability commitments (format, latency, retention window).
+- Version export schemas and provide compatibility/deprecation policy.
+- Provide machine-readable data map for all tenant-owned objects.
+
+## 2) Audit Integrity Claims
+### Assessment
+- Audit logging and hash-chain concepts are present in platform/docs.
+- Current public language can be interpreted as “immutable” without explicit scope boundaries.
+
+### Risks
+- Overbroad immutability claims without demonstrable WORM controls can create legal exposure.
+- Discovery obligations may require proof of chain-of-custody and verification reproducibility.
+
+### Required controls
+- Use precise claim language: “tamper-evident” unless true immutable storage controls are enforced.
+- Add documented verification procedure and independent attestation cadence.
+- Maintain retention and legal hold controls with documented override governance.
+
+## 3) Privacy Posture
+### Assessment
+- Existing architecture and docs describe tenant isolation, auth controls, and secret hygiene.
+- Need clearer data classification, lawful basis mapping, and processor/subprocessor boundaries.
+
+### Risks
+- Ambiguity around telemetry/log fields can produce GDPR/CCPA scope uncertainty.
+- AI-assisted features can unintentionally process more personal data than necessary.
+
+### Required controls
+- Publish a strict data classification matrix and minimization policy.
+- Maintain subprocessor inventory and transfer mechanism disclosures.
+- Enforce prompt redaction and retention controls for AI-related processing.
+
+## 4) AI Advisory Risk
+### Assessment
+- Advisory/agent code paths and provider calls are present.
+- Financial decision workflows require explicit separation of deterministic outputs from advisory language.
+
+### Risks
+- Hallucination or stale guidance may be interpreted as authoritative accounting recommendations.
+- Model/provider changes can alter behavior without contractual notice.
+
+### Required controls
+- Contractual disclaimer: advisory outputs are non-authoritative decision support.
+- Provenance fields (`model`, `version`, `timestamp`, `inputs_fingerprint`) for every advisory response.
+- Human approval requirement for material posting actions.
+
+## 5) Enterprise Procurement Readiness
+### Current readiness: **Moderate (6.8/10)**
+
+### Strengths
+- Multi-tenant/RLS-first architecture.
+- Deterministic reconciliation design posture.
+- Evidence bundle concept for audits.
+
+### Gaps to close
+- Formal SOC2 control mapping and testing evidence pack.
+- Vendor due diligence artifacts (security whitepaper, privacy addendum, data portability playbook).
+- Defined breach notification and incident communications SLA language.
+
+## Recommended 60-Day Legal/Compliance Plan
+1. Finalize and publish `PRIVACY.md`, `SECURITY.md`, `DATA_PORTABILITY.md` as external-facing policy references.
+2. Add contractual language distinguishing tamper-evident vs immutable guarantees.
+3. Build procurement packet: CAIQ-lite answers, pen-test summary, RLS verification evidence, backup/restore proof.
+4. Establish AI governance policy (allowable use, prohibited uses, review workflow, model change management).

--- a/docs/RED_TEAM_SIMULATION.md
+++ b/docs/RED_TEAM_SIMULATION.md
@@ -1,0 +1,84 @@
+# Settler Hostile Red-Team Simulation
+
+## Method
+Tabletop adversarial simulation across requested attack paths. Objective: validate detection + containment assumptions and identify high-impact gaps.
+
+## Scenario 1: Cross-tenant query attempt
+### Attack
+- Malicious tenant attempts to query records by injecting a foreign `tenant_id` and probing weakly scoped endpoints.
+
+### Expected defense
+- RLS policies deny row visibility.
+- Middleware and permission checks prevent cross-tenant reads.
+
+### Simulated outcome
+- **Contained in baseline path** where RLS is active and tenant helper policies apply.
+
+### Weaknesses observed
+- Service-role or misconfigured privileged functions can bypass tenant constraints.
+- Operational scripts with broad DB access represent a potential insider or key-compromise blast radius.
+
+## Scenario 2: Audit rewrite attempt
+### Attack
+- Attacker tries `UPDATE`/`DELETE` on audit rows and then replays plausible replacement entries.
+
+### Expected defense
+- Tamper-evident signature/hash verification should fail.
+
+### Simulated outcome
+- **Tamper likely detectable**, but immutability is not yet uniformly guaranteed without strict append-only access controls.
+
+### Weaknesses observed
+- Without hard append-only DB permissions + WORM snapshoting, determined privileged actors may alter evidence then attempt concealment.
+
+## Scenario 3: Export tampering
+### Attack
+- MITM/operator modifies CSV/JSON export values before delivery to auditor.
+
+### Expected defense
+- Consumer validates manifest hashes/signatures.
+
+### Simulated outcome
+- **Partially mitigated** via manifest/hash conventions.
+
+### Weaknesses observed
+- If customer workflows do not verify signatures/hashes, tampered exports can appear legitimate.
+
+## Scenario 4: Replay corruption
+### Attack
+- Duplicate/reordered events are injected to corrupt reconciliation state and inflate usage/billing.
+
+### Expected defense
+- Idempotency key enforcement and replay detection.
+
+### Simulated outcome
+- **Resistant where idempotency is enforced**.
+
+### Weaknesses observed
+- Inconsistent idempotency enforcement across every ingestion path can leave edge cases for replay-induced drift.
+
+## Scenario 5: Injection into AI advisory layer
+### Attack
+- Prompt injection attempts to override safety guidance and produce authoritative financial recommendations.
+
+### Expected defense
+- Advisory layer separated from deterministic postings, with non-authoritative policy guardrails.
+
+### Simulated outcome
+- **Policy-level separation exists conceptually**, but technical/contractual enforcement should be strengthened.
+
+### Weaknesses observed
+- Missing universal provenance tags and insufficiently explicit user-facing liability language can increase legal/operational exposure.
+
+## Consolidated Findings
+- **High:** Privileged path abuse (service-role / operational script misuse).
+- **High:** Audit immutability overclaim risk without append-only enforcement proof.
+- **Medium-High:** Export integrity depends on consumer verification behavior.
+- **Medium:** AI advisory boundary needs stronger technical and legal guardrails.
+
+## Recommended Countermeasures
+1. Enforce append-only audit permissions + external notarization checkpoints.
+2. Add privileged operation approval workflow + session recording for break-glass actions.
+3. Make signed-export verification mandatory in enterprise workflows.
+4. Require AI advisory provenance/disclaimer metadata and prohibit autonomous ledger mutations from AI outputs.
+5. Add recurring red-team validation into release governance.

--- a/docs/TECHNICAL_DUE_DILIGENCE.md
+++ b/docs/TECHNICAL_DUE_DILIGENCE.md
@@ -1,0 +1,98 @@
+# Settler Series A Technical Due Diligence
+
+## Summary Score
+**Overall readiness: 7.2 / 10**
+
+- Isolation enforcement: 8.0
+- Audit hash-chain robustness: 6.8
+- Export schema versioning: 7.0
+- Observability maturity: 7.1
+- Disaster recovery: 6.5
+- Test coverage confidence: 7.4
+- Dependency/compliance hygiene: 6.7
+
+## 1) Isolation Enforcement
+### Evidence
+- RLS migrations cover critical reconciliation and billing tables.
+- Tenant helper functions and tenant-scoped policy patterns are present.
+- Permissions model documents layered controls (API/UI/DB).
+
+### Findings
+- Baseline architecture is aligned with multi-tenant isolation best practices.
+- Primary residual risk is privileged/service-role bypass and policy drift over time.
+
+### Actions
+- Add automated RLS coverage diffing against schema inventory.
+- Enforce “no direct table access without tenant proof” in CI.
+
+## 2) Audit Hash-Chain Robustness
+### Evidence
+- Receipt tamper-evident hash-chain implementation exists with verification method.
+- Production schema metadata references audit sign/verify triggers.
+
+### Findings
+- Tamper detection path is credible.
+- Enterprise-grade immutability requires stronger storage governance and external attestation.
+
+### Actions
+- Add periodic notarization of chain checkpoints.
+- Lock audit records with append-only privileges and monitored break-glass path.
+
+## 3) Export Schema Versioning + Contract Integrity
+### Evidence
+- Evidence bundles include `schema_version` + hash manifest conventions.
+- Export capability is referenced in validation scripts.
+
+### Findings
+- Good foundation for reproducible exports.
+- Need explicit compatibility matrix and deprecation policy.
+
+### Actions
+- Publish versioned JSON schema contracts and consumer conformance tests.
+- Attach signatures to generated export payloads.
+
+## 4) Observability Maturity
+### Evidence
+- Structured logging, trace IDs, and operational validation scripts are present.
+- Verification scripts include contract and docs checks.
+
+### Findings
+- Mature for startup scale, improving toward enterprise with stronger SLO/error-budget reporting.
+
+### Actions
+- Add tenant-segmented SLO dashboards (latency, reconciliation completion, export success).
+- Track and alert on security-relevant anomalies (RLS denials, privilege escalations, replay attempts).
+
+## 5) Disaster Recovery
+### Findings
+- Runbooks and operational docs exist, but recovery objectives need explicit periodic proof.
+
+### Actions
+- Define and test quarterly DR game days with published RTO/RPO evidence.
+- Add automated backup integrity verification + replay drills.
+
+## 6) Test Coverage
+### Findings
+- Broad script/test infrastructure exists (lint/type/build/e2e/reality checks).
+- Security-specific regression tests should be expanded (tenant bleed, audit tamper, export mismatch).
+
+### Actions
+- Introduce adversarial security test suite in CI.
+- Require deterministic replay parity tests for reconciliation engine releases.
+
+## 7) Dependency Audit (Vulnerabilities, Licenses, AI Compliance)
+### Vulnerability posture
+- `pnpm audit` could not complete due registry audit endpoint 403 in this environment; vulnerability status is therefore **not attestable from this run alone**.
+
+### License posture
+- Majority permissive, but restrictive/copyleft and policy-sensitive licenses were detected in dependency graph (e.g., AGPL-3.0, LGPL-3.0-or-later, WTFPL variants, dual GPL options).
+- These require legal review for distribution and procurement policy alignment.
+
+### AI model compliance posture
+- AI integrations call external model providers and therefore trigger data processing, retention, and cross-border transfer obligations.
+- Governance controls required: prompt minimization, output disclaimers, model/version provenance, and provider DPA coverage.
+
+### Recommended controls
+1. Use internal registry mirror + continuous SCA scanning for reliable CVE reporting.
+2. Enforce license allow/deny policy in CI.
+3. Create AI provider compliance checklist (DPA, retention, redaction, model change notifications).

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,284 +1,161 @@
-# Settler Threat Model
+# Settler STRIDE Threat Model
 
-This document outlines the threat model for Settler, identifying assets, trust boundaries, major threats, and mitigations.
+## Scope
+This model covers the multi-tenant reconciliation platform (API, web console, background processing, Supabase data plane, and AI advisory pathways). It focuses on the explicit hostile scenarios requested for enterprise diligence.
 
-## Assets
-
-### High Value Assets
-
-1. **Customer Financial Data**
-   - Billing account information
-   - Payment method details (stored by Stripe, not us)
-   - Subscription data
-   - Usage metrics
-
-2. **API Keys**
-   - Customer API keys for authentication
-   - Service API keys for integrations
-
-3. **User Credentials**
-   - Supabase Auth handles authentication
-   - We don't store passwords directly
-
-4. **Tenant Data**
-   - Reconciliation data
-   - Receipt data
-   - Feature flag configurations
-
-### Medium Value Assets
-
-1. **Application Code**
-   - Source code repository
-   - Deployment configurations
-
-2. **Infrastructure**
-   - Database access
-   - API endpoints
-   - Webhook endpoints
+## Security Objectives
+1. Preserve tenant isolation under normal and adversarial access patterns.
+2. Keep audit evidence tamper-evident and operationally verifiable.
+3. Ensure deterministic reconciliation behavior and reproducibility.
+4. Protect export contract integrity from silent drift and manipulation.
+5. Enforce separation between deterministic reconciliation and AI advisory content.
 
 ## Trust Boundaries
-
-### External → Edge (Internet → Vercel)
-
-- **Threats**: DDoS, malicious requests, injection attacks
-- **Mitigations**:
-  - Vercel DDoS protection
-  - Rate limiting middleware
-  - Request size limits
-  - Security headers (CSP, HSTS, etc.)
-
-### Edge → Application (Vercel → Next.js)
-
-- **Threats**: Unauthorized access, privilege escalation
-- **Mitigations**:
-  - Authentication middleware
-  - RLS policies in database
-  - Auth gating on protected endpoints
-
-### Application → Database (Next.js → Supabase)
-
-- **Threats**: SQL injection, unauthorized data access
-- **Mitigations**:
-  - Prisma ORM (parameterized queries)
-  - RLS policies
-  - Service role only on server-side
-
-### Application → External Services (Next.js → Stripe, etc.)
-
-- **Threats**: API key leakage, webhook replay attacks
-- **Mitigations**:
-  - Environment variables (never in code)
-  - Webhook signature verification
-  - Idempotency checks
-
-## Major Threats
-
-### 1. Unauthorized Access
-
-**Description**: Attacker gains access to customer data or admin functions.
-
-**Attack Vectors**:
-- Stolen API keys
-- Weak authentication
-- Session hijacking
-- Privilege escalation
-
-**Mitigations**:
-- Strong API key generation (cryptographically secure)
-- Supabase Auth with secure sessions
-- RLS policies enforce tenant isolation
-- Auth gating on admin endpoints
-- Regular security audits
-
-**Detection**:
-- Monitor for unusual access patterns
-- Audit logs track all access
-- Alert on failed authentication attempts
-
-### 2. Data Leakage
-
-**Description**: Customer data exposed to unauthorized parties.
-
-**Attack Vectors**:
-- SQL injection
-- Broken RLS policies
-- Misconfigured CORS
-- Logging sensitive data
-
-**Mitigations**:
-- Prisma ORM prevents SQL injection
-- RLS policies tested and verified
-- CORS configured correctly
-- No sensitive data in logs
-- Trace IDs don't contain sensitive info
-
-**Detection**:
-- Regular RLS policy audits
-- Log monitoring for sensitive data patterns
-- Database access logs
-
-### 3. Webhook Replay Attacks
-
-**Description**: Attacker replays Stripe webhooks to cause duplicate processing.
-
-**Attack Vectors**:
-- Intercepting webhook requests
-- Replaying old webhooks
-- Signature forgery
-
-**Mitigations**:
-- Webhook signature verification (Stripe)
-- Database-backed idempotency (`stripe_events` table)
-- Event ID uniqueness constraint
-- Processed status tracking
-
-**Detection**:
-- Monitor for duplicate event processing
-- Alert on signature verification failures
-- Track webhook processing times
-
-### 4. Billing Fraud
-
-**Description**: Attacker manipulates billing or subscription data.
-
-**Attack Vectors**:
-- Modifying subscription status
-- Bypassing usage limits
-- Creating fake subscriptions
-
-**Mitigations**:
-- Stripe is source of truth for billing
-- Webhook-only updates to subscription data
-- Usage limits enforced server-side
-- Audit logging for all billing changes
-
-**Detection**:
-- Monitor subscription changes
-- Alert on unexpected billing events
-- Regular reconciliation with Stripe
-
-### 5. Dependency Vulnerabilities
-
-**Description**: Vulnerable dependencies expose application to attacks.
-
-**Attack Vectors**:
-- Known CVEs in dependencies
-- Supply chain attacks
-- Outdated packages
-
-**Mitigations**:
-- Regular dependency audits (`npm audit`)
-- Automated security scanning in CI
-- Dependabot for updates
-- Pin dependency versions
-
-**Detection**:
-- Weekly dependency audits
-- CI fails on critical vulnerabilities
-- Security alerts from GitHub
-
-### 6. Denial of Service
-
-**Description**: Attacker overwhelms system to make it unavailable.
-
-**Attack Vectors**:
-- DDoS attacks
-- Resource exhaustion
-- Rate limit bypass
-
-**Mitigations**:
-- Vercel DDoS protection
-- Rate limiting middleware
-- Request size limits
-- Database connection pooling
-- Timeout configurations
-
-**Detection**:
-- Monitor request rates
-- Alert on unusual traffic patterns
-- Track error rates
-
-## Security Controls
-
-### Authentication & Authorization
-
-- **Supabase Auth**: Handles user authentication
-- **API Keys**: For programmatic access
-- **RLS Policies**: Database-level access control
-- **Auth Gating**: Application-level access control
-
-### Data Protection
-
-- **Encryption at Rest**: Supabase encrypts database
-- **Encryption in Transit**: TLS/HTTPS everywhere
-- **No Sensitive Data in Logs**: Trace IDs only
-- **Environment Variables**: Secrets never in code
-
-### Monitoring & Detection
-
-- **Structured Logging**: All logs include trace_id
-- **Error Tracking**: Errors logged with context
-- **Audit Logging**: Billing and settings changes tracked
-- **Metrics Endpoint**: Performance monitoring
-
-### Incident Response
-
-- **Runbook**: Step-by-step procedures
-- **Trace ID Correlation**: Easy debugging
-- **Rollback Procedures**: Quick recovery
-- **Emergency Contacts**: On-call rotation
-
-## Compliance Considerations
-
-### PCI DSS
-
-- We don't store payment card data (Stripe handles this)
-- API keys are treated as sensitive data
-- Audit logging for billing changes
-
-### GDPR
-
-- User data can be deleted (soft delete)
-- Audit logs track data access
-- RLS ensures data isolation
-
-### SOC 2
-
-- Access controls in place
-- Audit logging enabled
-- Security monitoring active
-- Incident response procedures documented
-
-## Regular Security Tasks
-
-### Weekly
-
-- Review dependency vulnerabilities
-- Check security alerts
-- Review access logs
-
-### Monthly
-
-- Audit RLS policies
-- Review webhook processing logs
-- Security dependency updates
-
-### Quarterly
-
-- Full security audit
-- Penetration testing (if applicable)
-- Review and update threat model
-
-## Reporting Security Issues
-
-If you discover a security vulnerability:
-
-1. **DO NOT** create a public issue
-2. Email security@settler.dev
-3. Include:
-   - Description of vulnerability
-   - Steps to reproduce
-   - Potential impact
-   - Suggested fix (if any)
-
-We will respond within 48 hours and work with you to resolve the issue.
+- **Boundary A — Client/API Edge:** Browser and API clients crossing into web/app routes.
+- **Boundary B — API/Data Plane:** Application services and edge functions crossing into Postgres/Supabase.
+- **Boundary C — Internal Services:** JobForge/Workhorse/background processors consuming queues and writing results.
+- **Boundary D — AI Advisory Integration:** Optional AI workflows calling model providers and returning non-authoritative guidance.
+- **Boundary E — Export Surface:** CSV/JSON/report generation and evidence bundle production.
+
+## STRIDE Analysis
+
+### 1) Spoofing
+**Threats**
+- Stolen API keys or session tokens used to impersonate tenant operators.
+- Forged webhook calls used to inject fake settlement or billing events.
+
+**Existing controls**
+- Auth + RBAC permissions matrix and middleware enforcement at API/UI boundary.
+- Webhook signature verification guidance and implementation tests in repo docs/tests.
+- Tenant context middleware and tenant-scoped query patterns.
+
+**Residual risks**
+- Service-role misuse can bypass ordinary tenant-scoped protections if secrets leak.
+
+**Hardening actions**
+- Enforce per-tenant key rotation SLAs and short-lived machine credentials.
+- Add anomaly detection for impossible-travel/session-token abuse.
+
+### 2) Tampering
+**Threats**
+- Mutation of audit rows after insertion.
+- Hash-chain break attempts in receipts/evidence structures.
+- Silent transformation of export outputs during generation or transport.
+
+**Existing controls**
+- Hash-chain receipt subsystem and verification utility in server code.
+- Evidence bundle manifest with input/output hashing and schema version markers.
+- Migration-level references to audit signing/verification triggers in production schema metadata.
+
+**Residual risks**
+- Not all audit logs are currently documented as append-only with WORM retention.
+- Export outputs can be copied outside of signed envelopes unless consumers verify signatures.
+
+**Hardening actions**
+- Enforce append-only permissions on audit tables (deny UPDATE/DELETE except break-glass role).
+- Sign every export artifact + include detached signature in evidence package.
+
+### 3) Repudiation
+**Threats**
+- Operator denies having run a reconciliation or changed mapping/rules.
+- Background job actions become non-attributable across service boundaries.
+
+**Existing controls**
+- Audit log entities and usage across scripts/runtime checks.
+- Traceable event-style operational docs and runbooks.
+
+**Residual risks**
+- Attribution can be weakened when service-role operations do not carry explicit user delegation metadata.
+
+**Hardening actions**
+- Require delegated actor metadata (`actor_user_id`, `actor_service`, `trace_id`) on all privileged writes.
+- Periodically reconcile control-plane actions against immutable audit ledger snapshots.
+
+### 4) Information Disclosure
+**Threats**
+- Cross-tenant data leakage via missing tenant predicates or weak RLS policy.
+- Sensitive financial payload leakage in logs, exports, or AI prompts.
+
+**Existing controls**
+- RLS enablement and policy migrations on critical tables.
+- Tenant-membership helper functions and tenant-scoped policy checks.
+- Security/privacy docs that prohibit secret/PII leakage and require envelope-safe errors.
+
+**Residual risks**
+- Debug/diagnostic scripts with broad DB access can become exfiltration paths in poorly controlled environments.
+- AI prompts may include excessive transaction context if redaction is not enforced upstream.
+
+**Hardening actions**
+- Introduce static query linting for tenant predicates on all direct SQL paths.
+- Add mandatory PII/token redaction middleware before AI prompt assembly.
+
+### 5) Denial of Service
+**Threats**
+- Reconciliation job floods, replay storms, or expensive export generation bursts.
+- Audit verification endpoints abused for computational amplification.
+
+**Existing controls**
+- Idempotency key patterns and webhook replay handling guidance.
+- Queue-based async architecture (JobForge/Workhorse) to absorb spikes.
+
+**Residual risks**
+- Shared queue exhaustion can degrade unrelated tenants.
+
+**Hardening actions**
+- Add per-tenant rate quotas and queue fairness scheduling.
+- Add cost ceilings and circuit breakers for export generation and AI advisory calls.
+
+### 6) Elevation of Privilege
+**Threats**
+- Compromised support/admin path used to access tenant-restricted data.
+- Misconfigured role claims granting broader table access.
+
+**Existing controls**
+- Explicit RBAC permissions and route-level middleware checks.
+- RLS policy completion/hardening migrations across key tables.
+
+**Residual risks**
+- Privileged operational scripts can become privilege-escalation primitives without just-in-time approvals.
+
+**Hardening actions**
+- Enforce PAM/JIT controls for all service-role and super-admin actions.
+- Continuous policy diff checks in CI for RLS/function privilege drift.
+
+## Scenario-Focused Findings (Requested)
+
+### Cross-tenant data leakage
+- **Risk:** High.
+- **Current posture:** Strong baseline (RLS + tenant helper function + policy migrations) but depends on strict policy completeness and no service-role abuse.
+- **Priority controls:** Automated RLS regression tests, query-policy drift detection, production deny-by-default for tenant-less queries.
+
+### Audit chain tampering
+- **Risk:** High.
+- **Current posture:** Tamper-evident mechanisms exist (receipt hash chain, audit signing references), but enterprise-grade immutability controls should be made explicit and independently attestable.
+- **Priority controls:** Append-only storage controls, periodic external notarization checkpoint, signed audit exports.
+
+### Reconciliation corruption
+- **Risk:** High.
+- **Current posture:** Deterministic strategy is documented and represented in schema/config; reproducibility relies on frozen rules/input snapshots.
+- **Priority controls:** Mandatory ruleset version pinning + deterministic replay CI gate.
+
+### Export manipulation
+- **Risk:** Medium-High.
+- **Current posture:** Evidence bundle manifest and schema versioning are present; integrity guarantees are strongest only when consumers verify hashes/signatures.
+- **Priority controls:** Contract version pinning, cryptographic export signatures, strict backward-compatibility tests.
+
+### AI advisory hallucination liability
+- **Risk:** Medium-High.
+- **Current posture:** Advisory pathways and AI integrations exist; legal/safety boundary between advisory and deterministic engine must be contractually explicit.
+- **Priority controls:** Non-authoritative labeling, confidence + provenance metadata, hard prohibition on AI-only financial postings.
+
+### Privilege escalation
+- **Risk:** High.
+- **Current posture:** RBAC exists, but privileged script and service-role execution paths require governance hardening.
+- **Priority controls:** Break-glass workflow, full privileged action logging, quarterly access recertification.
+
+## Priority Remediation Plan
+1. **P0:** Enforce append-only audit controls + external checkpointing.
+2. **P0:** Add CI gate that fails when new SQL paths lack tenant-scope proofs.
+3. **P1:** Sign/export manifest with tenant-scoped verification CLI.
+4. **P1:** Formalize AI advisory boundary in policy and API contracts.
+5. **P2:** Publish quarterly security attestation pack (RLS coverage, replay tests, access recertification).

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "verify:app-router": "tsx scripts/validate-app-router.ts",
     "verify:env:typed": "tsx scripts/validate-typed-env.ts",
     "verify:docs": "node scripts/verify-docs.mjs",
+    "verify:red-team": "node scripts/verify-red-team-controls.mjs",
     "verify:skip-tests": "node scripts/verify.mjs --skip-tests",
     "verify:skip-build": "node scripts/verify.mjs --skip-build",
     "validate": "pnpm run lint && pnpm run typecheck && pnpm run format:check",

--- a/packages/web/src/__tests__/security/advisory-policy.test.ts
+++ b/packages/web/src/__tests__/security/advisory-policy.test.ts
@@ -1,0 +1,22 @@
+import {
+  assertNoAutonomousFinancialAction,
+  buildAdvisoryPolicyMetadata,
+} from '@/lib/ai/advisory-policy';
+
+describe('advisory policy controls', () => {
+  it('blocks autonomous ledger mutation requests', () => {
+    expect(() =>
+      assertNoAutonomousFinancialAction({ requestedAction: 'mutate_ledger' })
+    ).toThrow('Autonomous financial ledger mutations are prohibited');
+  });
+
+  it('attaches non-authoritative policy metadata and provenance', () => {
+    const metadata = buildAdvisoryPolicyMetadata({ route: 'test', input: 'sample' });
+
+    expect(metadata.nonAuthoritative).toBe(true);
+    expect(metadata.requiresHumanApprovalForFinancialPosting).toBe(true);
+    expect(metadata.allowLedgerMutation).toBe(false);
+    expect(metadata.disclaimer).toMatch(/non-authoritative guidance/i);
+    expect(metadata.provenance.inputFingerprint).toHaveLength(64);
+  });
+});

--- a/packages/web/src/__tests__/security/export-signature.test.ts
+++ b/packages/web/src/__tests__/security/export-signature.test.ts
@@ -1,0 +1,28 @@
+import { signExportPayload } from '@/lib/security/export-signature';
+
+describe('export signature controls', () => {
+  const original = process.env.EXPORT_SIGNING_KEY;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.EXPORT_SIGNING_KEY;
+    } else {
+      process.env.EXPORT_SIGNING_KEY = original;
+    }
+  });
+
+  it('requires signing key', () => {
+    delete process.env.EXPORT_SIGNING_KEY;
+    expect(() => signExportPayload('payload')).toThrow('EXPORT_SIGNING_KEY is required');
+  });
+
+  it('returns deterministic signature for same payload', () => {
+    process.env.EXPORT_SIGNING_KEY = 'test-signing-key';
+
+    const first = signExportPayload('export-data');
+    const second = signExportPayload('export-data');
+
+    expect(first.signature).toBe(second.signature);
+    expect(first.algorithm).toBe('hmac-sha256');
+  });
+});

--- a/packages/web/src/app/api/ai/data-insights/route.ts
+++ b/packages/web/src/app/api/ai/data-insights/route.ts
@@ -8,6 +8,10 @@ import { createClient } from "@/lib/supabase/server";
 import { withUniversalBillingGate } from '@/middleware/billing-gate-universal';
 import { appLogger } from '@/lib/utils/logger';
 import { withSecurity } from '@/lib/middleware/api-security';
+import {
+  assertNoAutonomousFinancialAction,
+  buildAdvisoryPolicyMetadata,
+} from '@/lib/ai/advisory-policy';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -26,6 +30,7 @@ export const GET = withSecurity(
 
     const { searchParams } = new URL(request.url);
     const dataType = searchParams.get("type") || "receipts";
+    assertNoAutonomousFinancialAction({ requestedAction: searchParams.get("requestedAction") || undefined });
 
     let insights: {
       summary: string;
@@ -127,7 +132,16 @@ export const GET = withSecurity(
       }
     }
 
-    return NextResponse.json(insights);
+    const advisoryPolicy = buildAdvisoryPolicyMetadata({
+      dataType,
+      userId: user.id,
+      route: "data-insights",
+    });
+
+    return NextResponse.json({
+      ...insights,
+      advisoryPolicy,
+    });
    
       } catch (error) {
     appLogger.error("AI data insights error", error);

--- a/packages/web/src/app/api/ai/onboarding-assistant/route.ts
+++ b/packages/web/src/app/api/ai/onboarding-assistant/route.ts
@@ -4,6 +4,10 @@ import { parseRequestBody } from "@/types/api";
 import { withUniversalBillingGate } from '@/middleware/billing-gate-universal';
 import { appLogger } from '@/lib/utils/logger';
 import { withSecurity } from '@/lib/middleware/api-security';
+import {
+  assertNoAutonomousFinancialAction,
+  buildAdvisoryPolicyMetadata,
+} from '@/lib/ai/advisory-policy';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs'; // Ensure Node.js runtime for Supabase
@@ -31,6 +35,7 @@ export const POST = withSecurity(
 
     const body = await parseRequestBody<OnboardingRequestBody>(request);
     const { message } = body;
+    assertNoAutonomousFinancialAction(body);
 
     // Get user context
     const { data: lifecycle } = await supabase
@@ -75,7 +80,8 @@ export const POST = withSecurity(
         " I notice you haven't completed your first reconciliation yet. Would you like me to guide you through that?";
     }
 
-    return NextResponse.json({ response });
+    const advisoryPolicy = buildAdvisoryPolicyMetadata({ message, userId: user.id, route: 'onboarding-assistant' });
+    return NextResponse.json({ response, advisoryPolicy });
    
       } catch (error) {
     appLogger.error("Error in onboarding-assistant POST", error);

--- a/packages/web/src/app/api/ai/support-assistant/route.ts
+++ b/packages/web/src/app/api/ai/support-assistant/route.ts
@@ -8,6 +8,10 @@ import { createClient } from "@/lib/supabase/server";
 import { withUniversalBillingGate } from '@/middleware/billing-gate-universal';
 import { appLogger } from '@/lib/utils/logger';
 import { withSecurity } from '@/lib/middleware/api-security';
+import {
+  assertNoAutonomousFinancialAction,
+  buildAdvisoryPolicyMetadata,
+} from '@/lib/ai/advisory-policy';
 
 interface SupportRequest {
   question: string;
@@ -29,6 +33,7 @@ export const POST = withSecurity(
 
     const body: SupportRequest = await request.json();
     const { question, context } = body;
+    assertNoAutonomousFinancialAction(body as unknown as Record<string, unknown>);
 
     if (!question || question.trim().length === 0) {
       return NextResponse.json(
@@ -82,10 +87,18 @@ export const POST = withSecurity(
       }
     }
 
+    const advisoryPolicy = buildAdvisoryPolicyMetadata({
+      question,
+      context,
+      userId: user?.id ?? null,
+      route: 'support-assistant',
+    });
+
     return NextResponse.json({
       answer: aiResponse.answer,
       suggestions: aiResponse.suggestions,
       related_docs: aiResponse.relatedDocs,
+      advisoryPolicy,
     });
    
       } catch (error) {

--- a/packages/web/src/app/api/ai/troubleshooting/route.ts
+++ b/packages/web/src/app/api/ai/troubleshooting/route.ts
@@ -3,6 +3,10 @@ import { createClient } from "@/lib/supabase/server";
 import { withUniversalBillingGate } from '@/middleware/billing-gate-universal';
 import { appLogger } from '@/lib/utils/logger';
 import { withSecurity } from '@/lib/middleware/api-security';
+import {
+  assertNoAutonomousFinancialAction,
+  buildAdvisoryPolicyMetadata,
+} from '@/lib/ai/advisory-policy';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs'; // Ensure Node.js runtime for Supabase
@@ -21,6 +25,7 @@ export const POST = withSecurity(
 
     const body = await request.json();
     const { answers } = body;
+    assertNoAutonomousFinancialAction(body as Record<string, unknown>);
 
     // Generate solution based on answers (in production, use AI/LLM)
     let solution = "";
@@ -49,7 +54,13 @@ export const POST = withSecurity(
       solution = `I understand you're experiencing an issue. To help you better:\n\n1. Check the error logs in your dashboard\n2. Review the documentation for your specific use case\n3. Try the troubleshooting steps in our help center\n4. Contact support with:\n   - What you were trying to do\n   - The exact error message\n   - Steps to reproduce the issue\n\nOur support team can help resolve this quickly.`;
     }
 
-    return NextResponse.json({ solution });
+    const advisoryPolicy = buildAdvisoryPolicyMetadata({
+      answers,
+      userId: user.id,
+      route: "troubleshooting",
+    });
+
+    return NextResponse.json({ solution, advisoryPolicy });
    
       } catch (error) {
     appLogger.error("Error in troubleshooting POST", error);

--- a/packages/web/src/app/api/console/ai-analysis/route.ts
+++ b/packages/web/src/app/api/console/ai-analysis/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireActiveSubscription } from '@/lib/security/billing-enforcement';
 import { withSecurity } from '@/lib/middleware/api-security';
+import { buildAdvisoryPolicyMetadata } from '@/lib/ai/advisory-policy';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,7 +13,13 @@ export const GET = withSecurity(async function GET(request: NextRequest) {
       { status: 403 }
     );
   }
-  return NextResponse.json({ message: 'Feature temporarily unavailable' }, { status: 503 });
+  return NextResponse.json(
+    {
+      message: 'Feature temporarily unavailable',
+      advisoryPolicy: buildAdvisoryPolicyMetadata({ route: 'console-ai-analysis', method: 'GET' }),
+    },
+    { status: 503 }
+  );
 },
   { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: true }
 );
@@ -25,7 +32,13 @@ export const POST = withSecurity(async function POST(request: NextRequest) {
       { status: 403 }
     );
   }
-  return NextResponse.json({ message: 'Feature temporarily unavailable' }, { status: 503 });
+  return NextResponse.json(
+    {
+      message: 'Feature temporarily unavailable',
+      advisoryPolicy: buildAdvisoryPolicyMetadata({ route: 'console-ai-analysis', method: 'POST' }),
+    },
+    { status: 503 }
+  );
 },
   { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: true }
 );

--- a/packages/web/src/app/api/console/usage/export/route.ts
+++ b/packages/web/src/app/api/console/usage/export/route.ts
@@ -10,6 +10,7 @@ import { prisma } from "@/shared/db/prismaClient";
 import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
 import { withSecurity } from "@/lib/middleware/api-security";
 import { appLogger } from "@/lib/utils/logger";
+import { signExportPayload } from "@/lib/security/export-signature";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -91,10 +92,29 @@ export const GET = withSecurity(
             }),
           ].join("\n");
 
+          let signed;
+          try {
+            signed = signExportPayload(csv);
+          } catch {
+            return NextResponse.json(
+              {
+                code: "EXPORT_SIGNING_KEY_MISSING",
+                message: "Signed exports are required but signing key is not configured",
+                traceId: `export-signature-${Date.now()}`,
+                retryable: false,
+              },
+              { status: 503 }
+            );
+          }
+
           return new NextResponse(csv, {
             headers: {
               "Content-Type": "text/csv",
               "Content-Disposition": `attachment; filename="settler-usage-${days}d.csv"`,
+              "X-Settler-Export-Signature": signed.signature,
+              "X-Settler-Export-Key-Id": signed.keyId,
+              "X-Settler-Export-Algorithm": signed.algorithm,
+              "X-Settler-Export-Signed": "true",
             },
           });
         } else {
@@ -114,10 +134,29 @@ export const GET = withSecurity(
             2
           );
 
+          let signed;
+          try {
+            signed = signExportPayload(json);
+          } catch {
+            return NextResponse.json(
+              {
+                code: "EXPORT_SIGNING_KEY_MISSING",
+                message: "Signed exports are required but signing key is not configured",
+                traceId: `export-signature-${Date.now()}`,
+                retryable: false,
+              },
+              { status: 503 }
+            );
+          }
+
           return new NextResponse(json, {
             headers: {
               "Content-Type": "application/json",
               "Content-Disposition": `attachment; filename="settler-usage-${days}d.json"`,
+              "X-Settler-Export-Signature": signed.signature,
+              "X-Settler-Export-Key-Id": signed.keyId,
+              "X-Settler-Export-Algorithm": signed.algorithm,
+              "X-Settler-Export-Signed": "true",
             },
           });
         }

--- a/packages/web/src/lib/ai/advisory-policy.ts
+++ b/packages/web/src/lib/ai/advisory-policy.ts
@@ -1,0 +1,67 @@
+import { createHash } from 'node:crypto';
+
+export interface AdvisoryPolicyMetadata {
+  disclaimer: string;
+  nonAuthoritative: true;
+  requiresHumanApprovalForFinancialPosting: true;
+  allowLedgerMutation: false;
+  provenance: {
+    provider: string;
+    model: string;
+    modelVersion: string;
+    generatedAt: string;
+    inputFingerprint: string;
+  };
+}
+
+const BLOCKED_ACTIONS = new Set([
+  'post_ledger_entry',
+  'mutate_ledger',
+  'approve_financial_posting',
+  'create_journal_entry',
+  'autonomous_posting',
+]);
+
+const ADVISORY_DISCLAIMER =
+  'AI advisory output is non-authoritative guidance only and must not be used to autonomously post or mutate financial ledger records.';
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`);
+
+  return `{${entries.join(',')}}`;
+}
+
+export function assertNoAutonomousFinancialAction(payload: Record<string, unknown>): void {
+  const requestedAction = payload.requestedAction;
+  if (typeof requestedAction === 'string' && BLOCKED_ACTIONS.has(requestedAction)) {
+    throw new Error('Autonomous financial ledger mutations are prohibited in advisory endpoints.');
+  }
+}
+
+export function buildAdvisoryPolicyMetadata(input: Record<string, unknown>): AdvisoryPolicyMetadata {
+  const fingerprint = createHash('sha256').update(stableStringify(input)).digest('hex');
+
+  return {
+    disclaimer: ADVISORY_DISCLAIMER,
+    nonAuthoritative: true,
+    requiresHumanApprovalForFinancialPosting: true,
+    allowLedgerMutation: false,
+    provenance: {
+      provider: 'settler',
+      model: 'rule-based-advisory',
+      modelVersion: '2026-02-redteam-controls',
+      generatedAt: new Date().toISOString(),
+      inputFingerprint: fingerprint,
+    },
+  };
+}

--- a/packages/web/src/lib/middleware/api-security.ts
+++ b/packages/web/src/lib/middleware/api-security.ts
@@ -6,7 +6,9 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { createHash } from 'node:crypto';
 import { withRateLimit } from '@/lib/api/rate-limit';
+import { appLogger } from '@/lib/utils/logger';
 
 export interface SecurityOptions {
   rateLimit?: {
@@ -17,6 +19,13 @@ export interface SecurityOptions {
   validateQuery?: boolean;
   validateBody?: boolean;
   csrf?: boolean;
+  requirePrivilegedApproval?: boolean;
+}
+
+function isPrivilegedMutation(request: NextRequest): boolean {
+  const method = request.method.toUpperCase();
+  const isMutation = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
+  return isMutation && request.nextUrl.pathname.startsWith('/api/admin');
 }
 
 /**
@@ -29,11 +38,57 @@ export function withSecurity<T extends (request: NextRequest, ...args: any[]) =>
 ): T {
   const {
     rateLimit = { maxRequests: 60, windowMs: 60 * 1000 },
+    requirePrivilegedApproval,
   } = options;
 
   // Apply rate limiting
   const securedHandler = withRateLimit(
     async (request: NextRequest, ...args: any[]) => {
+      const privilegedApprovalRequired = requirePrivilegedApproval ?? isPrivilegedMutation(request);
+      if (privilegedApprovalRequired) {
+        const method = request.method.toUpperCase();
+        const operatorId = request.headers.get('x-operator-id');
+        const breakGlassTicket = request.headers.get('x-breakglass-ticket');
+        const traceId = `priv-${Date.now()}`;
+
+        if (!operatorId || !breakGlassTicket) {
+          return NextResponse.json(
+            {
+              code: 'PRIVILEGED_APPROVAL_REQUIRED',
+              message:
+                'Privileged mutations require x-operator-id and x-breakglass-ticket headers.',
+              traceId,
+              retryable: false,
+            },
+            { status: 403 }
+          );
+        }
+
+        const sessionRecordId = createHash('sha256')
+          .update(`${operatorId}|${breakGlassTicket}|${request.nextUrl.pathname}|${Date.now()}`)
+          .digest('hex');
+
+        appLogger.info('Privileged mutation approved', {
+          operatorId,
+          breakGlassTicket,
+          path: request.nextUrl.pathname,
+          method,
+          sessionRecordId,
+          traceId,
+        });
+
+        const response = await handler(request, ...args);
+        response.headers.set('X-Privileged-Session-Record-Id', sessionRecordId);
+        response.headers.set('X-Privileged-Operator-Id', operatorId);
+        response.headers.set('X-Privileged-Breakglass-Ticket', breakGlassTicket);
+        response.headers.set('X-Privileged-Trace-Id', traceId);
+        response.headers.set('X-Content-Type-Options', 'nosniff');
+        response.headers.set('X-Frame-Options', 'DENY');
+        response.headers.set('X-XSS-Protection', '1; mode=block');
+        response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        return response;
+      }
+
       // Add security headers
       const response = await handler(request, ...args);
       

--- a/packages/web/src/lib/security/export-signature.ts
+++ b/packages/web/src/lib/security/export-signature.ts
@@ -1,0 +1,25 @@
+import { createHmac } from 'node:crypto';
+
+const SIGNING_ALGORITHM = 'hmac-sha256';
+
+export interface ExportSignatureResult {
+  signature: string;
+  keyId: string;
+  algorithm: string;
+}
+
+export function signExportPayload(payload: string): ExportSignatureResult {
+  const secret = process.env.EXPORT_SIGNING_KEY;
+  if (!secret) {
+    throw new Error('EXPORT_SIGNING_KEY is required for export signing.');
+  }
+
+  const keyId = process.env.EXPORT_SIGNING_KEY_ID || 'default';
+  const signature = createHmac('sha256', secret).update(payload).digest('hex');
+
+  return {
+    signature,
+    keyId,
+    algorithm: SIGNING_ALGORITHM,
+  };
+}

--- a/scripts/verify-red-team-controls.mjs
+++ b/scripts/verify-red-team-controls.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = process.cwd();
+
+function assertFile(path) {
+  if (!existsSync(resolve(root, path))) {
+    throw new Error(`Missing required file: ${path}`);
+  }
+}
+
+function assertContains(path, needle, description) {
+  const content = readFileSync(resolve(root, path), 'utf8');
+  if (!content.includes(needle)) {
+    throw new Error(`Missing ${description} in ${path}`);
+  }
+}
+
+try {
+  assertFile('supabase/migrations/20260218000000_red_team_security_controls.sql');
+  assertContains(
+    'packages/web/src/app/api/console/usage/export/route.ts',
+    'X-Settler-Export-Signature',
+    'signed export header enforcement'
+  );
+  assertContains(
+    'packages/web/src/lib/middleware/api-security.ts',
+    'X-Privileged-Session-Record-Id',
+    'privileged session record header'
+  );
+  assertContains(
+    'packages/web/src/lib/ai/advisory-policy.ts',
+    'requiresHumanApprovalForFinancialPosting',
+    'AI advisory human approval policy'
+  );
+
+  console.log('✅ Red-team control verification passed.');
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`❌ Red-team control verification failed: ${message}`);
+  process.exit(1);
+}

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -11,6 +11,7 @@ const checks = [
   ["Offline prerender harness", ["run", "test:web:offline-harness"]],
   ["Middleware /app gating tests", ["run", "test:web:middleware-gating"]],
   ["Typecheck", ["run", "typecheck"]],
+  ["Red-team controls", ["run", "verify:red-team"]],
   ["Docs parity", ["run", "verify:docs"]],
   ["Build", ["run", "build"]],
   ["Audit (high/critical threshold)", ["audit", "--audit-level=high", "--prod"]],

--- a/supabase/migrations/20260218000000_red_team_security_controls.sql
+++ b/supabase/migrations/20260218000000_red_team_security_controls.sql
@@ -1,0 +1,98 @@
+-- Red-team security hardening controls
+-- 1) Append-only audit logs enforcement
+-- 2) Audit notarization checkpoints
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'audit_logs'
+  ) THEN
+    CREATE OR REPLACE FUNCTION public.block_audit_log_mutation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $fn$
+    BEGIN
+      RAISE EXCEPTION 'audit_logs is append-only and cannot be %', TG_OP
+        USING ERRCODE = '42501';
+    END;
+    $fn$;
+
+    DROP TRIGGER IF EXISTS trg_block_audit_log_updates ON public.audit_logs;
+    CREATE TRIGGER trg_block_audit_log_updates
+      BEFORE UPDATE OR DELETE ON public.audit_logs
+      FOR EACH ROW
+      EXECUTE FUNCTION public.block_audit_log_mutation();
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.audit_notarization_checkpoints (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  checkpoint_at timestamptz NOT NULL DEFAULT now(),
+  audit_row_count bigint NOT NULL,
+  checkpoint_hash text NOT NULL,
+  source_window text NOT NULL DEFAULT 'latest_5000',
+  created_by text NOT NULL DEFAULT current_user
+);
+
+CREATE OR REPLACE FUNCTION public.compute_audit_notarization_hash(max_rows integer DEFAULT 5000)
+RETURNS text
+LANGUAGE plpgsql
+STABLE
+AS $fn$
+DECLARE
+  computed_hash text;
+BEGIN
+  IF max_rows < 1 THEN
+    max_rows := 1;
+  END IF;
+
+  SELECT md5(COALESCE(string_agg(to_jsonb(a)::text, '|' ORDER BY a.id::text), ''))
+  INTO computed_hash
+  FROM (
+    SELECT *
+    FROM public.audit_logs
+    ORDER BY id DESC
+    LIMIT max_rows
+  ) a;
+
+  RETURN computed_hash;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.write_audit_notarization_checkpoint(max_rows integer DEFAULT 5000)
+RETURNS public.audit_notarization_checkpoints
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_catalog'
+AS $fn$
+DECLARE
+  inserted_row public.audit_notarization_checkpoints;
+  audit_count bigint;
+  hash_value text;
+BEGIN
+  SELECT COUNT(*) INTO audit_count FROM public.audit_logs;
+  hash_value := public.compute_audit_notarization_hash(max_rows);
+
+  INSERT INTO public.audit_notarization_checkpoints (
+    audit_row_count,
+    checkpoint_hash,
+    source_window
+  ) VALUES (
+    audit_count,
+    hash_value,
+    format('latest_%s', max_rows)
+  )
+  RETURNING * INTO inserted_row;
+
+  RETURN inserted_row;
+END;
+$fn$;
+
+REVOKE UPDATE, DELETE ON public.audit_logs FROM authenticated, anon;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- The prior change surface added documentation for red-team findings but did not implement runtime enforcement for high-risk items like export integrity, privileged admin gating, AI advisory guardrails, and append-only audit protections. 
- This patch puts the red-team recommendations into executable controls so enterprise workflows can rely on cryptographic export integrity, just-in-time privileged approvals, and AI advisory non-authoritative gating. 
- Strengthening these controls reduces risk from export tampering, privileged-path abuse, and autonomous AI-driven ledger mutations.

### Description
- Added privileged-operation approval and session recording to the API security wrapper so mutating `/api/admin` paths require operator approval headers and emit `X-Privileged-Session-Record-Id` and related trace headers. 
- Implemented export signing with `signExportPayload` and enforced detached signature headers (`X-Settler-Export-Signature`, `X-Settler-Export-Key-Id`, `X-Settler-Export-Algorithm`) in the usage export route, returning a structured 503 error if signing is not configured. 
- Introduced an AI advisory policy utility that blocks autonomous financial-posting actions and attaches provenance/disclaimer metadata to advisory responses, and wired it into AI endpoints so advisory outputs include `advisoryPolicy` and are guarded against ledger mutations. 
- Added a DB migration that enforces append-only semantics for `audit_logs` and creates notarization checkpoint functions/tables to support periodic integrity notarization. 
- Added `scripts/verify-red-team-controls.mjs` and integrated `verify:red-team` into the repository verification pipeline to ensure these controls remain present; included focused unit tests for advisory guards and export signing.

### Testing
- Ran focused unit tests with `pnpm --filter @settler/web test -- advisory-policy.test.ts export-signature.test.ts` and both test suites passed. 
- Ran the red-team gate with `pnpm run verify:red-team` which completed successfully and confirmed presence of expected artifacts and headers. 
- Ran repo quality checks: `pnpm run lint` (completed with warnings only), `pnpm run typecheck` (passed), `pnpm run build` (passed), and `pnpm run verify:docs` (passed). 
- The repository verification chain flags existing legacy migration filename conventions in this repo (pre-existing files) during migration verification, which is unrelated to the new controls and should be remediated separately; the red-team controls themselves were validated by the new verifier and tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699527f4ff80832884c6b18cd4b5a511)