### PR TITLE
Harden security audit policy, add tenant runtime cross-tenant tests, and tier pre-commit hooks

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -12,6 +12,11 @@ on:
         description: Optional externally hosted URL for launch capture
         required: false
         type: string
+      allow_audit_soft_skip:
+        description: Allow release to continue when registry audit endpoint is unavailable
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   verify-fast:
@@ -53,7 +58,9 @@ jobs:
       - name: Dependency CVE scan + SBOM generation
         env:
           SECURITY_AUDIT_FAIL_LEVEL: high
-          SECURITY_AUDIT_ALLOW_UNAVAILABLE: "1"
+          SECURITY_AUDIT_CONTEXT: release
+          SECURITY_AUDIT_ALLOW_UNAVAILABLE: ${{ github.event.inputs.allow_audit_soft_skip == 'true' && '1' || '0' }}
+          SECURITY_AUDIT_ALLOW_UNAVAILABLE_ON_RELEASE: ${{ github.event.inputs.allow_audit_soft_skip == 'true' && '1' || '0' }}
         run: pnpm run verify:security:supply-chain
       - name: Upload supply-chain evidence
         if: always()
@@ -88,7 +95,7 @@ jobs:
       - name: Run release verification
         env:
           RELEASE_REQUIRE_SECURITY_EVIDENCE: "1"
-          RELEASE_ALLOW_AUDIT_UNAVAILABLE: "1"
+          RELEASE_ALLOW_AUDIT_UNAVAILABLE: ${{ github.event.inputs.allow_audit_soft_skip == 'true' && '1' || '0' }}
           LAUNCH_CAPTURE_BASE_URL: ${{ github.event.inputs.capture_base_url || 'http://127.0.0.1:3000' }}
         run: pnpm run verify:release -- --run-id=ci-release-${{ github.run_id }}
       - name: Upload release verification evidence

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Keep pre-commit low-memory and staged-aware.
+# Full verification remains in pre-push/CI.
+
 # Verify migrations before commit
 if git diff --cached --name-only | grep -q "supabase/migrations/"; then
   echo "🔍 Migration files detected, running verification..."
@@ -17,41 +20,22 @@ if git diff --cached --name-only | grep -q "prisma/schema.prisma"; then
   git add src/types/ 2>/dev/null || true
 fi
 
-# Validate ESLint config dependencies before linting
-echo "🔍 Validating ESLint config dependencies..."
-pnpm validate:eslint-config || {
-  echo "❌ ESLint config dependency issues found. Please fix them before committing."
-  exit 1
-}
-
-# Validate build safety
-echo "🔍 Validating build safety..."
-pnpm validate:build-safety || {
-  echo "❌ Build safety issues found. Please fix them before committing."
-  exit 1
-}
-
-# Validate lint configuration
-echo "🔍 Validating lint configuration..."
-pnpm validate:lint-config || {
-  echo "❌ Lint configuration issues found. Please fix them before committing."
-  exit 1
-}
-
 # Block unresolved merge conflict markers
 pnpm verify:conflict-markers || {
   echo "❌ Unresolved merge conflict markers detected. Please resolve them before committing."
   exit 1
 }
 
