### PR TITLE
Clarify product positioning: present Settler as Open Source Reconciliation Engine

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,22 @@
+# Settler Architecture Overview
+
+Settler is an Open Source Reconciliation Engine with a simple surface and a deterministic core.
+
+## System shape
+
+- **Web surface (`packages/web`)**: Dashboard, docs, and demo UX.
+- **API surface (`packages/api` + `packages/web/src/app/api`)**: Run creation, run listing, metrics, and evidence access.
+- **Engine + runner (`runner`, `scripts/moat`)**: Deterministic run execution and replay verification.
+- **Storage (Postgres/Supabase via Prisma)**: Tenant-scoped run state and metrics.
+
+## Runtime flow
+
+1. Operator or integration starts a run.
+2. Engine processes normalized records deterministically.
+3. Rule checks/policies shape routing and status.
+4. Results + evidence are persisted.
+5. Replay verifies fingerprints for provable outcomes.
+
+## Deep dive
+
+For detailed internals (deterministic replay, content-addressed evidence, policy engine, run storage, and execution model), read [`docs/ENGINE.md`](docs/ENGINE.md).

--- a/README.md
+++ b/README.md
@@ -1,27 +1,22 @@
-# Settler
+# Settler — Open Source Reconciliation Engine
 
-**Settler is the open-source reconciliation control plane for provable financial truth.**
+Settler runs reconciliation workflows, detects mismatches, and generates verifiable evidence for every result.
 
-Run deterministic reconciliation workflows, inspect mismatches with traceable context, replay the exact run, and export verifiable evidence.
+## Why Settler Exists
 
-## Why Settler exists
+Most teams still reconcile across spreadsheets, exports, and one-off scripts. When mismatches appear, operators lose hours tracing row-level differences and cannot clearly explain why balances diverged.
 
-Most teams reconcile across Stripe, ERP, banking, and internal ledgers with scripts + spreadsheets + dashboards that cannot explain divergence under pressure.
+Settler exists to replace fragile manual reconciliation with replayable runs, explicit rule checks, and audit-ready evidence.
 
-Settler gives you a system of record for reconciliation operations:
-- deterministic runs
-- policy-checked routing
-- review workflows
-- tamper-evident evidence outputs
+## What Settler Does
 
-## How it works
+- Run reconciliation workflows across source systems.
+- Detect mismatches across systems with deterministic matching.
+- Generate evidence for every run.
+- Replay runs to explain what changed and why.
+- Export audit proof for incidents and external reviews.
 
-1. **Ingest and normalize** records from source systems.
-2. **Reconcile and route** mismatches with explicit rules/policies.
-3. **Review and resolve** exceptions with operator context.
-4. **Replay and prove** results with exported evidence artifacts.
-
-## What you can do in 5 minutes
+## Five Minute Demo
 
 ```bash
 pnpm install
@@ -32,44 +27,32 @@ pnpm demo
 pnpm settler:replay examples/demo-output/evidence.json
 ```
 
-Demo outputs are written to `examples/demo-output`:
-- `run.json`
-- `results.json`
-- `evidence.json`
-- `report.html`
+After running the demo, inspect:
 
-## Why Settler is different
+- `examples/demo-output/run.json`
+- `examples/demo-output/results.json`
+- `examples/demo-output/evidence.json`
+- `examples/demo-output/report.html`
 
-- **Replay any run:** verify that reruns produce the same fingerprint for the same inputs/config.
-- **Prove every result:** export evidence packs per run for audit and incident response.
-- **Enforce policy in operations:** codify routing/review behavior instead of relying on tribal process.
-- **Keep OSS control:** self-host the core runtime and keep enterprise add-ons optional.
+The demo path shows reconciliation execution, mismatch detection, evidence generation, and replay verification.
 
-## OSS vs Enterprise at a glance
+## Key Features
 
-### OSS (this repo, self-hostable)
+- Replayable reconciliation
+- Proof-first operations
+- Policy enforcement
+- Evidence export
+- Audit-ready workflows
 
