### PR TITLE
Add Trust Graph Explorer APIs and Proof Explorer UI

### DIFF
--- a/packages/web/src/__tests__/trust-graph/explorer.test.ts
+++ b/packages/web/src/__tests__/trust-graph/explorer.test.ts
@@ -1,0 +1,80 @@
+import type { ReconciliationProofCapsule } from "@settler/protocol";
+import {
+  findPolicyImpact,
+  getExecutionGraph,
+  traceArtifactLineage,
+  verifyProofChain,
+} from "@/lib/trust-graph/explorer";
+
+describe("trust graph explorer", () => {
+  const proofCapsule = {
+    capsuleVersion: "1.0.0",
+    jobId: "run_123",
+    inputHash: "input_hash",
+    ruleHash: "rule_hash",
+    outputHash: "output_hash",
+    versionHash: "version_hash",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    signature: "sig",
+    signer: "Settler-Core",
+  } as ReconciliationProofCapsule;
+
+  const baseInput = {
+    tenantId: "tenant_1",
+    runId: "run_123",
+    proofCapsule,
+    metadata: { sourceAdapter: "stripe", fingerprint: "fp_1", policyId: "strict" },
+    summary: { policyEvaluation: "approved" },
+  };
+
+  it("builds deterministic graph shape", () => {
+    const graphA = getExecutionGraph(baseInput);
+    const graphB = getExecutionGraph(baseInput);
+
+    expect(graphA.graphHash).toBe(graphB.graphHash);
+    expect(graphA.nodes.map((node) => node.type).sort()).toEqual([
+      "artifact",
+      "connector",
+      "external_input",
+      "policy_decision",
+      "workflow_execution",
+    ]);
+    expect(graphA.edges.map((edge) => edge.type).sort()).toEqual([
+      "derived_from",
+      "derived_from",
+      "policy_evaluated_by",
+      "produced_artifact",
+      "verified_by",
+    ]);
+  });
+
+  it("traces artifact lineage back to input", () => {
+    const lineage = traceArtifactLineage(baseInput);
+    const nodeTypes = lineage.lineage.map((item) => item.node.type);
+    expect(nodeTypes).toContain("artifact");
+    expect(nodeTypes).toContain("policy_decision");
+    expect(nodeTypes).toContain("workflow_execution");
+    expect(nodeTypes).toContain("connector");
+    expect(nodeTypes).toContain("external_input");
+  });
+
+  it("verifies proof chain references graph nodes", () => {
+    const graph = getExecutionGraph(baseInput);
+    const verification = verifyProofChain({
+      ...baseInput,
+      proofCapsule: {
+        ...proofCapsule,
+        graphHash: graph.graphHash,
+      } as unknown as ReconciliationProofCapsule,
+    });
+
+    expect(verification.verified).toBe(true);
+    expect(verification.checks.proofReferencesGraphNodes).toBe(true);
+  });
+
+  it("calculates policy impact", () => {
+    const impact = findPolicyImpact(baseInput);
+    expect(impact.impactedArtifacts.length).toBeGreaterThan(0);
+    expect(impact.impactedExecutionNodes.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/src/app/api/v1/runs/[id]/evidence/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/evidence/route.ts
@@ -8,6 +8,7 @@ import {
   ok,
   setCachingHeaders,
 } from "@/lib/api/v1/recon/core";
+import { getExecutionGraph, verifyProofChain } from "@/lib/trust-graph/explorer";
 
 export const runtime = "nodejs";
 
@@ -31,6 +32,29 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         proof_capsule: result.proofCapsule || {},
         artifact_path: `/tenant/${ctx.tenantId}/runs/${id}/evidence.json`,
       },
+    };
+    const graph = getExecutionGraph({
+      tenantId: ctx.tenantId,
+      runId: id,
+      metadata: (result.metadata as Record<string, unknown> | null) || null,
+      summary: (result.summary as Record<string, unknown> | null) || null,
+      proofCapsule:
+        (result.proofCapsule as import("@settler/protocol").ReconciliationProofCapsule | null) ||
+        null,
+    });
+    const verification = verifyProofChain({
+      tenantId: ctx.tenantId,
+      runId: id,
+      metadata: (result.metadata as Record<string, unknown> | null) || null,
+      summary: (result.summary as Record<string, unknown> | null) || null,
+      proofCapsule:
+        (result.proofCapsule as import("@settler/protocol").ReconciliationProofCapsule | null) ||
+        null,
+    });
+    payload.evidence.proof_capsule = {
+      ...(payload.evidence.proof_capsule as Record<string, unknown>),
+      graphHash: graph.graphHash,
+      proofNodeRefs: verification.proofNodeRefs,
     };
     const notModified = checkConditionalGet(request, payload);
     if (notModified) return ok(notModified, ctx.requestId);

--- a/packages/web/src/app/api/v1/runs/[id]/trust-explorer/_shared.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/trust-explorer/_shared.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { applyRateLimit, buildContext, fail, getLatestResult, ok } from "@/lib/api/v1/recon/core";
+import type { ReconciliationProofCapsule } from "@settler/protocol";
+
+export type TrustRunContext = {
+  tenantId: string;
+  runId: string;
+  metadata: Record<string, unknown> | null;
+  summary: Record<string, unknown> | null;
+  proofCapsule: ReconciliationProofCapsule | null;
+};
+
+export async function withTrustRun(
+  request: NextRequest,
+  params: Promise<{ id: string }>,
+  fn: (ctx: TrustRunContext) => Promise<NextResponse> | NextResponse
+) {
+  const apiCtx = await buildContext(request);
+  if (apiCtx instanceof NextResponse) return apiCtx;
+  const limited = applyRateLimit(apiCtx, "read");
+  if (limited) return limited;
+
+  try {
+    const { id } = await params;
+    const result = await getLatestResult(apiCtx, id);
+
+    if (!result) {
+      return NextResponse.json(
+        { code: "SETTLER_NOT_FOUND", error: "Run evidence not found" },
+        { status: 404 }
+      );
+    }
+
+    const response = await fn({
+      tenantId: apiCtx.tenantId,
+      runId: id,
+      metadata: (result.metadata as Record<string, unknown> | null) || null,
+      summary: (result.summary as Record<string, unknown> | null) || null,
+      proofCapsule: (result.proofCapsule as ReconciliationProofCapsule | null) || null,
+    });
+
+    return ok(response, apiCtx.requestId);
+  } catch (error) {
+    return fail(error, request, apiCtx.requestId);
+  }
+}

--- a/packages/web/src/app/api/v1/runs/[id]/trust-explorer/findPolicyImpact/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/trust-explorer/findPolicyImpact/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { findPolicyImpact } from "@/lib/trust-graph/explorer";
+import { withTrustRun } from "../_shared";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withTrustRun(request, params, async (ctx) => {
+    const policyNodeId = request.nextUrl.searchParams.get("policyNodeId") || undefined;
+    const impact = findPolicyImpact({ ...ctx, policyNodeId });
+    return NextResponse.json({ run_id: ctx.runId, impact });
+  });
+}

--- a/packages/web/src/app/api/v1/runs/[id]/trust-explorer/getExecutionGraph/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/trust-explorer/getExecutionGraph/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getExecutionGraph } from "@/lib/trust-graph/explorer";
+import { withTrustRun } from "../_shared";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withTrustRun(request, params, async (ctx) => {
+    const graph = getExecutionGraph(ctx);
+    return NextResponse.json({ run_id: ctx.runId, graph });
+  });
+}