-# Run staged-package verification for local reliability
-echo "🔍 Running staged-package verification..."
-pnpm lint-staged || {
+# Stage-scoped lint/format, sequential to reduce memory spikes on constrained machines.
+echo "🔍 Running lint-staged (sequential, low-memory mode)..."
+pnpm lint-staged --concurrent false || {
   echo "❌ lint-staged failed. Please fix errors before committing."
   exit 1
 }
 
-node scripts/verify-staged-packages.mjs || {
-  echo "❌ Staged package verification failed. Please fix errors before committing."
+# Package-scoped quick reliability checks only (lint + config safety), no full typecheck/test here.
+node scripts/verify-staged-packages.mjs --tier=precommit || {
+  echo "❌ Pre-commit staged verification failed."
+  echo "💡 Run 'pnpm run verify:fast' before push for full local confidence."
   exit 1
 }

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,5 +4,9 @@
 echo "🔍 Checking for unresolved merge conflicts..."
 pnpm verify:conflict-markers || exit 1
 
-echo "🔍 Running fast verification gate..."
-pnpm verify:fast
+echo "🔍 Running broader pre-push verification gate..."
+pnpm verify:fast || {
+  echo "❌ pre-push verification failed."
+  echo "💡 For full release parity run: pnpm run verify:release"
+  exit 1
+}

--- a/docs/release/VERIFICATION.md
+++ b/docs/release/VERIFICATION.md
@@ -1,6 +1,16 @@
 # Release Verification Pipeline
 
-This repository uses a staged verification runner (`scripts/verify-release.mjs`) with bounded timeouts, per-stage logs, and machine-readable summaries.
+This repository uses a staged verification runner (`scripts/verify-release.mjs`) with bounded timeouts, per-stage logs, machine-readable summaries, and explicit security state carry-through.
+
+## Verification tiers
+
+| Tier       | Command                   | Scope                                                                                              | Goal                                                           |
+| ---------- | ------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| pre-commit | `.husky/pre-commit`       | staged lint/format + conflict marker + staged package lint only                                    | fast, low-memory, catches obvious local regressions            |
+| pre-push   | `.husky/pre-push`         | `verify:fast` (lint/typecheck/claims/boundaries/routes/security static checks)                     | broader local confidence without full release runtime workload |
+| CI/release | `pnpm run verify:release` | full staged pipeline including build, runtime smoke, tests, launch evidence, and security evidence | release integrity and auditable proof                          |
+
+If pre-commit fails due local constraints, run `pnpm run verify:fast` manually before push; do not normalize `--no-verify`.
 
 ## Command matrix
 
@@ -33,6 +43,18 @@ This repository uses a staged verification runner (`scripts/verify-release.mjs`)
 
 On first failure, the runner stops and emits stage-specific logs.
 
+## Security audit policy in release
+
+Supply-chain evidence includes an explicit audit state (`pass`, `fail`, `unavailable-hard`, `unavailable-soft`, `misconfigured`).
+
+Release behavior:
+
+- `pass` → release gate can proceed.
+- `fail` → release gate fails.
+- `unavailable-hard` → release gate fails.
+- `unavailable-soft` → release gate fails unless `RELEASE_ALLOW_AUDIT_UNAVAILABLE=1` is explicitly set.
+- `misconfigured` → release gate fails; fix auth/config, do not treat as environmental unavailability.
+
 ## Evidence artifacts
 
 Every run writes:
@@ -57,7 +79,8 @@ Use the `release-verify` workflow:
 
 - `verify-fast` runs fast static gates.
 - `security-supply-chain` runs dependency CVE scan + SBOM generation and uploads artifacts.
-- `verify-release` downloads those security artifacts and enforces `RELEASE_REQUIRE_SECURITY_EVIDENCE=1` (with optional `RELEASE_ALLOW_AUDIT_UNAVAILABLE=1` policy override when registry audit endpoint is unavailable).
+- `verify-release` downloads those security artifacts and enforces `RELEASE_REQUIRE_SECURITY_EVIDENCE=1`.
+- Release soft-skip requires explicit workflow input (`allow_audit_soft_skip=true`).
 
 ## Threat model
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -14,7 +14,7 @@
 
 - **Static/config verification (`pnpm run verify:security`)**
   - Verifies control and guardrail presence in high-risk files/routes.
-  - Includes tenant-isolation guardrail checks for selected routes.
+  - Includes tenant-isolation guardrail presence checks for selected routes (static signal only).
   - Does **not** prove exploit resistance or full runtime isolation.
 - **Runtime smoke verification (`pnpm run verify:security:runtime`)**
   - Starts/targets a real HTTP app instance and probes security headers, limiter behavior, and negative auth/tenant cases.
@@ -30,3 +30,11 @@
 - **Available now:** deterministic runs, evidence exports, operator review workflow, baseline auditability.
 - **Designed for:** deeper enterprise governance and broader controls-plane expansion.
 - **Future/experimental:** clearly marked in roadmap docs; do not present as shipped.
+
+## Verification tiering
+
+- **Pre-commit:** staged, low-memory checks only (format/lint + staged package lint guard).
+- **Pre-push:** `verify:fast` for broader local confidence.
+- **CI/Release:** `verify:release` + supply-chain evidence policy enforcement.
+
+See `docs/release/VERIFICATION.md` and `docs/security/VERIFICATION_SURFACES.md` for exact policy semantics.

--- a/docs/security/VERIFICATION_SURFACES.md
+++ b/docs/security/VERIFICATION_SURFACES.md
@@ -11,26 +11,31 @@ What it proves:
 - Required security control hooks are still present (headers, limiter hooks, middleware wiring).
 - Tenant-isolation guardrails are present on selected high-risk routes.
 - Production limiter backend configuration risk is surfaced (warning or failure, depending on policy).
+- Reports runtime tenant-coverage status if runtime artifacts exist.
 
 What it does **not** prove:
 
 - Runtime exploitability.
-- End-to-end tenant isolation under real credentials and data fixtures.
+- Full end-to-end tenant isolation under real credentials and fixtures by itself.
 - End-to-end distributed limiter behavior across multiple instances.
 
-## 2) Runtime security smoke
+## 2) Runtime security smoke + fixture-based tenant checks
 
-**Command:** `pnpm run verify:security:runtime`
+**Commands:**
 
-What it probes (live HTTP):
+- `pnpm run verify:security:runtime`
+- `pnpm --filter @settler/web exec jest src/__tests__/api/tenant-runtime-cross-tenant.test.ts --runInBand`
+
+What they probe (live/runtime behavior):
 
 - Security headers on `/api/v1/health`.
 - Rate-limit activation semantics on `/api/v1/receipts` with repeated requests.
 - Negative auth/tenant boundary on `/api/v1/runs` (expects unauthenticated denial).
+- Cross-tenant denial on high-risk run endpoints (direct read, list non-enumerability, results/evidence access).
 
 Behavior details:
 
-- Can launch a local server (if built) or target `--baseUrl` / `SECURITY_SMOKE_BASE_URL`.
+- Runtime smoke can launch a local server (if built) or target `--baseUrl` / `SECURITY_SMOKE_BASE_URL`.
 - Produces machine-readable output at `artifacts/security/runtime-smoke/<run-id>/summary.json`.
 - Uses `passed` / `failed` / `skipped` with explicit reasons (e.g., missing build, route missing, assertion failed).
 
@@ -38,30 +43,37 @@ Behavior details:
 
 **Command:** `pnpm run verify:security:supply-chain`
 
-What it does:
+Policy state model:
 
-- Runs dependency CVE scanning with `pnpm audit --json`.
-- Fails on vulnerabilities at or above `SECURITY_AUDIT_FAIL_LEVEL` (default: `high`).
-- If the registry audit endpoint is unavailable, run can soft-skip only when `SECURITY_AUDIT_ALLOW_UNAVAILABLE=1` (reason is recorded in summary).
-- Generates SBOM outputs in:
-  - CycloneDX (`sbom.cyclonedx.json`)
-  - SPDX (`sbom.spdx.json`)
+- `pass`: audit executed and met threshold.
+- `fail`: audit executed and exceeded threshold.
+- `unavailable-hard`: audit unavailable and policy forbids soft skip.
+- `unavailable-soft`: audit unavailable and explicit soft-skip policy is enabled.
+- `misconfigured`: local auth/config issue (e.g., missing token) prevented audit and cannot be soft-skipped as availability.
+
+Operational controls:
+
+- `SECURITY_AUDIT_FAIL_LEVEL` controls fail threshold (default `high`).
+- `SECURITY_AUDIT_ALLOW_UNAVAILABLE=1` permits soft-skip in non-release contexts.
+- `SECURITY_AUDIT_CONTEXT=release` + `SECURITY_AUDIT_ALLOW_UNAVAILABLE_ON_RELEASE=1` is required for release-context soft-skip.
+- Unavailability reason is explicitly classified (`endpoint_403`, `missing_auth`, `network_error`, `timeout`, `unsupported_environment`, `malformed_response`).
 
 Artifacts:
 
 - `artifacts/security/supply-chain/<run-id>/summary.json`
 - `artifacts/security/supply-chain/<run-id>/audit.json`
-- SBOM files listed above
+- `artifacts/security/supply-chain/<run-id>/sbom.cyclonedx.json`
+- `artifacts/security/supply-chain/<run-id>/sbom.spdx.json`
 
 ## 4) Release integration
 
-`verify:release` now validates security evidence via `verify:security:evidence`.
+`verify:release` validates security evidence via `verify:security:evidence` and carries forward audit state in verification summaries.
 
 In CI (`release-verify` workflow):
 
 - `security-supply-chain` job produces security artifacts.
 - `verify-release` job downloads those artifacts and runs with `RELEASE_REQUIRE_SECURITY_EVIDENCE=1`.
-- Release verification fails if supply-chain evidence is missing/invalid.
+- Soft-skip in release requires explicit workflow input (`allow_audit_soft_skip=true`); otherwise unavailable audit fails release.
 
 ## Redis-backed limiter guidance (production)
 

--- a/package.json
+++ b/package.json
@@ -220,7 +220,8 @@
     "verify:release": "node scripts/verify-release.mjs --profile=full",
     "capture:launch": "node scripts/capture-launch-assets.mjs --mode=auto",
     "capture:launch:primary": "node scripts/capture-launch-assets.mjs --mode=primary",
-    "capture:launch:fallback": "node scripts/capture-launch-assets.mjs --mode=fallback"
+    "capture:launch:fallback": "node scripts/capture-launch-assets.mjs --mode=fallback",
+    "test:security:supply-chain-policy": "node --test scripts/__tests__/supply-chain-policy.test.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/web/src/__tests__/api/tenant-runtime-cross-tenant.test.ts
+++ b/packages/web/src/__tests__/api/tenant-runtime-cross-tenant.test.ts
@@ -1,0 +1,161 @@
+/** @jest-environment node */
+
+import { GET as getRuns } from "@/app/api/v1/runs/route";
+import { GET as getRunById } from "@/app/api/v1/runs/[id]/route";
+import { GET as getRunResults } from "@/app/api/v1/runs/[id]/results/route";
+import { GET as getRunEvidence } from "@/app/api/v1/runs/[id]/evidence/route";
+
+const authByKey: Record<string, { userId: string; tenantId?: string }> = {
+  rk_tenant_a: { userId: "user-a", tenantId: "tenant-a" },
+  rk_tenant_b: { userId: "user-b", tenantId: "tenant-b" },
+  rk_missing_tenant: { userId: "user-no-tenant" },
+};
+
+const fixtureRuns = [
+  {
+    id: "run-tenant-a-1",
+    tenantId: "tenant-a",
+    status: "completed",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    sourceAdapter: "source-a",
+    targetAdapter: "target-a",
+    deletedAt: null,
+  },
+  {
+    id: "run-tenant-b-1",
+    tenantId: "tenant-b",
+    status: "queued",
+    createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    sourceAdapter: "source-b",
+    targetAdapter: "target-b",
+    deletedAt: null,
+  },
+];
+
+const fixtureResults = [
+  {
+    reconJobId: "run-tenant-a-1",
+    tenantId: "tenant-a",
+    status: "succeeded",
+    summary: { matched: 10 },
+    matchedCount: 10,
+    unmatchedSourceCount: 0,
+    unmatchedTargetCount: 0,
+    metadata: { fingerprint: "fp-a" },
+    proofCapsule: { root: "proof-a" },
+    startedAt: new Date("2026-01-01T01:00:00.000Z"),
+  },
+  {
+    reconJobId: "run-tenant-b-1",
+    tenantId: "tenant-b",
+    status: "failed",
+    summary: { matched: 1 },
+    matchedCount: 1,
+    unmatchedSourceCount: 2,
+    unmatchedTargetCount: 3,
+    metadata: { fingerprint: "fp-b" },
+    proofCapsule: { root: "proof-b" },
+    startedAt: new Date("2026-01-02T01:00:00.000Z"),
+  },
+];
+
+jest.mock("@/shared/auth/apiKey", () => ({
+  authenticateApiKey: jest.fn(
+    async (request: { headers: { get: (name: string) => string | null } }) => {
+      const key = request.headers.get("x-api-key");
+      return key ? authByKey[key] || null : null;
+    }
+  ),
+}));
+
+jest.mock("@/shared/db/prismaClient", () => ({
+  prisma: {
+    reconJob: {
+      findMany: jest.fn(async ({ where }: { where: { tenantId?: string; status?: string } }) =>
+        fixtureRuns.filter(
+          (run) =>
+            run.tenantId === where.tenantId && (where.status ? run.status === where.status : true)
+        )
+      ),
+      findFirst: jest.fn(
+        async ({ where }: { where: { id: string; tenantId: string; deletedAt: null } }) =>
+          fixtureRuns.find(
+            (run) =>
+              run.id === where.id &&
+              run.tenantId === where.tenantId &&
+              run.deletedAt === where.deletedAt
+          ) || null
+      ),
+    },
+    reconResult: {
+      findFirst: jest.fn(
+        async ({ where }: { where: { reconJobId: string; tenantId: string } }) =>
+          fixtureResults.find(
+            (result) => result.reconJobId === where.reconJobId && result.tenantId === where.tenantId
+          ) || null
+      ),
+    },
+    $executeRaw: jest.fn(async () => 1),
+  },
+}));
+
+jest.mock("@/lib/trust-graph/explorer", () => ({
+  getExecutionGraph: jest.fn(() => ({ graphHash: "graph-hash" })),
+  verifyProofChain: jest.fn(() => ({ proofNodeRefs: ["node-a", "node-b"] })),
+}));
+
+function req(url: string, apiKey?: string) {
+  const headers = new Headers();
+  if (apiKey) headers.set("x-api-key", apiKey);
+  return {
+    headers,
+    nextUrl: new URL(url),
+  } as any;
+}
+
+describe("tenant runtime cross-tenant denial", () => {
+  it("returns only caller tenant runs for list endpoint", async () => {
+    const response = await getRuns(req("http://localhost/api/v1/runs", "rk_tenant_b"));
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload.rows).toHaveLength(1);
+    expect(payload.rows[0].run_id).toBe("run-tenant-b-1");
+    expect(payload.rows[0].run_id).not.toBe("run-tenant-a-1");
+  });
+
+  it("denies direct cross-tenant reads by id and avoids leaking foreign metadata", async () => {
+    const directResponse = await getRunById(
+      req("http://localhost/api/v1/runs/run-tenant-a-1", "rk_tenant_b"),
+      {
+        params: Promise.resolve({ id: "run-tenant-a-1" }),
+      }
+    );
+    expect(directResponse.status).toBe(404);
+    const payload = await directResponse.json();
+    expect(payload.code).toBe("SETTLER_NOT_FOUND");
+    expect(JSON.stringify(payload)).not.toContain("tenant-a");
+
+    const resultsResponse = await getRunResults(
+      req("http://localhost/api/v1/runs/run-tenant-a-1/results", "rk_tenant_b"),
+      { params: Promise.resolve({ id: "run-tenant-a-1" }) }
+    );
+    expect(resultsResponse.status).toBe(404);
+
+    const evidenceResponse = await getRunEvidence(
+      req("http://localhost/api/v1/runs/run-tenant-a-1/evidence", "rk_tenant_b"),
+      { params: Promise.resolve({ id: "run-tenant-a-1" }) }
+    );
+    expect(evidenceResponse.status).toBe(404);
+  });
+
+  it("denies requests with missing tenant context", async () => {
+    const missingTenant = await getRuns(req("http://localhost/api/v1/runs", "rk_missing_tenant"));
+    expect(missingTenant.status).toBe(401);
+    const payload = await missingTenant.json();
+    expect(payload.code).toBe("SETTLER_AUTH_REQUIRED");
+
+    const unauthenticated = await getRuns(req("http://localhost/api/v1/runs"));
+    expect(unauthenticated.status).toBe(401);
+  });
+});

--- a/scripts/__tests__/supply-chain-policy.test.mjs
+++ b/scripts/__tests__/supply-chain-policy.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  AUDIT_STATES,
+  classifyAuditUnavailability,
+  resolveAuditState,
+} from "../security/supply-chain-policy.mjs";
+
+test("classifyAuditUnavailability distinguishes endpoint_403", () => {
+  const result = classifyAuditUnavailability("ERR_PNPM_AUDIT_BAD_RESPONSE statusCode: 403");
+  assert.equal(result.category, "endpoint_403");
+});
+
+test("classifyAuditUnavailability marks missing_auth", () => {
+  const result = classifyAuditUnavailability("ERR_PNPM_FETCH_401 No authorization header was set");
+  assert.equal(result.category, "missing_auth");
+});
+
+test("resolveAuditState selects unavailable-soft only when explicitly allowed", () => {
+  const soft = resolveAuditState({
+    auditUnavailable: true,
+    allowUnavailable: true,
+    misconfigured: false,
+    thresholdFailures: 0,
+  });
+  assert.equal(soft, AUDIT_STATES.UNAVAILABLE_SOFT);
+
+  const hard = resolveAuditState({
+    auditUnavailable: true,
+    allowUnavailable: false,
+    misconfigured: false,
+    thresholdFailures: 0,
+  });
+  assert.equal(hard, AUDIT_STATES.UNAVAILABLE_HARD);
+});
+
+test("resolveAuditState never downgrades misconfiguration", () => {
+  const result = resolveAuditState({
+    auditUnavailable: true,
+    allowUnavailable: true,
+    misconfigured: true,
+    thresholdFailures: 0,
+  });
+  assert.equal(result, AUDIT_STATES.MISCONFIGURED);
+});