-- Reconciliation API and data model for organizations/workspaces, connections, pipelines, runs, results, rules, and review workflows.
-- Next.js web surfaces for product, docs, and console operations.
-- SDKs (`@settler/sdk`, `@settler/react-settler`, Go/Python scaffolding) and adapters.
-- Baseline governance and audit primitives in core API/web flows.
-
-### Enterprise (optional extensions)
-
-- Enterprise route surfaces under `packages/web/src/app/enterprise` and enterprise API endpoints under `packages/web/src/app/api/enterprise`.
-- Advanced governance/tenancy controls and premium operational panels.
-- Enterprise capabilities are optional; OSS build and public routes work without enterprise-only configuration.
-
-Detailed boundary notes: [`docs/oss-vs-enterprise.md`](docs/oss-vs-enterprise.md).
-
-## Quickstart (OSS)
+## Quickstart
 
 Prerequisites:
+
 - Node.js 22+
 - pnpm 10.13.1+
-- Postgres/Supabase
+- Postgres or Supabase
 
-Set at minimum:
+Set environment values:
 
 ```bash
 DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DB
@@ -77,69 +60,79 @@ NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
 ```
 
-Run local stack:
+Run locally:
 
 ```bash
+pnpm install
 pnpm exec tsx scripts/run-migrations-remote.ts
 pnpm --filter @settler/web dev
 ```
 
 Open `http://localhost:3000`.
 
-## Self-host and local development
+## Why Settler
 
-- Primary setup and run flow: [`docs/getting-started/README.md`](docs/getting-started/README.md)
-- Deployment path: [`docs/deployment-guide.md`](docs/deployment-guide.md)
-- Enterprise compose example: [`enterprise/docker-compose.yml`](enterprise/docker-compose.yml)
+### 1) Problem
+Reconciling financial data across systems is fragile.
 
-If you are evaluating quickly, run `pnpm demo` first, then wire your own data sources.
+### Feature
+Settler records deterministic reconciliation runs with stable fingerprints.
 
-## Architecture overview
+### Outcome
+You can prove exactly how each result was produced.
 
-Core runtime primitives:
-- **Connections:** define external data sources.
-- **Pipelines:** deterministic processing configurations.
-- **Runs:** immutable execution instances.
-- **Results:** normalized reconciliation outputs.
-- **Review Queue:** operator decisions and resolution states.
-- **Governance/Audit:** policy, evidence, and traceability surfaces.
+### 2) Problem
+Manual triage makes mismatch resolution slow.
 
-Key packages:
-- `packages/api` – reconciliation API/domain/infrastructure.
-- `packages/web` – Next.js App Router product + console + docs routes.
-- `packages/adapters` – connector/adaptor implementations.
-- `packages/sdk`, `packages/react-settler`, `packages/sdk-go`, `packages/workhorse` – client and worker tooling.
+### Feature
+Settler surfaces mismatch outcomes with rule-checked routing.
 
-## Contributing
+### Outcome
+Teams focus on high-risk mismatches first.
 
-- Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- Verification baseline:
+### 3) Problem
+Audit and incident questions require evidence collection after the fact.
 
-```bash
-pnpm lint
-pnpm typecheck
-pnpm test
-pnpm build
-```
+### Feature
+Settler generates evidence bundles during every run.
 
-Full release-grade verification:
+### Outcome
+Operators can answer "what happened" immediately.
 
-```bash
-pnpm verify
-```
+### 4) Problem
+Run-to-run drift is hard to explain with scripts and spreadsheets.
 
