### PR TITLE
Harden route smoke verification for core app paths

### DIFF
--- a/scripts/verify-routes.mjs
+++ b/scripts/verify-routes.mjs
@@ -5,6 +5,16 @@ import { spawn } from "node:child_process";
 const port = Number(process.env.PORT || 3210);
 const base = `http://127.0.0.1:${port}`;
 
+const strict200Routes = ["/", "/docs"];
+const non500Routes = [
+  "/app",
+  "/app/assistant",
+  "/app/pipelines",
+  "/app/runs",
+  "/app/review-queue",
+  "/app/pipelines/demo-pipeline",
+];
+
 async function waitForServer(timeoutMs = 60000) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
@@ -43,21 +53,34 @@ function startWebServer() {
   return server;
 }
 
+async function assertRouteStatus(route, mode) {
+  const res = await fetch(`${base}${route}`, {
+    redirect: mode === "strict" ? "follow" : "manual",
+  });
+
+  if (mode === "strict") {
+    if (res.status !== 200) {
+      throw new Error(`${route} returned ${res.status} (expected 200)`);
+    }
+  } else if (res.status >= 500) {
+    throw new Error(`${route} returned ${res.status} (must not hard-500)`);
+  }
+
+  console.log(`✅ ${route} => ${res.status}`);
+}
+
 async function main() {
   const server = startWebServer();
 
   try {
     await waitForServer();
-    for (const route of ["/", "/docs"]) {
-      const res = await fetch(`${base}${route}`, { redirect: "follow" });
-      if (res.status !== 200) throw new Error(`${route} returned ${res.status}`);
-      console.log(`✅ ${route} => ${res.status}`);
+
+    for (const route of strict200Routes) {
+      await assertRouteStatus(route, "strict");
     }
 
-    for (const route of ["/app", "/app/pipelines/demo-pipeline"]) {
-      const res = await fetch(`${base}${route}`, { redirect: "manual" });
-      if (res.status >= 500) throw new Error(`${route} returned ${res.status}`);
-      console.log(`✅ ${route} => ${res.status}`);
+    for (const route of non500Routes) {
+      await assertRouteStatus(route, "non500");
     }
   } finally {
     server.kill("SIGTERM");


### PR DESCRIPTION
### Motivation
- Close a coverage gap in the route smoke verifier so core app entry points never hard-500 under partial config by explicitly asserting expected behavior for marketing and app surfaces.

### Description
- Update `scripts/verify-routes.mjs` to add `strict200Routes` (routes that must return `200`) and `non500Routes` (app routes that may redirect/404 but must not return `5xx`), and introduce `assertRouteStatus` to centralize assertions; the only changed file is `scripts/verify-routes.mjs`.

### Testing
- Ran baseline and verification commands: `pnpm lint` (completed with warnings), `pnpm typecheck` (passed), `pnpm build` (passed), `pnpm test` (tests passed overall with expected test-suite logs/warnings), `pnpm verify:routes` (passed and reported statuses for `/`, `/docs`, and the app routes), `pnpm verify:tenant-isolation` (passed), `pnpm verify:determinism` (passed), and `pnpm verify:replay` (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db1a771188328bdfa221895e8384c)