--- a/scripts/security/supply-chain-policy.mjs
+++ b/scripts/security/supply-chain-policy.mjs
@@ -1,0 +1,75 @@
+const AUDIT_STATES = {
+  PASS: "pass",
+  FAIL: "fail",
+  UNAVAILABLE_HARD: "unavailable-hard",
+  UNAVAILABLE_SOFT: "unavailable-soft",
+  MISCONFIGURED: "misconfigured",
+};
+
+export { AUDIT_STATES };
+
+export function classifyAuditUnavailability(rawOutput, { timedOut = false } = {}) {
+  const text = String(rawOutput || "");
+
+  if (timedOut) {
+    return { category: "timeout", detail: "pnpm audit timed out" };
+  }
+
+  if (
+    text.includes("ERR_PNPM_AUDIT_BAD_RESPONSE") &&
+    (text.includes("statusCode: 403") || text.includes("403"))
+  ) {
+    return { category: "endpoint_403", detail: "registry audit endpoint returned HTTP 403" };
+  }
+
+  if (
+    text.includes("ERR_PNPM_FETCH_401") ||
+    text.includes("ENEEDAUTH") ||
+    text.includes("No authorization header was set")
+  ) {
+    return { category: "missing_auth", detail: "registry credentials are missing or invalid" };
+  }
+
+  if (
+    text.includes("ETIMEDOUT") ||
+    text.includes("ECONNREFUSED") ||
+    text.includes("ENOTFOUND") ||
+    text.includes("network")
+  ) {
+    return { category: "network_error", detail: "network error while contacting registry" };
+  }
+
+  if (text.includes("not supported") || text.includes("unsupported")) {
+    return {
+      category: "unsupported_environment",
+      detail: "audit is unsupported in this environment",
+    };
+  }
+
+  if (text.trim().length === 0) {
+    return { category: "malformed_response", detail: "empty audit output" };
+  }
+
+  return { category: "malformed_response", detail: "audit output was not parseable JSON" };
+}
+
+export function resolveAuditState({
+  auditUnavailable,
+  allowUnavailable,
+  misconfigured,
+  thresholdFailures,
+}) {
+  if (misconfigured) {
+    return AUDIT_STATES.MISCONFIGURED;
+  }
+
+  if (!auditUnavailable && thresholdFailures > 0) {
+    return AUDIT_STATES.FAIL;
+  }
+
+  if (!auditUnavailable) {
+    return AUDIT_STATES.PASS;
+  }
+
+  return allowUnavailable ? AUDIT_STATES.UNAVAILABLE_SOFT : AUDIT_STATES.UNAVAILABLE_HARD;
+}