--- a/packages/web/src/app/api/v1/runs/[id]/trust-explorer/traceArtifactLineage/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/trust-explorer/traceArtifactLineage/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { traceArtifactLineage } from "@/lib/trust-graph/explorer";
+import { withTrustRun } from "../_shared";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withTrustRun(request, params, async (ctx) => {
+    const artifactNodeId = request.nextUrl.searchParams.get("artifactNodeId") || undefined;
+    const lineage = traceArtifactLineage({ ...ctx, artifactNodeId });
+    return NextResponse.json({ run_id: ctx.runId, lineage });
+  });
+}

--- a/packages/web/src/app/api/v1/runs/[id]/trust-explorer/verifyProofChain/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/trust-explorer/verifyProofChain/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getExecutionGraph, verifyProofChain } from "@/lib/trust-graph/explorer";
+import { withTrustRun } from "../_shared";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withTrustRun(request, params, async (ctx) => {
+    const graph = getExecutionGraph(ctx);
+    const verification = verifyProofChain(ctx);
+
+    return NextResponse.json({
+      run_id: ctx.runId,
+      verification,
+      proof_capsule: {
+        ...(ctx.proofCapsule || {}),
+        graphHash: graph.graphHash,
+        proofNodeRefs: verification.proofNodeRefs,
+      },
+    });
+  });
+}

