### PR TITLE
M1: lock marketing/app boundaries and add deterministic runs scaffold

### DIFF
--- a/docs/audit/M1-boundaries.md
+++ b/docs/audit/M1-boundaries.md
@@ -1,0 +1,41 @@
+# M1 Boundary Audit — Reality→Code Lock
+
+Date: 2026-02-24
+
+## Scope
+- Marketing/public routes under `packages/web/src/app`.
+- Authenticated shell under `/app` (`packages/web/src/app/app`).
+- Middleware and env access utilities.
+- Deterministic boundary for new minimal Runs scaffold.
+
+## Findings
+
+### 1) Route/provider boundary status
+- Root layout (`packages/web/src/app/layout.tsx`) is shared by both marketing and `/app` routes. It currently wires generic UI providers (`QueryProvider`, `RuntimeUiConfigProvider`, `TenantThemeProvider`) but does not directly import Supabase/session/auth modules. This is safe but broad-scoped.
+- `/app` subtree has its own layout at `packages/web/src/app/app/layout.tsx`, but before M1 it did not enforce auth or env checks.
+- Middleware matcher already scopes to `"/app/:path*"` and `"/api/:path*"`, so marketing routes are not auth-gated by middleware and avoid auth refresh execution.
+
+### 2) Auth/Supabase bleed risks
+- No direct imports of `@/lib/supabase` were detected in non-API marketing route files during audit.
+- `/app` lacked explicit server-side auth gating in its layout, allowing shell content to render without confirmed session state.
+
+### 3) Env safety and import-time throw risks
+- `packages/web/src/lib/env/runtime-access.ts` already provides non-throwing env status checks (good for graceful degradation).
+- `packages/web/src/lib/env/validator.ts` has throwing helpers (`getSupabaseEnv`, `requireEnvVar`) that are safe only when called intentionally at runtime, not at module import.
+- `packages/web/src/lib/supabase/server.ts` catches env errors in `createClient()` and returns degraded clients, reducing hard-500 risk.
+
+### 4) Determinism boundary audit
+- Existing codebase contains non-deterministic patterns (e.g., `Date.now()`, `Math.random()`, locale-sensitive compares in some areas), but they are outside M1’s minimal deterministic Runs scaffold.
+- No dedicated deterministic core helper module existed for stable sort + canonical JSON + run ID derivation for `/app/runs`.
+
+## Offenders / watchlist (outside strict M1 scope)
+- Locale-sensitive sort usage found (e.g., `localeCompare`), which can diverge across environments if locale is implicit.
+- Random/time-derived IDs in several utility modules (`Math.random`, `Date.now`) are unsuitable inside deterministic boundaries.
+
+## M1 lock decisions
+- Keep marketing auth-free and env-tolerant by enforcing checks only under `/app` layout + middleware.
+- Add deterministic helper module that uses:
+  - code-point string compare (no locale dependence)
+  - stable object key ordering
+  - SHA-256 hash from canonical serialized input for run IDs
+- Add tests that force locale/timezone changes and prove deterministic outputs remain stable.

--- a/package.json
+++ b/package.json
@@ -175,7 +175,8 @@
     "test:web:middleware-gating": "pnpm --filter @settler/web test -- app-auth-gating.test.ts",
     "test:e2e:marketing:prod": "pnpm --filter @settler/web build && playwright test -c playwright.prod.config.ts tests/e2e/marketing-crawl.spec.ts",
     "benchmark:check": "tsx benchmarks/reconciliationBenchmark.ts",
