### PR TITLE
Clarify Settler positioning and first-run UX messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,51 @@
 # Settler
 
-Settler is a deterministic reconciliation control plane for running auditable Connections → Pipelines → Runs → Results workflows with an operator Review Queue.
+**Settler is the open-source reconciliation control plane for provable financial truth.**
 
-## OSS vs Enterprise at a Glance
+Run deterministic reconciliation workflows, inspect mismatches with traceable context, replay the exact run, and export verifiable evidence.
+
+## Why Settler exists
+
+Most teams reconcile across Stripe, ERP, banking, and internal ledgers with scripts + spreadsheets + dashboards that cannot explain divergence under pressure.
+
+Settler gives you a system of record for reconciliation operations:
+- deterministic runs
+- policy-checked routing
+- review workflows
+- tamper-evident evidence outputs
+
+## How it works
+
+1. **Ingest and normalize** records from source systems.
+2. **Reconcile and route** mismatches with explicit rules/policies.
+3. **Review and resolve** exceptions with operator context.
+4. **Replay and prove** results with exported evidence artifacts.
+
+## What you can do in 5 minutes
+
+```bash
+pnpm install
+cp .env.example .env
+pnpm exec tsx scripts/run-migrations-remote.ts
+pnpm --filter @settler/web dev
+pnpm demo
+pnpm settler:replay examples/demo-output/evidence.json
+```
+
+Demo outputs are written to `examples/demo-output`:
+- `run.json`
+- `results.json`
+- `evidence.json`
+- `report.html`
+
+## Why Settler is different
+
+- **Replay any run:** verify that reruns produce the same fingerprint for the same inputs/config.
+- **Prove every result:** export evidence packs per run for audit and incident response.
+- **Enforce policy in operations:** codify routing/review behavior instead of relying on tribal process.
+- **Keep OSS control:** self-host the core runtime and keep enterprise add-ons optional.
+
+## OSS vs Enterprise at a glance
 
 ### OSS (this repo, self-hostable)
 
@@ -19,36 +62,12 @@ Settler is a deterministic reconciliation control plane for running auditable Co
 
 Detailed boundary notes: [`docs/oss-vs-enterprise.md`](docs/oss-vs-enterprise.md).
 
-## Architecture Overview
-
-Core runtime primitives:
-
-- **Connections:** define external data sources.
-- **Pipelines:** deterministic processing configurations.
-- **Runs:** immutable execution instances.
-- **Results:** normalized reconciliation outputs.
-- **Review Queue:** operator decisions and resolution states.
-- **Governance/Audit:** policy, evidence, and traceability surfaces.
-
-Key packages:
-
-- `packages/api` – reconciliation API/domain/infrastructure.
-- `packages/web` – Next.js App Router product + console + docs routes.
-- `packages/adapters` – connector/adaptor implementations.
-- `packages/sdk`, `packages/react-settler`, `packages/sdk-go`, `packages/workhorse` – client and worker tooling.
-
 ## Quickstart (OSS)
 
 Prerequisites:
-
 - Node.js 22+
 - pnpm 10.13.1+
 - Postgres/Supabase
-
-```bash
-pnpm install
-cp .env.example .env
-```
 
 Set at minimum:
 
@@ -67,58 +86,34 @@ pnpm --filter @settler/web dev
 
 Open `http://localhost:3000`.
 
-## CLI Install (release artifacts)
+## Self-host and local development
 
