### PR TITLE
docs: launch-readiness pass for OSS developer adoption

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,104 +1,52 @@
 # Settler Architecture Overview
 
-Settler is an Open Source Reconciliation Engine with a simple surface and a deterministic core.
+Settler is an open-source reconciliation system with deterministic execution, policy enforcement, and replayable proof artifacts.
 
-## System Shape
+## Runtime architecture diagram
 
-- **Web surface (`packages/web`)**: Dashboard, docs, and demo UX.
-- **API surface (`packages/api` + `packages/web/src/app/api`)**: Run creation, run listing, metrics, and evidence access.
-- **Engine + runner (`runner`, `scripts/moat`)**: Deterministic run execution and replay verification.
-- **Platform layer (`platform/`)**: Unified subsystem integration — trust graph, policy simulator, AI copilot, chaos harness, event consumers, connector registry.
-- **Connector ecosystem (`packages/adapters`)**: Sandboxed external data connectors with normalization.
-- **CLI (`packages/cli`)**: Command-line interface including MCP server, replay lab, foundry, and proof verification.
-- **Protocol (`packages/protocol`)**: Framework-agnostic types for reconciliation workflows.
-- **Storage (Postgres/Supabase via Prisma)**: Tenant-scoped run state and metrics.
-
-## Runtime Flow
-
-1. Operator or integration starts a run.
-2. Engine processes normalized records deterministically.
-3. Policy engine compiles and enforces governance rules.
-4. Results + evidence are persisted as content-addressed artifacts.
-5. Event backbone distributes events to subsystem consumers.
-6. Trust graph records execution lineage and artifact provenance.
-7. Replay verifies fingerprints for provable outcomes.
-
-## Subsystem Architecture
-
-### Core Primitives (`platform/primitives.ts`)
-
-All subsystems share these canonical types:
-
-| Primitive   | Purpose                                    |
-|-------------|---------------------------------------------|
-| Execution   | A workflow run with input/output hashes     |
-| Artifact    | Content-addressed output (evidence, report) |
-| Workflow    | Tenant-scoped reconciliation definition     |
-| Policy      | Governance rules with budgets and identity  |
-| Connector   | External data source adapter                |
-| Event       | Durable, idempotent platform event          |
-| Proof       | Cryptographic proof capsule with hash chain |
-| Tenant      | Isolated organizational boundary            |
-
-### Trust Graph (`platform/trust-graph.ts`)
-
-- **Nodes**: Execution, Artifact, Policy, Connector, Proof
-- **Edges**: produced, consumed, governed_by, proved_by, sourced_from, replayed_from, derived_from
-- Tenant-isolated: cross-tenant edges are forbidden
-- Content-addressed: node IDs are deterministic hashes
-- Snapshotable: produces a root hash for graph verification
-
-### Event Backbone (`runner/eventBackbone.ts` + `platform/event-consumers.ts`)
-
-- **Append-only NDJSON log** with idempotency keys
-- **Consumer offset tracking** for exactly-once processing
-- **Consumers**: Trust Graph, Observability, Policy Audit, Connector Metrics
-- **Replayable**: same event stream for live execution and replay
-
-### Policy Engine & Simulator (`policies/` + `platform/policy-simulator.ts`)
-
-- **Compilation** to enforcement plans with hash-based integrity
-- **Simulation**: what-if analysis against historical executions
-- **Comparison**: diff two policies to see retroactive impact
-
-### Determinism Guarantees (`platform/determinism.ts`)
-
-- **Auditor**: detects timestamps, random IDs, AI mutations, connector non-determinism
-- **Execution Fence**: blocks non-deterministic operations during deterministic blocks
-- **Connector Output Normalizer**: replaces random UUIDs with deterministic IDs
-- **Replay Verification**: asserts fingerprint match
-
-### AI Copilot (`platform/ai-copilot.ts`)
-
-- Advisory-only — never executes directly
-- Blocked during deterministic execution via execution fence
-- Requires human review; full audit trail
-- Rate-limited per execution
-
-### Chaos Harness (`platform/chaos-harness.ts`)
-
-- **Fault types**: worker crash, network partition, connector failure, event delay, partial write, artifact corruption
-- **Invariant checks**: replay correctness, proof integrity, execution idempotency, tenant isolation
-
-### MCP Server (`packages/cli/src/mcp/server.ts`)
-
-Exposes: runWorkflow, replayExecution, verifyProof, inspectPolicy, traceArtifact, listConnectors, eventBackboneHealth.
-
-## Data Flow
-
-```
-workflow trigger → event backbone → policy enforcement → worker execution
-→ artifact generation → proof pack → trust graph update → observability
+```mermaid
+flowchart LR
+    A[Workflow Trigger\nCLI / API / Scheduler] --> B[Execution Engine\nDeterministic Runner]
+    B --> C[Policy Evaluation\nIdentity + Budget + Guardrails]
+    C --> D[Worker Execution\nConnector Calls + Matching]
+    D --> E[Event Backbone\nAppend-only NDJSON Log]
+    D --> F[Artifact Store\nrun.json / results.json / report.html]
+    D --> G[Proof Generation\nevidence.json + hash chain]
+    E --> H[Event Consumers\nObservability / Metrics / Audit]
+    G --> I[Replay Verification\nFingerprint Match]
+    D --> J[Connector Integrations\nStripe, QuickBooks, etc.]
+    I --> K[Trust Graph\nExecution Lineage]
+    G --> K
+    C --> K
 ```
 
-## Determinism Contract
+## System shape
+
+- **Web surface (`packages/web`)**: dashboard, docs, and demo UX.
+- **API surface (`packages/api` + `packages/web/src/app/api`)**: run creation, listing, metrics, and evidence access.
+- **Engine + runner (`runner`, `scripts/moat`)**: deterministic execution and replay verification.
+- **Platform layer (`platform/`)**: trust graph, policy simulator, AI copilot, chaos harness, and event consumers.
+- **Connector ecosystem (`packages/adapters`)**: adapter drivers with normalization and safety controls.
+- **CLI (`packages/cli`)**: replay, verification, and foundry tooling.
+- **Storage (Postgres/Supabase via Prisma)**: tenant-scoped run state and metadata.
+
+## Runtime flow
+
+1. Operator or integration starts a workflow run.
+2. Policy is evaluated before deterministic execution proceeds.
+3. Worker execution reads normalized connector data and applies matching rules.
+4. Artifacts + proof are persisted (`run.json`, `results.json`, `evidence.json`, HTML report).
+5. Event backbone fans out updates to observability, trust, and audit consumers.
+6. Replay verifies the run fingerprint against stored evidence.
+
+## Determinism contract
 
 1. AI cannot modify deterministic execution path directly.
-2. Connector outputs are normalized; random UUIDs → deterministic IDs.
-3. All workflow state transitions are deterministic.
-4. Replay produces identical fingerprints.
-5. Non-deterministic operations are blocked inside execution fence.
+2. Connector outputs are normalized; unstable IDs are canonicalized.
+3. Workflow state transitions are deterministic.
+4. Replay must produce identical fingerprints.
+5. Non-deterministic operations are blocked inside execution fences.
 
-## Deep Dive
+## Deep dive
 
-For detailed internals (deterministic replay, content-addressed evidence, policy engine, run storage, and execution model), read [`docs/ENGINE.md`](docs/ENGINE.md).
+For internals (execution engine, lineage, proof model, and policy path), see [`docs/ENGINE.md`](docs/ENGINE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,27 @@ For workspace-specific tests:
 pnpm --filter @settler/web test
 ```
 