-    "verify:conflict-markers": "node scripts/check-conflict-markers.mjs"
+    "verify:conflict-markers": "node scripts/check-conflict-markers.mjs",
+    "smoke:m1": "tsx scripts/m1-smoke.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/web/src/__tests__/reconciliation/determinism-core.test.ts
+++ b/packages/web/src/__tests__/reconciliation/determinism-core.test.ts
@@ -1,0 +1,51 @@
+import { canonicalJson, stableSortStrings } from "@/lib/determinism/core";
+import { createDeterministicRun } from "@/lib/determinism/runs";
+
+describe("deterministic core", () => {
+  it("produces stable canonical JSON independent of object key insertion", () => {
+    const a = { z: 3, a: 1, nested: { b: 2, a: 1 } };
+    const b = { nested: { a: 1, b: 2 }, a: 1, z: 3 };
+
+    expect(canonicalJson(a)).toBe(canonicalJson(b));
+  });
+
+  it("sorts strings by code point without locale sensitivity", () => {
+    const originalLocale = process.env.LC_ALL;
+    const originalTz = process.env.TZ;
+    process.env.LC_ALL = "tr_TR.UTF-8";
+    process.env.TZ = "Pacific/Kiritimati";
+
+    const sorted = stableSortStrings(["z", "a", "ä", "A"]);
+
+    expect(sorted).toEqual(["A", "a", "z", "ä"]);
+
+    process.env.LC_ALL = originalLocale;
+    process.env.TZ = originalTz;
+  });
+
+  it("creates the same run ID and evidence pointers across locale/timezone changes", () => {
+    const input = {
+      tenantId: "tenant_123",
+      pipeline: "daily-settlement",
+      config: {
+        tolerances: { amount: 0.01 },
+        sources: ["bank", "processor"],
+        asOf: "2026-02-24",
+      },
+    };
+
+    const first = createDeterministicRun(input);
+    const originalLocale = process.env.LC_ALL;
+    const originalTz = process.env.TZ;
+
+    process.env.LC_ALL = "ja_JP.UTF-8";
+    process.env.TZ = "America/Los_Angeles";
+    const second = createDeterministicRun(input);
+
+    expect(second).toEqual(first);
+
+    process.env.LC_ALL = originalLocale;
+    process.env.TZ = originalTz;
+  });
+});
+

--- a/packages/web/src/app/app/layout.tsx
+++ b/packages/web/src/app/app/layout.tsx
@@ -1,35 +1,76 @@
+import Link from "next/link";
+import { EnvErrorPanel } from "@/components/env/EnvErrorPanel";
+import { getAppEnvStatus } from "@/lib/env/runtime-access";
+import { createClient } from "@/lib/supabase/server";
 