--- a/scripts/security/supply-chain.mjs
+++ b/scripts/security/supply-chain.mjs
@@ -3,6 +3,11 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
+import {
+  AUDIT_STATES,
+  classifyAuditUnavailability,
+  resolveAuditState,
+} from "./supply-chain-policy.mjs";
 
 const repoRoot = process.cwd();
 const runId = process.env.GITHUB_RUN_ID || new Date().toISOString().replace(/[:.]/g, "-");
@@ -19,6 +24,17 @@ function run(cmd, args, options = {}) {
     });
     let stdout = "";
     let stderr = "";
+    let timedOut = false;
+
+    const timeoutMs = options.timeoutMs || 0;
+    let timer = null;
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      }, timeoutMs);
+    }
+
     child.stdout.on("data", (chunk) => {
       const text = chunk.toString();
       if (options.logOutput !== false) process.stdout.write(text);
@@ -29,12 +45,20 @@ function run(cmd, args, options = {}) {
       if (options.logOutput !== false) process.stderr.write(text);
       stderr += text;
     });
-    child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
+    child.on("close", (code) => {
+      if (timer) clearTimeout(timer);
+      resolve({ code: code ?? 1, stdout, stderr, timedOut });
+    });
   });
 }
 
 function parseAudit(raw) {
   const parsed = JSON.parse(raw);
+  if (parsed?.error) {
+    throw new Error(
+      `pnpm_audit_error:${parsed.error.code || "unknown"}:${parsed.error.message || ""}`
+    );
+  }
   const vulnerabilities = parsed.metadata?.vulnerabilities || {};
   return {
     vulnerabilities,
@@ -118,33 +142,30 @@ function buildSpdx(packages) {
 async function main() {
   const severityThreshold = process.env.SECURITY_AUDIT_FAIL_LEVEL || "high";
   const allowAuditUnavailable = process.env.SECURITY_AUDIT_ALLOW_UNAVAILABLE === "1";
+  const allowUnavailableOnRelease = process.env.SECURITY_AUDIT_ALLOW_UNAVAILABLE_ON_RELEASE === "1";
+  const verificationContext = process.env.SECURITY_AUDIT_CONTEXT || "local";
+  const isReleaseContext = verificationContext === "release";
+  const strictSoftSkipInRelease = isReleaseContext && !allowUnavailableOnRelease;
   const severityOrder = ["info", "low", "moderate", "high", "critical"];
   const thresholdIndex = severityOrder.indexOf(severityThreshold);
-  if (thresholdIndex === -1)
+  if (thresholdIndex === -1) {
     throw new Error(`Unsupported SECURITY_AUDIT_FAIL_LEVEL='${severityThreshold}'`);
+  }
 
-  const auditRun = await run("pnpm", ["audit", "--json"]);
+  const auditRun = await run("pnpm", ["audit", "--json"], { timeoutMs: 90_000 });
   const auditRaw = auditRun.stdout || auditRun.stderr;
   const auditPath = path.join(outputDir, "audit.json");
   writeFileSync(auditPath, auditRaw, "utf8");
 
   let auditSummary = null;
-  let auditUnavailableReason = null;
+  let unavailable = null;
+  let misconfigured = false;
 
   try {
     auditSummary = parseAudit(auditRaw);
   } catch {
-    if (auditRaw.includes("ERR_PNPM_AUDIT_BAD_RESPONSE") || auditRaw.includes("403")) {
-      auditUnavailableReason = "registry_audit_endpoint_forbidden";
-    } else {
-      throw new Error("Unable to parse pnpm audit output as JSON.");
-    }
-  }
-
-  if (auditUnavailableReason && !allowAuditUnavailable) {
-    throw new Error(
-      `Dependency audit unavailable (${auditUnavailableReason}). Set SECURITY_AUDIT_ALLOW_UNAVAILABLE=1 to soft-skip.`
-    );
+    unavailable = classifyAuditUnavailability(auditRaw, { timedOut: auditRun.timedOut });
+    misconfigured = unavailable.category === "missing_auth";
   }
 
   const depTreeRun = await run("pnpm", ["list", "--json", "--depth", "99"], { logOutput: false });
@@ -170,11 +191,27 @@ async function main() {
     }
   }
 
+  const effectiveAllowUnavailable = allowAuditUnavailable && !strictSoftSkipInRelease;
+  const auditState = resolveAuditState({
+    auditUnavailable: Boolean(unavailable),
+    allowUnavailable: effectiveAllowUnavailable,
+    misconfigured,
+    thresholdFailures,
+  });
+
   const summary = {
     generatedAt: new Date().toISOString(),
     runId,
+    verificationContext,
     failLevel: severityThreshold,
-    auditUnavailableReason,
+    audit: {
+      state: auditState,
+      unavailableCategory: unavailable?.category || null,
+      unavailableDetail: unavailable?.detail || null,
+      softSkipAllowed: allowAuditUnavailable,
+      softSkipAllowedOnRelease: allowUnavailableOnRelease,
+      softSkipBlockedByReleasePolicy: strictSoftSkipInRelease,
+    },
     vulnerabilities: auditSummary?.totals || null,
     thresholdBreakdown,
     thresholdFailures,
@@ -199,16 +236,26 @@ async function main() {
   );
 
   console.log(`Supply-chain report: ${path.relative(repoRoot, summaryPath)}`);
+  console.log(`Supply-chain audit state: ${auditState}`);
 
-  if (!auditUnavailableReason && thresholdFailures > 0) {
+  if (auditState === AUDIT_STATES.UNAVAILABLE_SOFT) {
+    console.warn(
+      `⚠️ SECURITY_SOFT_SKIP state=unavailable-soft category=${unavailable?.category} detail=${unavailable?.detail}`
+    );
+  }
+
+  if (auditState === AUDIT_STATES.FAIL) {
     console.error(
       `Dependency vulnerabilities at/above '${severityThreshold}': ${thresholdFailures}.`
     );
     process.exit(1);
   }
 
-  if (auditUnavailableReason) {
-    console.warn(`⚠️ Dependency audit soft-skipped (${auditUnavailableReason}).`);
+  if (auditState === AUDIT_STATES.UNAVAILABLE_HARD || auditState === AUDIT_STATES.MISCONFIGURED) {
+    console.error(
+      `Dependency audit blocked state=${auditState} category=${unavailable?.category} detail=${unavailable?.detail}`
+    );
+    process.exit(1);
   }
 }
 

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 
@@ -178,15 +178,48 @@ async function runStage(stageName, runDir) {
   };
 }
 
+function readJsonIfExists(relPath) {
+  try {
+    return JSON.parse(readFileSync(path.join(repoRoot, relPath), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function collectVerificationSignals() {
+  const supplyChain = readJsonIfExists("artifacts/security/supply-chain-latest.json");
+  const runtimeSmoke = readJsonIfExists("artifacts/security/runtime-smoke-latest.json");
+  const staticSecurity = readJsonIfExists("artifacts/security/verify-security-summary.json");
+
+  return {
+    supplyChainAuditState: supplyChain?.audit?.state || "unknown",
+    supplyChainUnavailableCategory: supplyChain?.audit?.unavailableCategory || null,
+    tenantGuardrailStaticStatus:
+      Array.isArray(staticSecurity?.tenantGuardrailPresence) &&
+      staticSecurity.tenantGuardrailPresence.every((x) => x.status === "guardrail_present")
+        ? "pass"
+        : "incomplete",
+    tenantRuntimeCoverageStatus:
+      Array.isArray(runtimeSmoke?.checks) &&
+      runtimeSmoke.checks.some(
+        (x) => x.name === "auth_tenant_boundary_negative" && x.status === "passed"
+      )
+        ? "pass"
+        : "incomplete",
+  };
+}
+
 function emitSummary(args, results, runDir) {
   const completedAt = new Date().toISOString();
   const passed = results.every((item) => item.status === "passed");
+  const signals = collectVerificationSignals();
   const summary = {
     profile: args.profile,
     stageFilter: args.stage,
     runId: args.runId,
     completedAt,
     passed,
+    signals,
     results,
   };
 
@@ -200,6 +233,10 @@ function emitSummary(args, results, runDir) {
     `- Profile: ${args.profile}`,
     `- Passed: ${passed ? "yes" : "no"}`,
     `- Completed at: ${completedAt}`,
+    `- Supply-chain audit state: ${signals.supplyChainAuditState}`,
+    `- Supply-chain unavailable category: ${signals.supplyChainUnavailableCategory || "n/a"}`,
+    `- Tenant guardrail static status: ${signals.tenantGuardrailStaticStatus}`,
+    `- Tenant runtime coverage status: ${signals.tenantRuntimeCoverageStatus}`,
     "",
     "| Stage | Status | Duration (s) | Timeout (s) | Log |",
     "|---|---|---:|---:|---|",

--- a/scripts/verify-security-evidence.mjs
+++ b/scripts/verify-security-evidence.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 
 const repoRoot = process.cwd();
 const strict = process.env.RELEASE_REQUIRE_SECURITY_EVIDENCE === "1";
-const allowAuditUnavailable = process.env.RELEASE_ALLOW_AUDIT_UNAVAILABLE === "1";
+const allowUnavailableSoft = process.env.RELEASE_ALLOW_AUDIT_UNAVAILABLE === "1";
 const summaryFile =
   process.env.SECURITY_EVIDENCE_SUMMARY || "artifacts/security/supply-chain-latest.json";
 
@@ -15,6 +15,21 @@ function fail(message) {
 
 function warn(message) {
   console.warn(`⚠️ ${message}`);
+}
+
+function ensureFile(relPath, problems) {
+  if (!relPath) {
+    problems.push("missing path in summary metadata");
+    return;
+  }
+  try {
+    const stats = statSync(path.join(repoRoot, relPath));
+    if (!stats.isFile() || stats.size === 0) {
+      problems.push(`${relPath} is empty or not a file`);
+    }
+  } catch (error) {
+    problems.push(`${relPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 function main() {
@@ -33,45 +48,55 @@ function main() {
     return;
   }
 
-  const requiredPaths = [summary?.sbom?.cyclonedx, summary?.sbom?.spdx, summaryFile];
-  const missing = [];
+  const problems = [];
+  ensureFile(summary?.sbom?.cyclonedx, problems);
+  ensureFile(summary?.sbom?.spdx, problems);
+  ensureFile(summaryFile, problems);
 
-  for (const rel of requiredPaths) {
-    if (!rel) {
-      missing.push("missing path in summary metadata");
-      continue;
-    }
-    try {
-      const stats = statSync(path.join(repoRoot, rel));
-      if (!stats.isFile() || stats.size === 0) {
-        missing.push(`${rel} is empty or not a file`);
-      }
-    } catch (error) {
-      missing.push(`${rel}: ${error instanceof Error ? error.message : String(error)}`);
-    }
+  const auditState = summary?.audit?.state || "unknown";
+  if (
+    !["pass", "fail", "unavailable-hard", "unavailable-soft", "misconfigured"].includes(auditState)
+  ) {
+    problems.push(`unknown audit state '${auditState}'`);
   }
 
-  if (summary.thresholdFailures > 0) {
-    missing.push(
-      `thresholdFailures=${summary.thresholdFailures} at failLevel=${summary.failLevel}`
+  if (auditState === "fail") {
+    problems.push(`audit_state=fail thresholdFailures=${summary.thresholdFailures || 0}`);
+  }
+
+  if (auditState === "unavailable-hard") {
+    problems.push(
+      `audit unavailable under hard policy (${summary?.audit?.unavailableCategory || "unknown"})`
     );
   }
 
-  if (summary.auditUnavailableReason && strict && !allowAuditUnavailable) {
-    missing.push(
-      `auditUnavailableReason=${summary.auditUnavailableReason} (set RELEASE_ALLOW_AUDIT_UNAVAILABLE=1 to permit)`
+  if (auditState === "misconfigured") {
+    problems.push(
+      `audit misconfigured (${summary?.audit?.unavailableCategory || "unknown"}); fix registry auth/config instead of skipping`
     );
   }
 
-  if (missing.length) {
+  if (auditState === "unavailable-soft" && strict && !allowUnavailableSoft) {
+    problems.push(
+      `audit unavailable-soft requires RELEASE_ALLOW_AUDIT_UNAVAILABLE=1; category=${summary?.audit?.unavailableCategory || "unknown"}`
+    );
+  }
+
+  if (problems.length) {
     if (strict) {
-      fail(`Security evidence invalid:\n - ${missing.join("\n - ")}`);
+      fail(`Security evidence invalid:\n - ${problems.join("\n - ")}`);
     }
-    warn(`Security evidence has issues (non-strict mode):\n - ${missing.join("\n - ")}`);
+    warn(`Security evidence has issues (non-strict mode):\n - ${problems.join("\n - ")}`);
     return;
   }
 
-  console.log(`✅ Security evidence verified (${summaryFile})`);
+  if (auditState === "unavailable-soft") {
+    warn(
+      `SECURITY_SOFT_SKIP_RELEASE state=unavailable-soft category=${summary?.audit?.unavailableCategory || "unknown"}`
+    );
+  }
+
+  console.log(`✅ Security evidence verified (${summaryFile}) with audit_state=${auditState}`);
 }
 
 main();

--- a/scripts/verify-security.mjs
+++ b/scripts/verify-security.mjs
@@ -71,6 +71,46 @@ function runStaticChecks() {
   return results;
 }
 
+function readRuntimeTenantCoverage() {
+  try {
+    const runtimeSummary = JSON.parse(
+      readFileSync(
+        path.join(repoRoot, "artifacts", "security", "runtime-smoke-latest.json"),
+        "utf8"
+      )
+    );
+    const negativeCheck = runtimeSummary?.checks?.find(
+      (entry) => entry.name === "auth_tenant_boundary_negative"
+    );
+
+    if (!negativeCheck) {
+      return {
+        status: "not_executed",
+        message:
+          "Runtime security smoke artifact present, but tenant negative check was not found.",
+      };
+    }
+
+    if (negativeCheck.status === "passed") {
+      return {
+        status: "pass",
+        message: "Runtime tenant negative-path check passed in latest runtime smoke artifact.",
+      };
+    }
+
+    return {
+      status: negativeCheck.status,
+      message: `Runtime tenant negative-path check status='${negativeCheck.status}'.`,
+    };
+  } catch {
+    return {
+      status: "not_executed",
+      message:
+        "Runtime tenant coverage not executed in this run context. Run `pnpm run verify:security:runtime` for fixture/runtime assurance.",
+    };
+  }
+}
+
 function printSection(title) {
   console.log(`\n=== ${title} ===`);
 }
@@ -116,6 +156,7 @@ function main() {
   const staticResults = runStaticChecks();
   const tenantResults = evaluateTenantGuardrails(repoRoot);
   const limiterGuardrail = evaluateRateLimiterProductionGuardrail();
+  const runtimeTenantCoverage = readRuntimeTenantCoverage();
 
   const staticFailures = staticResults.filter((item) => item.status !== "present");
   const tenantFailures = tenantResults.filter((item) => item.status !== "guardrail_present");
@@ -126,10 +167,13 @@ function main() {
     scope: {
       static: "Control-presence verification (not dynamic attack simulation).",
       tenantGuardrails:
-        "High-risk route structure checks for auth/tenant/rate-limit guardrails. Requires runtime/manual follow-up for full isolation proof.",
+        "High-risk route structure checks for auth/tenant/rate-limit guardrails. Guardrail-presence only.",
+      tenantRuntime:
+        "Runtime/API cross-tenant negative-path coverage from latest runtime smoke or dedicated fixture tests.",
     },
     staticResults,
-    tenantIsolation: tenantResults,
+    tenantGuardrailPresence: tenantResults,
+    tenantRuntimeCoverage: runtimeTenantCoverage,
     limiterGuardrail,
     passed:
       staticFailures.length === 0 && tenantFailures.length === 0 && limiterFailures.length === 0,
@@ -149,7 +193,7 @@ function main() {
     }
   }
 
-  printSection("Tenant-isolation guardrail checks");
+  printSection("Tenant guardrail presence checks (static)");
   for (const result of tenantResults) {
     const statusIcon = result.status === "guardrail_present" ? "✅" : "❌";
     console.log(`${statusIcon} ${result.route} [${result.classification}]`);
@@ -159,8 +203,12 @@ function main() {
         console.log(`   missing guardrail: ${missing}`);
       }
     }
-    console.log(`   manual/runtime follow-up: ${result.manualValidation}`);
+    console.log(`   runtime follow-up target: ${result.manualValidation}`);
   }
+
+  printSection("Tenant runtime coverage status");
+  const runtimeIcon = runtimeTenantCoverage.status === "pass" ? "✅" : "⚠️";
+  console.log(`${runtimeIcon} ${runtimeTenantCoverage.message}`);
 
   printSection("Production limiter backend guardrail");
   const limiterIcon =
@@ -179,7 +227,7 @@ function main() {
   }
 
   console.log(
-    "\n✅ Security verification passed (static controls + tenant guardrail presence). This does not replace runtime smoke or full DAST/SAST testing."
+    "\n✅ Security verification passed (static controls + tenant guardrail presence). Runtime coverage is reported separately and must be reviewed explicitly."
   );
 }
 

--- a/scripts/verify-staged-packages.mjs
+++ b/scripts/verify-staged-packages.mjs
@@ -16,6 +16,16 @@ function run(cmd, args, options = {}) {
   }
 }
 
+function parseTier(argv) {
+  const tierArg = argv.find((arg) => arg.startsWith("--tier="));
+  const tier = tierArg ? tierArg.split("=")[1] : "prepush";
+  if (!["precommit", "prepush"].includes(tier)) {
+    console.error(`Unsupported tier '${tier}'. Use --tier=precommit|prepush`);
+    process.exit(1);
+  }
+  return tier;
+}
+
 function getStagedFiles() {
   const output = execSync("git diff --cached --name-only --diff-filter=ACMR", {
     encoding: "utf8",
@@ -31,6 +41,7 @@ function getPackageName(packageDir) {
   return pkg.name;
 }
 
+const tier = parseTier(process.argv.slice(2));
 const stagedFiles = getStagedFiles();
 
 if (stagedFiles.length === 0) {
@@ -41,11 +52,9 @@ if (stagedFiles.length === 0) {
 const changedPackageDirs = new Set();
 
 for (const file of stagedFiles) {
-  if (file.startsWith("packages/")) {
-    const [, pkgDir] = file.split("/");
-    if (pkgDir) changedPackageDirs.add(pkgDir);
-    continue;
-  }
+  if (!file.startsWith("packages/")) continue;
+  const [, pkgDir] = file.split("/");
+  if (pkgDir) changedPackageDirs.add(pkgDir);
 }
 
 const changedPackages = Array.from(changedPackageDirs)
@@ -60,9 +69,17 @@ if (changedPackages.length === 0) {
 const filters = changedPackages.flatMap((pkg) => ["--filter", `${pkg.name}...`]);
 
 console.log(`🔎 Staged package verify scope: ${changedPackages.map((p) => p.name).join(", ")}`);
+console.log(`🔎 Verification tier: ${tier}`);
 
 console.log("\n▶ Lint (changed packages)");
 run("pnpm", ["turbo", "run", "lint", ...filters]);
+
+if (tier === "precommit") {
+  console.log(
+    "\n✅ Pre-commit tier complete (staged lint only). Full typecheck/tests run in pre-push/CI."
+  );
+  process.exit(0);
+}
 
 console.log("\n▶ Typecheck (changed packages)");
 run("pnpm", ["turbo", "run", "typecheck", ...filters]);
@@ -71,8 +88,8 @@ for (const pkg of changedPackages) {
   console.log(`\n▶ Test (${pkg.name})`);
 
   if (pkg.name === "@settler/web") {
-    run("pnpm", ["--filter", "@settler/web", "exec", "jest", "--maxWorkers=50%"], {
-      env: { NODE_OPTIONS: "--max-old-space-size=4096" },
+    run("pnpm", ["--filter", "@settler/web", "exec", "jest", "--runInBand"], {
+      env: { NODE_OPTIONS: "--max-old-space-size=2048" },
     });
     continue;
   }


### PR DESCRIPTION
### Motivation
- Make dependency audit availability an auditable policy state instead of a silent soft-skip, and surface precise reasons for unavailability.
- Move tenant guardrail assurance from purely static token checks to include deterministic runtime fixture tests for high-risk flows.
- Stop pre-commit from doing heavyweight verification that can OOM on constrained developer machines while preserving meaningful local safety.

### Description
- Introduced an explicit audit state model and classifier in `scripts/security/supply-chain-policy.mjs` and wired it into `scripts/security/supply-chain.mjs` so summaries include `state`, `unavailableCategory`, and `detail` instead of a binary pass/skip. 
- Added release-context gating for soft-skips: `SECURITY_AUDIT_CONTEXT`, `SECURITY_AUDIT_ALLOW_UNAVAILABLE`, and `SECURITY_AUDIT_ALLOW_UNAVAILABLE_ON_RELEASE` with `release-verify` workflow input `allow_audit_soft_skip`. (CI wiring in `.github/workflows/release-verify.yml`.)
- Made evidence validation state-aware in `scripts/verify-security-evidence.mjs` so `misconfigured` / `unavailable-hard` block releases and `unavailable-soft` is visible and policy-gated. 
- Extended security verification summary and runner to carry explicit signals (supply-chain audit state and tenant static/runtime coverage) in `scripts/verify-release.mjs` and `scripts/verify-security.mjs`.
- Added deterministic runtime fixture tests for high-risk tenant surfaces under `packages/web/src/__tests__/api/tenant-runtime-cross-tenant.test.ts` to validate list non-enumerability, ID read denial, results/evidence denial, and missing-tenant denial.
- Tiered the local hooks and staged-package verifier: `.husky/pre-commit` now performs staged, sequential, low-memory checks and runs `scripts/verify-staged-packages.mjs --tier=precommit`; `.husky/pre-push` runs `verify:fast`; `scripts/verify-staged-packages.mjs` supports `--tier=precommit|prepush` and uses conservative Jest/Node memory flags.
- Added unit tests for the new supply-chain policy classifier at `scripts/__tests__/supply-chain-policy.test.mjs` and updated docs to reflect the new verification tiers and the precise audit-state semantics (`docs/security/VERIFICATION_SURFACES.md`, `docs/release/VERIFICATION.md`, `docs/security/README.md`).

### Testing
- Ran `node --test scripts/__tests__/tenant-guardrails.test.mjs` and `node --test scripts/__tests__/supply-chain-policy.test.mjs`; both test suites passed. (TAP output: all tests OK.)
- Ran tenant runtime fixture tests with `pnpm --filter @settler/web exec jest src/__tests__/api/tenant-runtime-cross-tenant.test.ts --runInBand` which passed (3 tests). 
- Ran repository-level checks: `pnpm run lint` completed with warnings (no blocking errors), `pnpm run typecheck` passed, and `pnpm run build` (web) completed successfully. 
- Ran verification flows: `pnpm run verify:security` passed (static guardrails present; runtime coverage reported separately), `pnpm run verify:security:supply-chain` produced a classified unavailable condition when the registry returned 403 and emitted `unavailable-soft` when allowed, and `pnpm run verify:security:evidence` validated evidence according to the new state rules (passed when soft-skip explicitly allowed). 
- End-to-end fast release runner `pnpm run verify:fast -- --run-id=local-fast-risk-closure` completed and emitted a machine-readable verification summary including the new supply-chain and tenant signals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac60f8f9d08328a99d314326966c40)