+## Adding a Connector (Minimal Path)
+
+1. Implement a driver in `packages/adapters/src/drivers/<your-connector>.ts`.
+2. Export it from `packages/adapters/src/drivers/index.ts`.
+3. Add deterministic normalization tests under `packages/adapters/src/__tests__`.
+4. Register metadata in `marketplace/adapters/registry.json` when the connector is user-visible.
+5. Run:
+
+```bash
+pnpm --filter @settler/adapters test
+pnpm --filter @settler/adapters build
+```
+
+Include fixture inputs/outputs in your PR so replay behavior can be validated.
+
+## Development Environment Notes
+
+- Use `pnpm install` at repo root; this is a workspace monorepo.
+- For reproducible checks, run `pnpm run verify:fast` before opening a PR.
+- If you touch launch/docs artifacts, also run `pnpm run verify:launch-assets`.
+
 ## Pull Request Process
 
 1. Create a feature branch.

--- a/README.md
+++ b/README.md
@@ -1,108 +1,75 @@
-# Settler — Open Source Reconciliation Platform
+# Settler
 
-**Settler runs deterministic reconciliation workflows, produces verifiable artifacts, and supports replay-backed audits for every execution.**
+**Settler is a deterministic workflow platform for financial reconciliation that emits verifiable proof artifacts for every run.**
 
