### PR TITLE
docs: establish canonical Settler narrative and documentation IA

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,14 @@ scripts/            # verification and release automation
 
 ## Canonical Documentation Map
 
-- Start here: [`docs/START_HERE.md`](docs/START_HERE.md)
-- Architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
-- Security: [`docs/SECURITY.md`](docs/SECURITY.md)
-- Operations: [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
-- API: [`docs/API.md`](docs/API.md)
-- Audit pack: [`docs/audit/`](docs/audit)
+- Docs home: [`docs/README.md`](docs/README.md)
+- Getting started: [`docs/getting-started/README.md`](docs/getting-started/README.md)
+- Product canon: [`docs/product/README.md`](docs/product/README.md)
+- Architecture: [`docs/architecture/README.md`](docs/architecture/README.md)
+- API + SDK: [`docs/api/README.md`](docs/api/README.md)
+- Security + trust: [`docs/security/README.md`](docs/security/README.md)
+- Operations: [`docs/ops/README.md`](docs/ops/README.md)
+- Strategic closure pack: [`docs/FINAL_CLOSURE_PACK.md`](docs/FINAL_CLOSURE_PACK.md)
 
 ## License and Contributing
 

--- a/docs/FINAL_CLOSURE_PACK.md
+++ b/docs/FINAL_CLOSURE_PACK.md
@@ -1,0 +1,93 @@
+# Settler Final Strategic Closure Pack
+
+## A) Product Canon
+
+### One-sentence definition
+Settler is a deterministic reconciliation control plane for ingesting financial records, reconciling them with explicit rules, and producing auditable evidence with operator-managed exceptions.
+
+### Three value props
+1. Deterministic, replayable outputs with traceable evidence.
+2. High-throughput exception operations with human authority preserved.
+3. Contract-first API/SDK surfaces that integrate reconciliation into production controls.
+
+### Elevator pitch
+Teams use Settler when spreadsheets and generic data pipelines can no longer satisfy reconciliation accuracy, auditability, and operational scale. Settler gives them deterministic reconciliation runs, explicit exception workflows, and reproducible evidence exports in a single control plane.
+
+### Why now / why this
+Financial teams are under simultaneous pressure to close faster, reduce operational risk, and prove decisions to auditors and stakeholders. Generic AI automation and generic ETL do not provide reliable evidence chains. Settler focuses on the narrow wedge where deterministic outputs and policy-aware operations are mandatory.
+
+### Moat paragraph
+Settler’s moat is not a single model or integration. It is the combined system: deterministic reconciliation primitives, policy-aware decision boundaries, operator exception lifecycle tooling, and a traceability spine that makes every run reproducible and defensible. This stack increases integration gravity and expands naturally from reconciliation into broader financial controls.
+
+## B) Information Architecture
+
+### Canonical doc map
+- `README.md`
+- `docs/getting-started/README.md`
+- `docs/product/README.md`
+- `docs/architecture/README.md`
+- `docs/api/README.md`
+- `docs/security/README.md`
+- `docs/ops/README.md`
+- `docs/launch/README.md`
+- `docs/archive/README.md`
+
+### Canonical route map
+- **Public product:** `/`, `/why-settler`, `/architecture`, `/comparison`, `/pricing`, `/security`, `/docs`
+- **App/operator plane:** `/app/*`, `/dashboard/*`
+- **Admin plane:** `/admin/*`
+
+### Public vs app vs admin boundary
+- Public routes explain value, trust, and integration shape.
+- App routes execute ingestion, reconciliation, review, and evidence export workflows.
+- Admin routes are privileged operational controls and must remain access-constrained.
+
+### OSS/public/private boundary
+OSS includes deterministic core reconciliation, API/web surfaces, and baseline governance. Enterprise layers extend controls and operations but cannot be required for OSS/public route stability.
+
+## C) Contradiction Resolution Log
+
+- Consolidated docs entrypoint to a single canonical map in `docs/README.md`.
+- Removed stale docs index references to non-canonical setup files and replaced with active paths.
+- Unified product definition language across docs to “deterministic reconciliation control plane.”
+- Standardized trust-path language around tenant isolation, evidence exports, and graceful degradation.
+
+## D) Launch Narrative Pack
+
+### Homepage section structure
+1. Problem: reconciliation drift and opaque operations.
+2. Workflow: ingest → normalize → reconcile → review exceptions → export evidence.
+3. Output artifact: deterministic run and audit pack.
+4. Operator/developer/buyer outcomes.
+5. Architecture and trust deep links.
+
+### README structure
+1. Product definition
+2. OSS vs enterprise boundary
+3. Architecture primitives
+4. Quickstart + demo + replay
+5. Verification and docs map
+
+### Docs landing structure
+Reader-oriented entrypoints: engineer, operator, buyer, diligence.
+
+### Demo flow
+Run `pnpm demo`, inspect `examples/demo-output/*`, replay with `pnpm settler:replay ...`.
+
+### Buyer trust path
+Security posture → access controls/tenancy → incident response → RLS verification → runbooks.
+
+### Developer trust path
+Quickstart → API contract → deterministic replay proof → SDK integration.
+
+## E) Residual Risk Register
+
+1. **Legacy documentation sprawl remains in long-tail folders.**
+   - Not launch-blocking because canonical map now exists and is linked first.
+   - Follow-up: migrate high-traffic legacy docs into canonical folders, then archive remainder.
+2. **Public route copy may still include older wording in secondary pages.**
+   - Not launch-blocking because canonical product narrative is now centralized.
+   - Follow-up: route-by-route copy pass on low-traffic pages.
+3. **Comparison and pricing details can drift over time.**
+   - Not launch-blocking if pricing page remains source of truth.
+   - Follow-up: add docs lint check for canonical terminology and route link consistency.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,53 +1,32 @@
 # Settler Documentation
 
-## Overview
+This is the canonical documentation entrypoint for Settler.
 
-This directory contains comprehensive documentation for Settler Enterprise.
+Settler is a deterministic reconciliation control plane: ingest transactions and documents, normalize records, reconcile with explicit rules, route exceptions to operators, and export evidence packs for audit.
 
-## Documentation Structure
+## Canonical doc map
 
-### Getting Started
-- [Quick Start](QUICK_START.md) - Get up and running quickly
-- [Environment Setup](../ENV_SETUP_GUIDE.md) - Configure your environment
-- [Remote Database Setup](../REMOTE_SETUP_GUIDE.md) - Set up remote database
+- **Getting started:** [`docs/getting-started/README.md`](getting-started/README.md)
+- **Product:** [`docs/product/README.md`](product/README.md)
+- **Architecture:** [`docs/architecture/README.md`](architecture/README.md)
+- **API + SDK:** [`docs/api/README.md`](api/README.md)
+- **Security + trust:** [`docs/security/README.md`](security/README.md)
+- **Operations:** [`docs/ops/README.md`](ops/README.md)
+- **Launch assets:** [`docs/launch/README.md`](launch/README.md)
+- **Archive:** [`docs/archive/README.md`](archive/README.md)
 
-### Developer Console
-- [Console Guide](CONSOLE.md) - Complete console documentation
-- [API Reference](API.md) - API endpoint documentation
-- [Authentication](AUTH.md) - Auth and authorization guide
+## First paths by reader
 
-### Architecture
-- [Architecture Overview](architecture.md) - System architecture
-- [Database Schema](database-schema.md) - Database structure
-- [API Design](api-design.md) - API design principles
+- **Engineer:** start at [`docs/getting-started/README.md`](getting-started/README.md), then [`docs/api/README.md`](api/README.md).
+- **Operator:** start at [`docs/product/README.md`](product/README.md), then [`docs/ops/README.md`](ops/README.md).
+- **Buyer / security reviewer:** start at [`docs/security/README.md`](security/README.md).
+- **Diligence skim (founder/investor):** start at [`docs/FINAL_CLOSURE_PACK.md`](FINAL_CLOSURE_PACK.md).
 
-### Operations
-- [Deployment](../DEPLOYMENT_CHECKLIST.md) - Deployment guide
-- [Monitoring](monitoring.md) - Monitoring and alerting
-- [Troubleshooting](troubleshooting.md) - Common issues and solutions
+## Canonical product and trust references
 
-### Reference
-- [API Reference](API_REFERENCE.md) - Complete API reference
-- [SDK Documentation](sdk.md) - SDK usage guide
-- [Examples](examples.md) - Code examples
-
-## Quick Links
-
-- [Main README](../README.md)
-- [Changelog](../CHANGELOG.md)
-- [Release Notes](../RELEASE_NOTES.md)
-- [Contributing](../CONTRIBUTING.md)
-
-## Documentation Standards
-
-- All documentation uses Markdown
-- Code examples include language tags
-- API examples use curl format
-- Screenshots stored in `docs/images/`
-
-## Contributing to Documentation
-
-1. Follow Markdown best practices
-2. Include code examples
-3. Keep documentation up to date
-4. Test all examples
+- Product definition + value props: [`docs/product/README.md`](product/README.md)
+- Architecture narrative: [`docs/architecture/README.md`](architecture/README.md)
+- OSS/public/private boundary: [`docs/oss-vs-enterprise.md`](oss-vs-enterprise.md)
+- API contract: [`docs/API.md`](API.md)
+- Determinism + replay: [`docs/determinism.md`](determinism.md)
+- Security posture: [`docs/SECURITY.md`](SECURITY.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,18 @@
+# API and SDK
+
+## Contract-first API summary
+
+Settler API exposes deterministic reconciliation workflows across connections, pipelines, runs, results, rules, and review operations.
+
+## Developer trust path
+
+1. Read API reference: [`docs/API.md`](../API.md)
+2. Run deterministic demo: [`docs/demo.md`](../demo.md)
+3. Validate replay contract: [`docs/determinism.md`](../determinism.md)
+4. Integrate with SDKs (`packages/sdk`, `packages/react-settler`, `packages/sdk-go`, `packages/sdk-python`)
+
+## Operational API concerns
+
+- Idempotency and retries are required for production ingestion and webhooks.
+- Failure paths should emit explicit errors and preserve evidence continuity.
+- Tenant boundary checks are mandatory at every read/write surface.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,27 @@
+# Architecture
+
+## Canonical architecture narrative
+
+Settler runs as a reconciliation control plane with a traceability spine:
+
+1. **Ingestion/connectors** pull transaction/document feeds.
+2. **Normalization** converts source variance into typed internal records.
+3. **Reconciliation engine** applies deterministic matching and tolerance rules.
+4. **Policy/rules layer** enforces governance and decision constraints.
+5. **Exception handling** routes unmatched/ambiguous records to operator review.
+6. **Evidence/audit layer** stores run lineage, decisions, hashes, and exports.
+7. **API/SDK layer** exposes contract-first execution and retrieval surfaces.
+8. **Operator/admin planes** provide monitoring, controls, and review lifecycle.
+
+## Hosted vs enterprise boundary
+
+- OSS/public surfaces must run without enterprise-only configuration.
+- Enterprise modules add advanced controls and operational tooling without changing deterministic core behavior.
+- Missing enterprise configuration must degrade gracefully on public routes.
+
+## Deep links
+
+- Full architecture: [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md)
+- Event model: [`docs/EVENT_MODEL.md`](../EVENT_MODEL.md)
+- Ingestion reference: [`docs/INGESTION.md`](../INGESTION.md)
+- Reliability and operations: [`docs/OPERATIONS.md`](../OPERATIONS.md)

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,9 @@
+# Archive
+
+Historical and superseded planning artifacts are stored here to preserve context without polluting canonical launch paths.
+
+## Usage
+
+- Keep legacy records discoverable.
+- Keep active product/architecture guidance in canonical docs folders.
+- When superseding documents, add a pointer to the new canonical location.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+## One quickstart path (canonical)
+
+1. Install dependencies and configure environment.
+2. Run migrations.
+3. Run web app.
+4. Execute demo and replay evidence.
+
+```bash
+pnpm install
+cp .env.example .env
+pnpm exec tsx scripts/run-migrations-remote.ts
+pnpm --filter @settler/web dev
+pnpm demo
+pnpm settler:replay examples/demo-output/evidence.json
+```
+
+## Inputs and outputs
+
+- **Inputs:** transaction feeds, documents, connector payloads, reconciliation rules, policy configuration.
+- **Outputs:** deterministic run results, exception queue items, evidence artifacts (`run.json`, `results.json`, `evidence.json`, `report.html`).
+
+## Where to go next
+
+- Developer API + SDK: [`docs/api/README.md`](../api/README.md)
+- Product and operator workflow: [`docs/product/README.md`](../product/README.md)
+- Security/reliability trust path: [`docs/security/README.md`](../security/README.md)

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -1,0 +1,13 @@
+# Launch
+
+This section contains launch-facing assets and validation artifacts.
+
+## Canonical launch surfaces
+
+- Repository entrypoint: [`README.md`](../../README.md)
+- Product website and docs routes: `packages/web/src/app`
+- Closure pack: [`docs/FINAL_CLOSURE_PACK.md`](../FINAL_CLOSURE_PACK.md)
+
+## Historical launch artifacts
+
+Legacy launch plans and narrative drafts remain accessible under [`docs/archive/`](../archive/) and root historical archives.

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,0 +1,16 @@
+# Operations
+
+Operational guidance for running Settler in production.
+
+## Core references
+
+- Operations baseline: [`docs/OPERATIONS.md`](../OPERATIONS.md)
+- Operations runbook: [`docs/OPERATIONS_RUNBOOK.md`](../OPERATIONS_RUNBOOK.md)
+- Deployment notes: [`docs/deployment-notes.md`](../deployment-notes.md)
+- Incident response: [`docs/INCIDENT_RESPONSE.md`](../INCIDENT_RESPONSE.md)
+
+## Reliability principles
+
+- Deterministic runs are immutable and replayable.
+- Exceptions are reviewed in explicit lifecycle states.
+- Failures should degrade gracefully on user-facing routes and preserve audit lineage.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,0 +1,29 @@
+# Product
+
+## One-sentence definition
+
+Settler is a deterministic reconciliation control plane that ingests financial records, applies explicit policy-aware matching rules, and produces auditable outputs with operator-managed exceptions.
+
+## Category explanation
+
+Settler sits between data ingestion tools and accounting/ERP systems. It is not a generic ETL layer and not an autonomous accounting agent: it is a reconciliation and financial-controls plane built for reproducibility, evidence traceability, and high-throughput exception operations.
+
+## Three core value propositions
+
+1. **Deterministic evidence chain:** same inputs + same rules = same outputs, replayable and exportable.
+2. **Operator leverage:** exception queues and review lifecycle prevent silent drift while reducing manual triage load.
+3. **Control-plane integration:** API/SDK/CLI and policy surfaces let teams embed reconciliation into governed production workflows.
+
+## AI role boundary
+
+AI is used to assist exception triage and operator prioritization. Final reconciliation outcomes remain rule-driven and human-reviewable where required.
+
+## Why not adjacent substitutes?
+
+- **Not spreadsheets:** lacks scale, repeatability, and controlled audit trails.
+- **Not generic ETL pipelines:** can move data but do not provide domain primitives for reconciliation decisions and evidence exports.
+- **Not LLM-only automation:** probabilistic output is insufficient for financial controls without deterministic proof layers.
+
+## Pricing explanation (canonical)
+
+Pricing is usage and capability based: OSS core is self-hostable; hosted and enterprise tiers add governance, advanced controls, and support. See product pricing page for current plans, and keep implementation claims bounded to currently shipped features.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,15 @@
+# Security and Reliability
+
+## Buyer trust path (canonical)
+
+1. Security posture: [`docs/SECURITY.md`](../SECURITY.md)
+2. Access controls + tenancy: [`docs/ACCESS_CONTROLS.md`](../ACCESS_CONTROLS.md)
+3. Incident response: [`docs/INCIDENT_RESPONSE.md`](../INCIDENT_RESPONSE.md)
+4. RLS verification: [`docs/RLS_POLICY_VERIFICATION.md`](../RLS_POLICY_VERIFICATION.md)
+5. Operational runbooks: [`docs/OPERATIONS_RUNBOOK.md`](../OPERATIONS_RUNBOOK.md)
+
+## Available now vs designed for
+
+- **Available now:** deterministic runs, evidence exports, operator review workflow, baseline auditability.
+- **Designed for:** deeper enterprise governance and broader controls-plane expansion.
+- **Future/experimental:** clearly marked in roadmap docs; do not present as shipped.

--- a/packages/web/src/app/docs/page.tsx
+++ b/packages/web/src/app/docs/page.tsx
@@ -122,9 +122,9 @@ pnpm settler:replay examples/demo-output/evidence.json`}
       <section className="mb-12">
         <h2>Quick Example</h2>
         <CodeBlock
-          code={`import { Settler } from '@settler/sdk';
+          code={`import { SettlerClient } from '@settler/sdk';
 
-const client = new Settler({
+const client = new SettlerClient({
   apiKey: process.env.SETTLER_API_KEY,
 });
 

--- a/packages/web/src/app/docs/quickstart/page.tsx
+++ b/packages/web/src/app/docs/quickstart/page.tsx
@@ -15,9 +15,9 @@ const steps = [
     title: 'Create a Workspace',
     description: 'Create a workspace to organize reconciliation runs',
     code: `# Using the SDK
-import { Settler } from '@settler/sdk';
+import { SettlerClient } from '@settler/sdk';
 
-const client = new Settler({
+const client = new SettlerClient({
   apiKey: process.env.SETTLER_API_KEY,
 });
 
@@ -52,7 +52,7 @@ const client = new Settler({
 
 // eslint-disable-next-line no-console
 console.log("Job created:", job.id);`,
-    action: { label: 'See Integrations', href: '/integrations' },
+    action: { label: 'See Integrations', href: '/docs/integrations' },
   },
   {
     title: 'Upload Receipt/Data',
@@ -139,7 +139,7 @@ export default function QuickstartPage() {
         </h2>
         <ul className="space-y-2 text-slate-700 dark:text-slate-300">
           <li>• <Link href="/docs/api" className="text-blue-600 dark:text-blue-400 hover:underline">Explore the API Reference</Link></li>
-          <li>• <Link href="/integrations" className="text-blue-600 dark:text-blue-400 hover:underline">Browse available integrations</Link></li>
+          <li>• <Link href="/docs/integrations" className="text-blue-600 dark:text-blue-400 hover:underline">Browse available integrations</Link></li>
           <li>• <Link href="/docs/auth" className="text-blue-600 dark:text-blue-400 hover:underline">Learn about authentication</Link></li>
           <li>• <Link href="/open-source" className="text-blue-600 dark:text-blue-400 hover:underline">Review the open-source governance</Link></li>
         </ul>


### PR DESCRIPTION
### Motivation
- Eliminate fragmented and contradictory documentation by providing one canonical docs entrypoint and a reader-oriented information architecture. 
- Give each primary audience (engineer, operator, buyer, diligence skim) a single clear path to the content they need. 
- Surface the product canon and moat in a single, verifiable closure pack so launch messaging matches shipped behavior. 
- Align in-repo web docs and code samples with the actual SDK surface and docs routes to reduce developer confusion.

### Description
- Added a canonical docs home and structured indexes under `docs/` including `docs/README.md`, `docs/getting-started/README.md`, `docs/product/README.md`, `docs/architecture/README.md`, `docs/api/README.md`, `docs/security/README.md`, `docs/ops/README.md`, `docs/launch/README.md`, and `docs/archive/README.md`.
- Introduced `docs/FINAL_CLOSURE_PACK.md` capturing the product canon, canonical IA, contradiction resolution log, launch narrative pack, and a residual risk register.
- Updated the root `README.md` canonical documentation map to point to the new `docs/` hierarchy and closure pack.
- Aligned web docs code samples and links by updating `packages/web/src/app/docs/page.tsx` and `packages/web/src/app/docs/quickstart/page.tsx` to use `SettlerClient` and to link to `/docs/integrations` where appropriate.

### Testing
- Ran `pnpm --filter @settler/web lint` which could not complete because the repository environment reported `Invalid package.json in package.json`, preventing lint execution. 
- Attempted a Playwright capture of `http://127.0.0.1:3000/docs/quickstart` which failed with `ERR_EMPTY_RESPONSE` because no local web server was reachable in this environment. 
- Files were committed and staged locally after the documentation changes; remaining verification steps to run in a developer environment are `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, and a local server check (e.g. run the web app and verify `/docs/quickstart` renders correctly).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa50e48eb4832888704cda9043e12c)