### PR TITLE
Harden security evidence model; add runtime RLS verification and deterministic verdict engine

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -82,19 +82,36 @@ jobs:
         run: |
           echo "${{ secrets.DEPENDABOT_ALERTS_EXPORT_B64 }}" | base64 -d > security/dependabot-alerts.json
 
-      - name: Enforce dependency triage completeness policy
-        env:
-          DEPENDENCY_TRIAGE_REQUIRE_AUTHENTICATED_EXPORT: "1"
-          DEPENDABOT_ALERTS_EXPORT_PATH: security/dependabot-alerts.json
-        run: node scripts/security/dependency-triage.mjs
-
-      - name: Generate security evidence + drift detection
+      - name: Generate layered security evidence (full mode)
         env:
           SECURITY_AUDIT_MODE: strict
           SECURITY_HEADER_PROBE_STRICT: "1"
-          DEPENDENCY_TRIAGE_REQUIRE_AUTHENTICATED_EXPORT: "1"
+          SECURITY_DEPENDENCY_EVIDENCE_MODE: standard
+          SECURITY_RLS_EVIDENCE_MODE: static-only
           DEPENDABOT_ALERTS_EXPORT_PATH: security/dependabot-alerts.json
-        run: pnpm run security:evidence
+        run: pnpm run verify:security:full
+
+      - name: Enterprise gate (strict evidence when secrets exist)
+        if: ${{ secrets.DEPENDABOT_ALERTS_EXPORT_B64 != '' && (secrets.DATABASE_URL != '' || secrets.DIRECT_URL != '' || secrets.SUPABASE_DB_URL != '') }}
+        env:
+          SECURITY_AUDIT_MODE: strict
+          SECURITY_HEADER_PROBE_STRICT: "1"
+          SECURITY_DEPENDENCY_EVIDENCE_MODE: strict
+          SECURITY_RLS_EVIDENCE_MODE: runtime-rls-required
+          DEPENDABOT_ALERTS_EXPORT_PATH: security/dependabot-alerts.json
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: pnpm run verify:security:enterprise
+
+      - name: Upload security evidence artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-evidence-${{ github.run_id }}
+          path: |
+            artifacts/security
+            security/*.json
+            security/*.md
 
   secret-scanning:
     name: Secret Scanning

--- a/docs/security/DEPENDENCY_EVIDENCE.md
+++ b/docs/security/DEPENDENCY_EVIDENCE.md
@@ -1,0 +1,21 @@
+# Dependency Evidence
+
+## What is verified
+
+1. Local audit findings from `artifacts/security/dependency-audit-latest.json`
+2. Lockfile inventory presence
+3. Authenticated advisory completeness from either:
+   - `DEPENDABOT_ALERTS_EXPORT_PATH` import
+   - `gh api repos/:repo/dependabot/alerts` with token + repo context
+
+## Status semantics
+
+- `PASS`: local audit clear and authenticated advisory completeness confirmed
+- `PASS_WITH_DEGRADED_EVIDENCE`: local audit clear, advisory completeness partial/unavailable in standard mode
+- `FAIL`: local audit failed or strict mode lacks authenticated advisory completeness
+
+## Operator commands
+
+- Standard: `SECURITY_DEPENDENCY_EVIDENCE_MODE=standard node scripts/security/dependency-evidence.mjs`
+- Strict: `SECURITY_DEPENDENCY_EVIDENCE_MODE=strict node scripts/security/dependency-evidence.mjs`
+- Import export: `DEPENDABOT_ALERTS_EXPORT_PATH=security/dependabot-alerts.json ...`

--- a/docs/security/LAUNCH_GATE.md
+++ b/docs/security/LAUNCH_GATE.md
@@ -1,0 +1,22 @@
+# Launch Gate Criteria
+
+## DEVELOPMENT SAFE
+
+`YES` when no blocking dimensions fail in `security/security-verdict.json`.
+
+## LAUNCH SAFE
+
+- `YES`: no blocking fails and no degraded dependency/RLS evidence.
+- `CONDITIONAL`: no blocking fails, but dependency advisory completeness or runtime RLS evidence is degraded.
+- `NO`: any blocking dimension fails.
+
+## ENTERPRISE REVIEW SAFE
+
+- `YES`: authenticated advisory completeness = complete and RLS evidence = runtime-confirmed.
+- `IMPROVED_NOT_COMPLETE`: otherwise, with explicit constraints and operator actions.
+
+## Recommended flows
+
+- PR: `pnpm run verify:security:fast`
+- Main/release: `pnpm run verify:security:full`
+- Enterprise release gate: `pnpm run verify:security:enterprise`

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -9,6 +9,10 @@
 5. Operational runbooks: [`docs/OPERATIONS_RUNBOOK.md`](../OPERATIONS_RUNBOOK.md)
 6. Security verification surfaces: [`docs/security/VERIFICATION_SURFACES.md`](./VERIFICATION_SURFACES.md)
 7. Production limiter guidance: [`docs/security/RATE_LIMITING_PRODUCTION.md`](./RATE_LIMITING_PRODUCTION.md)
+8. Verification model: [`docs/security/VERIFICATION_MODEL.md`](./VERIFICATION_MODEL.md)
+9. Dependency evidence: [`docs/security/DEPENDENCY_EVIDENCE.md`](./DEPENDENCY_EVIDENCE.md)
+10. Runtime RLS verification: [`docs/security/RLS_VERIFICATION.md`](./RLS_VERIFICATION.md)
+11. Launch gate semantics: [`docs/security/LAUNCH_GATE.md`](./LAUNCH_GATE.md)
 
 ## Security verification boundaries (no puffery)
 

--- a/docs/security/RLS_VERIFICATION.md
+++ b/docs/security/RLS_VERIFICATION.md
@@ -1,0 +1,27 @@
+# RLS Verification
+
+## Runtime harness
+
+`verify-rls-status.ts` now executes:
+
+- policy presence checks on critical tables
+- isolated runtime fixture in `settler_security.rls_runtime_probe`
+- allow/deny matrix:
+  - same tenant allow
+  - cross tenant deny
+  - anonymous deny
+
+## Modes
+
+- `static-only`: records static boundary only
+- `runtime-rls`: executes runtime probe when DB env exists
+- `runtime-rls-required`: fails when runtime proof missing/failing
+
+## Required env
+
+- `DATABASE_URL` or `DIRECT_URL` or `SUPABASE_DB_URL`
+
+## Commands
+
+- `SECURITY_RLS_EVIDENCE_MODE=runtime-rls pnpm run verify:rls:live`
+- `SECURITY_RLS_EVIDENCE_MODE=runtime-rls node scripts/security/verify-rls-boundary.mjs`

--- a/docs/security/VERIFICATION_MODEL.md
+++ b/docs/security/VERIFICATION_MODEL.md
@@ -1,0 +1,30 @@
+# Security Verification Model
+
+Settler verification now separates **verified**, **degraded**, **skipped**, **unavailable**, and **failed** evidence lanes.
+
+## Modes
+
+- `verify:security:fast`: static checks + local runtime checks + dependency evidence in `standard` mode.
+- `verify:security:full`: full evidence pipeline with explicit degraded reporting.
+- `verify:security:enterprise`: strict dependency completeness + required runtime RLS proof.
+
+## Evidence dimensions
+
+- Dependency evidence (`security/dependency-evidence.json`)
+- RLS evidence (`security/rls-evidence.json`)
+- Final verdict (`security/security-verdict.json`)
+
+Each artifact includes:
+
+- `status`
+- `reason`
+- `evidenceCompleteness`/`evidenceLevel`
+- `environmentConstraints`
+- `nextOperatorAction`
+
+## Policy controls
+
+- `SECURITY_DEPENDENCY_EVIDENCE_MODE=standard|strict`
+- `SECURITY_RLS_EVIDENCE_MODE=static-only|runtime-rls|runtime-rls-required`
+
+Strict policy fails when required evidence is missing.

--- a/package.json
+++ b/package.json
@@ -228,8 +228,11 @@
     "audit:deps": "node scripts/audit-deps.mjs",
     "verify:security:headers": "node scripts/security/header-probe.mjs",
     "verify:security:drift": "node scripts/security-drift-check.mjs",
-    "security:evidence": "pnpm run security:routes && pnpm run verify:tenant && pnpm run test:cross-tenant && node scripts/security/admin-route-authz.mjs && pnpm run verify:security:headers && SECURITY_AUDIT_MODE=${SECURITY_AUDIT_MODE:-warn} pnpm run audit:deps && node scripts/security/dependency-triage.mjs && node scripts/security/verify-rls-boundary.mjs && node scripts/security-evidence.mjs && pnpm run verify:security:drift",
-    "verify:rls:live": "pnpm exec tsx scripts/verify-rls-status.ts"
+    "security:evidence": "pnpm run security:routes && pnpm run verify:tenant && pnpm run test:cross-tenant && node scripts/security/admin-route-authz.mjs && pnpm run verify:security:headers && SECURITY_AUDIT_MODE=${SECURITY_AUDIT_MODE:-warn} pnpm run audit:deps && node scripts/security/dependency-triage.mjs && node scripts/security/dependency-evidence.mjs && node scripts/security/verify-rls-boundary.mjs && node scripts/security/rls-evidence.mjs && node scripts/security-evidence.mjs && node scripts/security/verdict.mjs && pnpm run verify:security:drift",
+    "verify:rls:live": "pnpm exec tsx scripts/verify-rls-status.ts",
+    "verify:security:fast": "pnpm run security:routes && pnpm run verify:tenant && pnpm run test:cross-tenant && SECURITY_AUDIT_MODE=warn SECURITY_DEPENDENCY_EVIDENCE_MODE=standard pnpm run audit:deps && node scripts/security/dependency-evidence.mjs && SECURITY_RLS_EVIDENCE_MODE=static-only node scripts/security/verify-rls-boundary.mjs && node scripts/security/rls-evidence.mjs && node scripts/security/verdict.mjs",
+    "verify:security:full": "pnpm run security:evidence && node scripts/security/verdict.mjs",
+    "verify:security:enterprise": "SECURITY_DEPENDENCY_EVIDENCE_MODE=strict SECURITY_RLS_EVIDENCE_MODE=runtime-rls-required pnpm run security:evidence && node scripts/security/verdict.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/scripts/__tests__/dependency-evidence.test.mjs
+++ b/scripts/__tests__/dependency-evidence.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { evaluateDependencyEvidence } from "../security/dependency-evidence-lib.mjs";
+
+const lockfiles = [{ ecosystem: "npm", path: "pnpm-lock.yaml", present: true }];
+
+test("downgrades in standard mode when advisory auth is missing", () => {
+  const result = evaluateDependencyEvidence({
+    mode: "standard",
+    lockfiles,
+    advisory: {
+      status: "unauthenticated",
+      reason: "Missing token",
+      nextAction: "Provide token",
+    },
+    audit: {
+      findingsSummary: { high: 0, critical: 0 },
+      finalOutcome: "passed",
+      degraded: false,
+    },
+  });
+
+  assert.equal(result.status, "PASS_WITH_DEGRADED_EVIDENCE");
+  assert.equal(result.evidenceCompleteness, "partial");
+});
+
+test("upgrades to pass when authenticated advisory evidence exists", () => {
+  const result = evaluateDependencyEvidence({
+    mode: "strict",
+    lockfiles,
+    advisory: {
+      status: "complete",
+      reason: "Authenticated export",
+      nextAction: null,
+    },
+    audit: {
+      findingsSummary: { high: 0, critical: 0 },
+      finalOutcome: "passed",
+      degraded: false,
+    },
+  });
+
+  assert.equal(result.status, "PASS");
+  assert.equal(result.evidenceCompleteness, "complete");
+});

--- a/scripts/__tests__/rls-evidence.test.mjs
+++ b/scripts/__tests__/rls-evidence.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { evaluateRlsEvidence } from "../security/rls-evidence-lib.mjs";
+
+test("runtime confirmation upgrades evidence level from static-only", () => {
+  const staticOnly = evaluateRlsEvidence({
+    mode: "runtime-rls",
+    verification: { status: "skipped", proofLevel: "static-only", liveDbConfigured: false },
+  });
+  const runtime = evaluateRlsEvidence({
+    mode: "runtime-rls",
+    verification: { status: "passed", proofLevel: "live-db-confirmed", liveDbConfigured: true },
+  });
+
+  assert.equal(staticOnly.evidenceLevel, "static-only");
+  assert.equal(runtime.evidenceLevel, "runtime-confirmed");
+  assert.equal(runtime.status, "PASS");
+});
+
+test("cross-tenant deny in runtime harness remains required for pass semantics", () => {
+  const result = evaluateRlsEvidence({
+    mode: "runtime-rls",
+    verification: {
+      status: "passed",
+      proofLevel: "live-db-confirmed",
+      liveDbConfigured: true,
+      allowDenyMatrix: { sameTenantAllow: true, crossTenantDeny: true, anonymousDeny: true },
+    },
+  });
+
+  assert.equal(result.status, "PASS");
+  assert.equal(result.allowDenyMatrix.crossTenantDeny, true);
+});

--- a/scripts/__tests__/security-verdict.test.mjs
+++ b/scripts/__tests__/security-verdict.test.mjs
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { computeSecurityVerdict } from "../security/verdict-lib.mjs";
+
+test("verdict is conditional when advisory completeness missing", () => {
+  const verdict = computeSecurityVerdict({
+    dependencyEvidence: {
+      status: "PASS_WITH_DEGRADED_EVIDENCE",
+      evidenceCompleteness: "partial",
+      reason: "No advisory auth",
+      advisoryCompleteness: { status: "unauthenticated", reason: "missing auth" },
+      nextOperatorAction: ["provide auth"],
+    },
+    rlsEvidence: {
+      status: "PASS_WITH_DEGRADED_EVIDENCE",
+      evidenceLevel: "static-only",
+      reason: "not run",
+    },
+    headerProbe: { counts: { failedBlocking: 0 }, degraded: false },
+    crossTenant: { status: "passed" },
+  });
+
+  assert.equal(verdict.overall.overall_launch_safe, "CONDITIONAL");
+  assert.equal(verdict.overall.overall_enterprise_review_safe, "IMPROVED_NOT_COMPLETE");
+});

--- a/scripts/security-evidence.mjs
+++ b/scripts/security-evidence.mjs
@@ -51,6 +51,9 @@ const artifacts = [
   maybeCopy("artifacts/security/admin-route-authz-latest.json", "admin-route-authz.json"),
   maybeCopy("artifacts/security/rls-verification-latest.json", "rls-verification.json", false),
   maybeCopy("security/dependency-triage.json", "dependency-triage.json", false),
+  maybeCopy("security/dependency-evidence.json", "dependency-evidence.json", false),
+  maybeCopy("security/rls-evidence.json", "rls-evidence.json", false),
+  maybeCopy("security/security-verdict.json", "security-verdict.json", false),
 ];
 
 const missingRequired = artifacts.filter((entry) => entry.required && !entry.present);
@@ -73,8 +76,11 @@ const crossTenant = safeRead("security/evidence/cross-tenant-results.json");
 const headerProbe = safeRead("security/evidence/header-probe.json");
 const depAudit = safeRead("security/evidence/dependency-audit.json");
 const depTriage = safeRead("security/evidence/dependency-triage.json");
+const depEvidence = safeRead("security/evidence/dependency-evidence.json");
 const adminAuthz = safeRead("security/evidence/admin-route-authz.json");
 const rlsVerification = safeRead("security/evidence/rls-verification.json");
+const rlsEvidence = safeRead("security/evidence/rls-evidence.json");
+const verdict = safeRead("security/evidence/security-verdict.json");
 
 const headerBlockingFailures =
   headerProbe?.counts?.failedBlocking ?? headerProbe?.counts?.failed ?? 0;
@@ -95,6 +101,8 @@ const headerContractCompleteness = headerProbe?.degraded
     : "enforced-contract-satisfied";
 
 const rlsProofLevel = rlsVerification?.proofLevel ?? "not-captured";
+const dependencyEvidenceStatus = depEvidence?.status ?? "not-captured";
+const rlsEvidenceStatus = rlsEvidence?.status ?? "not-captured";
 
 const releaseBlockingFindings = [
   ...(headerBlockingFailures > 0
@@ -154,7 +162,9 @@ const manifest = {
   evidenceCompleteness,
   headerContractCompleteness,
   dependencyTriageCompleteness,
+  dependencyEvidenceStatus,
   rlsProofLevel,
+  rlsEvidenceStatus,
   releaseBlockingFindings,
   degradedChecks,
   artifacts: artifacts.map((entry) => ({
@@ -174,7 +184,9 @@ const summaryJson = {
   evidenceCompleteness,
   headerContractCompleteness,
   dependencyTriageCompleteness,
+  dependencyEvidenceStatus,
   rlsProofLevel,
+  rlsEvidenceStatus,
   releaseBlockingFindings,
   degradedChecks,
   results: {
@@ -202,6 +214,11 @@ const summaryJson = {
       blockedByMissingAuthenticatedInput:
         depTriage?.triageCompleteness?.blockedByMissingAuthenticatedInput ?? null,
     },
+    dependencyEvidence: {
+      status: depEvidence?.status ?? null,
+      evidenceCompleteness: depEvidence?.evidenceCompleteness ?? null,
+      advisoryStatus: depEvidence?.advisoryCompleteness?.status ?? null,
+    },
     adminAuthz: {
       totalRoutes: adminAuthz?.totalAdminRoutes ?? null,
       failed: adminAuthz?.failed ?? null,
@@ -212,6 +229,11 @@ const summaryJson = {
       status: rlsVerification?.status ?? null,
       boundary: rlsVerification?.boundary ?? null,
     },
+    rlsEvidence: {
+      status: rlsEvidence?.status ?? null,
+      evidenceLevel: rlsEvidence?.evidenceLevel ?? null,
+    },
+    verdict: verdict?.overall ?? null,
   },
 };
 writeFileSync(
@@ -230,7 +252,9 @@ const summary = [
   `- Evidence Completeness: ${evidenceCompleteness}`,
   `- Header Contract Completeness: ${headerContractCompleteness}`,
   `- Dependency Triage Completeness: ${dependencyTriageCompleteness}`,
+  `- Dependency Evidence Status: ${dependencyEvidenceStatus}`,
   `- RLS Proof Level: ${rlsProofLevel}`,
+  `- RLS Evidence Status: ${rlsEvidenceStatus}`,
   "",
   "## Snapshot",
   `- Route registry total: ${routeRegistry?.totalRoutes ?? "n/a"}`,

--- a/scripts/security/dependency-evidence-lib.mjs
+++ b/scripts/security/dependency-evidence-lib.mjs
@@ -1,0 +1,95 @@
+export const DEPENDENCY_EVIDENCE_MODES = new Set(["standard", "strict"]);
+
+export function summarizeLockfiles(lockfiles) {
+  const present = lockfiles.filter((item) => item.present);
+  return {
+    total: lockfiles.length,
+    presentCount: present.length,
+    ecosystems: [...new Set(present.map((item) => item.ecosystem))].sort(),
+    complete: present.length > 0,
+  };
+}
+
+export function evaluateDependencyEvidence({ mode, audit, advisory, lockfiles }) {
+  if (!DEPENDENCY_EVIDENCE_MODES.has(mode)) {
+    throw new Error(`Unsupported dependency evidence mode: ${mode}`);
+  }
+
+  const reasons = [];
+  const environmentConstraints = [];
+  const nextActions = [];
+
+  const localAuditKnown = Boolean(audit?.findingsSummary);
+  const localAuditPass =
+    localAuditKnown &&
+    (audit.findingsSummary.high || 0) + (audit.findingsSummary.critical || 0) === 0 &&
+    !String(audit.finalOutcome || "").startsWith("failed");
+
+  if (!localAuditKnown) {
+    reasons.push("Local dependency audit artifact was not available.");
+    environmentConstraints.push("Run `pnpm run audit:deps` to capture local audit state.");
+    nextActions.push("Run `pnpm run audit:deps` before release verification.");
+  }
+
+  if (audit?.degraded) {
+    reasons.push(
+      `Local dependency audit was degraded: ${(audit.degradedReasons || []).join(", ") || "unknown"}.`
+    );
+    environmentConstraints.push("Package registry audit backend/tooling degraded.");
+    nextActions.push("Restore registry audit connectivity/auth and rerun `pnpm run audit:deps`.");
+  }
+
+  const advisoryState = advisory?.status || "unavailable";
+  if (advisoryState !== "complete") {
+    reasons.push(`Authenticated advisory completeness is ${advisoryState}.`);
+    environmentConstraints.push(
+      advisory?.reason || "Authenticated GitHub advisory evidence unavailable."
+    );
+    if (advisory?.nextAction) {
+      nextActions.push(advisory.nextAction);
+    }
+  }
+
+  const lockSummary = summarizeLockfiles(lockfiles);
+  if (!lockSummary.complete) {
+    reasons.push("No supported lockfile found; package inventory completeness is unavailable.");
+    nextActions.push("Commit lockfile(s) for each ecosystem to improve inventory completeness.");
+  }
+
+  let status = "PASS";
+  let evidenceCompleteness = "complete";
+
+  if (!localAuditPass) {
+    status = "FAIL";
+    evidenceCompleteness = "partial";
+  }
+
+  if (status === "PASS" && advisoryState !== "complete") {
+    status = mode === "strict" ? "FAIL" : "PASS_WITH_DEGRADED_EVIDENCE";
+    evidenceCompleteness = "partial";
+  }
+
+  if (status === "PASS" && audit?.degraded) {
+    status = mode === "strict" ? "FAIL" : "PASS_WITH_DEGRADED_EVIDENCE";
+    evidenceCompleteness = "degraded";
+  }
+
+  return {
+    mode,
+    status,
+    evidenceCompleteness,
+    localAudit: {
+      available: localAuditKnown,
+      pass: localAuditPass,
+      degraded: Boolean(audit?.degraded),
+      summary: audit?.findingsSummary || null,
+      outcome: audit?.finalOutcome || "unavailable",
+    },
+    advisory,
+    lockfiles,
+    lockSummary,
+    reason: reasons.join(" "),
+    environmentConstraints: [...new Set(environmentConstraints)],
+    nextActions: [...new Set(nextActions)],
+  };
+}

--- a/scripts/security/dependency-evidence.mjs
+++ b/scripts/security/dependency-evidence.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { evaluateDependencyEvidence } from "./dependency-evidence-lib.mjs";
+
+const repoRoot = process.cwd();
+const runId = process.env.GITHUB_RUN_ID || new Date().toISOString().replace(/[:.]/g, "-");
+const outputDir = path.join(repoRoot, "artifacts", "security", "dependency-evidence", runId);
+mkdirSync(outputDir, { recursive: true });
+mkdirSync(path.join(repoRoot, "security"), { recursive: true });
+
+const mode = process.env.SECURITY_DEPENDENCY_EVIDENCE_MODE || "standard";
+const advisoryImportPath =
+  process.env.DEPENDABOT_ALERTS_EXPORT_PATH || "security/dependabot-alerts.json";
+
+function readJson(relPath) {
+  try {
+    return JSON.parse(readFileSync(path.join(repoRoot, relPath), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readJsonCandidate(candidatePath) {
+  try {
+    const full = path.isAbsolute(candidatePath)
+      ? candidatePath
+      : path.join(repoRoot, candidatePath);
+    return JSON.parse(readFileSync(full, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function resolveAdvisory() {
+  const imported = readJsonCandidate(advisoryImportPath);
+  if (Array.isArray(imported?.alerts)) {
+    return {
+      status: "complete",
+      source: "dependabot_export_import",
+      authenticated: true,
+      advisoryCount: imported.alerts.length,
+      reason: "Authenticated Dependabot export imported successfully.",
+      provenance: {
+        importPath: advisoryImportPath,
+        generatedAt: imported.generatedAt || imported.exportedAt || null,
+      },
+      nextAction: null,
+    };
+  }
+
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || null;
+  const repo = process.env.GITHUB_REPOSITORY || null;
+  if (token && repo) {
+    const cmd = `gh api repos/${repo}/dependabot/alerts --paginate -q '.'`;
+    const result = spawnSync("bash", ["-lc", cmd], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, GH_TOKEN: token },
+      timeout: 60_000,
+    });
+
+    if (result.status === 0) {
+      try {
+        const alerts = JSON.parse(result.stdout);
+        if (Array.isArray(alerts)) {
+          return {
+            status: "complete",
+            source: "github_dependabot_api",
+            authenticated: true,
+            advisoryCount: alerts.length,
+            reason: "Authenticated advisory evidence pulled from GitHub API.",
+            provenance: {
+              repository: repo,
+              fetchedAt: new Date().toISOString(),
+              command: cmd,
+            },
+            nextAction: null,
+          };
+        }
+      } catch {
+        return {
+          status: "failed",
+          source: "github_dependabot_api",
+          authenticated: true,
+          advisoryCount: null,
+          reason: "GitHub advisory API response was not valid JSON.",
+          provenance: { repository: repo, command: cmd },
+          nextAction: "Verify gh auth/token scopes and rerun advisory collection.",
+        };
+      }
+    }
+
+    return {
+      status: "degraded",
+      source: "github_dependabot_api",
+      authenticated: true,
+      advisoryCount: null,
+      reason: (result.stderr || result.stdout || "GitHub advisory API call failed.")
+        .trim()
+        .slice(0, 280),
+      provenance: { repository: repo, command: cmd, exitCode: result.status },
+      nextAction: "Use DEPENDABOT_ALERTS_EXPORT_PATH with an authenticated export artifact.",
+    };
+  }
+
+  return {
+    status: token ? "partial" : "unauthenticated",
+    source: "none",
+    authenticated: Boolean(token),
+    advisoryCount: null,
+    reason: token
+      ? "Token present but repository context missing for authenticated advisory pull."
+      : "No authenticated advisory source configured.",
+    provenance: { importPath: advisoryImportPath, repository: repo },
+    nextAction:
+      "Provide DEPENDABOT_ALERTS_EXPORT_PATH or set GITHUB_TOKEN/GH_TOKEN with GITHUB_REPOSITORY.",
+  };
+}
+
+const audit = readJson("artifacts/security/dependency-audit-latest.json");
+const advisory = resolveAdvisory();
+const lockfiles = [
+  {
+    ecosystem: "npm",
+    path: "pnpm-lock.yaml",
+    present: existsSync(path.join(repoRoot, "pnpm-lock.yaml")),
+  },
+  {
+    ecosystem: "npm",
+    path: "package-lock.json",
+    present: existsSync(path.join(repoRoot, "package-lock.json")),
+  },
+  { ecosystem: "npm", path: "yarn.lock", present: existsSync(path.join(repoRoot, "yarn.lock")) },
+  {
+    ecosystem: "cargo",
+    path: "Cargo.lock",
+    present: existsSync(path.join(repoRoot, "Cargo.lock")),
+  },
+];
+
+const evaluation = evaluateDependencyEvidence({ mode, audit, advisory, lockfiles });
+
+const artifact = {
+  reportVersion: "2026-03-09.1",
+  generatedAt: new Date().toISOString(),
+  runId,
+  status: evaluation.status,
+  reason: evaluation.reason,
+  evidenceCompleteness: evaluation.evidenceCompleteness,
+  environmentConstraints: evaluation.environmentConstraints,
+  nextOperatorAction: evaluation.nextActions,
+  policy: { mode },
+  ecosystems: evaluation.lockSummary.ecosystems,
+  lockfiles: evaluation.lockfiles,
+  localAudit: evaluation.localAudit,
+  advisoryCompleteness: evaluation.advisory,
+};
+
+const outJson = path.join(outputDir, "dependency-evidence.json");
+writeFileSync(outJson, JSON.stringify(artifact, null, 2));
+writeFileSync(
+  path.join(repoRoot, "security", "dependency-evidence.json"),
+  JSON.stringify(artifact, null, 2)
+);
+writeFileSync(
+  path.join(repoRoot, "artifacts", "security", "dependency-evidence-latest.json"),
+  JSON.stringify(artifact, null, 2)
+);
+
+const md = [
+  "# Dependency Evidence",
+  `- status: ${artifact.status}`,
+  `- evidenceCompleteness: ${artifact.evidenceCompleteness}`,
+  `- mode: ${mode}`,
+  `- ecosystems: ${artifact.ecosystems.join(", ") || "none"}`,
+  `- localAuditOutcome: ${artifact.localAudit.outcome}`,
+  `- advisoryStatus: ${artifact.advisoryCompleteness.status}`,
+  "",
+  "## Environment constraints",
+  ...(artifact.environmentConstraints.length
+    ? artifact.environmentConstraints.map((item) => `- ${item}`)
+    : ["- none"]),
+  "",
+  "## Next operator action",
+  ...(artifact.nextOperatorAction.length
+    ? artifact.nextOperatorAction.map((item) => `- ${item}`)
+    : ["- none"]),
+].join("\n");
+
+writeFileSync(path.join(outputDir, "dependency-evidence.md"), md);
+writeFileSync(path.join(repoRoot, "security", "dependency-evidence.md"), md);
+
+console.log(`Dependency evidence artifact: ${path.relative(repoRoot, outJson)}`);
+console.log(`Dependency evidence status: ${artifact.status}`);
+
+if (mode === "strict" && artifact.status !== "PASS") {
+  process.exit(1);
+}

--- a/scripts/security/rls-evidence-lib.mjs
+++ b/scripts/security/rls-evidence-lib.mjs
@@ -1,0 +1,75 @@
+export function evaluateRlsEvidence({ mode, verification }) {
+  const runtimeExecuted = verification?.liveDbConfigured === true;
+  const staticStatus = verification?.proofLevel === "static-only" ? "PASS" : "PASS";
+
+  const base = {
+    mode,
+    testedTables: verification?.testedTables || [],
+    runtimeExecuted,
+    fixtures: verification?.fixtures || null,
+    allowDenyMatrix: verification?.allowDenyMatrix || null,
+    policyPresence: verification?.policyPresence || null,
+    reason: verification?.boundary || "RLS verification artifact unavailable.",
+    environmentConstraints: [],
+    nextOperatorAction: [],
+  };
+
+  if (!verification) {
+    return {
+      ...base,
+      status: mode === "runtime-rls-required" ? "FAIL" : "UNAVAILABLE",
+      evidenceLevel: "unavailable",
+      environmentConstraints: [
+        "Run `node scripts/security/verify-rls-boundary.mjs` to generate baseline artifact.",
+      ],
+      nextOperatorAction: [
+        "Provide DB env and run `pnpm run verify:rls:live` for runtime confirmation.",
+      ],
+    };
+  }
+
+  if (verification.proofLevel === "live-db-confirmed" && verification.status === "passed") {
+    return {
+      ...base,
+      status: "PASS",
+      evidenceLevel: "runtime-confirmed",
+    };
+  }
+
+  if (verification.status === "failed") {
+    return {
+      ...base,
+      status: "FAIL",
+      evidenceLevel:
+        verification.proofLevel === "live-db-attempted-failed"
+          ? "runtime-attempted-failed"
+          : "static-only",
+      environmentConstraints:
+        verification.proofLevel === "live-db-required-missing-config"
+          ? ["Live DB credentials missing while runtime RLS is required."]
+          : [],
+      nextOperatorAction: ["Fix DB configuration/policies and rerun `pnpm run verify:rls:live`."],
+    };
+  }
+
+  if (!runtimeExecuted) {
+    const required = mode === "runtime-rls-required";
+    return {
+      ...base,
+      status: required ? "FAIL" : "PASS_WITH_DEGRADED_EVIDENCE",
+      evidenceLevel: "static-only",
+      environmentConstraints: [
+        "Runtime RLS verification not executed; only static boundary/policy checks were captured.",
+      ],
+      nextOperatorAction: [
+        "Set DATABASE_URL (or DIRECT_URL/SUPABASE_DB_URL) and run `pnpm run verify:rls:live`.",
+      ],
+    };
+  }
+
+  return {
+    ...base,
+    status: staticStatus,
+    evidenceLevel: "static-only",
+  };
+}

--- a/scripts/security/rls-evidence.mjs
+++ b/scripts/security/rls-evidence.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { evaluateRlsEvidence } from "./rls-evidence-lib.mjs";
+
+const repoRoot = process.cwd();
+const runId = process.env.GITHUB_RUN_ID || new Date().toISOString().replace(/[:.]/g, "-");
+const outputDir = path.join(repoRoot, "artifacts", "security", "rls-evidence", runId);
+mkdirSync(outputDir, { recursive: true });
+mkdirSync(path.join(repoRoot, "security"), { recursive: true });
+
+const mode = process.env.SECURITY_RLS_EVIDENCE_MODE || "static-only";
+
+let verification = null;
+try {
+  verification = JSON.parse(
+    readFileSync(
+      path.join(repoRoot, "artifacts", "security", "rls-verification-latest.json"),
+      "utf8"
+    )
+  );
+} catch {
+  verification = null;
+}
+
+const evaluation = evaluateRlsEvidence({ mode, verification });
+
+const artifact = {
+  reportVersion: "2026-03-09.1",
+  generatedAt: new Date().toISOString(),
+  runId,
+  status: evaluation.status,
+  reason: evaluation.reason,
+  evidenceLevel: evaluation.evidenceLevel,
+  environmentConstraints: evaluation.environmentConstraints,
+  nextOperatorAction: evaluation.nextOperatorAction,
+  runtimeExecuted: evaluation.runtimeExecuted,
+  policy: {
+    mode,
+  },
+  testedTables: evaluation.testedTables,
+  fixtures: evaluation.fixtures,
+  allowDenyMatrix: evaluation.allowDenyMatrix,
+  policyPresence: evaluation.policyPresence,
+};
+
+const outJson = path.join(outputDir, "rls-evidence.json");
+writeFileSync(outJson, JSON.stringify(artifact, null, 2));
+writeFileSync(
+  path.join(repoRoot, "security", "rls-evidence.json"),
+  JSON.stringify(artifact, null, 2)
+);
+writeFileSync(
+  path.join(repoRoot, "artifacts", "security", "rls-evidence-latest.json"),
+  JSON.stringify(artifact, null, 2)
+);
+
+const md = [
+  "# RLS Evidence",
+  `- status: ${artifact.status}`,
+  `- evidenceLevel: ${artifact.evidenceLevel}`,
+  `- mode: ${mode}`,
+  `- runtimeExecuted: ${artifact.runtimeExecuted}`,
+  `- reason: ${artifact.reason}`,
+  "",
+  "## Environment constraints",
+  ...(artifact.environmentConstraints.length
+    ? artifact.environmentConstraints.map((item) => `- ${item}`)
+    : ["- none"]),
+  "",
+  "## Next operator action",
+  ...(artifact.nextOperatorAction.length
+    ? artifact.nextOperatorAction.map((item) => `- ${item}`)
+    : ["- none"]),
+].join("\n");
+
+writeFileSync(path.join(outputDir, "rls-evidence.md"), md);
+writeFileSync(path.join(repoRoot, "security", "rls-evidence.md"), md);
+
+console.log(`RLS evidence artifact: ${path.relative(repoRoot, outJson)}`);
+console.log(`RLS evidence status: ${artifact.status}`);
+
+if (mode === "runtime-rls-required" && artifact.status !== "PASS") {
+  process.exit(1);
+}

--- a/scripts/security/verdict-lib.mjs
+++ b/scripts/security/verdict-lib.mjs
@@ -1,0 +1,113 @@
+const BLOCKING = new Set(["FAIL"]);
+
+function dim(status, evidenceLevel, blocking, reason, nextAction = []) {
+  return { status, evidenceLevel, blocking, reason, nextAction };
+}
+
+export function computeSecurityVerdict(inputs) {
+  const dependency = inputs.dependencyEvidence;
+  const rls = inputs.rlsEvidence;
+  const headerProbe = inputs.headerProbe;
+  const crossTenant = inputs.crossTenant;
+
+  const dimensions = {
+    code_security_status:
+      headerProbe?.counts?.failedBlocking > 0
+        ? dim("FAIL", "runtime-probed", true, "Blocking header/CSP contract failures found.")
+        : dim(
+            "PASS",
+            headerProbe?.degraded ? "degraded" : "runtime-probed",
+            false,
+            "Header contract checks passed without blocking failures."
+          ),
+
+    dependency_evidence_status: dim(
+      dependency?.status || "UNAVAILABLE",
+      dependency?.evidenceCompleteness || "unavailable",
+      true,
+      dependency?.reason || "Dependency evidence artifact unavailable.",
+      dependency?.nextOperatorAction || []
+    ),
+
+    advisory_completeness_status: dim(
+      dependency?.advisoryCompleteness?.status === "complete" ? "PASS" : "CONDITIONAL",
+      dependency?.advisoryCompleteness?.status || "unavailable",
+      false,
+      dependency?.advisoryCompleteness?.reason ||
+        "Authenticated advisory completeness unavailable.",
+      dependency?.nextOperatorAction || []
+    ),
+
+    tenant_isolation_status:
+      crossTenant?.status === "passed"
+        ? dim("PASS", "runtime-api", false, "Cross-tenant runtime denial checks passed.")
+        : dim(
+            "CONDITIONAL",
+            "runtime-api-missing",
+            false,
+            "Cross-tenant runtime denial evidence missing or not passing."
+          ),
+
+    runtime_probe_status:
+      rls?.evidenceLevel === "runtime-confirmed"
+        ? dim("PASS", "runtime-confirmed", false, "RLS runtime allow/deny matrix confirmed.")
+        : rls?.status === "FAIL"
+          ? dim(
+              "FAIL",
+              rls?.evidenceLevel || "unavailable",
+              true,
+              rls?.reason || "RLS runtime verification failed.",
+              rls?.nextOperatorAction || []
+            )
+          : dim(
+              "CONDITIONAL",
+              rls?.evidenceLevel || "static-only",
+              false,
+              rls?.reason || "RLS runtime verification not executed.",
+              rls?.nextOperatorAction || []
+            ),
+
+    tenant_isolation_rls_status: dim(
+      rls?.status || "UNAVAILABLE",
+      rls?.evidenceLevel || "unavailable",
+      rls?.status === "FAIL",
+      rls?.reason || "RLS evidence artifact unavailable.",
+      rls?.nextOperatorAction || []
+    ),
+  };
+
+  const blockingFails = Object.values(dimensions).filter(
+    (d) => d.blocking && BLOCKING.has(d.status)
+  );
+
+  const overall_development_safe = blockingFails.length === 0 ? "YES" : "NO";
+  const launchBlocking = [
+    dimensions.code_security_status,
+    dimensions.dependency_evidence_status,
+    dimensions.tenant_isolation_rls_status,
+  ].some((d) => d.status === "FAIL");
+  const launchDegraded = [
+    dimensions.dependency_evidence_status,
+    dimensions.runtime_probe_status,
+  ].some((d) => ["CONDITIONAL", "PASS_WITH_DEGRADED_EVIDENCE"].includes(d.status));
+
+  const overall_launch_safe = launchBlocking ? "NO" : launchDegraded ? "CONDITIONAL" : "YES";
+
+  const enterpriseRequiresFull =
+    dimensions.advisory_completeness_status.status === "PASS" &&
+    dimensions.runtime_probe_status.status === "PASS" &&
+    !launchBlocking;
+
+  const overall_enterprise_review_safe = enterpriseRequiresFull ? "YES" : "IMPROVED_NOT_COMPLETE";
+
+  return {
+    reportVersion: "2026-03-09.1",
+    generatedAt: new Date().toISOString(),
+    dimensions,
+    overall: {
+      overall_development_safe,
+      overall_launch_safe,
+      overall_enterprise_review_safe,
+    },
+  };
+}

--- a/scripts/security/verdict.mjs
+++ b/scripts/security/verdict.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { computeSecurityVerdict } from "./verdict-lib.mjs";
+
+const repoRoot = process.cwd();
+const runId = process.env.GITHUB_RUN_ID || new Date().toISOString().replace(/[:.]/g, "-");
+const outputDir = path.join(repoRoot, "artifacts", "security", "verdict", runId);
+mkdirSync(outputDir, { recursive: true });
+mkdirSync(path.join(repoRoot, "security"), { recursive: true });
+
+function readJson(rel) {
+  try {
+    return JSON.parse(readFileSync(path.join(repoRoot, rel), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+const verdict = computeSecurityVerdict({
+  dependencyEvidence: readJson("artifacts/security/dependency-evidence-latest.json"),
+  rlsEvidence: readJson("artifacts/security/rls-evidence-latest.json"),
+  headerProbe: readJson("artifacts/security/header-probe-latest.json"),
+  crossTenant: readJson("artifacts/security/cross-tenant-results-latest.json"),
+});
+
+const jsonPath = path.join(outputDir, "security-verdict.json");
+writeFileSync(jsonPath, JSON.stringify(verdict, null, 2));
+writeFileSync(
+  path.join(repoRoot, "security", "security-verdict.json"),
+  JSON.stringify(verdict, null, 2)
+);
+writeFileSync(
+  path.join(repoRoot, "artifacts", "security", "security-verdict-latest.json"),
+  JSON.stringify(verdict, null, 2)
+);
+
+const md = [
+  "# Security Launch Verdict",
+  `- Development Safe: ${verdict.overall.overall_development_safe}`,
+  `- Launch Safe: ${verdict.overall.overall_launch_safe}`,
+  `- Enterprise Review Safe: ${verdict.overall.overall_enterprise_review_safe}`,
+  "",
+  "## Dimensions",
+  ...Object.entries(verdict.dimensions).map(
+    ([name, dim]) => `- ${name}: ${dim.status} (${dim.evidenceLevel}) — ${dim.reason}`
+  ),
+].join("\n");
+
+writeFileSync(path.join(outputDir, "security-verdict.md"), md);
+writeFileSync(path.join(repoRoot, "security", "security-verdict.md"), md);
+
+console.log(`Security verdict artifact: ${path.relative(repoRoot, jsonPath)}`);
+console.log(`Launch Safe: ${verdict.overall.overall_launch_safe}`);
+
+if (verdict.overall.overall_launch_safe === "NO") {
+  process.exit(1);
+}

--- a/scripts/security/verify-rls-boundary.mjs
+++ b/scripts/security/verify-rls-boundary.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -10,63 +10,96 @@ mkdirSync(outputDir, { recursive: true });
 
 const dbUrl =
   process.env.DATABASE_URL || process.env.DIRECT_URL || process.env.SUPABASE_DB_URL || null;
-const requireLive = process.env.SECURITY_REQUIRE_LIVE_RLS === "1";
+const mode = process.env.SECURITY_RLS_EVIDENCE_MODE || "static-only";
+const requireLive =
+  mode === "runtime-rls-required" || process.env.SECURITY_REQUIRE_LIVE_RLS === "1";
+const runtimeMode = mode === "runtime-rls" || mode === "runtime-rls-required";
+const rlsStatusOut = path.join(outputDir, "rls-status.json");
 
 function main() {
   const summary = {
     generatedAt: new Date().toISOString(),
-    verifierVersion: "2026-03-08.1",
+    verifierVersion: "2026-03-09.1",
+    reportVersion: "2026-03-09.1",
     runId,
+    mode,
     status: "not-run",
     proofLevel: "static-only",
     boundary:
-      "Live database RLS enforcement not executed in this run. Static migration/policy assertions and app-level tenant denial are separate controls.",
+      "Runtime RLS verification not executed in this run; only static/policy boundary is available.",
     policy: {
       requireLiveVerification: requireLive,
+      runtimeMode,
     },
     liveDbConfigured: Boolean(dbUrl),
     command: "pnpm exec tsx scripts/verify-rls-status.ts",
     commandStatus: null,
     stdout: "",
     stderr: "",
+    testedTables: [],
+    policyPresence: null,
+    fixtures: null,
+    allowDenyMatrix: null,
+    failures: [],
+    skipped: [],
     operatorGuidance: {
       liveVerificationEntrypoint: "pnpm run verify:rls:live",
       requiredEnv: ["DATABASE_URL or DIRECT_URL or SUPABASE_DB_URL"],
       expectations: [
-        "RLS is enabled on critical tenant tables",
-        "Policy count is non-zero for each critical table",
-        "Failures are blocking when SECURITY_REQUIRE_LIVE_RLS=1",
+        "same-tenant allow",
+        "cross-tenant deny",
+        "anonymous deny",
+        "RLS enabled + policies present on critical tables",
       ],
     },
   };
 
-  if (dbUrl) {
+  if (dbUrl && runtimeMode) {
     const result = spawnSync("pnpm", ["exec", "tsx", "scripts/verify-rls-status.ts"], {
       cwd: repoRoot,
       encoding: "utf8",
       timeout: 120_000,
+      env: { ...process.env, RLS_STATUS_OUTPUT: rlsStatusOut },
     });
 
     summary.commandStatus = result.status;
     summary.stdout = result.stdout || "";
     summary.stderr = result.stderr || "";
 
+    try {
+      const parsed = JSON.parse(readFileSync(rlsStatusOut, "utf8"));
+      summary.testedTables = parsed.criticalTables || [];
+      summary.policyPresence = parsed.policyPresence || null;
+      summary.fixtures = parsed.runtimeHarness?.fixtures || null;
+      summary.allowDenyMatrix = parsed.runtimeHarness?.allowDenyMatrix || null;
+      if (parsed.runtimeHarness?.errors?.length) {
+        summary.failures.push(...parsed.runtimeHarness.errors);
+      }
+    } catch {
+      summary.failures.push("RLS status output was not generated or unreadable.");
+    }
+
     if (result.status === 0) {
       summary.status = "passed";
       summary.proofLevel = "live-db-confirmed";
-      summary.boundary =
-        "Live DB RLS status verified for critical tables via verify-rls-status.ts.";
+      summary.boundary = "Live DB RLS policy and runtime allow/deny matrix were confirmed.";
     } else {
       summary.status = "failed";
       summary.proofLevel = "live-db-attempted-failed";
       summary.boundary =
-        "Live DB credentials were present, but RLS verification failed. Review stdout/stderr in artifact.";
+        "Live DB runtime verification attempted but failed. Review allow/deny matrix and table policy presence.";
     }
+  } else if (!runtimeMode) {
+    summary.status = "skipped";
+    summary.skipped.push("SECURITY_RLS_EVIDENCE_MODE=static-only");
   } else if (requireLive) {
     summary.status = "failed";
     summary.proofLevel = "live-db-required-missing-config";
-    summary.boundary =
-      "Live RLS verification required by policy but database credentials are missing.";
+    summary.boundary = "Runtime RLS verification required but database credentials are missing.";
+    summary.failures.push("Missing DATABASE_URL/DIRECT_URL/SUPABASE_DB_URL.");
+  } else {
+    summary.status = "skipped";
+    summary.skipped.push("No DB credentials available for runtime RLS verification.");
   }
 
   const outPath = path.join(outputDir, "rls-verification.json");

--- a/scripts/verify-rls-status.ts
+++ b/scripts/verify-rls-status.ts
@@ -1,127 +1,175 @@
 #!/usr/bin/env tsx
-/**
- * Verify RLS Status on Production Database
- * 
- * Checks if RLS is enabled on critical tables.
- */
-
-import { Pool } from 'pg';
-import * as dotenv from 'dotenv';
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { Pool } from "pg";
+import * as dotenv from "dotenv";
 
 dotenv.config();
 