-import Link from 'next/link';
+function SignedOutScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <div className="max-w-md rounded-xl border border-border-light bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-text-main">You&apos;re signed out</h2>
+        <p className="mt-2 text-sm text-text-secondary">
+          The Settler app shell requires an authenticated session. Sign in to continue.
+        </p>
+        <div className="mt-4 flex gap-3">
+          <Link href="/login" className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white">
+            Sign in
+          </Link>
+          <Link href="/" className="rounded-md border border-border-light px-4 py-2 text-sm font-medium">
+            Back to marketing site
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const env = getAppEnvStatus();
+
+  if (!env.ok) {
+    return <EnvErrorPanel missingVars={env.missing} />;
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return <SignedOutScreen />;
+  }
+
   const navItems = [
-    { name: 'Overview', href: '/app' },
-    { name: 'Connections', href: '/app/connections' },
-    { name: 'Pipelines', href: '/app/pipelines' },
-    { name: 'Runs', href: '/app/runs' },
-    { name: 'Results', href: '/app/results' },
-    { name: 'Review Queue', href: '/app/review' },
-    { name: 'Rules', href: '/app/rules' },
-    { name: 'Governance', href: '/app/governance' },
-    { name: 'Integrations', href: '/app/integrations' },
-    { name: 'Artifacts', href: '/app/artifacts' },
-    { name: 'Alerts', href: '/app/alerts' },
-    { name: 'Traces', href: '/app/traces' },
-    { name: 'Settings', href: '/app/settings' },
+    { name: "Overview", href: "/app" },
+    { name: "Connections", href: "/app/connections" },
+    { name: "Pipelines", href: "/app/pipelines" },
+    { name: "Runs", href: "/app/runs" },
+    { name: "Results", href: "/app/results" },
+    { name: "Review Queue", href: "/app/review" },
+    { name: "Rules", href: "/app/rules" },
+    { name: "Governance", href: "/app/governance" },
+    { name: "Integrations", href: "/app/integrations" },
+    { name: "Artifacts", href: "/app/artifacts" },
+    { name: "Alerts", href: "/app/alerts" },
+    { name: "Traces", href: "/app/traces" },
+    { name: "Settings", href: "/app/settings" },
   ];
 
   return (
     <div className="flex h-screen bg-background-light dark:bg-background-dark">
-      <aside className="w-64 flex-shrink-0 bg-white dark:bg-surface-darker border-r border-slate-200 dark:border-slate-800">
-        <div className="flex flex-col h-full">
-          <div className="flex items-center justify-center h-16 border-b border-slate-200 dark:border-slate-800">
+      <aside className="w-64 flex-shrink-0 border-r border-slate-200 bg-white dark:border-slate-800 dark:bg-surface-darker">
+        <div className="flex h-full flex-col">
+          <div className="flex h-16 items-center justify-center border-b border-slate-200 dark:border-slate-800">
             <h1 className="text-xl font-bold">Settler</h1>
           </div>
           <nav className="flex-1 overflow-y-auto">
-            <ul className="p-4 space-y-2">
+            <ul className="space-y-2 p-4">
               {navItems.map((item) => (
                 <li key={item.name}>
-                  <Link href={item.href} className="flex items-center p-2 text-base font-normal text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700">
+                  <Link
+                    href={item.href}
+                    className="flex items-center rounded-lg p-2 text-base font-normal text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
+                  >
                     {item.name}
                   </Link>
                 </li>
@@ -38,9 +79,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           </nav>
         </div>
       </aside>
-      <div className="flex-1 flex flex-col overflow-hidden">
-        {children}
-      </div>
+      <div className="flex flex-1 flex-col overflow-hidden">{children}</div>
     </div>
   );
 }

--- a/packages/web/src/app/app/runs/page.tsx
+++ b/packages/web/src/app/app/runs/page.tsx
@@ -1,230 +1,49 @@
+import { createDeterministicRun } from "@/lib/determinism/runs";
 
-import React from 'react';
+export default function RunsPage() {
+  const exampleInput = {
+    tenantId: "tenant_demo",
+    pipeline: "daily-settlement",
+    config: {
+      sources: ["bank", "processor"],
+      tolerances: { amount: 0.01, fee: 0.001 },
+      orderBy: ["transaction_id", "settlement_date"],
+    },
+  };
 
-const RunsPage: React.FC = () => {
+  const run = createDeterministicRun(exampleInput);
+
   return (
-    <div className="bg-background min-h-screen text-text-main font-display pb-24 relative selection:bg-primary/20">
-      <header className="sticky top-0 z-30 bg-background/95 backdrop-blur-md border-b border-border-light">
-        <div className="px-4 py-3 flex items-center justify-between">
-          <h1 className="text-xl font-bold tracking-tight text-text-main">Execution Control</h1>
-          <div className="flex items-center gap-3">
-            <button className="relative p-2 rounded-full hover:bg-surface-highlight transition-colors text-text-secondary">
-              <span className="material-symbols-outlined">notifications</span>
-              <span className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full ring-2 ring-white"></span>
-            </button>
-          </div>
-        </div>
-        <div className="px-4 pb-4">
-          <div className="bg-surface rounded-xl p-4 border border-border-light shadow-sm flex items-center justify-between">
-            <div>
-              <div className="flex items-center gap-2 mb-1">
-                <span className="relative flex h-3 w-3">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-3 w-3 bg-emerald-500"></span>
-                </span>
-                <h2 className="font-semibold text-sm text-text-main">Queue is Active</h2>
-              </div>
-              <p className="text-xs text-text-secondary">2 active runs processing</p>
-            </div>
-            <label className="relative inline-flex items-center cursor-pointer">
-              <input defaultChecked className="sr-only peer" type="checkbox" value="" />
-              <div className="w-11 h-6 bg-slate-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/20 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary shadow-inner"></div>
-            </label>
-          </div>
-        </div>
-      </header>
-      <main className="px-4 py-2 space-y-6">
-        <section>
-          <button className="w-full bg-primary hover:bg-primary-dark text-white font-semibold py-3 px-4 rounded-xl shadow-lg shadow-blue-500/20 flex items-center justify-center gap-2 transition-all active:scale-[0.98]">
-            <span className="material-symbols-outlined">play_arrow</span>
-            Trigger New Run
-          </button>
-          <div className="flex gap-2 mt-3 justify-center">
-            <div className="flex items-center gap-2 px-3 py-1 bg-surface-highlight rounded-full border border-border-light">
-              <span className="material-symbols-outlined text-amber-600 text-[16px]">science</span>
-              <span className="text-xs text-text-secondary font-medium">Dry-Run: Off</span>
-            </div>
-            <div className="flex items-center gap-2 px-3 py-1 bg-surface-highlight rounded-full border border-border-light">
-              <span className="material-symbols-outlined text-purple-600 text-[16px]">low_priority</span>
-              <span className="text-xs text-text-secondary font-medium">Priority: High</span>
-            </div>
-          </div>
-        </section>
-        <section>
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-lg font-bold text-text-main">Active Runs</h3>
-            <span className="px-2 py-0.5 rounded-md bg-blue-50 text-primary border border-blue-100 text-xs font-bold">2 Running</span>
-          </div>
-          <div className="space-y-3">
-            <div className="bg-white rounded-xl p-4 border border-border-light shadow-[0_2px_8px_rgba(0,0,0,0.04)] relative overflow-hidden group">
-              <div className="absolute top-0 left-0 w-1.5 h-full bg-primary"></div>
-              <div className="flex justify-between items-start mb-3 pl-2">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-sm text-text-secondary font-medium">#8821</span>
-                    <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-600 border border-blue-100 uppercase tracking-wider">Reconcile</span>
-                  </div>
-                  <h4 className="font-bold text-text-main mt-1 text-base">Daily Batch Settlement</h4>
-                </div>
-                <button aria-label="Abort Run" className="text-text-tertiary hover:text-red-500 transition-colors p-1 bg-gray-50 hover:bg-red-50 rounded-lg">
-                  <span className="material-symbols-outlined">cancel</span>
-                </button>
-              </div>
-              <div className="flex items-center justify-between text-xs text-text-secondary mb-2 pl-2">
-                <div className="flex items-center gap-1 font-mono cursor-pointer hover:text-primary transition-colors bg-surface-highlight px-2 py-1 rounded border border-border-light">
-                  <span className="material-symbols-outlined text-[14px] text-text-tertiary">fingerprint</span>
-                  <span className="font-bold text-text-main">8f7a...9b1</span>
-                </div>
-                <span className="font-semibold text-primary">65%</span>
-              </div>
-              <div className="w-full bg-surface-highlight rounded-full h-2.5 mb-4 overflow-hidden pl-2">
-                <div className="bg-primary h-2.5 rounded-full relative" style={{ width: '65%' }}>
-                  <div className="absolute inset-0 bg-white/30 w-full h-full animate-[shimmer_2s_infinite] bg-gradient-to-r from-transparent via-white/40 to-transparent -skew-x-12"></div>
-                </div>
-              </div>
-              <div className="flex gap-2 pl-2">
-                <button className="flex-1 py-2 px-3 rounded-lg border border-border-light bg-surface hover:bg-surface-highlight text-xs font-semibold text-text-secondary transition-colors">
-                  View Live Logs
-                </button>
-              </div>
-            </div>
-            <div className="bg-white rounded-xl p-4 border border-border-light shadow-[0_2px_8px_rgba(0,0,0,0.04)] relative overflow-hidden">
-              <div className="absolute top-0 left-0 w-1.5 h-full bg-amber-500"></div>
-              <div className="flex justify-between items-start mb-3 pl-2">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-sm text-text-secondary font-medium">#8822</span>
-                    <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-amber-50 text-amber-600 border border-amber-100 uppercase tracking-wider">Dry-Run</span>
-                  </div>
-                  <h4 className="font-bold text-text-main mt-1 text-base">Staging Sync</h4>
-                </div>
-                <button aria-label="Abort Run" className="text-text-tertiary hover:text-red-500 transition-colors p-1 bg-gray-50 hover:bg-red-50 rounded-lg">
-                  <span className="material-symbols-outlined">cancel</span>
-                </button>
-              </div>
-              <div className="flex items-center justify-between text-xs text-text-secondary mb-2 pl-2">
-                <div className="flex items-center gap-1 font-mono cursor-pointer hover:text-primary transition-colors bg-surface-highlight px-2 py-1 rounded border border-border-light">
-                  <span className="material-symbols-outlined text-[14px] text-text-tertiary">fingerprint</span>
-                  <span className="font-bold text-text-main">2c3d...a4f</span>
-                </div>
-                <span className="font-semibold text-amber-600">12%</span>
-              </div>
-              <div className="w-full bg-surface-highlight rounded-full h-2.5 mb-4 overflow-hidden pl-2">
-                <div className="bg-amber-500 h-2.5 rounded-full" style={{ width: '12%' }}></div>
-              </div>
-              <div className="flex gap-2 pl-2">
-                <button className="flex-1 py-2 px-3 rounded-lg border border-border-light bg-surface hover:bg-surface-highlight text-xs font-semibold text-text-secondary transition-colors">
-                  View Live Logs
-                </button>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section className="pb-6">
-          <h3 className="text-lg font-bold text-text-main mb-3">Run History</h3>
-          <div className="flex gap-2 overflow-x-auto hide-scrollbar pb-2 mb-2">
-            <button className="px-4 py-1.5 rounded-full bg-primary text-white text-sm font-semibold whitespace-nowrap shadow-sm">All Runs</button>
-            <button className="px-4 py-1.5 rounded-full bg-white border border-border-light text-text-secondary text-sm font-medium whitespace-nowrap hover:bg-surface-highlight hover:text-text-main transition-colors">Success</button>
-            <button className="px-4 py-1.5 rounded-full bg-white border border-border-light text-text-secondary text-sm font-medium whitespace-nowrap hover:bg-surface-highlight hover:text-text-main transition-colors">Failed</button>
-            <button className="px-4 py-1.5 rounded-full bg-white border border-border-light text-text-secondary text-sm font-medium whitespace-nowrap hover:bg-surface-highlight hover:text-text-main transition-colors">Dry-Run</button>
-          </div>
-          <div className="bg-white rounded-xl border border-border-light divide-y divide-border-light shadow-sm">
-            <div className="p-4 flex items-center justify-between group hover:bg-surface-highlight transition-colors">
-              <div className="flex items-center gap-3">
-                <div className="w-9 h-9 rounded-full bg-emerald-50 border border-emerald-100 flex items-center justify-center shrink-0">
-                  <span className="material-symbols-outlined text-emerald-600 text-sm font-bold">check_circle</span>
-                </div>
-                <div className="flex flex-col">
-                  <div className="flex items-center gap-2">
-                    <span className="font-bold text-text-main text-sm">Run #8820</span>
-                    <span className="text-xs text-text-tertiary">2m ago</span>
-                  </div>
-                  <span className="text-xs font-mono text-text-secondary bg-surface rounded px-1 -ml-1 mt-0.5 inline-block w-fit font-semibold">Trace: 9a2b...3c4</span>
-                </div>
-              </div>
-              <div className="flex items-center gap-1">
-                <button className="p-2 rounded-lg text-text-tertiary hover:text-primary hover:bg-primary/10 transition-colors" title="View Trace">
-                  <span className="material-symbols-outlined text-[20px]">visibility</span>
-                </button>
-                <button className="p-2 rounded-lg text-text-tertiary hover:text-primary hover:bg-primary/10 transition-colors" title="View Artifacts">
-                  <span className="material-symbols-outlined text-[20px]">inventory_2</span>
-                </button>
-              </div>
-            </div>
-            <div className="p-4 flex items-center justify-between group hover:bg-surface-highlight transition-colors">
-              <div className="flex items-center gap-3">
-                <div className="w-9 h-9 rounded-full bg-red-50 border border-red-100 flex items-center justify-center shrink-0">
-                  <span className="material-symbols-outlined text-red-600 text-sm font-bold">error</span>
-                </div>
-                <div className="flex flex-col">
-                  <div className="flex items-center gap-2">
-                    <span className="font-bold text-text-main text-sm">Run #8819</span>
-                    <span className="text-xs text-text-tertiary">15m ago</span>
-                  </div>
-                  <span className="text-xs font-mono text-text-secondary bg-surface rounded px-1 -ml-1 mt-0.5 inline-block w-fit font-semibold">Trace: 7d8e...1f2</span>
-                </div>
-              </div>
-              <div className="flex items-center gap-1">
-                <button className="p-2 rounded-lg text-text-tertiary hover:text-primary hover:bg-primary/10 transition-colors" title="View Trace">
-                  <span className="material-symbols-outlined text-[20px]">visibility</span>
-                </button>
-                <button className="p-2 rounded-lg text-text-tertiary hover:text-primary hover:bg-primary/10 transition-colors" title="View Artifacts">
-                  <span className="material-symbols-outlined text-[20px]">inventory_2</span>
-                </button>
-              </div>
-            </div>
-            <div className="p-4 flex items-center justify-between group hover:bg-surface-highlight transition-colors">
-              <div className="flex items-center gap-3">
-                <div className="w-9 h-9 rounded-full bg-emerald-50 border border-emerald-100 flex items-center justify-center shrink-0">
-                  <span className="material-symbols-outlined text-emerald-600 text-sm font-bold">check_circle</span>
-                </div>
-                <div className="flex flex-col">
-                  <div className="flex items-center gap-2">
-                    <span className="font-bold text-text-main text-sm">Run #8818</span>
-                    <span className="text-xs text-text-tertiary">1h ago</span>
-                  </div>
-                  <span className="text-xs font-mono text-text-secondary bg-surface rounded px-1 -ml-1 mt-0.5 inline-block w-fit font-semibold">Trace: 4b5c...8d9</span>
-                </div>
-              </div>
-              <div className="flex items-center gap-1">
-                <button className="p-2 rounded-lg text-text-tertiary hover:text-primary hover:bg-primary/10 transition-colors" title="View Trace">
-                  <span className="material-symbols-outlined text-[20px]">visibility</span>
-                </button>
-                <button className="p-2 rounded-lg text-text-tertiary hover:text-primary hover:bg-primary/10 transition-colors" title="View Artifacts">
-                  <span className="material-symbols-outlined text-[20px]">inventory_2</span>
-                </button>
-              </div>
-            </div>
-            <div className="p-4 flex items-center justify-between group hover:bg-surface-highlight transition-colors">
-              <div className="flex items-center gap-3">
-                <div className="w-9 h-9 rounded-full bg-amber-50 border border-amber-100 flex items-center justify-center shrink-0">
-                  <span className="material-symbols-outlined text-amber-600 text-sm font-bold">science</span>
-                </div>
-                <div className="flex flex-col">
-                  <div className="flex items-center gap-2">
-                    <span className="font-bold text-text-main text-sm">Run #8817</span>
-                    <span className="text-xs text-text-tertiary">3h ago</span>
-                  </div>
-                  <span className="text-xs font-mono text-text-secondary bg-surface rounded px-1 -ml-1 mt-0.5 inline-block w-fit font-semibold">Trace: 1a2b...3c4</span>
-                </div>
-              </div>
-              <div className="flex items-center gap-1">
-                <button className="p-2 rounded-lg text-text-tertiary hover:text-primary hover:bg-primary/10 transition-colors" title="View Trace">
-                  <span className="material-symbols-outlined text-[20px]">visibility</span>
-                </button>
-                <button className="p-2 rounded-lg text-text-tertiary hover:text-primary hover:bg-primary/10 transition-colors" title="View Artifacts">
-                  <span className="material-symbols-outlined text-[20px]">inventory_2</span>
-                </button>
-              </div>
-            </div>
-          </div>
-          <button className="w-full mt-4 py-3 text-sm text-text-secondary hover:text-primary font-medium text-center border border-border-light rounded-xl bg-white hover:bg-surface-highlight transition-all">
-            View Older Runs
-          </button>
-        </section>
-      </main>
-    </div>
-  );
-};
+    <main className="min-h-screen bg-background p-6 text-text-main">
+      <h1 className="text-2xl font-bold">Deterministic Runs</h1>
+      <p className="mt-2 text-sm text-text-secondary">
+        This run record is derived from canonicalized input and deterministic SHA-256 ID rules.
+      </p>
 
-export default RunsPage;
+      <section className="mt-6 rounded-xl border border-border-light bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold">Run Record</h2>
+        <dl className="mt-3 space-y-2 text-sm">
+          <div>
+            <dt className="font-medium">Run ID</dt>
+            <dd className="font-mono">{run.runId}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Canonical Config Pointer</dt>
+            <dd className="font-mono">{run.evidenceManifest.canonicalConfigPointer}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Summary Pointer</dt>
+            <dd className="font-mono">{run.evidenceManifest.summaryPointer}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="mt-6 rounded-xl border border-border-light bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold">Canonical Input</h2>
+        <pre className="mt-3 overflow-auto rounded-md bg-slate-950 p-4 text-xs text-emerald-200">
+          {run.canonicalInput}
+        </pre>
+      </section>
+    </main>
+  );
+}

--- a/packages/web/src/lib/determinism/core.ts
+++ b/packages/web/src/lib/determinism/core.ts
@@ -1,0 +1,46 @@
+import { createHash } from "crypto";
+
+export function codePointCompare(a: string, b: string): number {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+export function stableSortStrings(values: readonly string[]): string[] {
+  return [...values].sort(codePointCompare);
+}
+
+type CanonicalValue = null | boolean | number | string | CanonicalValue[] | { [key: string]: CanonicalValue };
+
+function canonicalize(value: unknown): CanonicalValue {
+  if (value === null) return null;
+  if (typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+
+  if (typeof value === "object") {
+    const input = value as Record<string, unknown>;
+    const keys = stableSortStrings(Object.keys(input));
+    const normalized: Record<string, CanonicalValue> = {};
+    for (const key of keys) {
+      const nested = input[key];
+      if (nested === undefined) continue;
+      normalized[key] = canonicalize(nested);
+    }
+    return normalized;
+  }
+
+  return String(value);
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function stableSha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+

--- a/packages/web/src/lib/determinism/runs.ts
+++ b/packages/web/src/lib/determinism/runs.ts
@@ -1,0 +1,32 @@
+import { canonicalJson, stableSha256 } from "@/lib/determinism/core";
+
+export interface RunInput {
+  tenantId: string;
+  pipeline: string;
+  config: Record<string, unknown>;
+}
+
+export interface RunRecord {
+  runId: string;
+  canonicalInput: string;
+  evidenceManifest: {
+    canonicalConfigPointer: string;
+    summaryPointer: string;
+  };
+}
+
+export function createDeterministicRun(input: RunInput): RunRecord {
+  const canonicalInput = canonicalJson(input);
+  const digest = stableSha256(canonicalInput);
+  const runId = `run_${digest.slice(0, 24)}`;
+
+  return {
+    runId,
+    canonicalInput,
+    evidenceManifest: {
+      canonicalConfigPointer: `evidence://${runId}/canonical-config.json`,
+      summaryPointer: `evidence://${runId}/summary.json`,
+    },
+  };
+}
+

--- a/scripts/m1-smoke.ts
+++ b/scripts/m1-smoke.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+
+const WEB_DIR = "packages/web";
+const PORT = 4010;
+
+function runCommand(command: string, args: string[], env: NodeJS.ProcessEnv): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: WEB_DIR,
+      env,
+      stdio: "inherit",
+    });
+
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(" ")} failed with exit code ${code}`));
+    });
+  });
+}
+
+async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // ignore until ready
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function main() {
+  const baseEnv = {
+    ...process.env,
+    NEXT_PUBLIC_SITE_URL: "http://localhost:3000",
+    NEXT_PUBLIC_SUPABASE_URL: "",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "",
+    SUPABASE_URL: "",
+    SUPABASE_ANON_KEY: "",
+    SUPABASE_SERVICE_ROLE_KEY: "",
+  };
+
+  console.log("[M1 smoke] Build with marketing-safe minimal env...");
+  await runCommand("pnpm", ["build"], baseEnv);
+
+  console.log("[M1 smoke] Start app with missing secrets and check /app fails gracefully...");
+  const startProc = spawn("node", ["node_modules/next/dist/bin/next", "start", "-p", String(PORT)], {
+    cwd: WEB_DIR,
+    env: baseEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  startProc.stdout.on("data", (chunk) => process.stdout.write(chunk));
+  startProc.stderr.on("data", (chunk) => process.stderr.write(chunk));
+
+  try {
+    await waitForHttp(`http://127.0.0.1:${PORT}/`, 45_000);
+    const marketingResponse = await fetch(`http://127.0.0.1:${PORT}/`);
+    if (!marketingResponse.ok) {
+      throw new Error(`Marketing route returned status ${marketingResponse.status}`);
+    }
+
+    const appResponse = await fetch(`http://127.0.0.1:${PORT}/app`);
+    const appHtml = await appResponse.text();
+    if (!appResponse.ok) {
+      throw new Error(`/app returned status ${appResponse.status}`);
+    }
+    if (!appHtml.includes("Configuration Required")) {
+      throw new Error("/app did not render misconfigured environment screen");
+    }
+
+    console.log("[M1 smoke] PASS");
+  } finally {
+    startProc.kill("SIGTERM");
+    await new Promise((resolve) => startProc.once("exit", resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error("[M1 smoke] FAIL", error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Prevent marketing routes from importing or executing auth/supabase/session logic and ensure public pages build and render without secrets. 
- Add a minimal deterministic “Runs” scaffold (canonicalization → stable ID → evidence pointers) so a provable determinism boundary exists in the UI. 
- Provide runtime-safe env checks and friendly fallbacks so /app degrades gracefully when required secrets are missing (no hard 500s). 

### Description
- Isolate and harden the app shell by introducing env + auth gating in `packages/web/src/app/app/layout.tsx`, rendering a friendly misconfiguration UI via `EnvErrorPanel` and a signed-out screen when no session is present. 
- Add deterministic core helpers in `packages/web/src/lib/determinism/core.ts` (code-point sort, stable canonical JSON, stable SHA-256) and a run factory `packages/web/src/lib/determinism/runs.ts` that returns `runId`, `canonicalInput`, and evidence manifest pointers. 
- Replace the `/app/runs` page with a deterministic demo/ui that renders the canonical input and evidence pointers using `createDeterministicRun`. 
- Add an audit doc `docs/audit/M1-boundaries.md`, tests `packages/web/src/__tests__/reconciliation/determinism-core.test.ts`, and a smoke script `scripts/m1-smoke.ts` plus `smoke:m1` npm script to validate marketing build + /app graceful degrade flows. 

### Testing
- Lint: ran `pnpm --filter @settler/web lint` and received warnings only (no blocking errors). 
- Unit tests: ran the new determinism test with `pnpm --filter @settler/web test -- src/__tests__/reconciliation/determinism-core.test.ts` and it passed. 
- Build: produced a successful production build for `@settler/web` using `pnpm --filter @settler/web build`, and static pages were generated without the app crashing. 
- Smoke: ran `pnpm smoke:m1` (build + start + HTTP checks) and it passed, confirming marketing pages build with minimal env and `/app` renders the friendly misconfiguration screen instead of 500; note that repository-wide `typecheck` verification surfaced unrelated pre-existing type errors in other packages (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d051031e88328b3fd03169f94e224)