### PR TITLE
Add launch asset verification, assets manifest, and GH CLI preflight in smoke workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,3 +39,9 @@
 /packages/cli/ @settler/maintainers @settler/contributors
 /docs/public/ @settler/maintainers @settler/contributors
 /examples/ @settler/maintainers @settler/contributors
+/scripts/capture-launch-assets.ts @settler/maintainers
+/scripts/build-launch-gif.mjs @settler/maintainers
+/scripts/verify-launch-assets.mjs @settler/maintainers
+/launch/assets-manifest.json @settler/maintainers
+/scripts/mirror-verify.ts @settler/maintainers
+/scripts/test-mirror-publishing.sh @settler/maintainers

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -37,6 +37,14 @@ jobs:
         env:
           BASE_URL: ${{ secrets.E2E_BASE_URL || 'https://settler.dev' }}
         continue-on-error: true
+      - name: Verify GitHub CLI availability
+        if: github.event_name == 'pull_request'
+        run: |
+          if ! gh --version; then
+            echo "GitHub CLI (gh) required for this workflow. Install gh or update the runner image."
+            exit 1
+          fi
+
       - name: Get Vercel Preview URL
         if: github.event_name == 'pull_request'
         id: vercel-preview

--- a/launch/assets-manifest.json
+++ b/launch/assets-manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "assets": [
+    {
+      "path": "launch/twitter-thread.md",
+      "sha256": "0223edecb32e3fe8e73186b7c06a5ffca7db0ff19a7d27f6311e6d3126bb25aa"
+    },
+    {
+      "path": "launch/ph.md",
+      "sha256": "e9c55d1e60b317a7a9ba11c63765f7e34e0ef4925f9143ebcd887b5efbd8abea"
+    },
+    {
+      "path": "launch/reddit.md",
+      "sha256": "364a290d5c137b4ddf06fa0dc06b55dc065f540e5fcc76ee0ca10c741b8a7e8d"
+    },
+    {
+      "path": "launch/hn.md",
+      "sha256": "abcf83ee42665c275813822cf881ce950321bf3d7a5ab7a3f2ccca6b60e915a6"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "clean:all": "node scripts/clean.mjs --all",
     "demo:seed": "npx tsx scripts/seed-demo.ts",
     "demo:seed:reset": "npx tsx scripts/seed-demo.ts --reset",
-    "verify": "pnpm run lint && pnpm run typecheck && pnpm run build && pnpm run test:ci:verify && pnpm run verify:boundaries && pnpm run verify:policy && pnpm run verify:routes",
+    "verify": "pnpm run lint && pnpm run typecheck && pnpm run build && pnpm run test:ci:verify && pnpm run verify:boundaries && pnpm run verify:policy && pnpm run verify:routes && pnpm run verify:launch-assets",
     "verify:fast": "node scripts/verify.mjs --fast",
     "verify:staged": "node scripts/verify-staged-packages.mjs",
     "verify:full": "node scripts/verify.mjs --full",
@@ -199,7 +199,8 @@
     "verify:foundry:metamorphic": "pnpm --filter @settler/cli exec tsx src/index.ts foundry metamorphic generate --base-suite core --per 1 --seed 1",
     "verify:foundry:faults": "pnpm --filter @settler/cli exec tsx src/index.ts foundry generate --type faults --seeds 1 && FOUNDRY_FAULTS=1 pnpm --filter @settler/cli exec tsx src/index.ts foundry report --last 1",
     "verify:api": "node scripts/verify-api.mjs",
-    "verify:security": "node scripts/verify-security.mjs"
+    "verify:security": "node scripts/verify-security.mjs",
+    "verify:launch-assets": "node scripts/verify-launch-assets.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/scripts/verify-launch-assets.mjs
+++ b/scripts/verify-launch-assets.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const manifestPath = path.join(repoRoot, "launch", "assets-manifest.json");
+
+async function fileHash(absolutePath) {
+  const content = await fs.readFile(absolutePath);
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function main() {
+  const manifestRaw = await fs.readFile(manifestPath, "utf8");
+  const manifest = JSON.parse(manifestRaw);
+
+  if (!Array.isArray(manifest.assets) || manifest.assets.length === 0) {
+    throw new Error("launch/assets-manifest.json must contain a non-empty assets array");
+  }
+
+  const failures = [];
+
+  for (const asset of manifest.assets) {
+    const relativePath = asset.path;
+    const absolutePath = path.join(repoRoot, relativePath);
+
+    try {
+      const stats = await fs.stat(absolutePath);
+      if (!stats.isFile()) {
+        failures.push(`${relativePath}: not a file`);
+        continue;
+      }
+      if (stats.size <= 0) {
+        failures.push(`${relativePath}: file is empty`);
+      }
+
+      const hash = await fileHash(absolutePath);
+      if (asset.sha256 !== hash) {
+        failures.push(`${relativePath}: sha256 mismatch (expected ${asset.sha256}, got ${hash})`);
+      }
+    } catch (error) {
+      failures.push(`${relativePath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error("Launch asset verification failed:");
+    for (const failure of failures) {
+      console.error(` - ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Verified ${manifest.assets.length} launch assets from launch/assets-manifest.json`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Ensure launch collateral is authoritative, machine-verifiable, and enforced in CI by providing a canonical manifest of launch assets and an integrity gate. 
- Prevent workflow failures caused by missing `gh` usage by adding an explicit preflight that fails fast with a clear message if the GitHub CLI is not present. 

### Description

- Added a canonical manifest `launch/assets-manifest.json` that lists tracked launch collateral with pinned `sha256` checksums. 
- Implemented `scripts/verify-launch-assets.mjs` which validates the manifest and each asset for existence, non-zero size, and SHA-256 match, failing with actionable output on mismatch. 
- Exposed a `verify:launch-assets` script in `package.json` and chained it into the top-level `verify` pipeline so launch asset checks run as part of root verification. 
- Inserted a GitHub CLI availability preflight in `.github/workflows/smoke.yml` (runs `gh --version` and hard-fails with a clear message if missing) before any `gh pr view` usage. 
- Extended `.github/CODEOWNERS` to include ownership entries for launch-related scripts and the manifest to ensure review coverage. 

### Testing

- Ran `node scripts/verify-launch-assets.mjs` which completed successfully and printed `Verified 4 launch assets from launch/assets-manifest.json`.
- Ran `pnpm run verify:launch-assets` which invoked the new script and succeeded. 
- Ran `pnpm run verify:routes` as part of validation and observed an unrelated pre-existing failure (runtime/script issue: `appRoute is not defined`) which prevented full route verification; this is not caused by these additive changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a91c0eb75483288896291cc2cf8f33)