-Use signed release artifacts and SHA256 checksums for install.
+- Primary setup and run flow: [`docs/getting-started/README.md`](docs/getting-started/README.md)
+- Deployment path: [`docs/deployment-guide.md`](docs/deployment-guide.md)
+- Enterprise compose example: [`enterprise/docker-compose.yml`](enterprise/docker-compose.yml)
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/settler/settler/main/scripts/install/install.sh | bash
-settler version
-settler doctor
-```
+If you are evaluating quickly, run `pnpm demo` first, then wire your own data sources.
 
-Windows PowerShell:
+## Architecture overview
 
-```powershell
-irm https://raw.githubusercontent.com/settler/settler/main/scripts/install/install.ps1 | iex
-settler version
-settler doctor
-```
+Core runtime primitives:
+- **Connections:** define external data sources.
+- **Pipelines:** deterministic processing configurations.
+- **Runs:** immutable execution instances.
+- **Results:** normalized reconciliation outputs.
+- **Review Queue:** operator decisions and resolution states.
+- **Governance/Audit:** policy, evidence, and traceability surfaces.
 
-See [`LAUNCHKIT.md`](LAUNCHKIT.md) for artifact naming, manual checksum verification, and release workflow details.
+Key packages:
+- `packages/api` – reconciliation API/domain/infrastructure.
+- `packages/web` – Next.js App Router product + console + docs routes.
+- `packages/adapters` – connector/adaptor implementations.
+- `packages/sdk`, `packages/react-settler`, `packages/sdk-go`, `packages/workhorse` – client and worker tooling.
 
-## One-command demo
+## Contributing
 
-```bash
-pnpm demo
-```
-
-The demo is local-only, deterministic, and writes proof artifacts to `examples/demo-output` (`run.json`, `results.json`, `evidence.json`, `report.html`). Replay is first-class via:
-
-```bash
-pnpm settler:replay examples/demo-output/evidence.json
-```
-
-## Environment Variables
-
-### Minimal OSS
-
-- `DATABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-
-### Optional OSS Integrations
-
-- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
-- `STRIPE_SECRET_KEY`
-- `STRIPE_WEBHOOK_SECRET`
-
-### Enterprise-only
-
-- Enterprise operational variables are isolated to enterprise routes/modules and are optional for OSS runtime.
-- Missing enterprise env must not crash public marketing/product routes.
-
-## Local Development and Release Build
+- Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Verification baseline:
 
 ```bash
 pnpm lint
@@ -127,30 +122,13 @@ pnpm test
 pnpm build
 ```
 
-## Verification
+Full release-grade verification:
 
 ```bash
 pnpm verify
 ```
 
-`pnpm verify` runs release gates including conflict-marker checks, lint, typecheck, test, build, smoke, boundary linting, and security audit threshold checks.
-
-## Repository Structure
-
-```text
-packages/
-  api/              # core reconciliation API
-  web/              # Next.js app router surfaces
-  adapters/         # connectors/adapters
-  sdk/              # TS SDK
-  react-settler/    # React bindings
-  workhorse/        # Python worker
-enterprise/         # enterprise-specific materials
-docs/               # operational and product docs
-scripts/            # verification and release automation
-```
-
-## Canonical Documentation Map
+## Documentation map
 
 - Docs home: [`docs/README.md`](docs/README.md)
 - Getting started: [`docs/getting-started/README.md`](docs/getting-started/README.md)
@@ -159,22 +137,9 @@ scripts/            # verification and release automation
 - API + SDK: [`docs/api/README.md`](docs/api/README.md)
 - Security + trust: [`docs/security/README.md`](docs/security/README.md)
 - Operations: [`docs/ops/README.md`](docs/ops/README.md)
-- Strategic closure pack: [`docs/FINAL_CLOSURE_PACK.md`](docs/FINAL_CLOSURE_PACK.md)
 
-## License and Contributing
+## License and support
 
 - License: [`LICENSE`](LICENSE)
-- Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
-
-## Support
-
+- Security reports: [`SECURITY.md`](SECURITY.md)
 - Issues: open a GitHub issue with reproduction details.