-const DATABASE_URL = process.env.DATABASE_URL || 
-  process.env.DIRECT_URL ||
-  process.env.SUPABASE_DB_URL;
+const repoRoot = process.cwd();
+const outputPath =
+  process.env.RLS_STATUS_OUTPUT ||
+  path.join(repoRoot, "artifacts", "security", "rls-status-latest.json");
 
+const DATABASE_URL =
+  process.env.DATABASE_URL || process.env.DIRECT_URL || process.env.SUPABASE_DB_URL;
 if (!DATABASE_URL) {
-  console.error('❌ Missing DATABASE_URL, DIRECT_URL, or SUPABASE_DB_URL');
+  console.error("❌ Missing DATABASE_URL, DIRECT_URL, or SUPABASE_DB_URL");
   process.exit(1);
 }
 
 const criticalTables = [
-  'billing_accounts',
-  'subscriptions',
-  'usage_events',
-  'recon_jobs',
-  'recon_results',
-  'normalized_transactions',
-  'reconciliation_runs',
-  'reconciliation_matches',
-  'receipt_uploads',
-  'receipts',
-  'feature_flags',
-  'tenants',
+  "billing_accounts",
+  "subscriptions",
+  "usage_events",
+  "recon_jobs",
+  "recon_results",
+  "normalized_transactions",
+  "reconciliation_runs",
+  "reconciliation_matches",
+  "receipt_uploads",
+  "receipts",
+  "feature_flags",
+  "tenants",
 ];
 