-If Stripe, banking data, and your internal ledger disagree, Settler identifies mismatches, records why they happened, and exports proof artifacts you can replay later.
+Engineering teams routinely hit the same failure mode: Stripe, bank exports, and internal ledgers diverge, but root-cause analysis is slow because execution history is incomplete or non-replayable. Settler solves this by combining deterministic execution, policy evaluation, and replay verification in one auditable path.
 
-## What Settler does
+## Key capabilities
 
-1. **Workflow execution** across tenant-scoped connectors and policies.
-2. **Deterministic reconciliation** with explicit matching rules.
-3. **Mismatch detection** with review-ready context.
-4. **Artifact + proof generation** (inputs, policy, outputs, hashes).
-5. **Replay verification** against canonical execution artifacts.
+- **Deterministic workflow execution** for recon pipelines across normalized connector inputs.
+- **Replay with cryptographic evidence** so every run can be re-verified from stored artifacts.
+- **Policy-governed operations** that evaluate access, budgets, and guardrails as part of execution.
 
-## Five Minute Demo
+## Quick usage example
 
 ```bash
 pnpm install
-cp .env.example .env
-pnpm exec tsx scripts/run-migrations-remote.ts
-pnpm --filter @settler/web dev
 pnpm demo
 pnpm settler:replay examples/demo-output/evidence.json
 ```
 
-Demo outputs are written to `examples/demo-output` (`run.json`, `results.json`, `evidence.json`, `report.html`).
+This generates `examples/demo-output/run.json`, `results.json`, `evidence.json`, and `report.html` from a deterministic Stripe↔QuickBooks demo workflow.
 
-## Capability reality (OSS)
+## Quick start (time-to-first-value)
 
-| Capability                         | Status                         | Notes                                                                                 |
-| ---------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------- |
-| Deterministic workflow execution   | ✅ Implemented                 | Deterministic guarantees apply to canonicalized inputs + rules + policy context.      |
-| Replayable execution               | ✅ Implemented                 | Replay verifies outputs against stored artifacts and hashes.                          |
-| Proof chains                       | ✅ Implemented                 | Hash-linked proof artifacts are generated and verified by scripts and runtime checks. |
-| Policy enforcement                 | ✅ Implemented                 | Execution policy is evaluated during runtime and verification gates.                  |
-| Connector normalization and safety | ✅ Implemented                 | Connector output normalization and sandbox controls are present in platform modules.  |
-| AI copilot                         | ✅ Implemented (advisory only) | Copilot suggests actions; it does not execute workflow changes directly.              |
-| Chaos-tested reliability           | ✅ Implemented                 | Chaos harness and reliability scripts validate deterministic invariants.              |
-| Multi-tenant isolation             | ✅ Implemented                 | Tenant boundaries enforced through RLS and isolation checks.                          |
+1. **Clone + install**
+   ```bash
+   git clone https://github.com/settler/settler.git
+   cd settler
+   pnpm install
+   ```
+2. **Set environment values**
+   ```bash
+   cp .env.example .env
+   ```
+   For demo and replay, `DATABASE_URL` is not required.
+3. **Execute a deterministic example workflow**
+   ```bash
+   pnpm demo
+   ```
+4. **Inspect outputs + proof**
+   ```bash
+   cat examples/demo-output/results.json
+   cat examples/demo-output/evidence.json
+   ```
+5. **Replay verification**
+   ```bash
+   pnpm settler:replay examples/demo-output/evidence.json
+   ```
 
-See [docs/positioning/CLAIM_VALIDATION.md](docs/positioning/CLAIM_VALIDATION.md) for claim-by-claim evidence and boundaries.
+For expanded launch-oriented walkthroughs (example workflows, expected outputs, replay instructions), see [`docs/launch/QUICK_START.md`](docs/launch/QUICK_START.md).
 
-## Core primitives
+## Architecture at a glance
 
-Settler documentation and user-facing surfaces normalize to these primitives:
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the runtime diagram and component flow (workflow execution, event backbone, workers, artifact store, proof generation, connector integrations, policy engine).
 
-- **Workflow**
-- **Execution**
-- **Artifact**
-- **Proof**
-- **Replay**
-- **Policy**
-- **Connector**
-- **Event**
-- **Tenant**
-- **Copilot**
-- **Chaos Harness**
+## Technical differentiation
 
-Reference: [docs/TERMINOLOGY.md](docs/TERMINOLOGY.md).
+Settler differs from generic workflow tools in five concrete ways:
 
-## Quickstart
+1. **Determinism is enforced** (not advisory) via execution fences and canonicalization.
+2. **Proof artifacts are first-class outputs** (`evidence.json`, fingerprints, hash-linked lineage).
+3. **Replay is a built-in verification path**, not a best-effort debug mode.
+4. **Policy evaluation is in the execution loop**, not a separate post-processing stage.
+5. **Connector safety includes normalization + tenant boundaries** to reduce non-deterministic drift.
 