-- Discussions: use GitHub Discussions for Q&A and architecture proposals.
-- Security reports: follow [`SECURITY.md`](SECURITY.md).
-
-## Deterministic Proof Links
-
-- Demo guide: `docs/demo.md`
-- Determinism contract: `docs/determinism.md`
-- Policy compiler and runtime guards: `docs/policies.md`
-- Investor truth anchors: `docs/investor.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,20 @@
 # Settler Documentation
 
-This is the canonical documentation entrypoint for Settler.
+Settler is an open-source reconciliation control plane for provable financial truth.
 
-Settler is a deterministic reconciliation control plane: ingest transactions and documents, normalize records, reconcile with explicit rules, route exceptions to operators, and export evidence packs for audit.
+Use this docs hub to go from first run → mismatch explanation → replay verification → evidence export.
+
+## Start here in 5 minutes
+
+1. Run the local quickstart: [`docs/getting-started/README.md`](getting-started/README.md)
+2. Execute the deterministic demo + replay:
+
+```bash
+pnpm demo
+pnpm settler:replay examples/demo-output/evidence.json
+```
+
+3. Inspect generated artifacts in `examples/demo-output`.
 
 ## Canonical doc map
 
@@ -12,21 +24,11 @@ Settler is a deterministic reconciliation control plane: ingest transactions and
 - **API + SDK:** [`docs/api/README.md`](api/README.md)
 - **Security + trust:** [`docs/security/README.md`](security/README.md)
 - **Operations:** [`docs/ops/README.md`](ops/README.md)
-- **Launch assets:** [`docs/launch/README.md`](launch/README.md)
-- **Archive:** [`docs/archive/README.md`](archive/README.md)
+- **OSS vs Enterprise boundary:** [`docs/oss-vs-enterprise.md`](oss-vs-enterprise.md)
 
 ## First paths by reader
 
-- **Engineer:** start at [`docs/getting-started/README.md`](getting-started/README.md), then [`docs/api/README.md`](api/README.md).
-- **Operator:** start at [`docs/product/README.md`](product/README.md), then [`docs/ops/README.md`](ops/README.md).
-- **Buyer / security reviewer:** start at [`docs/security/README.md`](security/README.md).
-- **Diligence skim (founder/investor):** start at [`docs/FINAL_CLOSURE_PACK.md`](FINAL_CLOSURE_PACK.md).
-
-## Canonical product and trust references
-
-- Product definition + value props: [`docs/product/README.md`](product/README.md)
-- Architecture narrative: [`docs/architecture/README.md`](architecture/README.md)
-- OSS/public/private boundary: [`docs/oss-vs-enterprise.md`](oss-vs-enterprise.md)
-- API contract: [`docs/API.md`](API.md)
-- Determinism + replay: [`docs/determinism.md`](determinism.md)
-- Security posture: [`docs/SECURITY.md`](SECURITY.md)
+- **Engineer:** start with [`docs/getting-started/README.md`](getting-started/README.md), then [`docs/api/README.md`](api/README.md).
+- **Finance/Ops operator:** start with [`docs/product/README.md`](product/README.md), then [`docs/ops/README.md`](ops/README.md).
+- **Security reviewer:** start with [`docs/security/README.md`](security/README.md).
+- **Founder / evaluator:** start with [`docs/product/README.md`](product/README.md), then [`docs/oss-vs-enterprise.md`](oss-vs-enterprise.md).

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -2,17 +2,27 @@
 
 This is the canonical onboarding index for Settler.
 
-## 1) What to run first
+## 1) See value first (recommended)
 
 ```bash
-pnpm install --frozen-lockfile
+pnpm install
+cp .env.example .env
+pnpm exec tsx scripts/run-migrations-remote.ts
+pnpm --filter @settler/web dev
+pnpm demo
+pnpm settler:replay examples/demo-output/evidence.json
+```
+
+## 2) Core quality checks
+
+```bash
 pnpm lint
 pnpm typecheck
 pnpm test
 pnpm build
 ```
 
-## 2) Release-grade verification
+## 3) Release-grade verification
 
 ```bash
 pnpm verify