-async function verifyRLS() {
-  console.log('🔍 Verifying RLS Status on Critical Tables...\n');
+async function countWithTenant(pool: Pool, tenantId: string, sql: string) {
+  await pool.query("BEGIN");
+  try {
+    await pool.query("SELECT set_config('request.jwt.claim.tenant_id', $1, true)", [tenantId]);
+    const result = await pool.query(sql);
+    await pool.query("ROLLBACK");
+    return Number(result.rows[0]?.count || 0);
+  } catch (error) {
+    await pool.query("ROLLBACK");
+    throw error;
+  }
+}
 
+async function verifyRLS() {
   const pool = new Pool({
     connectionString: DATABASE_URL,
-    ssl: DATABASE_URL.includes('supabase') ? { rejectUnauthorized: false } : false,
+    ssl: DATABASE_URL.includes("supabase") ? { rejectUnauthorized: false } : false,
   });
 
-  try {
-    await pool.query('SELECT 1');
-    console.log('✅ Connected to database\n');
+  const report: any = {
+    generatedAt: new Date().toISOString(),
+    status: "passed",
+    criticalTables: [],
+    policyPresence: { totalChecked: 0, missingRls: [], missingPolicies: [] },
+    runtimeHarness: {
+      executed: false,
+      fixtures: {
+        schema: "settler_security",
+        table: "rls_runtime_probe",
+        tenants: ["tenant_A", "tenant_B"],
+      },
+      allowDenyMatrix: {},
+      errors: [],
+    },
+  };
 
-    let allEnabled = true;
-    const results: Array<{ table: string; rlsEnabled: boolean; policies: number }> = [];
+  try {
+    await pool.query("SELECT 1");
 
     for (const table of criticalTables) {
-      try {
-        // Check if RLS is enabled
-        const rlsCheck = await pool.query(`
-          SELECT tablename, rowsecurity 
-          FROM pg_tables 
-          WHERE schemaname = 'public' AND tablename = $1
-        `, [table]);
+      const rlsCheck = await pool.query(
+        `SELECT tablename, rowsecurity FROM pg_tables WHERE schemaname = 'public' AND tablename = $1`,
+        [table]
+      );
+      if (rlsCheck.rows.length === 0) continue;
 
-        if (rlsCheck.rows.length === 0) {
-          console.log(`⚠️  ${table}: Table not found`);
-          continue;
-        }
-
-        const rlsEnabled = rlsCheck.rows[0].rowsecurity;
-
-        // Count policies
-        const policyCheck = await pool.query(`
-          SELECT COUNT(*) as count
-          FROM pg_policies
-          WHERE schemaname = 'public' AND tablename = $1
-        `, [table]);
-
-        const policyCount = parseInt(policyCheck.rows[0].count, 10);
-
-        results.push({
-          table,
-          rlsEnabled,
-          policies: policyCount,
-        });
-
-        const icon = rlsEnabled ? '✅' : '❌';
-        const policyIcon = policyCount > 0 ? '🔒' : '⚠️';
-        console.log(`${icon} ${policyIcon} ${table}: RLS ${rlsEnabled ? 'ENABLED' : 'DISABLED'} (${policyCount} policies)`);
-
-        if (!rlsEnabled) {
-          allEnabled = false;
-        }
-      } catch (error) {
-        console.error(`❌ Error checking ${table}:`, error instanceof Error ? error.message : String(error));
-        allEnabled = false;
-      }
+      const policyCheck = await pool.query(
+        `SELECT COUNT(*)::int AS count FROM pg_policies WHERE schemaname = 'public' AND tablename = $1`,
+        [table]
+      );
+      const row = {
+        table,
+        rlsEnabled: Boolean(rlsCheck.rows[0].rowsecurity),
+        policies: Number(policyCheck.rows[0].count),
+      };
+      report.criticalTables.push(row);
+      report.policyPresence.totalChecked += 1;
+      if (!row.rlsEnabled) report.policyPresence.missingRls.push(table);
+      if (row.policies === 0) report.policyPresence.missingPolicies.push(table);
     }
 
-    console.log('\n═══════════════════════════════════════════════════════════');
-    console.log('RLS VERIFICATION SUMMARY');
-    console.log('═══════════════════════════════════════════════════════════\n');
+    // Runtime harness in isolated schema.
+    await pool.query(`
+      CREATE SCHEMA IF NOT EXISTS settler_security;
+      CREATE TABLE IF NOT EXISTS settler_security.rls_runtime_probe (
+        id serial PRIMARY KEY,
+        tenant_id text NOT NULL,
+        payload text NOT NULL
+      );
+      ALTER TABLE settler_security.rls_runtime_probe ENABLE ROW LEVEL SECURITY;
+      DROP POLICY IF EXISTS tenant_isolation_probe ON settler_security.rls_runtime_probe;
+      CREATE POLICY tenant_isolation_probe ON settler_security.rls_runtime_probe
+      USING (tenant_id = current_setting('request.jwt.claim.tenant_id', true))
+      WITH CHECK (tenant_id = current_setting('request.jwt.claim.tenant_id', true));
+      DELETE FROM settler_security.rls_runtime_probe;
+      INSERT INTO settler_security.rls_runtime_probe (tenant_id, payload)
+      VALUES ('tenant_A', 'alpha'), ('tenant_B', 'beta');
+    `);
 
-    const enabledCount = results.filter(r => r.rlsEnabled).length;
-    const disabledCount = results.filter(r => !r.rlsEnabled).length;
+    report.runtimeHarness.executed = true;
 
-    console.log(`Total tables checked: ${results.length}`);
-    console.log(`✅ RLS Enabled: ${enabledCount}`);
-    console.log(`❌ RLS Disabled: ${disabledCount}\n`);
+    const sameTenant = await countWithTenant(
+      pool,
+      "tenant_A",
+      "SELECT COUNT(*)::int AS count FROM settler_security.rls_runtime_probe WHERE tenant_id = 'tenant_A'"
+    );
+    const crossTenant = await countWithTenant(
+      pool,
+      "tenant_A",
+      "SELECT COUNT(*)::int AS count FROM settler_security.rls_runtime_probe WHERE tenant_id = 'tenant_B'"
+    );
 
-    if (allEnabled && results.every(r => r.policies > 0)) {
-      console.log('✅ All critical tables have RLS enabled with policies!');
-      console.log('🚀 Database is secure for production launch.\n');
-    } else {
-      console.log('⚠️  Some tables are missing RLS or policies.');
-      console.log('💡 Apply migration: supabase/migrations/20250122000000_rls_enforcement_critical.sql\n');
+    const unauthorized = await pool.query(
+      "SELECT COUNT(*)::int AS count FROM settler_security.rls_runtime_probe"
+    );
+
+    report.runtimeHarness.allowDenyMatrix = {
+      sameTenantAllow: sameTenant >= 1,
+      crossTenantDeny: crossTenant === 0,
+      anonymousDeny: Number(unauthorized.rows[0].count) === 0,
+    };
+
+    const matrix = report.runtimeHarness.allowDenyMatrix;
+    if (!matrix.sameTenantAllow || !matrix.crossTenantDeny || !matrix.anonymousDeny) {
+      report.status = "failed";
+    }
+
+    if (
+      report.policyPresence.missingRls.length > 0 ||
+      report.policyPresence.missingPolicies.length > 0
+    ) {
+      report.status = "failed";
+    }
+
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, JSON.stringify(report, null, 2));
+
+    if (report.status !== "passed") {
+      console.error("❌ RLS verification failed.");
       process.exit(1);
     }
 
+    console.log("✅ RLS verification passed.");
+    console.log(`Report: ${path.relative(repoRoot, outputPath)}`);
   } catch (error) {
-    console.error('❌ Verification failed:', error);
+    report.status = "failed";
+    report.runtimeHarness.errors.push(error instanceof Error ? error.message : String(error));
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, JSON.stringify(report, null, 2));
+    console.error(
+      "❌ Verification failed:",
+      error instanceof Error ? error.message : String(error)
+    );
     process.exit(1);
   } finally {
     await pool.end();
   }
 }
 
-verifyRLS().catch(error => {
-  console.error('❌ Fatal error:', error);
-  process.exit(1);
-});
+verifyRLS();


### PR DESCRIPTION
### Motivation
- Close two remaining evidence gaps by making dependency advisory ingestion first-class and by providing a runtime RLS verification harness when DB creds are available. 
- Make final launch judgments deterministic, auditable, and explicit about what was runtime-confirmed vs static-only. 
- Provide operator guidance and CI gates so missing external inputs (Dependabot export, DB creds) downgrade evidence rather than produce vague blockers.

### Description
- Adds a dependency evidence lane with `standard|strict` policy, support for importing `DEPENDABOT_ALERTS_EXPORT_PATH` or fetching via authenticated GitHub `gh api`, explicit provenance fields, and JSON/MD artifacts (`scripts/security/dependency-evidence.mjs`, `scripts/security/dependency-evidence-lib.mjs`).
- Implements runtime-aware RLS verification and evidence plumbing: `verify-rls-status.ts` now contains an isolated runtime harness (schema `settler_security.rls_runtime_probe`) checking same-tenant allow, cross-tenant deny, anonymous deny, and policy presence, plus boundary wrapper and evaluator (`scripts/security/verify-rls-boundary.mjs`, `scripts/security/rls-evidence.mjs`, `scripts/security/rls-evidence-lib.mjs`).
- Adds a deterministic verdict engine that computes explicit dimensions and overall gates (`PASS`, `PASS_WITH_DEGRADED_EVIDENCE`, `CONDITIONAL`, `FAIL`, `UNAVAILABLE`) and emits machine-readable + markdown verdict artifacts (`scripts/security/verdict-lib.mjs`, `scripts/security/verdict.mjs`).
- Wires the artifacts into the security evidence pack and manifest, surfaces dependency/RLS/verdict status in `security/evidence` and `artifacts/security`, and updates the CI workflow and npm scripts with layered modes (`verify:security:fast|full|enterprise`) and conditional enterprise gate that requires secrets to run strict checks (`.github/workflows/security.yml`, `package.json`).
- Adds docs and runbooks describing the verification model, dependency evidence semantics, RLS runtime harness, and launch-gate criteria (`docs/security/VERIFICATION_MODEL.md`, `DEPENDENCY_EVIDENCE.md`, `RLS_VERIFICATION.md`, `LAUNCH_GATE.md`) and links them from the security index.
- Adds unit tests for evidence/verdict behavior and small harness tests that prove downgrade/upgrade rules and RLS evidence semantics (`scripts/__tests__/dependency-evidence.test.mjs`, `rls-evidence.test.mjs`, `security-verdict.test.mjs`).

### Testing
- Ran unit tests: `node --test scripts/__tests__/dependency-evidence.test.mjs scripts/__tests__/rls-evidence.test.mjs scripts/__tests__/security-verdict.test.mjs scripts/__tests__/supply-chain-policy.test.mjs scripts/__tests__/tenant-guardrails.test.mjs` — all tests passed.
- Project checks: `pnpm run lint`, `pnpm run typecheck`, and `pnpm run build` — all succeeded (lint produced warnings only, no failures).
- End-to-end verification: `pnpm run verify:security:fast` (standard/fast pipeline exercising route registry, tenant coverage, cross-tenant tests, dependency audit in warning mode, dependency-evidence, static RLS boundary, RLS evidence, and verdict) — completed and produced artifacts with final launch judgment `CONDITIONAL` in this environment.
- `pnpm run security:evidence` / full evidence pipeline was exercised in-session and artifacts were generated, though an interactive run was temporarily interrupted during troubleshooting; artifacts and summaries were ultimately produced and are included under `artifacts/security` and `security/*.json|md` for operator review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aca59b9b74832884913d454a585cb8)