--- a/packages/web/src/app/openapi.json/route.ts
+++ b/packages/web/src/app/openapi.json/route.ts
@@ -9,6 +9,14 @@ const openapi = {
     "/api/v1/runs/{id}/results": { get: { summary: "Get results" } },
     "/api/v1/runs/{id}/evidence": { get: { summary: "Get evidence" } },
     "/api/v1/runs/{id}/replay": { post: { summary: "Replay run" } },
+    "/api/v1/runs/{id}/trust-explorer/getExecutionGraph": {
+      get: { summary: "Get execution trust graph" },
+    },
+    "/api/v1/runs/{id}/trust-explorer/traceArtifactLineage": {
+      get: { summary: "Trace artifact lineage" },
+    },
+    "/api/v1/runs/{id}/trust-explorer/verifyProofChain": { get: { summary: "Verify proof chain" } },
+    "/api/v1/runs/{id}/trust-explorer/findPolicyImpact": { get: { summary: "Find policy impact" } },
     "/api/v1/datasets": { get: { summary: "List datasets" }, post: { summary: "Create dataset" } },
     "/api/v1/health": { get: { summary: "Liveness" } },
     "/api/v1/ready": { get: { summary: "Readiness" } },

--- a/packages/web/src/app/proof-explorer/page.tsx
+++ b/packages/web/src/app/proof-explorer/page.tsx
@@ -1,0 +1,14 @@
+import { ProofExplorer } from "@/components/proof/ProofExplorer";
+
+export const metadata = {
+  title: "Proof Explorer",
+  description: "Navigate trust graphs for execution proofs and artifact lineage.",
+};
+
+export default function ProofExplorerPage() {
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <ProofExplorer />
+    </main>
+  );
+}