@@ -21,16 +31,17 @@ pnpm verify:routes
 pnpm verify:boundaries
 ```
 
-## 3) Canonical docs
+## 4) Canonical docs
 
 - Product + setup: `README.md`
-- Architecture: `docs/ARCHITECTURE.md`
-- Security: `docs/SECURITY.md`
-- Operations: `docs/OPERATIONS.md`
-- API: `docs/API.md`
-- Audit package: `docs/audit/*`
+- Docs hub: `docs/README.md`
+- Getting started: `docs/getting-started/README.md`
+- Architecture: `docs/architecture/README.md`
+- Security: `docs/security/README.md`
+- Operations: `docs/ops/README.md`
+- API: `docs/api/README.md`
 
-## 4) Guarantees (verified scope)
+## 5) Verified guarantees
 
 - OSS and enterprise boundaries are guarded by static verification scripts.
 - Route and boundary checks are part of release verification scripts.

--- a/docs/strategy/POSITIONING_TRUTH.md
+++ b/docs/strategy/POSITIONING_TRUTH.md
@@ -1,0 +1,40 @@
+# Settler Positioning Truth (Repo-Grounded)
+
+## Primary category
+**Open-source reconciliation control plane** for provable financial truth.
+
+## Primary one-line description
+Settler helps teams run deterministic reconciliation workflows, explain mismatches, and export verifiable evidence for every run.
+
+## Primary painkiller (today)
+When finance and ops systems disagree, Settler gives teams a repeatable way to prove what happened, what changed, and why.
+
+## Target users
+- Engineers building reconciliation pipelines and integrations.
+- Finance and operations teams resolving exceptions.
+- Founders and technical evaluators who need audit-ready operational history.
+
+## Top 3 differentiators (defensible now)
+1. **Deterministic replay:** rerun workflows from evidence and verify fingerprints match.
+2. **Proof-first outputs:** each run can produce evidence artifacts (`run.json`, `results.json`, `evidence.json`, `report.html`).
+3. **Policy-checked operations:** routing and review behavior can be encoded as explicit rules and attached to traces/audit context.
+
+## Wording to avoid
+- "Autonomous finance brain"
+- "Self-healing financial AGI"
+- "Fully automatic close with zero review"
+- "Guaranteed compliance"
+
+## Claims allowed
+- Open-source reconciliation control plane.
+- Deterministic run + replay workflow.
+- Explainable mismatch routing with policy and review surfaces.
+- Evidence export for audit and operator handoff.
+- OSS core with optional enterprise extensions.
+
+## Claims disallowed until proven in repo
+- Real-time guarantees across all connectors.
+- End-to-end SOC2/ISO certification claims.
+- Zero-manual-ops automation claims.
+- Universal ERP/payment connector coverage.
+- Guaranteed revenue recovery outcomes.

--- a/packages/web/src/app/demo/page.tsx
+++ b/packages/web/src/app/demo/page.tsx
@@ -28,15 +28,31 @@ export default function DemoPage() {
             variants={staggerItem}
             className="text-4xl sm:text-5xl md:text-6xl font-bold mb-4 sm:mb-6 bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 dark:from-white dark:via-slate-100 dark:to-white bg-clip-text text-transparent"
           >
-            Interactive Demo Preview
+            Run the Settler Demo Path
           </motion.h1>
           <motion.p
             variants={staggerItem}
             className="text-lg sm:text-xl md:text-2xl text-slate-600 dark:text-slate-300 max-w-3xl mx-auto"
           >
-            Explore Settler&apos;s reconciliation engine, receipt ingestion, and API playground.
-            All data is deterministic and reproducible—no authentication required.
+            See one concrete path: run reconciliation, inspect a mismatch, review evidence, and replay the run.
+            All demo data is deterministic and reproducible—no authentication required.
           </motion.p>
+        </motion.div>
+
+
+        <motion.div
+          initial="hidden"
+          animate="visible"
+          variants={fadeUp}
+          className="mb-10 rounded-lg border bg-white/80 p-6 dark:bg-slate-900/60"
+        >
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-white">How this demo works</h2>
+          <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-slate-700 dark:text-slate-300">
+            <li>Open the reconciliation demo and run deterministic matching across sample systems.</li>
+            <li>Inspect mismatches and policy outcomes in the results view.</li>
+            <li>Review attached evidence and trace context.</li>
+            <li>Replay with the same inputs to verify reproducible output.</li>
+          </ol>
         </motion.div>
 
         {/* Demo Cards */}