-## Documentation map
+### Feature
+Settler replays historical runs against the same inputs and config.
+
+### Outcome
+You can isolate behavioral changes before release.
+
+### 5) Problem
+Compliance reviews fail when controls are implicit.
+
+### Feature
+Settler applies policy checks as part of run execution.
+
+### Outcome
+Control behavior becomes testable and reviewable.
+
+## Architecture
+
+Learn how the engine works → [`docs/ENGINE.md`](docs/ENGINE.md)
+
+For contributor workflow, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+For a top-level system map, see [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+## Documentation
 
 - Docs home: [`docs/README.md`](docs/README.md)
 - Getting started: [`docs/getting-started/README.md`](docs/getting-started/README.md)
-- Product canon: [`docs/product/README.md`](docs/product/README.md)
-- Architecture: [`docs/architecture/README.md`](docs/architecture/README.md)
+- Product docs: [`docs/product/README.md`](docs/product/README.md)
 - API + SDK: [`docs/api/README.md`](docs/api/README.md)
-- Security + trust: [`docs/security/README.md`](docs/security/README.md)
-- Operations: [`docs/ops/README.md`](docs/ops/README.md)
+- Security docs: [`docs/security/README.md`](docs/security/README.md)
 
 ## License and support
 
 - License: [`LICENSE`](LICENSE)
 - Security reports: [`SECURITY.md`](SECURITY.md)
-- Issues: open a GitHub issue with reproduction details.

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -1,0 +1,35 @@
+# Settler Engine
+
+This document describes the technical internals behind Settler, the Open Source Reconciliation Engine.
+
+## Deterministic replay
+
+Settler executes reconciliation workflows with deterministic inputs and configuration so the same run can be replayed and verified later. Replay checks compare expected and actual fingerprints to validate run integrity.
+
+## Content-addressed evidence
+
+Each run produces evidence payloads that include hashes/fingerprints. Evidence is content-addressed so run outputs can be verified independently from UI state.
+
+## Policy engine
+
+Settler applies policy checks during run execution (for routing, control gates, and outcomes). Policy behavior is explicit and reviewable through run metadata and evidence.
+
+## Run storage
+
+Runs are persisted as immutable records with timestamps, status, and policy references. This storage model supports traceability, audit review, and repeatable replay.
+
+## Execution model
+
+At a high level:
+
+1. Ingest/normalize source records.
+2. Execute deterministic matching/reconciliation logic.
+3. Apply rule checks and routing decisions.
+4. Write run results + evidence.
+5. Replay and verify when needed.
+
+## Related docs
+
+- Top-level architecture: [`ARCHITECTURE.md`](../ARCHITECTURE.md)
+- API routes: [`docs/api/README.md`](api/README.md)
+- Operations: [`docs/ops/README.md`](ops/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,34 +1,27 @@
-# Settler Documentation
+# Settler Docs
 
-Settler is an open-source reconciliation control plane for provable financial truth.
+Settler is an Open Source Reconciliation Engine.
 
-Use this docs hub to go from first run → mismatch explanation → replay verification → evidence export.
+Use this docs hub to go from first run → mismatch detection → evidence inspection → replay verification.
 
-## Start here in 5 minutes
+## Start here
 
-1. Run the local quickstart: [`docs/getting-started/README.md`](getting-started/README.md)
-2. Execute the deterministic demo + replay:
+1. Run the quickstart: [`docs/getting-started/README.md`](getting-started/README.md)
+2. Run the demo workflow:
 
 ```bash
 pnpm demo
 pnpm settler:replay examples/demo-output/evidence.json
 ```
 
-3. Inspect generated artifacts in `examples/demo-output`.
+3. Review generated demo outputs in `examples/demo-output`.
 
-## Canonical doc map
+## Documentation map
 
-- **Getting started:** [`docs/getting-started/README.md`](getting-started/README.md)
+- **Quickstart:** [`docs/getting-started/README.md`](getting-started/README.md)
+- **Engine internals:** [`docs/ENGINE.md`](ENGINE.md)
+- **Architecture overview:** [`ARCHITECTURE.md`](../ARCHITECTURE.md)
 - **Product:** [`docs/product/README.md`](product/README.md)
-- **Architecture:** [`docs/architecture/README.md`](architecture/README.md)
 - **API + SDK:** [`docs/api/README.md`](api/README.md)
 - **Security + trust:** [`docs/security/README.md`](security/README.md)
 - **Operations:** [`docs/ops/README.md`](ops/README.md)
-- **OSS vs Enterprise boundary:** [`docs/oss-vs-enterprise.md`](oss-vs-enterprise.md)
-
-## First paths by reader
-
-- **Engineer:** start with [`docs/getting-started/README.md`](getting-started/README.md), then [`docs/api/README.md`](api/README.md).
-- **Finance/Ops operator:** start with [`docs/product/README.md`](product/README.md), then [`docs/ops/README.md`](ops/README.md).
-- **Security reviewer:** start with [`docs/security/README.md`](security/README.md).
-- **Founder / evaluator:** start with [`docs/product/README.md`](product/README.md), then [`docs/oss-vs-enterprise.md`](oss-vs-enterprise.md).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "settler-monorepo",
   "version": "1.0.0",
   "private": true,
-  "description": "Reconciliation-as-a-Service API - Complete monorepo",
+  "description": "Settler - Open Source Reconciliation Engine",
   "workspaces": [
     "packages/*"
   ],
@@ -203,7 +203,7 @@
     "verify:launch-assets": "node scripts/verify-launch-assets.mjs",
     "verify:route-parity": "tsx scripts/verify-route-parity.ts",
     "verify:vercel-runtime-parity": "tsx scripts/verify-vercel-runtime-parity.ts",
-    "verify:api-surface": "tsx scripts/verify-api-surface.ts"
+    "verify:api-surface": "tsx scripts/verify-api-surface.ts",
     "qa:marketing-ctas": "node scripts/marketing-cta-smoke.mjs",
     "qa:visual:landing": "cross-env CI_VISUAL_LANDING=1 playwright test tests/e2e/landing-home.visual.spec.ts --project=visual-desktop-light --project=visual-mobile-light"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -251,7 +251,7 @@ async function main(): Promise<void> {
   const program = new Command();
   const argv = process.argv.slice(2);
 
-  program.name("settler").description("CLI tool for Settler API");
+  program.name("settler").description("Settler CLI for the Open Source Reconciliation Engine");
 
   program
     .option("-k, --api-key <key>", "API key")

--- a/packages/web/src/app/(marketing)/home/page.tsx
+++ b/packages/web/src/app/(marketing)/home/page.tsx
@@ -469,7 +469,7 @@ const variances = await client.reconciliations.getVariances(reconciliation.id);`
                   icon: Layers,
                   title: "Operational Maturity",
                   description:
-                    "From manual exports to version-controlled rules. From fragile scripts to deterministic pipelines. From hope to operational confidence.",
+                    "From manual exports to version-controlled rules. From fragile scripts to replayable workflows. From hope to operational confidence.",
                 },
               ].map((item, idx) => {
                 const Icon = item.icon;

--- a/packages/web/src/app/app/layout.tsx
+++ b/packages/web/src/app/app/layout.tsx
@@ -31,10 +31,11 @@ function SignedOutScreen() {
 }
 
 const navItems = [
-  { name: "Overview", href: "/app" },
-  { name: "Runs", href: "/app/runs" },
+  { name: "Recent Runs", href: "/app/runs" },
+  { name: "Detected Mismatches", href: "/app/mismatches" },
   { name: "Evidence", href: "/app/evidence" },
   { name: "Policies", href: "/app/policies" },
+  { name: "Overview", href: "/app" },
   { name: "Metrics", href: "/app/metrics" },
   { name: "Settings", href: "/app/settings" },
 ];

--- a/packages/web/src/app/app/mismatches/page.tsx
+++ b/packages/web/src/app/app/mismatches/page.tsx
@@ -5,7 +5,7 @@ async function getRuns() {
   const h = await headers();
   const host = h.get("host") || "localhost:3000";
   const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-  const res = await fetch(`${protocol}://${host}/api/v1/runs?limit=20`, {
+  const res = await fetch(`${protocol}://${host}/api/v1/runs?limit=50`, {
     headers: { authorization: h.get("authorization") || "" },
     cache: "no-store",
   });
@@ -14,12 +14,13 @@ async function getRuns() {
   return data.rows || [];
 }
 
-export default async function RunsPage() {
-  const rows = await getRuns();
+export default async function MismatchesPage() {
+  const runs = await getRuns();
+  const mismatches = runs.filter((run: { status?: string }) => run.status !== "succeeded");
 
   return (
     <div>
-      <h1 className="text-2xl font-semibold">Recent Runs</h1>
+      <h1 className="text-2xl font-semibold">Detected Mismatches</h1>
       <div className="mt-4 overflow-hidden rounded border border-slate-200 bg-white">
         <table className="min-w-full text-sm">
           <thead className="bg-slate-50 text-left">
@@ -27,25 +28,27 @@ export default async function RunsPage() {
               <th className="px-3 py-2">Run ID</th>
               <th className="px-3 py-2">Created</th>
               <th className="px-3 py-2">Status</th>
-              <th className="px-3 py-2">Policy</th>
+              <th className="px-3 py-2">Action</th>
             </tr>
           </thead>
           <tbody>
-            {rows.length === 0 ? (
+            {mismatches.length === 0 ? (
               <tr>
                 <td colSpan={4} className="px-3 py-6 text-center text-slate-500">
-                  No runs yet. Start a reconciliation workflow to populate this list.
+                  No mismatches detected yet. Run a reconciliation workflow to surface differences.
                 </td>
               </tr>
             ) : (
-              rows.map((row: any) => (
+              mismatches.map((row: { run_id: string; created_at: string; status: string }) => (
                 <tr key={row.run_id} className="border-t border-slate-100">
-                  <td className="px-3 py-2 font-mono text-xs">
-                    <Link href={`/app/runs/${row.run_id}`}>{row.run_id}</Link>
-                  </td>
+                  <td className="px-3 py-2 font-mono text-xs">{row.run_id}</td>
                   <td className="px-3 py-2">{row.created_at}</td>
                   <td className="px-3 py-2">{row.status}</td>
-                  <td className="px-3 py-2">{row.policy}</td>
+                  <td className="px-3 py-2">
+                    <Link href={`/app/runs/${row.run_id}`} className="text-blue-600 hover:underline">
+                      Review run
+                    </Link>
+                  </td>
                 </tr>
               ))
             )}

--- a/packages/web/src/app/app/page.tsx
+++ b/packages/web/src/app/app/page.tsx
@@ -1,39 +1,88 @@
 import { headers } from "next/headers";
+import Link from "next/link";
 
-async function getSummary() {
+async function getRuns() {
   const h = await headers();
   const host = h.get("host") || "localhost:3000";
   const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-  const res = await fetch(`${protocol}://${host}/api/v1/metrics/summary?window=7d`, {
+  const res = await fetch(`${protocol}://${host}/api/v1/runs?limit=20`, {
     headers: { authorization: h.get("authorization") || "" },
     cache: "no-store",
   });
-  if (!res.ok) return null;
-  return res.json();
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.rows || [];
 }
 
 export default async function AppPage() {
-  const summary = await getSummary();
-  const cards = [
-    ["Runs (24h)", summary?.runs_total ?? 0],
-    ["Success rate", `${Math.round((Number(summary?.success_rate ?? 0) || 0) * 100)}%`],
-    ["Replay verified", `${Math.round((Number(summary?.replay_verified_rate ?? 0) || 0) * 100)}%`],
-    ["Avg latency", `${Math.round(Number(summary?.avg_latency ?? 0))}ms`],
-    ["Rate-limited", `${Math.round((Number(summary?.rate_limited_rate ?? 0) || 0) * 100)}%`],
-    ["Cache hit", `${Math.round((Number(summary?.cache_hit_rate ?? 0) || 0) * 100)}%`],
-  ];
+  const runs = await getRuns();
+  const mismatches = runs.filter((run: { status?: string }) => run.status !== "succeeded");
 
   return (
-    <div>
+    <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Overview</h1>
-      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
-        {cards.map(([label, value]) => (
-          <div key={label} className="rounded border border-slate-200 bg-white p-4">
-            <div className="text-sm text-slate-600">{label}</div>
-            <div className="mt-2 text-2xl font-semibold">{String(value)}</div>
-          </div>
-        ))}
-      </div>
+
+      <section className="rounded border border-slate-200 bg-white p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Recent Runs</h2>
+          <Link href="/app/runs" className="text-sm text-blue-600 hover:underline">
+            View all
+          </Link>
+        </div>
+        {runs.length === 0 ? (
+          <p className="mt-2 text-sm text-slate-600">
+            No runs yet. Start your first reconciliation run to populate run history.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-2 text-sm">
+            {runs.slice(0, 5).map((run: { run_id: string; created_at: string; status: string }) => (
+              <li key={run.run_id} className="rounded border border-slate-100 p-2">
+                <div className="font-mono text-xs">{run.run_id}</div>
+                <div className="text-slate-600">{run.created_at}</div>
+                <div className="font-medium">Status: {run.status}</div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="rounded border border-slate-200 bg-white p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Detected Mismatches</h2>
+          <Link href="/app/mismatches" className="text-sm text-blue-600 hover:underline">
+            Open mismatches
+          </Link>
+        </div>
+        {mismatches.length === 0 ? (
+          <p className="mt-2 text-sm text-slate-600">
+            No mismatches detected in recent runs.
+          </p>
+        ) : (
+          <p className="mt-2 text-sm text-slate-700">
+            {mismatches.length} recent run(s) need review. Open the mismatch view to triage by run.
+          </p>
+        )}
+      </section>
+
+      <section className="rounded border border-slate-200 bg-white p-4">
+        <h2 className="text-lg font-semibold">Evidence</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Every run stores verifiable evidence. Open Evidence to inspect run fingerprints and proofs.
+        </p>
+        <Link href="/app/evidence" className="mt-3 inline-block text-sm text-blue-600 hover:underline">
+          Go to Evidence
+        </Link>
+      </section>
+
+      <section className="rounded border border-slate-200 bg-white p-4">
+        <h2 className="text-lg font-semibold">Policies</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Rule checks are applied during runs to keep outcomes deterministic and reviewable.
+        </p>
+        <Link href="/app/policies" className="mt-3 inline-block text-sm text-blue-600 hover:underline">
+          Go to Policies
+        </Link>
+      </section>
     </div>
   );
 }

--- a/packages/web/src/app/docs/page.tsx
+++ b/packages/web/src/app/docs/page.tsx
@@ -9,13 +9,13 @@ import { Rocket, Code, Zap, Shield } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Documentation - Settler",
-  description: "Docs for running deterministic reconciliation workflows, replaying runs, and exporting evidence with Settler",
+  description: "Docs for Settler, the Open Source Reconciliation Engine: run workflows, detect mismatches, replay runs, and export evidence.",
 };
 
 export default function DocsPage() {
   return (
     <div className="prose prose-slate dark:prose-invert max-w-none">
-      <h1>Documentation</h1>
+      <h1>Open Source Reconciliation Engine Docs</h1>
 
       <p className="text-lg text-slate-600 dark:text-slate-400">
         Start here to run your first reconciliation flow, inspect mismatches, replay the same run, and export evidence.

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -20,11 +20,11 @@ import { RuntimeUiOptionalFeatures } from "@/components/polish/RuntimeUiOptional
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || "https://settler.dev"),
   title: {
-    default: "Settler - Open-Source Reconciliation Control Plane",
+    default: "Settler - Open Source Reconciliation Engine",
     template: "%s | Settler",
   },
   description:
-    "Settler is an open-source reconciliation control plane that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
+    "Settler is an open source reconciliation engine that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
   keywords: [
     "reconciliation engine",
     "financial reconciliation",
@@ -95,9 +95,9 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: "https://settler.dev",
     siteName: "Settler",
-    title: "Settler - Open-Source Reconciliation Control Plane",
+    title: "Settler - Open Source Reconciliation Engine",
     description:
-      "Settler is an open-source reconciliation control plane that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
+      "Settler is an open source reconciliation engine that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
     images: [
       {
         url: getImageUrl("ogImage"),
@@ -109,9 +109,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Settler - Open-Source Reconciliation Control Plane",
+    title: "Settler - Open Source Reconciliation Engine",
     description:
-      "Settler is an open-source reconciliation control plane that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
+      "Settler is an open source reconciliation engine that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
     images: [getImageUrl("twitterCard")],
     creator: "@settler_io",
   },

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -50,7 +50,7 @@ const protocolCards = [
     id: "prove-learn",
     title: "Review and resolve with evidence",
     description:
-      "Attach evidence artifacts and trace IDs so operators can explain every decision in review.",
+      "Attach evidence records and trace IDs so operators can explain every decision in review.",
   },
   {
     step: "04",
@@ -347,7 +347,7 @@ export default function Home() {
         <div className="relative z-10 mx-auto w-full max-w-7xl px-6 pb-16 md:pb-24">
           <div className="max-w-3xl">
             <p className="mb-4 text-xs uppercase tracking-[0.28em] text-cyan-200/80">
-              Open-source reconciliation control plane
+              Open Source Reconciliation Engine
             </p>
             <h1 className="text-5xl font-bold leading-[0.95] text-white sm:text-6xl md:text-7xl">
               Reconcile the
@@ -460,7 +460,7 @@ export default function Home() {
                   ["Source system", "Stripe + NetSuite"],
                   ["Unmatched amount", "$42,190.18"],
                   ["Policy result", "Tolerance exceeded"],
-                  ["Evidence attached", "6 artifacts"],
+                  ["Evidence attached", "6 records"],
                 ].map(([label, value]) => (
                   <div
                     key={label}
@@ -548,7 +548,7 @@ export default function Home() {
           <div>
             <p className="text-lg font-semibold tracking-[0.14em] text-white">SETTLER</p>
             <p className="mt-3 text-sm text-slate-300">
-              Open-source reconciliation control plane for replayable, evidence-backed financial truth.
+              Open Source Reconciliation Engine for replayable, evidence-backed financial truth.
             </p>
             <div className="mt-6 flex items-center gap-2 text-xs font-mono text-emerald-200">
               <Circle className="h-2.5 w-2.5 fill-emerald-400 text-emerald-400 animate-pulse" />


### PR DESCRIPTION
### Motivation
- Unify product language and remove conflicting category terms so the repository surface clearly presents Settler as an "Open Source Reconciliation Engine" across marketing, docs, CLI, and the web UI.
- Surface a simple, demo-ready experience (quickstart + 5-minute demo) on the README and docs while moving deep technical details into a dedicated engine doc.
- Improve console UX ordering so the dashboard highlights operational value (Recent Runs, Detected Mismatches, Evidence, Policies) and provide helpful empty states.

### Description
- Enforced category language and metadata: updated `package.json` description, website metadata (`packages/web/src/app/layout.tsx`), marketing hero and landing copy (`packages/web/src/app/page.tsx`, `packages/web/src/app/(marketing)/home/page.tsx`), and docs landing (`packages/web/src/app/docs/page.tsx`).
- Rewrote top-level `README.md` to the requested structure including title, one-sentence description, why it exists, what it does, five-minute demo, key features, quickstart, architecture link, and differentiation (Problem → Feature → Outcome).`
- Added engine-level documentation `docs/ENGINE.md` and a concise `ARCHITECTURE.md` containing the deterministic replay, evidence model, policy engine, run storage, and execution model, and refreshed `docs/README.md` to point to the demo path.
- Normalized UI language (e.g. "artifacts" → "records", "deterministic pipelines" → "replayable workflows") and adjusted marketing phrases to match the canonical category.
- Reordered app navigation and reworked console pages: changed nav to `Recent Runs → Detected Mismatches → Evidence → Policies`, created `/app/mismatches` with review links, updated `/app/runs` heading and empty-state copy, and rebuilt the overview to emphasize Recent Runs / Detected Mismatches / Evidence / Policies.
- Updated CLI help description in `packages/cli/src/index.ts` to align with the Open Source Reconciliation Engine phrasing.
- Fixed a malformed root `package.json` scripts JSON (missing comma) to restore valid JSON parsing.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` to validate `package.json` syntax and it returned success. (passed)
- Attempted `pnpm lint` but the command failed in this environment due to `turbo` not being available and missing installed dependencies. (environment failure)
- Attempted `pnpm install` but the install was blocked by registry authorization (`ERR_PNPM_FETCH_403` fetching `@shopify/shopify-api`), preventing dependency installation. (environment failure)
- Attempted to run the web dev server `pnpm --filter @settler/web dev` but it failed because dependencies (including `next`) were not installed in this environment. (environment failure)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab6eabe4708328b3adeb6e1f9b84a9)