--- a/packages/web/src/components/proof/ProofExplorer.tsx
+++ b/packages/web/src/components/proof/ProofExplorer.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type ExplorerPayload = {
+  run_id: string;
+  graph?: {
+    graphHash: string;
+    nodes: Array<{ id: string; label: string; type: string }>;
+    edges: Array<{ id: string; from: string; to: string; type: string }>;
+  };
+  lineage?: {
+    lineage: Array<{
+      node: { id: string; label: string; type: string };
+      viaEdge: { type: string } | null;
+    }>;
+  };
+  impact?: {
+    impactedArtifacts: Array<{ id: string; label: string }>;
+    impactedExecutionNodes: Array<{ id: string; label: string }>;
+  };
+  verification?: {
+    verified: boolean;
+    checks: Record<string, boolean>;
+    graphHash: string;
+    proofNodeRefs: string[];
+  };
+};
+
+async function fetchJson(path: string, apiKey: string) {
+  const response = await fetch(path, {
+    headers: { "X-API-Key": apiKey },
+  });
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(payload?.error || payload?.detail || `Request failed: ${response.status}`);
+  }
+  return payload;
+}
+
+export function ProofExplorer() {
+  const [runId, setRunId] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [graph, setGraph] = useState<ExplorerPayload | null>(null);
+  const [lineage, setLineage] = useState<ExplorerPayload | null>(null);
+  const [impact, setImpact] = useState<ExplorerPayload | null>(null);
+  const [verification, setVerification] = useState<ExplorerPayload | null>(null);
+  const [replayResult, setReplayResult] = useState<string | null>(null);
+
+  const basePath = useMemo(() => `/api/v1/runs/${runId}/trust-explorer`, [runId]);
+
+  async function loadExplorer() {
+    setLoading(true);
+    setError(null);
+    setReplayResult(null);
+    try {
+      const [graphRes, lineageRes, verifyRes, impactRes] = await Promise.all([
+        fetchJson(`${basePath}/getExecutionGraph`, apiKey),
+        fetchJson(`${basePath}/traceArtifactLineage`, apiKey),
+        fetchJson(`${basePath}/verifyProofChain`, apiKey),
+        fetchJson(`${basePath}/findPolicyImpact`, apiKey),
+      ]);
+      setGraph(graphRes);
+      setLineage(lineageRes);
+      setVerification(verifyRes);
+      setImpact(impactRes);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Unable to load Trust Explorer.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function replayRun() {
+    setReplayResult(null);
+    try {
+      const replay = await fetchJson(`/api/v1/runs/${runId}/replay`, apiKey);
+      setReplayResult(`Replay integrity: ${replay.match ? "verified" : "drift detected"}`);
+    } catch (replayError) {
+      setReplayResult(replayError instanceof Error ? replayError.message : "Replay failed");
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-slate-200 dark:border-slate-800 p-4 bg-white dark:bg-slate-900">
+        <h2 className="text-xl font-semibold mb-3">Proof Explorer</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">
+          Trace input → workflow → policy → artifact with deterministic node hashes and proof
+          checks.
+        </p>
+        <div className="grid gap-3 md:grid-cols-3">
+          <input
+            className="rounded border border-slate-300 dark:border-slate-700 bg-transparent px-3 py-2 text-sm"
+            placeholder="Run ID"
+            value={runId}
+            onChange={(event) => setRunId(event.target.value.trim())}
+          />
+          <input
+            className="rounded border border-slate-300 dark:border-slate-700 bg-transparent px-3 py-2 text-sm"
+            placeholder="API Key"
+            value={apiKey}
+            type="password"
+            onChange={(event) => setApiKey(event.target.value)}
+          />
+          <button
+            type="button"
+            disabled={!runId || !apiKey || loading}
+            onClick={loadExplorer}
+            className="rounded bg-slate-900 text-white dark:bg-white dark:text-slate-900 px-4 py-2 text-sm disabled:opacity-50"
+          >
+            {loading ? "Loading…" : "Load execution graph"}
+          </button>
+        </div>
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+      </div>
+
+      {graph?.graph && (
+        <div className="grid gap-4 md:grid-cols-2">
+          <section className="rounded-xl border border-slate-200 dark:border-slate-800 p-4 bg-white dark:bg-slate-900">
+            <h3 className="font-semibold mb-2">Execution Timeline</h3>
+            <ul className="space-y-2 text-sm">
+              {graph.graph.nodes.map((node) => (
+                <li key={node.id} className="border-l-2 border-blue-500 pl-3">
+                  <span className="font-medium">{node.label}</span>
+                  <div className="text-slate-500">{node.type}</div>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-xl border border-slate-200 dark:border-slate-800 p-4 bg-white dark:bg-slate-900">
+            <h3 className="font-semibold mb-2">Artifact Dependency Tree</h3>
+            <ul className="space-y-2 text-sm">
+              {lineage?.lineage?.lineage.map((entry) => (
+                <li key={entry.node.id}>
+                  <span className="font-medium">{entry.node.label}</span>
+                  <span className="text-slate-500"> ({entry.node.type})</span>
+                  {entry.viaEdge && (
+                    <div className="text-xs text-slate-500">via {entry.viaEdge.type}</div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-xl border border-slate-200 dark:border-slate-800 p-4 bg-white dark:bg-slate-900">
+            <h3 className="font-semibold mb-2">Policy Decision Viewer</h3>
+            <p className="text-sm mb-2">Impacted artifacts:</p>
+            <ul className="list-disc pl-5 text-sm">
+              {impact?.impact?.impactedArtifacts.map((artifact) => (
+                <li key={artifact.id}>{artifact.label}</li>
+              ))}
+            </ul>
+            <p className="text-sm mt-3 mb-2">Impacted workflow nodes:</p>
+            <ul className="list-disc pl-5 text-sm">
+              {impact?.impact?.impactedExecutionNodes.map((execution) => (
+                <li key={execution.id}>{execution.label}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-xl border border-slate-200 dark:border-slate-800 p-4 bg-white dark:bg-slate-900">
+            <h3 className="font-semibold mb-2">Proof Integrity</h3>
+            <p className="text-sm">
+              Graph hash:{" "}
+              <code>{verification?.verification?.graphHash || graph.graph.graphHash}</code>
+            </p>
+            <p className="text-sm mt-2">
+              Verification: {verification?.verification?.verified ? "Verified" : "Failed"}
+            </p>
+            <button
+              type="button"
+              onClick={replayRun}
+              className="mt-3 rounded bg-blue-600 text-white px-3 py-2 text-sm"
+            >
+              Replay run
+            </button>
+            {replayResult && <p className="text-sm mt-2">{replayResult}</p>}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/trust-graph/builder.ts
+++ b/packages/web/src/lib/trust-graph/builder.ts
@@ -1,0 +1,157 @@
+import { stableHash, type ReconciliationProofCapsule } from "@settler/protocol";
+import type { TrustGraph, TrustGraphEdge, TrustGraphNode } from "@/lib/trust-graph/types";
+import { buildCasRef, graphHashFromShape } from "@/lib/trust-graph/store";
+
+type BuildInput = {
+  tenantId: string;
+  runId: string;
+  proofCapsule: ReconciliationProofCapsule | null;
+  metadata: Record<string, unknown> | null;
+  summary: Record<string, unknown> | null;
+};
+
+function makeNode(
+  type: TrustGraphNode["type"],
+  runId: string,
+  label: string,
+  metadata: Record<string, unknown>,
+  createdAt: string
+): TrustGraphNode {
+  const hashRef = buildCasRef({ type, runId, label, metadata, createdAt });
+  return {
+    id: `node_${stableHash({ type, label, hashRef }).slice(0, 16)}`,
+    type,
+    hashRef,
+    label,
+    runId,
+    createdAt,
+    metadata,
+  };
+}
+
+function makeEdge(
+  from: string,
+  to: string,
+  type: TrustGraphEdge["type"],
+  metadata: Record<string, unknown>
+): TrustGraphEdge {
+  const hashRef = buildCasRef({ from, to, type, metadata });
+  return {
+    id: `edge_${stableHash({ from, to, type, hashRef }).slice(0, 16)}`,
+    from,
+    to,
+    type,
+    hashRef,
+    metadata,
+  };
+}
+
+function sorted<T extends { id: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function buildDeterministicTrustGraph(input: BuildInput): TrustGraph {
+  const createdAt = input.proofCapsule?.createdAt || new Date(0).toISOString();
+  const connectorLabel = String(input.metadata?.sourceAdapter || "connector:unknown");
+
+  const externalInputNode = makeNode(
+    "external_input",
+    input.runId,
+    "External Input",
+    {
+      inputHash: input.proofCapsule?.inputHash || null,
+      canonicalFingerprint: input.metadata?.fingerprint || null,
+    },
+    createdAt
+  );
+
+  const connectorNode = makeNode(
+    "connector",
+    input.runId,
+    connectorLabel,
+    {
+      sourceConfigHash: buildCasRef(input.metadata?.sourceConfig || {}),
+      targetAdapter: input.metadata?.targetAdapter || null,
+    },
+    createdAt
+  );
+
+  const workflowNode = makeNode(
+    "workflow_execution",
+    input.runId,
+    "Workflow Execution",
+    {
+      status: input.metadata?.status || "unknown",
+      runFingerprint: input.metadata?.fingerprint || null,
+      versionHash: input.proofCapsule?.versionHash || null,
+    },
+    createdAt
+  );
+
+  const policyNode = makeNode(
+    "policy_decision",
+    input.runId,
+    "Policy Decision",
+    {
+      ruleHash: input.proofCapsule?.ruleHash || null,
+      policyId: input.metadata?.policyId || "default",
+      evaluation: input.summary?.policyEvaluation || "applied",
+    },
+    createdAt
+  );
+
+  const artifactNode = makeNode(
+    "artifact",
+    input.runId,
+    "Reconciliation Artifact",
+    {
+      outputHash: input.proofCapsule?.outputHash || null,
+      summaryHash: buildCasRef(input.summary || {}),
+      proofCapsuleHash: buildCasRef(input.proofCapsule || {}),
+    },
+    createdAt
+  );
+
+  const edges = sorted([
+    makeEdge(externalInputNode.id, connectorNode.id, "derived_from", { trust: "input-bound" }),
+    makeEdge(connectorNode.id, workflowNode.id, "derived_from", {
+      reason: "connector normalized external input",
+    }),
+    makeEdge(workflowNode.id, policyNode.id, "policy_evaluated_by", {
+      policyHash: input.proofCapsule?.ruleHash || null,
+    }),
+    makeEdge(policyNode.id, artifactNode.id, "produced_artifact", {
+      outputHash: input.proofCapsule?.outputHash || null,
+    }),
+    makeEdge(artifactNode.id, workflowNode.id, "verified_by", {
+      verifier: input.proofCapsule?.signer || "Settler-Core",
+      signature: input.proofCapsule?.signature || null,
+    }),
+  ]);
+
+  const nodes = sorted([externalInputNode, connectorNode, workflowNode, policyNode, artifactNode]);
+
+  const graphHash = graphHashFromShape({
+    runId: input.runId,
+    nodes: nodes.map((node) => ({ id: node.id, hashRef: node.hashRef, type: node.type })),
+    edges: edges.map((edge) => ({ id: edge.id, hashRef: edge.hashRef, type: edge.type })),
+  });
+
+  const casIndex = Object.fromEntries(
+    nodes
+      .map((node) => [node.id, node.hashRef])
+      .concat(edges.map((edge) => [edge.id, edge.hashRef]))
+  );
+  const nodeHashRefs = Object.fromEntries(nodes.map((node) => [node.id, node.hashRef]));
+
+  return {
+    graphId: `graph_${stableHash({ tenant: input.tenantId, runId: input.runId }).slice(0, 16)}`,
+    tenantId: input.tenantId,
+    runId: input.runId,
+    graphHash,
+    casIndex,
+    nodeHashRefs,
+    nodes,
+    edges,
+  };
+}

--- a/packages/web/src/lib/trust-graph/explorer.ts
+++ b/packages/web/src/lib/trust-graph/explorer.ts
@@ -1,0 +1,148 @@
+import type { ReconciliationProofCapsule } from "@settler/protocol";
+import { buildDeterministicTrustGraph } from "@/lib/trust-graph/builder";
+import { persistTrustGraph, readTrustGraph } from "@/lib/trust-graph/store";
+import type {
+  ArtifactLineage,
+  PolicyImpact,
+  ProofVerification,
+  TrustGraph,
+  TrustGraphEdge,
+  TrustGraphNode,
+} from "@/lib/trust-graph/types";
+
+function ensureGraph(input: {
+  tenantId: string;
+  runId: string;
+  proofCapsule: ReconciliationProofCapsule | null;
+  metadata: Record<string, unknown> | null;
+  summary: Record<string, unknown> | null;
+}) {
+  const existing = readTrustGraph(input.tenantId, input.runId);
+  if (existing) return existing;
+  return persistTrustGraph(buildDeterministicTrustGraph(input));
+}
+
+export function getExecutionGraph(input: {
+  tenantId: string;
+  runId: string;
+  proofCapsule: ReconciliationProofCapsule | null;
+  metadata: Record<string, unknown> | null;
+  summary: Record<string, unknown> | null;
+}): TrustGraph {
+  return ensureGraph(input);
+}
+
+function parentEdge(graph: TrustGraph, nodeId: string): TrustGraphEdge | null {
+  return graph.edges.find((edge) => edge.to === nodeId) || null;
+}
+
+function findNode(graph: TrustGraph, nodeId: string): TrustGraphNode {
+  const node = graph.nodes.find((candidate) => candidate.id === nodeId);
+  if (!node) {
+    throw new Error(`Trust graph node not found: ${nodeId}`);
+  }
+  return node;
+}
+
+export function traceArtifactLineage(input: {
+  tenantId: string;
+  runId: string;
+  artifactNodeId?: string;
+  proofCapsule: ReconciliationProofCapsule | null;
+  metadata: Record<string, unknown> | null;
+  summary: Record<string, unknown> | null;
+}): ArtifactLineage {
+  const graph = ensureGraph(input);
+  const artifactNode =
+    (input.artifactNodeId && graph.nodes.find((node) => node.id === input.artifactNodeId)) ||
+    graph.nodes.find((node) => node.type === "artifact");
+
+  if (!artifactNode) throw new Error(`Artifact node unavailable for run ${input.runId}`);
+
+  const lineage: ArtifactLineage["lineage"] = [{ node: artifactNode, viaEdge: null }];
+  let cursor = artifactNode.id;
+  const seen = new Set<string>([cursor]);
+
+  while (true) {
+    const edge = parentEdge(graph, cursor);
+    if (!edge) break;
+    const upstream = findNode(graph, edge.from);
+    if (seen.has(upstream.id)) break;
+    lineage.push({ node: upstream, viaEdge: edge });
+    seen.add(upstream.id);
+    cursor = upstream.id;
+  }
+
+  return {
+    runId: input.runId,
+    artifactNodeId: artifactNode.id,
+    lineage,
+  };
+}
+
+export function verifyProofChain(input: {
+  tenantId: string;
+  runId: string;
+  proofCapsule: ReconciliationProofCapsule | null;
+  metadata: Record<string, unknown> | null;
+  summary: Record<string, unknown> | null;
+}): ProofVerification {
+  const graph = ensureGraph(input);
+  const proofNodeRefs = ["workflow_execution", "policy_decision", "artifact"].map(
+    (type) => graph.nodes.find((node) => node.type === type)?.id || ""
+  );
+
+  const proofGraphHash = String(
+    (input.proofCapsule as Record<string, unknown> | null)?.graphHash || ""
+  );
+  const graphHashMatches = Boolean(proofGraphHash && proofGraphHash === graph.graphHash);
+
+  return {
+    runId: input.runId,
+    verified:
+      graph.nodes.some((node) => node.type === "workflow_execution") &&
+      graph.nodes.some((node) => node.type === "artifact") &&
+      graph.nodes.some((node) => node.type === "policy_decision") &&
+      graphHashMatches,
+    checks: {
+      hasWorkflowNode: graph.nodes.some((node) => node.type === "workflow_execution"),
+      hasArtifactNode: graph.nodes.some((node) => node.type === "artifact"),
+      hasPolicyNode: graph.nodes.some((node) => node.type === "policy_decision"),
+      graphHashMatches,
+      proofReferencesGraphNodes: proofNodeRefs.every(Boolean),
+    },
+    graphHash: graph.graphHash,
+    proofNodeRefs,
+  };
+}
+
+export function findPolicyImpact(input: {
+  tenantId: string;
+  runId: string;
+  policyNodeId?: string;
+  proofCapsule: ReconciliationProofCapsule | null;
+  metadata: Record<string, unknown> | null;
+  summary: Record<string, unknown> | null;
+}): PolicyImpact {
+  const graph = ensureGraph(input);
+  const policyNode =
+    (input.policyNodeId && graph.nodes.find((node) => node.id === input.policyNodeId)) ||
+    graph.nodes.find((node) => node.type === "policy_decision");
+
+  if (!policyNode) throw new Error(`Policy node unavailable for run ${input.runId}`);
+
+  const impactedArtifactIds = graph.edges
+    .filter((edge) => edge.from === policyNode.id && edge.type === "produced_artifact")
+    .map((edge) => edge.to);
+
+  const impactedExecutionIds = graph.edges
+    .filter((edge) => edge.to === policyNode.id && edge.type === "policy_evaluated_by")
+    .map((edge) => edge.from);
+
+  return {
+    runId: input.runId,
+    policyNodeId: policyNode.id,
+    impactedArtifacts: graph.nodes.filter((node) => impactedArtifactIds.includes(node.id)),
+    impactedExecutionNodes: graph.nodes.filter((node) => impactedExecutionIds.includes(node.id)),
+  };
+}

--- a/packages/web/src/lib/trust-graph/store.ts
+++ b/packages/web/src/lib/trust-graph/store.ts
@@ -1,0 +1,26 @@
+import { stableHash } from "@settler/protocol";
+import type { TrustGraph } from "@/lib/trust-graph/types";
+
+const graphStore = new Map<string, TrustGraph>();
+
+function key(tenantId: string, runId: string) {
+  return `${tenantId}:${runId}`;
+}
+
+export function buildCasRef(payload: unknown) {
+  const hash = stableHash(payload);
+  return `cas://${hash}`;
+}
+
+export function persistTrustGraph(graph: TrustGraph) {
+  graphStore.set(key(graph.tenantId, graph.runId), graph);
+  return graph;
+}
+
+export function readTrustGraph(tenantId: string, runId: string) {
+  return graphStore.get(key(tenantId, runId)) || null;
+}
+
+export function graphHashFromShape(shape: { runId: string; nodes: unknown; edges: unknown }) {
+  return stableHash(shape);
+}

--- a/packages/web/src/lib/trust-graph/types.ts
+++ b/packages/web/src/lib/trust-graph/types.ts
@@ -1,0 +1,72 @@
+export type TrustGraphNodeType =
+  | "workflow_execution"
+  | "artifact"
+  | "policy_decision"
+  | "connector"
+  | "external_input";
+
+export type TrustGraphEdgeType =
+  | "derived_from"
+  | "verified_by"
+  | "policy_evaluated_by"
+  | "produced_artifact";
+
+export interface TrustGraphNode {
+  id: string;
+  type: TrustGraphNodeType;
+  hashRef: string;
+  label: string;
+  runId: string;
+  createdAt: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface TrustGraphEdge {
+  id: string;
+  from: string;
+  to: string;
+  type: TrustGraphEdgeType;
+  hashRef: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface TrustGraph {
+  graphId: string;
+  runId: string;
+  tenantId: string;
+  graphHash: string;
+  casIndex: Record<string, string>;
+  nodeHashRefs: Record<string, string>;
+  nodes: TrustGraphNode[];
+  edges: TrustGraphEdge[];
+}
+
+export interface ArtifactLineage {
+  runId: string;
+  artifactNodeId: string;
+  lineage: Array<{
+    node: TrustGraphNode;
+    viaEdge: TrustGraphEdge | null;
+  }>;
+}
+
+export interface PolicyImpact {
+  runId: string;
+  policyNodeId: string;
+  impactedArtifacts: TrustGraphNode[];
+  impactedExecutionNodes: TrustGraphNode[];
+}
+
+export interface ProofVerification {
+  runId: string;
+  verified: boolean;
+  checks: {
+    hasWorkflowNode: boolean;
+    hasArtifactNode: boolean;
+    hasPolicyNode: boolean;
+    graphHashMatches: boolean;
+    proofReferencesGraphNodes: boolean;
+  };
+  graphHash: string;
+  proofNodeRefs: string[];
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic, verifiable trust graph model so execution proofs and evidence can be navigated and cryptographically referenced. 
- Anchor lineage, policy decisions, and replayability in a CAS-style index to guarantee deterministic construction and tamper-evident references. 
- Surface proof inspection in the web UI to let developers trace input → workflow → policy → artifact → output and run integrity checks.

### Description
- Introduced a Trust Graph domain model and CAS-backed storage including node/edge types, node hash refs, and stable graph hashing in `packages/web/src/lib/trust-graph/*`.
- Implemented a deterministic graph builder and explorer service that provides `getExecutionGraph`, `traceArtifactLineage`, `verifyProofChain`, and `findPolicyImpact` functions in `packages/web/src/lib/trust-graph/*`.
- Added authenticated, rate-limited API endpoints under `/api/v1/runs/{id}/trust-explorer/*` and enriched the existing `/api/v1/runs/{id}/evidence` response with `graphHash` and `proofNodeRefs` to link proof capsules to graph nodes.
- Added a Proof Explorer UI at `/proof-explorer` plus a client component that loads the graph, lineage, policy impact, and proof verification and exposes a replay button to run integrity checks.

### Testing
- Ran unit tests for the new trust-graph suite and related recon core checks with `pnpm --filter @settler/web test -- --runTestsByPath src/__tests__/trust-graph/explorer.test.ts src/__tests__/api/recon-core.test.ts` and both test suites passed.
- Performed full TypeScript type checking with `pnpm --filter @settler/web typecheck` and it completed successfully across the workspace.
- Ran targeted ESLint on the new files with `cd packages/web && pnpm exec eslint --max-warnings=0 src/lib/trust-graph src/app/api/v1/runs/[id]/trust-explorer src/components/proof/ProofExplorer.tsx src/app/proof-explorer/page.tsx src/app/api/v1/runs/[id]/evidence/route.ts src/app/openapi.json/route.ts` which executed successfully against the new code (repo-wide lint warnings in unrelated packages were observed but unchanged).
- Attempted an automated Playwright screenshot of `/proof-explorer` but Chromium crashed in this environment (SIGSEGV) so UI render capture was not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab9396bba8832885fda96e0363b718)