@@ -53,7 +69,7 @@ export default function DemoPage() {
                 <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center mb-4">
                   <RefreshCw className="w-6 h-6 text-white" />
                 </div>
-                <CardTitle>Reconciliation Engine</CardTitle>
+                <CardTitle>Reconciliation Run</CardTitle>
                 <CardDescription>
                   See how transactions from Stripe, Shopify, QuickBooks, and bank payouts are
                   automatically matched with deterministic rules.
@@ -62,7 +78,7 @@ export default function DemoPage() {
               <CardContent>
                 <Button asChild className="w-full">
                   <Link href="/demo/reconciliation">
-                    Try Reconciliation Demo
+                    Start Reconciliation Demo
                     <ArrowRight className="w-4 h-4 ml-2" />
                   </Link>
                 </Button>
@@ -70,14 +86,14 @@ export default function DemoPage() {
             </Card>
           </motion.div>
 
-          {/* Receipt Ingestion Demo */}
+          {/* Evidence & Receipts Demo */}
           <motion.div variants={staggerItem}>
             <Card className="h-full hover:shadow-lg transition-shadow" elevation="default">
               <CardHeader>
                 <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center mb-4">
                   <FileText className="w-6 h-6 text-white" />
                 </div>
-                <CardTitle>Receipt Ingestion</CardTitle>
+                <CardTitle>Evidence & Receipts</CardTitle>
                 <CardDescription>
                   Watch receipts transform from raw data into structured JSON, then match to
                   transactions automatically.
@@ -86,7 +102,7 @@ export default function DemoPage() {
               <CardContent>
                 <Button asChild className="w-full">
                   <Link href="/demo/receipts">
-                    Try Receipt Demo
+                    Open Receipt Evidence Demo
                     <ArrowRight className="w-4 h-4 ml-2" />
                   </Link>
                 </Button>
@@ -94,14 +110,14 @@ export default function DemoPage() {
             </Card>
           </motion.div>
 
-          {/* API Playground */}
+          {/* API + Policy Playground */}
           <motion.div variants={staggerItem}>
             <Card className="h-full hover:shadow-lg transition-shadow" elevation="default">
               <CardHeader>
                 <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-purple-500 to-pink-600 flex items-center justify-center mb-4">
                   <Code className="w-6 h-6 text-white" />
                 </div>
-                <CardTitle>API Playground</CardTitle>
+                <CardTitle>API + Policy Playground</CardTitle>
                 <CardDescription>
                   Explore the API with feature flags and plan tiers. See how responses change
                   based on configuration.
@@ -110,7 +126,7 @@ export default function DemoPage() {
               <CardContent>
                 <Button asChild className="w-full">
                   <Link href="/demo/api">
-                    Try API Playground
+                    Try API + Policy Playground
                     <ArrowRight className="w-4 h-4 ml-2" />
                   </Link>
                 </Button>

--- a/packages/web/src/app/docs/page.tsx
+++ b/packages/web/src/app/docs/page.tsx
@@ -9,7 +9,7 @@ import { Rocket, Code, Zap, Shield } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Documentation - Settler",
-  description: "Documentation, quickstart guides, and determinism notes for Settler",
+  description: "Docs for running deterministic reconciliation workflows, replaying runs, and exporting evidence with Settler",
 };
 
 export default function DocsPage() {
@@ -18,17 +18,16 @@ export default function DocsPage() {
       <h1>Documentation</h1>
 
       <p className="text-lg text-slate-600 dark:text-slate-400">
-        Everything you need to integrate Settler into your reconciliation workflows, with explicit
-        rules and deterministic outputs.
+        Start here to run your first reconciliation flow, inspect mismatches, replay the same run, and export evidence.
       </p>
 
       <section
         id="run-demo"
         className="my-8 p-6 rounded-xl border border-slate-200 dark:border-slate-800"
       >
-        <h2 className="mt-0">30-second proof demo</h2>
+        <h2 className="mt-0">5-minute proof demo</h2>
         <p>
-          Run <code>pnpm demo</code> to generate deterministic artifacts and replay verification.
+          Run <code>pnpm demo</code> to generate a deterministic run, then replay it to verify the same fingerprint.
         </p>
         <CodeBlock
           code={`pnpm demo
@@ -62,7 +61,7 @@ pnpm settler:replay examples/demo-output/evidence.json`}
           <CardHeader>
             <Rocket className="w-8 h-8 mb-2 text-blue-600" />
             <CardTitle>Getting Started</CardTitle>
-            <CardDescription>New to Settler? Start with the basics</CardDescription>
+            <CardDescription>Install, run, and see first value quickly</CardDescription>
           </CardHeader>
           <CardContent>
             <Link href="/docs/getting-started">
@@ -77,7 +76,7 @@ pnpm settler:replay examples/demo-output/evidence.json`}
           <CardHeader>
             <Zap className="w-8 h-8 mb-2 text-green-600" />
             <CardTitle>Quickstart</CardTitle>
-            <CardDescription>Create your first deterministic reconciliation run</CardDescription>
+            <CardDescription>Run the canonical local workflow end-to-end</CardDescription>
           </CardHeader>
           <CardContent>
             <Link href="/docs/quickstart">
@@ -92,7 +91,7 @@ pnpm settler:replay examples/demo-output/evidence.json`}
           <CardHeader>
             <Code className="w-8 h-8 mb-2 text-purple-600" />
             <CardTitle>API Reference</CardTitle>
-            <CardDescription>Complete API documentation</CardDescription>
+            <CardDescription>Integrate run, replay, and evidence workflows</CardDescription>
           </CardHeader>
           <CardContent>
             <Link href="/docs/api">
@@ -107,7 +106,7 @@ pnpm settler:replay examples/demo-output/evidence.json`}
           <CardHeader>
             <Shield className="w-8 h-8 mb-2 text-amber-600" />
             <CardTitle>Auth & Security</CardTitle>
-            <CardDescription>Auth flows and security boundaries</CardDescription>
+            <CardDescription>Review auth, tenant boundaries, and controls</CardDescription>
           </CardHeader>
           <CardContent>
             <Link href="/docs/auth">

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -20,11 +20,11 @@ import { RuntimeUiOptionalFeatures } from "@/components/polish/RuntimeUiOptional
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || "https://settler.dev"),
   title: {
-    default: "Settler - Open-Source Reconciliation Engine",
+    default: "Settler - Open-Source Reconciliation Control Plane",
     template: "%s | Settler",
   },
   description:
-    "Settler is an open-source reconciliation engine that normalizes financial data, applies explicit rules, and surfaces variances for human review.",
+    "Settler is an open-source reconciliation control plane that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
   keywords: [
     "reconciliation engine",
     "financial reconciliation",
@@ -95,9 +95,9 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: "https://settler.dev",
     siteName: "Settler",
-    title: "Settler - Open-Source Reconciliation Engine",
+    title: "Settler - Open-Source Reconciliation Control Plane",
     description:
-      "Settler is an open-source reconciliation engine that normalizes financial data, applies explicit rules, and surfaces variances for human review.",
+      "Settler is an open-source reconciliation control plane that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
     images: [
       {
         url: getImageUrl("ogImage"),
@@ -109,9 +109,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Settler - Open-Source Reconciliation Engine",
+    title: "Settler - Open-Source Reconciliation Control Plane",
     description:
-      "Settler is an open-source reconciliation engine that normalizes financial data, applies explicit rules, and surfaces variances for human review.",
+      "Settler is an open-source reconciliation control plane that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
     images: [getImageUrl("twitterCard")],
     creator: "@settler_io",
   },

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -7,50 +7,57 @@ import { ArrowRight, Circle, Dot } from "lucide-react";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 
 const capabilityChips = [
-  "Deterministic Workflows",
-  "Policy-Based Routing",
-  "Audit-Ready Evidence",
-  "API-First Control Plane",
-  "Enterprise Controls",
+  "Replay any run",
+  "Explain mismatches fast",
+  "Export verifiable evidence",
+  "Policy-checked operations",
+  "Tenant-safe by design",
 ];
 
 const stackLabels = [
-  "Unmatched Records",
-  "Policy-Routed Items",
-  "Evidence Pending",
-  "Auto-Classified Variance",
-  "Review Required",
+  "High-risk mismatches",
+  "Policy-check failures",
+  "Evidence required",
+  "Variance auto-classified",
+  "Awaiting operator review",
 ];
 
 const feedLines = [
-  "[11:42:06] Normalized ledger input",
-  "[11:42:07] Policy rule applied",
-  "[11:42:08] Trace attached to exception",
-  "[11:42:09] Evidence bundle assembled",
-  "[11:42:10] Review state committed",
+  "[11:42:06] Reconciliation input normalized",
+  "[11:42:07] Policy checks evaluated",
+  "[11:42:08] Trace ID attached to mismatch",
+  "[11:42:09] Evidence bundle generated",
+  "[11:42:10] Review decision committed",
 ];
 
 const protocolCards = [
   {
     step: "01",
     id: "ingest-normalize",
-    title: "Ingest / Normalize",
+    title: "Ingest and normalize records",
     description:
       "Ingest records from source systems and map them into canonical structures with deterministic transforms.",
   },
   {
     step: "02",
     id: "route-resolve",
-    title: "Compare / Route / Resolve",
+    title: "Compare and route mismatches",
     description:
       "Compare record states, apply routing policy, and move exceptions to controlled queues with explicit ownership.",
   },
   {
     step: "03",
     id: "prove-learn",
-    title: "Record / Prove / Learn",
+    title: "Review and resolve with evidence",
     description:
-      "Commit evidence artifacts, preserve trace IDs, and keep decision history reproducible for audits and runbooks.",
+      "Attach evidence artifacts and trace IDs so operators can explain every decision in review.",
+  },
+  {
+    step: "04",
+    id: "replay-export",
+    title: "Replay and export proof",
+    description:
+      "Replay the exact run and export evidence bundles for audits, incident response, and handoffs.",
   },
 ];
 
@@ -77,9 +84,9 @@ function ExceptionStackCard({ reducedMotion }: { reducedMotion: boolean }) {
 
   return (
     <article className="rounded-[2rem] border border-white/15 bg-white/[0.04] p-6 shadow-[0_40px_100px_-60px_rgba(0,0,0,0.8)] backdrop-blur-md">
-      <h3 className="text-xl font-semibold text-white">Exception Stack Shuffler</h3>
+      <h3 className="text-xl font-semibold text-white">Mismatch Queue</h3>
       <p className="mt-2 text-sm text-slate-300">
-        Prioritized queues rotate by policy outcome so operators work the highest-risk path first.
+        Prioritized queues reorder by policy outcome so teams can resolve the riskiest mismatches first.
       </p>
       <div className="relative mt-8 h-52">
         {visible.map((label, slot) => (
@@ -137,9 +144,9 @@ function EvidenceFeedCard({ reducedMotion }: { reducedMotion: boolean }) {
 
   return (
     <article className="rounded-[2rem] border border-white/15 bg-white/[0.04] p-6 shadow-[0_40px_100px_-60px_rgba(0,0,0,0.8)] backdrop-blur-md">
-      <h3 className="text-xl font-semibold text-white">Evidence Feed Typewriter</h3>
+      <h3 className="text-xl font-semibold text-white">Evidence Feed</h3>
       <p className="mt-2 text-sm text-slate-300">
-        Live proof-chain events show what changed, why it changed, and where it was committed.
+        Live evidence events show what changed, why it changed, and when it was committed.
       </p>
       <div className="mt-8 rounded-2xl border border-emerald-400/20 bg-slate-950/80 p-4 font-mono text-xs text-emerald-200">
         <div className="mb-3 flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-emerald-300/80">
@@ -181,9 +188,9 @@ function SchedulerCard({ reducedMotion }: { reducedMotion: boolean }) {
 
   return (
     <article className="rounded-[2rem] border border-white/15 bg-white/[0.04] p-6 shadow-[0_40px_100px_-60px_rgba(0,0,0,0.8)] backdrop-blur-md">
-      <h3 className="text-xl font-semibold text-white">Resolution Scheduler Protocol</h3>
+      <h3 className="text-xl font-semibold text-white">Review Scheduler</h3>
       <p className="mt-2 text-sm text-slate-300">
-        Review windows align to routing windows so approvals happen on schedule, not by inbox chaos.
+        Review windows align to routing windows so approvals happen on schedule, not in spreadsheet fire drills.
       </p>
       <div className="mt-8 rounded-2xl border border-white/15 bg-slate-950/80 p-4">
         <div className="grid grid-cols-4 gap-2">
@@ -340,7 +347,7 @@ export default function Home() {
         <div className="relative z-10 mx-auto w-full max-w-7xl px-6 pb-16 md:pb-24">
           <div className="max-w-3xl">
             <p className="mb-4 text-xs uppercase tracking-[0.28em] text-cyan-200/80">
-              Deterministic reconciliation control plane
+              Open-source reconciliation control plane
             </p>
             <h1 className="text-5xl font-bold leading-[0.95] text-white sm:text-6xl md:text-7xl">
               Reconcile the
@@ -349,15 +356,14 @@ export default function Home() {
               </span>
             </h1>
             <p className="mt-6 max-w-2xl text-base text-slate-200 sm:text-lg">
-              Settler gives finance and operations teams a deterministic workflow for comparison,
-              routing, and evidence-backed exception resolution.
+              Settler helps engineering, finance, and operations teams reconcile faster, explain mismatches, and prove every result.
             </p>
             <div className="mt-9 flex flex-wrap gap-4">
               <Link
                 href="/architecture"
                 className="inline-flex items-center gap-2 rounded-full bg-cyan-300 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200"
               >
-                View Architecture <ArrowRight className="h-4 w-4" />
+                See How It Works <ArrowRight className="h-4 w-4" />
               </Link>
               <Link
                 href="/docs"
@@ -400,12 +406,10 @@ export default function Home() {
         />
         <div className="absolute inset-0 bg-slate-950/75" />
         <div className="relative z-10 mx-auto max-w-5xl px-6 text-center">
-          <p className="text-sm text-slate-300">
-            Most systems focus on: dashboards without closure.
-          </p>
+          <p className="text-sm text-slate-300">How Settler works in practice</p>
           <p className="mt-6 text-3xl font-semibold leading-tight text-white sm:text-5xl">
-            Settler focuses on:
-            <span className="text-cyan-300"> traceable decisions under pressure.</span>
+            Run reconciliation, inspect divergences, and
+            <span className="text-cyan-300"> prove outcomes with replayable evidence.</span>
           </p>
         </div>
       </section>
@@ -502,24 +506,24 @@ export default function Home() {
 
       <section className="mx-auto max-w-7xl px-6 pb-24">
         <div className="rounded-[2.25rem] border border-white/15 bg-slate-900/70 p-8 md:p-10">
-          <h2 className="text-3xl font-semibold text-white">Get Started with Settler</h2>
+          <h2 className="text-3xl font-semibold text-white">Get started in minutes</h2>
           <div className="mt-8 grid gap-5 md:grid-cols-3">
             {(
               [
                 [
-                  "Explore the Architecture",
+                  "See the architecture",
                   "/architecture",
-                  "System boundaries, policy flow, and deterministic invariants.",
+                  "Understand deterministic runs, policy checks, and evidence flow.",
                 ],
                 [
-                  "Read the Docs",
+                  "Run the quickstart",
                   "/docs",
-                  "API contracts, setup guides, and deterministic run semantics.",
+                  "Install, run demo data, replay a run, and inspect evidence.",
                 ],
                 [
-                  "Book a Demo",
-                  "/contact",
-                  "Walk through a real control-plane workflow with our team.",
+                  "Open the live demo",
+                  "/demo",
+                  "Walk through reconciliation, mismatches, and evidence without auth.",
                 ],
               ] as const
             ).map(([title, href, text]) => (
@@ -544,7 +548,7 @@ export default function Home() {
           <div>
             <p className="text-lg font-semibold tracking-[0.14em] text-white">SETTLER</p>
             <p className="mt-3 text-sm text-slate-300">
-              Deterministic reconciliation infrastructure for evidence-backed operational truth.
+              Open-source reconciliation control plane for replayable, evidence-backed financial truth.
             </p>
             <div className="mt-6 flex items-center gap-2 text-xs font-mono text-emerald-200">
               <Circle className="h-2.5 w-2.5 fill-emerald-400 text-emerald-400 animate-pulse" />


### PR DESCRIPTION
### Motivation
- Make Settler instantly explainable to engineers, operators, and OSS evaluators by shifting messaging to a defensible, outcome-first wedge (deterministic runs → mismatch explanation → replayable evidence). 
- Reduce “research-project” fog on the landing/docs/demo surfaces while preserving all runtime invariants and routes. 
- Provide a small, repo-grounded positioning artifact so copy stays honest and testable.

### Description
- Rewrote the root README to a concise one-line pitch, clearer “Why it exists”, a 4-step workflow, a 5-minute quick path, and explicit OSS vs Enterprise notes (`README.md`).
- Added a repo-grounded positioning decision artifact with category, one-line pitch, primary painkiller, differentiators, and allowed/disallowed claims (`docs/strategy/POSITIONING_TRUTH.md`).
- Updated docs hub and onboarding to surface a concrete demo → replay → evidence path (`docs/README.md`, `docs/START_HERE.md`, `docs/getting-started/README.md` references).
- Refined web app messaging and metadata: changed global metadata from “engine” to “control plane”, refreshed landing hero/capabilities, added a 4th protocol step (replay/export), tightened labels and CTAs to point users to the demo (`packages/web/src/app/layout.tsx`, `packages/web/src/app/page.tsx`, `packages/web/src/app/docs/page.tsx`, `packages/web/src/app/demo/page.tsx`).

### Testing
- Ran `git diff --check` and static diff checks: passed. 
- Attempted repo verification (`pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`) but these commands failed in this environment due to a pre-existing root `package.json` parse error (`Invalid package.json in package.json`) that prevented the workspace scripts from starting. 
- Attempted a playwright screenshot to validate the landing change; the browser run failed in this environment (headless browser startup/navigation errors), so no runtime UI screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab6092710083288e95d59feef7d25e)