-Prerequisites:
+## Contributor on-ramp
 
-- Node.js 24+ (see `.nvmrc`)
-- pnpm 10.13.1+
-- Postgres or Supabase
+- Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup and quality gates.
+- Browse launch-ready examples in [`docs/launch/EXAMPLE_WORKFLOWS.md`](docs/launch/EXAMPLE_WORKFLOWS.md).
+- Use issue/PR templates in [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE) and [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
 
-Set environment values:
-
-```bash
-DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DB
-NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
-```
-
-Run locally:
-
-```bash
-pnpm install
-pnpm exec tsx scripts/run-migrations-remote.ts
-pnpm --filter @settler/web dev
-```
-
-Open `http://localhost:3000`.
-
-## Key packages
-
-- `packages/api` – reconciliation API, domain logic, and data layer
-- `packages/web` – Next.js web app (console, docs, marketing)
-- `packages/adapters` – connector implementations for Stripe, banks, ERPs, and other sources
-- `packages/sdk`, `packages/react-settler`, `packages/sdk-go`, `packages/workhorse` – SDKs and workers
-
-## Documentation path
-
-- Start here: [`docs/START_HERE.md`](docs/START_HERE.md)
-- Quick start + onboarding: [`docs/getting-started/README.md`](docs/getting-started/README.md)
-- Core concepts + guarantees: [`docs/TERMINOLOGY.md`](docs/TERMINOLOGY.md), [`docs/SYSTEM_GUARANTEES.md`](docs/SYSTEM_GUARANTEES.md)
-- Workflows and execution: [`docs/WORKFLOWS.md`](docs/WORKFLOWS.md), [`docs/ENGINE.md`](docs/ENGINE.md)
-- Proofs and replay: [`docs/EVIDENCE.md`](docs/EVIDENCE.md), [`docs/LINEAGE.md`](docs/LINEAGE.md)
-- Connectors: [`docs/integrations/connectors-overview.md`](docs/integrations/connectors-overview.md)
-- AI copilot + chaos harness: [`MODEL_SPEC.md`](MODEL_SPEC.md), [`platform/chaos-harness.ts`](platform/chaos-harness.ts)
-- Architecture + contributing: [`ARCHITECTURE.md`](ARCHITECTURE.md), [`CONTRIBUTING.md`](CONTRIBUTING.md)
-
-## License and support
+## License and security
 
 - License: [`LICENSE`](LICENSE)
-- Security reports: [`SECURITY.md`](SECURITY.md)
+- Security policy: [`SECURITY.md`](SECURITY.md)

--- a/docs/launch/EXAMPLE_WORKFLOWS.md
+++ b/docs/launch/EXAMPLE_WORKFLOWS.md
@@ -1,0 +1,86 @@
+# Launch Example Workflows
+
+This document includes reproducible examples with source workflow, expected output, proof artifact, and replay instructions.
+
+## Example 1 — Financial reconciliation (Stripe ↔ QuickBooks)
+
+### Source workflow
+
+- Entrypoint: `scripts/settler-demo.ts`
+- Inputs: `stripe` and `quickbooks` arrays seeded by the demo script
+- Matching rule: composite match on `invoice_number` + `amount` with 1% tolerance
+
+### Run command
+
+```bash
+pnpm demo
+```
+
+### Expected output
+
+File: `examples/demo-output/results.json`
+
+Expected summary:
+
+- `output.matches = 2`
+- `output.mismatches = 0`
+- `output.reviewQueue = 0`
+
+### Generated proof artifact
+
+File: `examples/demo-output/evidence.json`
+
+Fields to validate:
+
+- `run_id = "demo-run-1"`
+- `policy_id = "demo.strict"`
+- `run_fingerprint` is present
+- `provenance.hash_chain` is non-empty
+
+### Replay instructions
+
+```bash
+pnpm settler:replay examples/demo-output/evidence.json
+```
+
+Expected terminal result: `Replay Verified: OK`.
+
+---
+
+## Example 2 — Replay verification from frozen fixture
+
+### Source workflow
+
+- Fixture: `examples/demo-output-fixtures/demo-run-1/evidence.json`
+- Purpose: deterministic replay smoke independent of newly generated output
+
+### Run command
+
+```bash
+pnpm settler:replay examples/demo-output-fixtures/demo-run-1/evidence.json
+```
+
+### Expected output
+
+- Replay command exits successfully.
+- Fingerprint match is true.
+
+### Generated proof artifact
+
+- Existing fixture already includes `run.json`, `results.json`, and `evidence.json`.
+- Useful for CI and regression checks when validating replay behavior.
+
+### Replay instructions
+
+The run command above is the replay instruction. Use this in CI or pre-release checks.
+
+---
+
+## Example connector reference
+
+If you want to extend data ingestion from this demo path, start with:
+
+- `packages/adapters/src/drivers/stripe-connect.ts`
+- `packages/adapters/src/drivers/netsuite.ts`
+
+Connector contributions should preserve deterministic normalization and include tests.

--- a/docs/launch/QUICK_START.md
+++ b/docs/launch/QUICK_START.md
@@ -1,0 +1,78 @@
+# Launch Quick Start (Developer First)
+
+This quick start is optimized for first-run verification in under 10 minutes.
+
+## What you will do
+
+1. Run a deterministic reconciliation workflow.
+2. Inspect generated outputs and proof artifacts.
+3. Replay the run and verify the fingerprint.
+
+## Prerequisites
+
+- Node.js `>=22` (Node 24 recommended)
+- pnpm `>=10.13.1`
+
+## 1) Install dependencies
+
+```bash
+pnpm install
+```
+
+## 2) Execute the example workflow
+
+```bash
+pnpm demo
+```
+
+The command runs `scripts/settler-demo.ts` and writes artifacts to `examples/demo-output`.
+
+## 3) Inspect generated outputs
+
+```bash
+cat examples/demo-output/run.json
+cat examples/demo-output/results.json
+cat examples/demo-output/evidence.json
+```
+
+You should see:
+
+- workflow input payload (`run.json`)
+- deterministic reconciliation outcome (`results.json`)
+- proof artifact with fingerprints and policy context (`evidence.json`)
+
+## 4) Replay verification
+
+```bash
+pnpm settler:replay examples/demo-output/evidence.json
+```
+
+Expected terminal signal includes:
+
+- fingerprint comparison
+- `matches: true`
+
+## 5) Optional: open HTML report
+
+```bash
+python3 -m http.server 4173 --directory examples/demo-output
+```
+
+Then visit `http://localhost:4173/report.html`.
+
+## Example connector + workflow references
+
+- Example workflow source: `scripts/settler-demo.ts`
+- Connector implementation surface: `packages/adapters/src/drivers/stripe-connect.ts`
+- Replay implementation: `scripts/settler-replay.ts`
+
+## Troubleshooting
+
+- If `pnpm demo` fails, run:
+  ```bash
+  pnpm install --frozen-lockfile
+  ```
+- If replay fails with fingerprint mismatch, regenerate demo artifacts and replay again:
+  ```bash
+  pnpm demo && pnpm settler:replay examples/demo-output/evidence.json
+  ```

--- a/launch/assets-manifest.json
+++ b/launch/assets-manifest.json
@@ -3,19 +3,27 @@
   "assets": [
     {
       "path": "launch/twitter-thread.md",
-      "sha256": "0223edecb32e3fe8e73186b7c06a5ffca7db0ff19a7d27f6311e6d3126bb25aa"
+      "sha256": "92edf0dda8c591e4706ec2753ce180a495bb1bd0c240cf2abdf07d97d0b38654"
     },
     {
       "path": "launch/ph.md",
-      "sha256": "e9c55d1e60b317a7a9ba11c63765f7e34e0ef4925f9143ebcd887b5efbd8abea"
+      "sha256": "7368c14834ef530d587928ee4c8dabaa172a37efa0ecddebb096705163b9075a"
     },
     {
       "path": "launch/reddit.md",
-      "sha256": "364a290d5c137b4ddf06fa0dc06b55dc065f540e5fcc76ee0ca10c741b8a7e8d"
+      "sha256": "aea87a688e80bba6af518622978d2bc0318bc49788536f6e5ed82fd896e9acad"
     },
     {
       "path": "launch/hn.md",
-      "sha256": "abcf83ee42665c275813822cf881ce950321bf3d7a5ab7a3f2ccca6b60e915a6"
+      "sha256": "84629930e92f02d65eedceced4ba6b811841e5fb9d7e8eb4b47421bcb0422ac1"
+    },
+    {
+      "path": "launch/launch-summary.md",
+      "sha256": "0644cc316698600beb074d103cdd9a9e30d296688a9815bcb21992fd8dc00c1b"
+    },
+    {
+      "path": "launch/workflow-artifacts.md",
+      "sha256": "8b3018fbf4857fef4d99cbc8fdc30368a8e27a2dfe156a89678d1a2f2bbcfe53"
     }
   ]
 }

