### PR TITLE
fix: resolve API 400 errors for billing account and API key auth

### DIFF
--- a/packages/web/src/app/api/v1/convert/route.ts
+++ b/packages/web/src/app/api/v1/convert/route.ts
@@ -121,7 +121,7 @@ export const POST = withSecurity(
     if (!auth || !auth.billingAccountId) {
       return NextResponse.json(
         { error: 'Billing account required' },
-        { status: 400 }
+        { status: 402 }
       );
     }
 

--- a/packages/web/src/app/api/v1/feature-flags/[id]/route.ts
+++ b/packages/web/src/app/api/v1/feature-flags/[id]/route.ts
@@ -58,7 +58,7 @@ export const PATCH = withSecurity(
     if (!auth || !auth.billingAccountId) {
       return NextResponse.json(
         { error: 'Billing account required' },
-        { status: 400 }
+        { status: 402 }
       );
     }
 

--- a/packages/web/src/app/api/v1/feature-flags/evaluate/route.ts
+++ b/packages/web/src/app/api/v1/feature-flags/evaluate/route.ts
@@ -54,7 +54,7 @@ export const POST = withSecurity(
     if (!auth || !auth.billingAccountId) {
       return NextResponse.json(
         { error: 'Billing account required' },
-        { status: 400 }
+        { status: 402 }
       );
     }
 

--- a/packages/web/src/app/api/v1/feature-flags/route.ts
+++ b/packages/web/src/app/api/v1/feature-flags/route.ts
@@ -56,7 +56,7 @@ export const POST = withSecurity(async function POST(request: NextRequest) {
     if (!auth || !auth.billingAccountId) {
       return NextResponse.json(
         { error: 'Billing account required' },
-        { status: 400 }
+        { status: 402 }
       );
     }
 
@@ -156,7 +156,7 @@ export const GET = withSecurity(async function GET(request: NextRequest) {
     if (!auth || !auth.billingAccountId) {
       return NextResponse.json(
         { error: 'Billing account required' },
-        { status: 400 }
+        { status: 402 }
       );
     }
 

--- a/packages/web/src/app/api/v1/receipts/route.ts
+++ b/packages/web/src/app/api/v1/receipts/route.ts
@@ -161,7 +161,7 @@ export async function POST(request: NextRequest) {
     if (!auth || !auth.billingAccountId) {
       const response = NextResponse.json(
         createActionableErrorResponse("BILLING_ACCOUNT_REQUIRED"),
-        { status: 400 }
+        { status: 402 }
       );
       return addCorrelationHeaders(response, correlationId);
     }

--- a/packages/web/src/app/api/v1/recon/jobs/route.ts
+++ b/packages/web/src/app/api/v1/recon/jobs/route.ts
@@ -70,7 +70,7 @@ export const POST = withSecurity(
 
       // For authenticated users, check billing account
       if (!auth?.billingAccountId) {
-        return NextResponse.json({ error: "Billing account required" }, { status: 400 });
+        return NextResponse.json({ error: "Billing account required" }, { status: 402 });
       }
 
       // Enforce usage limits (for authenticated users)

--- a/packages/web/src/lib/security/billing-enforcement.ts
+++ b/packages/web/src/lib/security/billing-enforcement.ts
@@ -34,8 +34,10 @@ export async function requireActiveSubscription(
     
     // Get authenticated user
     const { data: { user }, error: authError } = await supabaseClient.auth.getUser();
-    
-    if (authError || !user) {
+
+    // Support API key authenticated requests: when userId is explicitly provided
+    // (e.g. from validateApiKey), allow billing check without a session cookie.
+    if ((authError || !user) && !userId) {
       return {
         allowed: false,
         error: NextResponse.json(
@@ -50,7 +52,7 @@ export async function requireActiveSubscription(
       };
     }
 
-    const targetUserId = userId || user.id;
+    const targetUserId = userId || user!.id;
 
     // Get billing account
     const billingAccountResult = await supabaseClient


### PR DESCRIPTION
- Fix requireActiveSubscription to support API key requests: when userId
  is explicitly provided (from validateApiKey), allow the billing lookup
  to proceed without requiring a Supabase session cookie. Previously all
  pure API-key requests received 401 because the session check failed.

- Change HTTP 400 → 402 (Payment Required) for missing billing account
  responses across all v1 API routes (receipts, recon/jobs, convert,
  feature-flags GET/POST/[id]/evaluate). HTTP 400 (Bad Request) was
  semantically incorrect; 402 correctly signals that billing setup is
  required, not that the request itself was malformed.

Files changed:
  packages/web/src/lib/security/billing-enforcement.ts
  packages/web/src/app/api/v1/receipts/route.ts
  packages/web/src/app/api/v1/recon/jobs/route.ts
  packages/web/src/app/api/v1/convert/route.ts
  packages/web/src/app/api/v1/feature-flags/route.ts
  packages/web/src/app/api/v1/feature-flags/[id]/route.ts
  packages/web/src/app/api/v1/feature-flags/evaluate/route.ts

https://claude.ai/code/session_01HDc6qqGvHgH4z9joYYTNJY