### PR TITLE
fix: resolve all Vercel/Next.js build blockers

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -146,6 +146,20 @@ const nextConfig = {
         new NormalModuleReplacementPlugin(/shared[\\/]db[\\/]prismaClient/, stubPath)
       );
 
+      // Handle node: URI scheme for packages like @settler/protocol that use node:crypto.
+      // Webpack cannot resolve node: protocol URIs in client bundles; strip the prefix so
+      // webpack falls through to its built-in Node.js polyfill layer instead.
+      config.plugins.push(
+        new NormalModuleReplacementPlugin(/^node:/, (resource) => {
+          resource.request = resource.request.replace(/^node:/, "");
+        })
+      );
+      // Polyfill or stub Node.js built-ins that @settler/protocol pulls in
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        crypto: false,
+      };
+
       // Also mark Prisma packages as externals to prevent bundling
       config.externals = config.externals || [];
       if (typeof config.externals === "function") {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,6 +9,7 @@
     "dev": "next dev",
     "clean:build": "rm -rf .next dist out .next/tsconfig.tsbuildinfo",
     "validate:api-routes": "test -f ../../scripts/validate-api-routes.ts && tsx ../../scripts/validate-api-routes.ts || echo '\u26a0\ufe0f  API route validation skipped (script not found)'",
+    "validate:boundary": "tsx ./scripts/check-public-route-boundary.ts",
     "build": "next build --webpack",
     "build:vercel": "next build --webpack",
     "postinstall": "export SENTRY_SKIP_AUTO_INSTALL=1 || set SENTRY_SKIP_AUTO_INSTALL=1 || true",

--- a/packages/web/src/app/app/onboarding/page.tsx
+++ b/packages/web/src/app/app/onboarding/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 
 import React from 'react';
 

--- a/packages/web/src/app/categorize/page.tsx
+++ b/packages/web/src/app/categorize/page.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React from "react";
 import AppPageLayout from "@/components/AppPageLayout";

--- a/packages/web/src/app/exports/page.tsx
+++ b/packages/web/src/app/exports/page.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React from "react";
 import AppPageLayout from "@/components/AppPageLayout";

--- a/packages/web/src/app/parser/page.tsx
+++ b/packages/web/src/app/parser/page.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React from "react";
 import AppPageLayout from "@/components/AppPageLayout";

--- a/packages/web/src/app/reconcile/page.tsx
+++ b/packages/web/src/app/reconcile/page.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React from "react";
 import AppPageLayout from "@/components/AppPageLayout";

--- a/packages/web/src/components/AppPageLayout.tsx
+++ b/packages/web/src/components/AppPageLayout.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React from "react";
 

--- a/packages/web/src/components/CategorizationStudio.tsx
+++ b/packages/web/src/components/CategorizationStudio.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React from "react";
 

--- a/packages/web/src/components/ExportPreview.tsx
+++ b/packages/web/src/components/ExportPreview.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React, { useState } from "react";
 

--- a/packages/web/src/components/HeroMedia.tsx
+++ b/packages/web/src/components/HeroMedia.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React, { useEffect, useRef, useState } from "react";
 

--- a/packages/web/src/components/QueueTable.tsx
+++ b/packages/web/src/components/QueueTable.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React from "react";
 

--- a/packages/web/src/components/ReceiptParser.tsx
+++ b/packages/web/src/components/ReceiptParser.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React, { useState } from "react";
 

--- a/packages/web/src/components/ReconciliationPanel.tsx
+++ b/packages/web/src/components/ReconciliationPanel.tsx
@@ -1,4 +1,4 @@
-"use strict";
+"use client";
 
 import React from "react";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   fast-xml-parser: ^5.3.4
   esbuild: ^0.25.0
   glob: ^10.5.0
+  minimatch: '>=10.2.1'
   eslint: ^9.26.0
 
 importers:
@@ -5286,8 +5287,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.3:
+    resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
+    engines: {node: 20 || >=22}
 
   base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
@@ -5351,11 +5353,9 @@ packages:
   bowser@2.13.1:
     resolution: {integrity: sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.2:
+    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5716,9 +5716,6 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -8152,24 +8149,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
-    engines: {node: '>=10'}
-
-  minimatch@9.0.1:
-    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@10.2.2:
+    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+    engines: {node: 18 || 20 || >=22}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -12336,7 +12318,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 3.1.2
+      minimatch: 10.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12357,7 +12339,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -13119,7 +13101,7 @@ snapshots:
       indent-string: 4.0.0
       is-wsl: 2.2.0
       lilconfig: 3.1.3
-      minimatch: 9.0.5
+      minimatch: 10.2.2
       semver: 7.7.3
       string-width: 4.2.3
       supports-color: 8.1.1
@@ -15856,7 +15838,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      minimatch: 9.0.3
+      minimatch: 10.2.2
       semver: 7.7.3
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
@@ -15871,7 +15853,7 @@ snapshots:
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 9.0.5
+      minimatch: 10.2.2
       semver: 7.7.3
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -16723,7 +16705,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.3: {}
 
   base64-js@0.0.8: {}
 
@@ -16793,14 +16775,9 @@ snapshots:
 
   bowser@2.13.1: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@5.0.2:
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.3
 
   braces@3.0.3:
     dependencies:
@@ -17181,8 +17158,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
     dependencies:
@@ -17660,7 +17635,7 @@ snapshots:
     dependencies:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
-      minimatch: 9.0.1
+      minimatch: 10.2.2
       semver: 7.7.3
 
   ee-first@1.1.1: {}
@@ -18015,7 +17990,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -18043,7 +18018,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -18064,7 +18039,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -18122,7 +18097,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -18163,7 +18138,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -18411,7 +18386,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 10.2.2
 
   filing-cabinet@5.0.3:
     dependencies:
@@ -18672,7 +18647,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 10.2.2
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -20036,7 +20011,7 @@ snapshots:
 
   matcher-collection@1.1.2:
     dependencies:
-      minimatch: 3.1.2
+      minimatch: 10.2.2
 
   math-intrinsics@1.1.0: {}
 
@@ -20386,25 +20361,9 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@3.1.2:
+  minimatch@10.2.2:
     dependencies:
-      brace-expansion: 1.1.12
-
-  minimatch@5.1.6:
-    dependencies:
-      brace-expansion: 2.0.2
-
-  minimatch@9.0.1:
-    dependencies:
-      brace-expansion: 2.0.2
-
-  minimatch@9.0.3:
-    dependencies:
-      brace-expansion: 2.0.2
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.2
 
   minimist@1.2.8: {}
 
@@ -21299,7 +21258,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 10.2.2
 
   readdirp@3.6.0:
     dependencies:
@@ -22196,7 +22155,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.5.0
-      minimatch: 3.1.2
+      minimatch: 10.2.2
 
   text-hex@1.0.0: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -776,6 +776,29 @@ model ExperimentMetricEvent {
 }
 
 
+model ReceiptUpload {
+  id                String    @id @default(uuid())
+  tenantId          String    @db.Uuid
+  userId            String    @db.Uuid
+  fileUrl           String    @db.Text
+  fileName          String
+  fileSizeBytes     Int?
+  mimeType          String    @default("image/jpeg")
+  status            String    @default("pending")
+  errorMessage      String?   @db.Text
+  metadata          Json      @default("{}")
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  receipt           Receipt?
+
+  @@index([tenantId])
+  @@index([userId])
+  @@index([status])
+  @@index([createdAt(sort: Desc)])
+  @@map("receipt_uploads")
+}
+
 model Receipt {
   id                String    @id @default(uuid())
   uploadId           String    @db.Uuid @unique
@@ -1028,165 +1051,6 @@ model AuditLog {
   @@map("audit_logs")
 }
 
-model TenantBranding {
-  id                String    @id @default(uuid())
-  tenantId           String    @db.Uuid @unique
-  logoUrl            String?
-  faviconUrl         String?
-  primaryColor       String    @default("#2563eb")
-  secondaryColor     String    @default("#7c3aed")
-  accentColor        String    @default("#06b6d4")
-  backgroundColor    String    @default("#ffffff")
-  borderRadiusScale   Decimal?  @db.Decimal(3, 2) // e.g., 0.5, 1.0, 1.5
-  fontFamilyPrimary   String?   // Selected from safe set
-  fontFamilySecondary String?
-  metadata           Json      @default("{}")
-  createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
-
-  tenant             Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-
-  @@index([tenantId])
-  @@map("tenant_branding")
-}
-
-model TenantNavigation {
-  id                String    @id @default(uuid())
-  tenantId           String    @db.Uuid @unique
-  navItems           Json      @default("[]") // Structured list of nav items
-  footerItems        Json      @default("[]") // Structured list of footer items
-  metadata           Json      @default("{}")
-  createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
-
-  tenant             Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-
-  @@index([tenantId])
-  @@map("tenant_navigation")
-}
-
-model TenantPage {
-  id                String    @id @default(uuid())
-  tenantId           String    @db.Uuid
-  slug               String    // e.g., "" for homepage, "pricing", "docs/overview"
-  pageType           String    // "marketing" | "docs" | "landing" | "custom"
-  schemaVersion      String    @default("1.0")
-  blocks             Json      @default("[]") // Ordered list of content blocks/sections
-  seoTitle           String?
-  seoDescription     String?
-  seoImageUrl        String?
-  isDraft            Boolean   @default(false)
-  metadata           Json      @default("{}")
-  createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
-
-  tenant             Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  revisions          TenantPageRevision[]
-  experiments        Experiment[]
-
-  @@unique([tenantId, slug])
-  @@index([tenantId])
-  @@index([slug])
-  @@index([pageType])
-  @@index([isDraft])
-  @@map("tenant_pages")
-}
-
-model TenantPageRevision {
-  id                String    @id @default(uuid())
-  tenantPageId       String    @db.Uuid
-  editorUserId       String?   @db.Uuid
-  snapshot           Json      // Full copy of blocks and optionally SEO fields
-  comment            String?
-  approvedByUserId   String?   @db.Uuid
-  approvedAt          DateTime?
-  createdAt          DateTime  @default(now())
-
-  tenantPage         TenantPage @relation(fields: [tenantPageId], references: [id], onDelete: Cascade)
-
-  @@index([tenantPageId])
-  @@index([editorUserId])
-  @@index([approvedByUserId])
-  @@index([createdAt(sort: Desc)])
-  @@map("tenant_page_revisions")
-}
-
-// ============================================================================
-// A/B TESTING & EXPERIMENTS MODELS
-// Experiment management and metrics tracking for site builder
-// ============================================================================
-
-model Experiment {
-  id                String    @id @default(uuid())
-  tenantId           String    @db.Uuid
-  targetPageId       String    @db.Uuid
-  name               String
-  slug               String
-  status             String    @default("draft") // "draft" | "running" | "paused" | "completed"
-  trafficSplit       Json      @default("{}") // Mapping variantKey → percentage
-  primaryMetric      String    @default("click_through") // "click_through" | "signup" | "conversion" | "custom"
-  startsAt           DateTime?
-  endsAt             DateTime?
-  metadata           Json      @default("{}")
-  createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
-
-  tenant             Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  targetPage         TenantPage @relation(fields: [targetPageId], references: [id], onDelete: Cascade)
-  variants           ExperimentVariant[]
-  metricEvents       ExperimentMetricEvent[]
-
-  @@unique([tenantId, slug])
-  @@index([tenantId])
-  @@index([targetPageId])
-  @@index([status])
-  @@index([startsAt])
-  @@index([endsAt])
-  @@map("experiments")
-}
-
-model ExperimentVariant {
-  id                String    @id @default(uuid())
-  experimentId       String    @db.Uuid
-  key                String    // e.g., "A", "B", "control", "variant-1"
-  label              String    // e.g., "Control", "New Hero"
-  blocksOverride     Json      @default("{}") // Partial or full overrides for TenantPage.blocks
-  metadata           Json      @default("{}")
-  createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
-
-  experiment         Experiment @relation(fields: [experimentId], references: [id], onDelete: Cascade)
-
-  @@unique([experimentId, key])
-  @@index([experimentId])
-  @@index([key])
-  @@map("experiment_variants")
-}
-
-model ExperimentMetricEvent {
-  id                String    @id @default(uuid())
-  experimentId       String    @db.Uuid
-  variantKey         String
-  tenantId           String    @db.Uuid
-  pageId             String    @db.Uuid
-  eventType          String    // "view" | "click" | "conversion" | "custom"
-  sessionId          String?
-  userId             String?   @db.Uuid
-  meta               Json      @default("{}")
-  createdAt          DateTime  @default(now())
-
-  experiment         Experiment @relation(fields: [experimentId], references: [id], onDelete: Cascade)
-
-  @@index([experimentId])
-  @@index([variantKey])
-  @@index([tenantId])
-  @@index([pageId])
-  @@index([eventType])
-  @@index([sessionId])
-  @@index([userId])
-  @@index([createdAt])
-  @@map("experiment_metric_events")
-}
 
 // ============================================================================
 // WEBHOOK MODELS


### PR DESCRIPTION
- prisma/schema.prisma: remove 7 duplicate model definitions
  (TenantBranding, TenantNavigation, TenantPage, TenantPageRevision,
  Experiment, ExperimentVariant, ExperimentMetricEvent) that caused
  Prisma P1012 validation errors and prevented @prisma/client generation
- prisma/schema.prisma: add missing ReceiptUpload model referenced by
  Receipt relation (uploadId) but not previously defined
- packages/web/src/components/*.tsx, app pages: replace "use strict"
  with "use client" on 10 interactive components/pages that use React
  hooks (useState etc.) — were being incorrectly treated as Server
  Components causing webpack RSC errors
- packages/web/next.config.js: add NormalModuleReplacementPlugin to
  strip node: URI prefix and crypto: false fallback so @settler/protocol
  (which imports node:crypto) can be bundled without UnhandledSchemeError
- packages/web/src/app/app/onboarding/page.tsx: add "use client" to
  fix "Event handlers cannot be passed to Client Component props" error
  during static page generation (form had onSubmit handler)
- packages/web/package.json: restore validate:boundary script
- pnpm-lock.yaml: updated after pnpm install resolves minimatch transitive
  vulnerability (audit now shows 0 high/critical, was 3 high)

Build result: 10/10 tasks successful, @settler/web compiles + static pages generate cleanly

https://claude.ai/code/session_011LnJsPvqELAdQ92MwaR3Ne