--- a/launch/hn.md
+++ b/launch/hn.md
@@ -1,25 +1,31 @@
-# Show HN: Settler – Open-source API for financial reconciliation and receipt parsing
+# Show HN: Settler — deterministic reconciliation workflows with replayable proof artifacts
 
-Hi HN, we are the team behind Settler.dev. We've built an API infrastructure that handles the "boring but critical" parts of fintech: reconciliation, receipt parsing, and deterministic unit conversion.
+Hi HN — we open-sourced Settler to make reconciliation workflows reproducible and auditable.
 
-## The Problem
-Every fintech company eventually builds an internal "Reconciliation Service". It usually starts as a cron job matching Stripe payouts to DB rows, then grows into a monster dealing with currency conversion, fuzzy matching, and PDF parsing. It's fragile, unmaintained, and incorrect.
+## What it does
 
-## The Solution
-Settler is a double-entry ledger and reconciliation engine wrapped in a clean, typed API.
+- Runs deterministic reconciliation workflows.
+- Emits proof artifacts (`run.json`, `results.json`, `evidence.json`, `report.html`) for each run.
+- Replays from evidence and verifies fingerprint matches.
 
-- **Reconcile**: Match transactions across any two sources (Stripe, Shopify, DB, CSV) with configurable rules.
-- **Receipts**: Send us a PDF/Image, get back structured JSON (Vendor, Date, Line Items, Tax) using our edge-optimized OCR.
-- **Flags**: Feature flags designed for financial rollout (e.g. "enable for users with >$10k volume").
+## Why we built it
 
