### PR TITLE
fix: add missing minimatch override to resolve pnpm lockfile config mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
       "fast-xml-parser": "^5.3.4",
       "esbuild": "^0.25.0",
       "glob": "^10.5.0",
+      "minimatch": ">=10.2.1",
       "eslint": "^9.26.0"
     }
   }


### PR DESCRIPTION
The pnpm-lock.yaml contained a minimatch override (>=10.2.1) that was
not present in package.json pnpm.overrides, causing ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
and blocking Vercel builds with frozen-lockfile installs.

https://claude.ai/code/session_01SpbF5B3EiwRxeYEGm3gdcC