-## Tech Stack
-- Typescript / Node.js
-- Event Sourcing for auditability
-- Edge-first architecture for low latency
+Most teams end up with ad-hoc recon scripts that are hard to debug after the fact. When outcomes change between runs, it is difficult to prove whether data changed, policy changed, or execution changed.
 
-## Links
-- Docs: https://settler.dev/docs
-- Repo: https://github.com/settler/settler
-- Playground: https://settler.dev/console/playground
+Settler is opinionated around deterministic execution + replay so failure analysis is concrete instead of forensic guesswork.
 
-We'd love your feedback on the API design and the specific reconciliation pain points you've faced!
+## How to try it locally
+
+```bash
+pnpm install
+pnpm demo
+pnpm settler:replay examples/demo-output/evidence.json
+```
+
+## Repo references
+
+- Architecture: `ARCHITECTURE.md`
+- Quick start: `docs/launch/QUICK_START.md`
+- Example workflows: `docs/launch/EXAMPLE_WORKFLOWS.md`
+
+Feedback request: if your team has reconciliation pain points, where does deterministic replay help most (incident response, audits, or regression testing)?

--- a/launch/launch-summary.md
+++ b/launch/launch-summary.md
@@ -1,0 +1,3 @@
+# Launch Summary
+
+Settler is an open-source deterministic workflow platform for financial reconciliation. It executes workflows with policy checks, generates verifiable artifacts (`run.json`, `results.json`, `evidence.json`), and supports replay verification so engineers can reproduce outcomes and audit run provenance without relying on fragile ad-hoc scripts.

--- a/launch/ph.md
+++ b/launch/ph.md
@@ -1,20 +1,31 @@
 # Name
+
 Settler
 
 # Tagline
-The API Infrastructure for Financial Evidence.
 
-# Description
-Settler gives engineering teams the primitives to build reliable financial software. Stop building fragile cron jobs for reconciliation and receipt parsing. Use Settler's typed API to ensure your numbers always match the bank.
+Deterministic reconciliation workflows with replayable proof.
 
-# Key Features
-- **Automated Reconciliation**: Match transactions across Stripe, Shopify, and your database with 100% accuracy.
-- **Receipts to JSON**: Turn PDFs and images into structured data with enterprise-grade OCR.
-- **Deterministic Math**: Handle currency conversion and unit math without floating point errors.
-- **Developer First**: Great SDKs, detailed docs, and a beautiful console.
+# Launch summary
 
-# Gallery
-[Insert Screenshots of Console, Playground, and VS Code]
+Settler is an open-source platform for running deterministic reconciliation workflows that produce verifiable evidence artifacts and support replay-based verification. It is designed for engineering teams that need reproducible outcomes, audit-friendly execution history, and policy-governed workflow operations.
 
-# Website
-https://settler.dev
+# What engineers can test quickly
+
+- Run the demo workflow: `pnpm demo`
+- Verify replay from generated evidence: `pnpm settler:replay examples/demo-output/evidence.json`
+- Inspect architecture and contributor docs in-repo
+
+# Core technical points
+
+- Deterministic execution path
+- Evidence artifact generation (`run.json`, `results.json`, `evidence.json`)
+- Replay verification with fingerprint matching
+- Policy checks in execution loop
+- Connector normalization with tenant-aware boundaries
+
+# Links
+
+- Repo: https://github.com/settler/settler
+- Quick start: https://github.com/settler/settler/blob/main/docs/launch/QUICK_START.md
+- Architecture: https://github.com/settler/settler/blob/main/ARCHITECTURE.md

--- a/launch/reddit.md
+++ b/launch/reddit.md
@@ -1,37 +1,40 @@
-# We open sourced our financial reconciliation engine
+# We open sourced Settler: deterministic reconciliation with proof + replay
 
 Hi r/programming,
 
-We've spent the last year building **Settler**, an API infrastructure for financial reconciliation and evidence.
+We open sourced Settler, a workflow system focused on one thing: deterministic reconciliation runs that can be replayed and verified later.
 
-**Repo:** [Link to Repo]
-**Docs:** https://settler.dev/docs
+## Why this exists
 
-### Why?
-In previous roles at fintech companies, we saw the same pattern:
-1. Build a product.
-2. Realize the numbers don't match the bank.
-3. Panic.
-4. Build a hasty "Recon Service" that scrapes CSVs and runs fragile SQL queries.
-5. Spend 20% of engineering time maintaining it.
+In many systems, reconciliation logic evolves through cron jobs and one-off SQL. When output changes unexpectedly, root-cause analysis is expensive because run context is incomplete.
 
-We decided to extract this problem into a standalone, robust infrastructure layer.
+Settler's core model is:
 
-### Architecture
-Settler is built on **Event Sourcing**. Every state change (Transaction Created, Match Attempted, Conflict Resolved) is an immutable event. This allows us to:
-- Replay history to fix bugs without data loss.
-- Provide a perfect audit trail for compliance (SOC2/ISO).
-- Run deterministic "what-if" scenarios.
+1. deterministic execution
+2. policy checks in the run path
+3. proof artifact generation
+4. replay verification
 
-### Features
-- **Reconciliation Engine**: Matches disparate data sources based on configurable heuristic rules.
-- **Receipt Parsing**: Uses a specialized OCR model tuned for financial documents (receipts, invoices).
-- **Convert**: A deterministic math library for currency and unit conversion, avoiding floating-point errors.
+## What you can run today
 
-### Tech Stack
-- Node.js / TypeScript
-- PostgreSQL (Ledger)
-- Redis (Queue)
-- Edge Functions (Latency-sensitive ops)
+```bash
+pnpm install
+pnpm demo
+pnpm settler:replay examples/demo-output/evidence.json
+```
 
-We're looking for feedback on the SDK design and the reconciliation rules engine. Let us know what you think!
+The demo generates:
+
+- `examples/demo-output/run.json`
+- `examples/demo-output/results.json`
+- `examples/demo-output/evidence.json`
+- `examples/demo-output/report.html`
+
+## Useful entry points
+
+- `ARCHITECTURE.md`
+- `docs/launch/QUICK_START.md`
+- `docs/launch/EXAMPLE_WORKFLOWS.md`
+- `CONTRIBUTING.md`
+
+If you build data/recon pipelines, we'd appreciate feedback on the determinism + replay model and where it breaks down.

--- a/launch/twitter-thread.md
+++ b/launch/twitter-thread.md
@@ -1,39 +1,29 @@
-1/ Building fintech? You're probably wasting 30% of your eng time on reconciliation.
+1/ We open sourced Settler: deterministic reconciliation workflows with replayable proof artifacts.
 
-We fixed it.
+2/ Problem: many reconciliation systems start as scripts + cron. Later, outcomes drift and post-incident debugging turns into guesswork.
 
-Introducing Settler.dev – The API Infrastructure for Financial Evidence. 🧵👇
+3/ Settler's model is explicit:
 
-2/ Every financial app needs to prove its numbers are correct. This means matching internal DB records with external payment gateways (Stripe, PayPal, Banks).
+- deterministic run execution
+- policy checks in-path
+- generated evidence (`run.json`, `results.json`, `evidence.json`)
+- replay verification against fingerprints
 
-Doing this manually is a nightmare. Building it yourself is a distraction.
+4/ Try it locally:
 
-3/ Settler provides a clean, typed API to handle:
-✅ Multi-way Reconciliation (N-way matching)
-✅ Receipt Parsing (OCR -> JSON)
-✅ Deterministic Currency Conversion
-✅ Financial Feature Flags
+```bash
+pnpm install
+pnpm demo
+pnpm settler:replay examples/demo-output/evidence.json
+```
 
-4/ 🧾 Receipts API
-Stop writing regex for receipts. Send us the file, we return structured data.
-- Vendor Name
-- Tax Line Items
-- Currency detection
-- 99.8% Accuracy
+5/ The demo writes concrete artifacts under `examples/demo-output/`, including an HTML report and replayable evidence.
 
-5/ 🔄 Reconciliation API
-Define rules like:
-"Match if OrderID matches EXACTLY AND Amount is within $0.05"
+6/ Repo entry points:
 
-We handle the conflict resolution, reporting, and audit trail.
+- `ARCHITECTURE.md`
+- `docs/launch/QUICK_START.md`
+- `docs/launch/EXAMPLE_WORKFLOWS.md`
+- `CONTRIBUTING.md`
 
-6/ 🏗️ Developer Experience First
-We built the SDKs we wanted to use.
-- Fully typed (TypeScript, Go, Python)
-- Local dev sandbox
-- Interactive playground
-
-7/ We're live today.
-Get your API key and stop worrying about financial correctness.
-
-👉 https://settler.dev
+7/ We'd value feedback from engineers running high-integrity data pipelines: where does deterministic replay help most in your stack?

--- a/launch/workflow-artifacts.md
+++ b/launch/workflow-artifacts.md
@@ -1,0 +1,33 @@
+# Example Workflow Output + Proof Artifact
+
+## Generated output (`examples/demo-output/results.json`)
+
+```json
+{
+  "output": {
+    "matches": 2,
+    "mismatches": 0,
+    "reviewQueue": 0
+  }
+}
+```
+
+## Generated proof (`examples/demo-output/evidence.json`)
+
+```json
+{
+  "run_id": "demo-run-1",
+  "policy_id": "demo.strict",
+  "run_fingerprint": "48c781e97fd3557ea0722087a34c3098579d9bef56d76f41c5f96c46199631b5",
+  "metadata": {
+    "replay_required": true,
+    "evidence_level": "full"
+  }
+}
+```
+
+## Replay command
+
+```bash
+pnpm settler:replay examples/demo-output/evidence.json
+```


### PR DESCRIPTION
### Motivation

- Improve first-impression clarity so engineers understand what Settler does in seconds and can get a working demo running quickly.  
- Provide a minimal, reproducible Quick Start and example workflows that demonstrate real value (determinism, evidence, replay).  
- Harden launch artifacts and contributor onboarding to boost OSS credibility and lower the time-to-first-contribution.

### Description

- Rewrote the repository top-level README to lead with a one-line positioning, a short problem statement, three concrete capabilities, a short usage example, and a time-to-first-value quick start (`README.md`).
- Added a focused Quick Start for launch-oriented developer verification at `docs/launch/QUICK_START.md` and reproducible example workflow docs at `docs/launch/EXAMPLE_WORKFLOWS.md`.
- Updated `ARCHITECTURE.md` to include a clear Mermaid runtime diagram and tightened the determinism contract and runtime flow language.
- Extended `CONTRIBUTING.md` with a minimal connector contribution path, deterministic test guidance, and notes about verifying launch assets.
- Added/rewrote launch copy and artifacts under `launch/` (`hn.md`, `reddit.md`, `ph.md`, `twitter-thread.md`, `launch-summary.md`, `workflow-artifacts.md`) and updated `launch/assets-manifest.json` with new SHA256 entries for integrity verification.

### Testing

- Ran `pnpm demo` and the demo completed with a run fingerprint and reported `Replay Verified: OK`. (success)
- Ran `pnpm settler:replay examples/demo-output/evidence.json` and the replay verification returned `Replay Verified: OK`. (success)
- Ran `pnpm settler:replay examples/demo-output-fixtures/demo-run-1/evidence.json` against the frozen fixture and it returned `Replay Verified: OK`. (success)
- Ran `pnpm run verify:launch-assets` to validate `launch/assets-manifest.json` hashes and it reported verified assets. (success)
- Ran `pnpm run verify:fast` as a lightweight repo check; it completed lint/typecheck/build steps but reported a pre-existing `root-cleanliness` failure due to unrelated root entries in the repository, and the full build segment was interrupted by environment constraints; this is a pre-existing baseline issue, not caused by these documentation changes. (warning)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac259516bc83288b9528a547aa5b20)