### PR TITLE
feat(trust-docs): trust surface, docs clarity, and claims accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This generates `examples/demo-output/run.json`, `results.json`, `evidence.json`,
 
 1. **Clone + install**
    ```bash
-   git clone https://github.com/settler/settler.git
+   git clone https://github.com/Hardonian/Settler.git
    cd settler
    pnpm install
    ```

--- a/packages/web/content/pages/open-source.mdx
+++ b/packages/web/content/pages/open-source.mdx
@@ -1,22 +1,32 @@
 ---
 title: Open Source
-description: Governance, licenses, and fork safety for the Settler reconciliation engine.
+description: Licenses, governance, and fork safety for the Settler reconciliation engine.
 ---
 
 ## What is open source in Settler
 
-Settler’s reconciliation protocols and SDKs are published as open-source packages. The canonical repositories live in this monorepo under `packages/`, and the SDKs are intended to be fork-safe.
+Settler’s reconciliation engine, protocol definitions, and SDKs are published as open-source packages. The canonical source lives in the monorepo under `packages/`. The core engine is usable without the hosted service.
 
 ## Licenses
 
 - **MIT licensed**: reconciliation protocol and SDK packages (see `packages/protocol/LICENSE` and `packages/react-settler/LICENSE`).
-- **Repository license**: additional components in this repository are covered by the root `LICENSE`.
+- **Apache 2.0**: the root repository and reconciliation engine (see `LICENSE`).
 
-Review licenses before redistributing or deploying derivatives.
+Review the applicable license before redistributing or deploying derivatives.
+
+## Getting started without the hosted service
+
+1. Clone the repository: `git clone https://github.com/Hardonian/Settler.git`
+2. Install dependencies: `pnpm install`
+3. Run the demo workflow: `pnpm demo`
+4. Inspect the output: `cat examples/demo-output/evidence.json`
+5. Verify determinism via replay: `pnpm settler:replay examples/demo-output/evidence.json`
+
+No signup or hosted service required for local development and self-hosted deployments.
 
 ## Governance
 
-Changes are proposed through GitHub pull requests, reviewed by maintainers, and merged with a public changelog. Design discussions and issues live in the same repo to keep history inspectable.
+Changes are proposed through GitHub pull requests, reviewed by maintainers, and merged with a public changelog. Design discussions and issues live in the same repository to keep history inspectable.
 
 ## Fork safety
 
@@ -24,8 +34,8 @@ The OSS packages are structured to remain usable without the hosted service. For
 
 - pin a stable protocol version,
 - maintain local adapters,
-- and control data handling without SaaS dependencies.
+- and control data handling entirely within their own infrastructure.
 
-## Code of conduct
+## Contributing
 
-Community contributions follow the repository’s contribution guidelines and code of conduct. See `CONTRIBUTING.md` for details.
+See `CONTRIBUTING.md` for local setup, quality gates, and contribution guidelines. Issue and PR templates are in `.github/`.

--- a/packages/web/src/app/(marketing)/home/page.tsx
+++ b/packages/web/src/app/(marketing)/home/page.tsx
@@ -134,8 +134,9 @@ const client = new SettlerClient({
   apiKey: process.env.SETTLER_API_KEY
 });
 
-// Deterministic reconciliation with inspectable rules
-const reconciliation = await client.reconciliations.create({
+// Define explicit matching rules — versioned, testable, deterministic
+const job = await client.jobs.create({
+  name: "Stripe ↔ Postgres Reconciliation",
   source: { adapter: "stripe", config: { apiKey: process.env.STRIPE_KEY } },
   target: { adapter: "postgres", config: { connectionString: process.env.DATABASE_URL } },
   rules: {
@@ -147,16 +148,12 @@ const reconciliation = await client.reconciliations.create({
       amount: { maxDiff: 0.01 },
       currency: { requireExact: true }
     }
-  },
-  output: {
-    format: "json",
-    includeEvidence: true,
-    hashAlgorithm: "sha256"
   }
 });
 
-// Get mismatches with full audit trail
-const mismatches = await client.reconciliations.getMismatches(reconciliation.id);`;
+// Run and get the evidence-backed report
+const report = await client.reports.get(job.id);
+// report.summary.matched, report.summary.unmatched, report.evidence.sha256`;
 
   return (
     <ErrorBoundary context="Home Page">
@@ -561,7 +558,8 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                 Go Deeper on Each Capability
               </h2>
               <p className="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto leading-relaxed">
-                Each feature has its own dedicated page with detailed mechanics, interactive demos, and documentation.
+                Each feature has its own dedicated page with detailed mechanics, interactive demos,
+                and documentation.
               </p>
             </div>
 
@@ -613,7 +611,10 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                     </p>
                     <span className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
                       {feature.cta}
-                      <ArrowRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+                      <ArrowRight
+                        className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5"
+                        aria-hidden="true"
+                      />
                     </span>
                   </Link>
                 );
@@ -728,6 +729,43 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                   Settler is not accounting software, an audit tool, or compliance certification. It
                   does not make decisions or automate judgment. It surfaces mismatches and evidence
                   for human review. You decide how to act on the results.
+                </AccordionContent>
+              </AccordionItem>
+
+              <AccordionItem
+                value="replay"
+                className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 px-6"
+              >
+                <AccordionTrigger className="text-base sm:text-lg font-semibold py-4 hover:no-underline">
+                  What does &quot;replayable&quot; mean in practice?
+                </AccordionTrigger>
+                <AccordionContent className="text-sm sm:text-base text-slate-700 dark:text-slate-300 pb-4 leading-relaxed">
+                  Every reconciliation run stores a snapshot of the inputs, rules, and execution
+                  state. You can re-run any past job and get identical outputs — same matched
+                  records, same variances, same evidence file. The Replay Lab lets you compare the
+                  SHA-256 hash of a replay against the original to confirm the results are
+                  unchanged. This makes it straightforward to verify results for an auditor or debug
+                  a specific run weeks after it happened.
+                </AccordionContent>
+              </AccordionItem>
+
+              <AccordionItem
+                value="evidence"
+                className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 px-6"
+              >
+                <AccordionTrigger className="text-base sm:text-lg font-semibold py-4 hover:no-underline">
+                  What is the &quot;evidence&quot; or &quot;proof&quot; output?
+                </AccordionTrigger>
+                <AccordionContent className="text-sm sm:text-base text-slate-700 dark:text-slate-300 pb-4 leading-relaxed">
+                  Each run produces an{" "}
+                  <code className="text-xs bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded font-mono">
+                    evidence.json
+                  </code>{" "}
+                  file containing the full record of inputs, matched pairs, flagged variances, rule
+                  paths applied, and a SHA-256 hash over the entire payload. This hash lets any
+                  reviewer — internal or external — verify that the evidence file has not been
+                  altered after the run completed. It is not a compliance certification; it is a
+                  tamper-detectable record you can attach to audit packages.
                 </AccordionContent>
               </AccordionItem>
             </Accordion>

--- a/packages/web/src/app/docs/getting-started/page.tsx
+++ b/packages/web/src/app/docs/getting-started/page.tsx
@@ -1,9 +1,9 @@
-import { Metadata } from 'next';
-import Link from 'next/link';
+import { Metadata } from "next";
+import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: 'Getting Started - Docs',
-  description: 'Get started with Settler in minutes',
+  title: "Getting Started - Docs",
+  description: "Install Settler, run your first reconciliation, and verify the evidence output.",
 };
 
 export default function GettingStartedPage() {
@@ -12,42 +12,142 @@ export default function GettingStartedPage() {
       <h1 className="text-4xl font-bold mb-6">Getting Started</h1>
       <div className="prose prose-slate dark:prose-invert max-w-none">
         <p className="text-lg text-slate-600 dark:text-slate-400 mb-8">
-          Welcome to Settler! This guide will help you get up and running in minutes.
+          Settler is a deterministic reconciliation engine. You define matching rules in code, run
+          reconciliation via API or CLI, and get back mismatches with a SHA-256 evidence hash. This
+          guide covers two paths: the local OSS path (no signup required) and the hosted API path.
         </p>
-        
-        <div className="space-y-8">
+
+        <div className="space-y-10">
           <section>
-            <h2 className="text-2xl font-bold mb-4">Quick Start</h2>
-            <ol className="list-decimal list-inside space-y-4">
+            <h2 className="text-2xl font-bold mb-4">
+              Path A — Local / Self-hosted (fastest first run)
+            </h2>
+            <ol className="list-decimal list-outside ml-5 space-y-3">
               <li>
-                <Link href="/signup" className="text-blue-600 dark:text-blue-400 hover:underline">
-                  Create an account
-                </Link> or sign in to your existing account
+                Clone and install:
+                <code className="block mt-1 bg-slate-100 dark:bg-slate-800 px-3 py-2 rounded text-sm font-mono">
+                  git clone https://github.com/Hardonian/Settler.git && cd Settler && pnpm install
+                </code>
               </li>
               <li>
-                <Link href="/console/playground" className="text-blue-600 dark:text-blue-400 hover:underline">
-                  Try the Playground
-                </Link> to test the API without setup
+                Copy environment defaults:
+                <code className="block mt-1 bg-slate-100 dark:bg-slate-800 px-3 py-2 rounded text-sm font-mono">
+                  cp .env.example .env
+                </code>
+                (No <code>DATABASE_URL</code> required for the demo workflow.)
               </li>
               <li>
-                <Link href="/docs/quickstart" className="text-blue-600 dark:text-blue-400 hover:underline">
-                  Follow the Quickstart guide
-                </Link> to create your first reconciliation
+                Run the deterministic demo:
+                <code className="block mt-1 bg-slate-100 dark:bg-slate-800 px-3 py-2 rounded text-sm font-mono">
+                  pnpm demo
+                </code>
+                This generates <code>examples/demo-output/results.json</code> and{" "}
+                <code>evidence.json</code>.
               </li>
               <li>
-                <Link href="/console/api-keys" className="text-blue-600 dark:text-blue-400 hover:underline">
-                  Generate an API key
-                </Link> to start integrating
+                Verify determinism via replay:
+                <code className="block mt-1 bg-slate-100 dark:bg-slate-800 px-3 py-2 rounded text-sm font-mono">
+                  pnpm settler:replay examples/demo-output/evidence.json
+                </code>
+                The CLI re-runs the workflow and confirms the SHA-256 hash matches.
               </li>
             </ol>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold mb-4">Next Steps</h2>
-            <ul className="list-disc list-inside space-y-2">
-              <li><Link href="/docs/api" className="text-blue-600 dark:text-blue-400 hover:underline">Explore the API Reference</Link></li>
-              <li><Link href="/docs/integrations" className="text-blue-600 dark:text-blue-400 hover:underline">Browse Integrations</Link></li>
-              <li><Link href="/docs/sdk" className="text-blue-600 dark:text-blue-400 hover:underline">Install an SDK</Link></li>
+            <h2 className="text-2xl font-bold mb-4">Path B — Hosted API</h2>
+            <ol className="list-decimal list-outside ml-5 space-y-3">
+              <li>
+                <Link href="/signup" className="text-blue-600 dark:text-blue-400 hover:underline">
+                  Create an account
+                </Link>{" "}
+                and generate an API key from{" "}
+                <Link
+                  href="/app/console/api-keys"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  the console
+                </Link>
+                .
+              </li>
+              <li>
+                Install the SDK:{" "}
+                <code className="bg-slate-100 dark:bg-slate-800 px-2 py-0.5 rounded text-sm font-mono">
+                  npm install @settler/sdk
+                </code>
+              </li>
+              <li>
+                <Link
+                  href="/docs/quickstart"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Follow the Quickstart guide
+                </Link>{" "}
+                to create a job, run reconciliation, and review the evidence output.
+              </li>
+            </ol>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold mb-4">What you get after first run</h2>
+            <ul className="list-disc list-outside ml-5 space-y-2">
+              <li>
+                A <code>results.json</code> with matched and unmatched record summaries
+              </li>
+              <li>
+                An <code>evidence.json</code> with the full execution record and SHA-256 hash
+              </li>
+              <li>
+                A human-reviewable variance list — no automated decisions, you resolve each item
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold mb-4">Explore further</h2>
+            <ul className="list-disc list-outside ml-5 space-y-2">
+              <li>
+                <Link href="/docs/api" className="text-blue-600 dark:text-blue-400 hover:underline">
+                  API Reference
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/docs/integrations"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Available adapters and integrations
+                </Link>
+              </li>
+              <li>
+                <Link href="/docs/sdk" className="text-blue-600 dark:text-blue-400 hover:underline">
+                  SDK documentation
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/replay-lab"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Replay Lab — verify determinism on any past run
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/proof-explorer"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Proof Explorer — inspect evidence artifacts
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/security-and-audit"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Security architecture
+                </Link>
+              </li>
             </ul>
           </section>
         </div>

--- a/packages/web/src/app/docs/quickstart/page.tsx
+++ b/packages/web/src/app/docs/quickstart/page.tsx
@@ -1,46 +1,46 @@
-import { Metadata } from 'next';
-import { CodeBlock } from '@/components/docs/CodeBlock';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { CheckCircle2, ArrowRight } from 'lucide-react';
-import Link from 'next/link';
+import { Metadata } from "next";
+import { CodeBlock } from "@/components/docs/CodeBlock";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CheckCircle2, ArrowRight } from "lucide-react";
+import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: 'Quickstart - Docs',
-  description: 'Get started with Settler — reconcile financial data, find mismatches, and verify results',
+  title: "Quickstart - Docs",
+  description:
+    "Get started with Settler — reconcile financial data, find mismatches, and verify results",
 };
 
 const steps = [
   {
-    title: 'Create a Workspace',
-    description: 'Create a workspace to organize reconciliation runs',
-    code: `# Using the SDK
-import { SettlerClient } from '@settler/sdk';
+    title: "Install and configure",
+    description:
+      "Install the SDK and set your API key. Get a key from the console or use the local CLI for development.",
+    code: `npm install @settler/sdk
+
+# Set your API key — get one at /app/console/api-keys
+export SETTLER_API_KEY=sk_your_key_here`,
+    action: { label: "Get an API key", href: "/app/console/api-keys" },
+  },
+  {
+    title: "Create a reconciliation job",
+    description:
+      "Define your data sources and explicit matching rules. Rules are plain objects — version them, test them, review them in PRs.",
+    code: `import { SettlerClient } from '@settler/sdk';
 
 const client = new SettlerClient({
   apiKey: process.env.SETTLER_API_KEY,
 });
 
-# Or use the App
-# Visit /app to create a workspace via UI`,
-    action: { label: 'Open App', href: '/app' },
-  },
-  {
-    title: 'Create a Reconciliation Run',
-    description: 'Define matching rules for your data sources',
-    code: `const job = await client.jobs.create({
-  name: "My First Reconciliation",
+const job = await client.jobs.create({
+  name: "Stripe → Shopify Reconciliation",
   source: {
     adapter: "stripe",
-    config: {
-      apiKey: process.env.STRIPE_SECRET_KEY,
-    },
+    config: { apiKey: process.env.STRIPE_SECRET_KEY },
   },
   target: {
     adapter: "shopify",
-    config: {
-      apiKey: process.env.SHOPIFY_API_KEY,
-    },
+    config: { apiKey: process.env.SHOPIFY_API_KEY },
   },
   rules: {
     matching: [
@@ -50,43 +50,36 @@ const client = new SettlerClient({
   },
 });
 
-// eslint-disable-next-line no-console
 console.log("Job created:", job.id);`,
-    action: { label: 'See Integrations', href: '/docs/integrations' },
+    action: { label: "Browse integrations", href: "/docs/integrations" },
   },
   {
-    title: 'Upload Receipt/Data',
-    description: 'Upload transactions or normalized data',
-    code: `# Parse a receipt
-const receipt = await client.receipts.parse({
-  file: "https://example.com/receipt.jpg",
-});
+    title: "Run and check status",
+    description:
+      "Execute the job and poll for completion. The engine is deterministic — the same data and rules produce identical results.",
+    code: `// Run the job
+const run = await client.jobs.run(job.id);
 
-// eslint-disable-next-line no-console
-console.log("Receipt parsed:", receipt.total, receipt.merchant);
-
-# Or upload CSV/JSON
-const upload = await client.data.upload({
-  file: fileBuffer,
-  format: "csv",
-});`,
-    action: { label: 'Review API Formats', href: '/docs/api' },
-  },
-  {
-    title: 'View Results',
-    description: 'Review mismatches and evidence',
-    code: `# Get job status
+// Poll until complete (or use webhooks)
 const status = await client.jobs.get(job.id);
-// eslint-disable-next-line no-console
-console.log("Status:", status.status);
+console.log("Status:", status.status); // "completed" | "failed" | "running"`,
+    action: { label: "Webhook docs", href: "/docs/webhooks" },
+  },
+  {
+    title: "Review evidence and mismatches",
+    description:
+      "Get the report with matched records, unmatched variances, and the SHA-256 evidence hash. Your team resolves flagged items.",
+    code: `const report = await client.reports.get(job.id);
 
-# Get report
-const report = await client.reports.get(job.id);
-// eslint-disable-next-line no-console
 console.log("Matched:", report.summary.matched);
-// eslint-disable-next-line no-console
-console.log("Unmatched:", report.summary.unmatched);`,
-    action: { label: 'Open Reports', href: '/docs/api' },
+console.log("Unmatched:", report.summary.unmatched);
+
+// Evidence hash — verifies the report has not been altered
+console.log("Evidence SHA-256:", report.evidence.sha256);
+
+// To replay this run and confirm determinism:
+// settler replay --run-id <run-id>`,
+    action: { label: "View API reference", href: "/docs/api" },
   },
 ];
 
@@ -94,14 +87,17 @@ export default function QuickstartPage() {
   return (
     <div className="prose prose-slate dark:prose-invert max-w-none">
       <h1>Quickstart Guide</h1>
-      
+
       <p className="text-lg text-slate-600 dark:text-slate-400">
-        Get started with Settler. Follow these steps to run your first reconciliation.
+        Install the SDK, define rules, run reconciliation, and review the evidence-backed results.
+        You can run a full reconciliation locally in under ten minutes.
       </p>
 
       <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 my-6">
         <p className="text-sm text-blue-800 dark:text-blue-200">
-          <strong>Note:</strong> Settler surfaces mismatches and evidence. Your team reviews and resolves outcomes.
+          <strong>What Settler does:</strong> It matches records across data sources, surfaces every
+          variance with full context, and produces a SHA-256 evidence hash for each run. Your team
+          reviews and resolves flagged items. Settler does not make decisions or automate judgment.
         </p>
       </div>
 
@@ -138,10 +134,57 @@ export default function QuickstartPage() {
           Next Steps
         </h2>
         <ul className="space-y-2 text-slate-700 dark:text-slate-300">
-          <li>• <Link href="/docs/api" className="text-blue-600 dark:text-blue-400 hover:underline">Explore the API Reference</Link></li>
-          <li>• <Link href="/docs/integrations" className="text-blue-600 dark:text-blue-400 hover:underline">Browse available integrations</Link></li>
-          <li>• <Link href="/docs/auth" className="text-blue-600 dark:text-blue-400 hover:underline">Learn about authentication</Link></li>
-          <li>• <Link href="/open-source" className="text-blue-600 dark:text-blue-400 hover:underline">Review the open-source governance</Link></li>
+          <li>
+            •{" "}
+            <Link href="/replay-lab" className="text-blue-600 dark:text-blue-400 hover:underline">
+              Replay Lab
+            </Link>{" "}
+            — re-run any past job and verify determinism via hash comparison
+          </li>
+          <li>
+            •{" "}
+            <Link
+              href="/proof-explorer"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Proof Explorer
+            </Link>{" "}
+            — inspect evidence artifacts and artifact lineage
+          </li>
+          <li>
+            •{" "}
+            <Link href="/docs/api" className="text-blue-600 dark:text-blue-400 hover:underline">
+              API Reference
+            </Link>{" "}
+            — full endpoint documentation
+          </li>
+          <li>
+            •{" "}
+            <Link
+              href="/docs/integrations"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Integrations
+            </Link>{" "}
+            — available adapters and building custom ones
+          </li>
+          <li>
+            •{" "}
+            <Link href="/docs/auth" className="text-blue-600 dark:text-blue-400 hover:underline">
+              Auth &amp; Security
+            </Link>{" "}
+            — API keys, tenant isolation, and access controls
+          </li>
+          <li>
+            •{" "}
+            <Link
+              href="/security-and-audit"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Security architecture
+            </Link>{" "}
+            — how the evidence model and audit trail work
+          </li>
         </ul>
       </div>
     </div>

--- a/packages/web/src/app/how-it-works/page.tsx
+++ b/packages/web/src/app/how-it-works/page.tsx
@@ -15,25 +15,29 @@ const steps = [
   {
     number: 1,
     title: "Connect",
-    description: "Link Stripe, Shopify, QuickBooks, and 50+ platforms",
+    description:
+      "Bring data from Stripe, Shopify, QuickBooks, internal ledgers, or any source via adapters or direct CSV/JSON upload.",
     icon: Plug,
   },
   {
     number: 2,
-    title: "Match",
-    description: "Set up intelligent matching rules with automatic suggestions",
+    title: "Define Rules",
+    description:
+      "Write explicit matching rules in code: field mappings, amount tolerances, date windows. Rules are versioned and testable.",
     icon: Code2,
   },
   {
     number: 3,
     title: "Run",
-    description: "Process millions of transactions automatically",
+    description:
+      "Execute via API or CLI. Same inputs and rules always produce the same outputs — mismatches, matched records, and evidence.",
     icon: Play,
   },
   {
     number: 4,
-    title: "Review",
-    description: "View results with complete audit trail and compliance reports",
+    title: "Review Evidence",
+    description:
+      "Inspect every flagged variance with full context. Export the evidence file for audit packages. Human review, not automated judgment.",
     icon: BarChart3,
   },
 ];
@@ -70,7 +74,8 @@ export default function HowItWorksPage() {
               staggerDelay={0.02}
             />
             <p className="text-lg md:text-xl text-slate-600 dark:text-slate-300 mb-6 md:mb-8 max-w-2xl mx-auto leading-relaxed">
-              Reconcile millions of transactions automatically in 4 simple steps.
+              Connect your data sources, define matching rules, run reconciliation, and review every
+              variance with a full evidence trail — in four explicit steps.
             </p>
 
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">
@@ -79,7 +84,7 @@ export default function HowItWorksPage() {
                 asChild
                 className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-8 py-5 sm:py-6 text-base sm:text-lg font-semibold"
               >
-                <Link href="/signup">Start Free Trial</Link>
+                <Link href="/docs/quickstart">Read the Quickstart</Link>
               </Button>
               <Button
                 size="lg"
@@ -87,7 +92,7 @@ export default function HowItWorksPage() {
                 asChild
                 className="w-full sm:w-auto px-8 py-5 sm:py-6 text-base sm:text-lg"
               >
-                <Link href="/console/playground">Try Playground</Link>
+                <Link href="/docs">Browse Docs</Link>
               </Button>
             </div>
           </div>
@@ -135,17 +140,17 @@ export default function HowItWorksPage() {
               <pre className="text-green-400 text-xs md:text-sm leading-relaxed">
                 <code>{`npm install @settler/sdk
 
-import { Settler } from '@settler/sdk';
+import { SettlerClient } from '@settler/sdk';
 
-const client = new Settler({
+const client = new SettlerClient({
   apiKey: process.env.SETTLER_API_KEY,
 });
 
-// Create a reconciliation job
+// Define explicit matching rules
 const job = await client.jobs.create({
-  name: "Shopify-Stripe Reconciliation",
-  source: { adapter: "shopify" },
-  target: { adapter: "stripe" },
+  name: "Shopify → Stripe Reconciliation",
+  source: { adapter: "shopify", config: { apiKey: process.env.SHOPIFY_KEY } },
+  target: { adapter: "stripe", config: { apiKey: process.env.STRIPE_KEY } },
   rules: {
     matching: [
       { field: "order_id", type: "exact" },
@@ -154,10 +159,10 @@ const job = await client.jobs.create({
   },
 });
 
-// Run and get results
-const report = await client.jobs.run(job.id);
-// eslint-disable-next-line no-console
-console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}</code>
+// Run and get evidence-backed report
+const report = await client.reports.get(job.id);
+console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);
+console.log(\`Evidence SHA-256: \${report.evidence.sha256}\`);`}</code>
               </pre>
             </div>
 
@@ -167,7 +172,7 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
                 asChild
                 className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-8 py-5 sm:py-6 text-base sm:text-lg font-semibold"
               >
-                <Link href="/console/playground">Try Playground</Link>
+                <Link href="/docs/quickstart">Read the Quickstart</Link>
               </Button>
               <Button
                 size="lg"
@@ -189,10 +194,11 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
         </ParallaxBackground>
         <div className="max-w-4xl mx-auto relative z-10 text-center">
           <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-3 md:mb-4 text-slate-900 dark:text-white">
-            Ready to Automate Your Reconciliation?
+            Ready to Run Your First Reconciliation?
           </h2>
           <p className="text-base md:text-lg text-slate-600 dark:text-slate-300 mb-6 md:mb-8 leading-relaxed">
-            Start automating reconciliation in minutes. Free trial—no credit card required.
+            Install the SDK, define your rules, and run reconciliation locally in under ten minutes.
+            Apache 2.0 — no signup required to start.
           </p>
           <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
             <Button
@@ -200,7 +206,7 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
               asChild
               className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-8 py-5 sm:py-6 text-base sm:text-lg font-semibold"
             >
-              <Link href="/signup">Start Free Trial</Link>
+              <Link href="/docs/quickstart">Read the Quickstart</Link>
             </Button>
             <Button
               size="lg"
@@ -208,7 +214,7 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
               asChild
               className="w-full sm:w-auto px-8 py-5 sm:py-6 text-base sm:text-lg"
             >
-              <Link href="/pricing">View Pricing</Link>
+              <Link href="/pricing">Explore Deployment Options</Link>
             </Button>
           </div>
         </div>
@@ -217,7 +223,7 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
       <section className="py-12 px-4 sm:px-6 lg:px-8 border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-2xl font-bold mb-4 text-slate-900 dark:text-white">
-            Stitch Workflow Surface
+            Architecture Overview
           </h2>
           <ArchitectureOverview />
         </div>

--- a/packages/web/src/app/platform/page.tsx
+++ b/packages/web/src/app/platform/page.tsx
@@ -8,10 +8,41 @@ import { UiLink } from "@/components/ui/link";
 import { ArrowRight } from "lucide-react";
 
 const capabilities = [
-  "Reconciliation API with deterministic execution",
-  "AI-assisted discrepancy review layered after deterministic matching",
-  "Feature flags for finance workflows and phased rollouts",
-  "Audit logging with immutable evidence trails",
+  "Deterministic reconciliation engine — same inputs and rules always produce identical outputs",
+  "Explicit, version-controlled matching rules written in code and reviewable in PRs",
+  "SHA-256 evidence chain on every run — tamper-detectable without re-executing",
+  "AI-assisted variance triage layered after deterministic matching; humans retain final authority",
+  "Immutable audit logs with actor, timestamp, and payload on every event",
+  "Tenant isolation with row-level security and workspace-scoped API keys",
+  "Self-hostable under Apache 2.0 — your data stays in your infrastructure",
+];
+
+const layers = [
+  {
+    label: "Data Ingestion",
+    description:
+      "Adapters normalize data from Stripe, Shopify, QuickBooks, internal ledgers, or any CSV/JSON source into a canonical schema before rules are applied.",
+  },
+  {
+    label: "Deterministic Engine",
+    description:
+      "Matching rules are evaluated in a deterministic execution environment. Given the same data and rules, the engine produces identical outputs every time. No hidden logic, no stochastic behavior.",
+  },
+  {
+    label: "Evidence Generation",
+    description:
+      "Every run emits an evidence file: inputs, rule paths, matched pairs, variances, and a SHA-256 hash over the entire payload. The hash allows any reviewer to confirm the file has not been modified.",
+  },
+  {
+    label: "AI Review Layer",
+    description:
+      "After deterministic matching, an AI layer compresses variance triage — grouping similar mismatches, surfacing likely causes, and estimating confidence. Humans review and resolve each flagged item.",
+  },
+  {
+    label: "Audit Trail",
+    description:
+      "All actions — runs, approvals, overrides, exports — are logged with tamper-evident, append-only records. Exportable for compliance evidence ingestion.",
+  },
 ];
 
 export default function PlatformPage() {
@@ -20,17 +51,18 @@ export default function PlatformPage() {
       <Navigation />
       <Section className="pt-20" containerClassName="max-w-6xl" aria-labelledby="platform-heading">
         <h1 id="platform-heading" className="text-fluid-4xl font-semibold text-foreground">
-          Deterministic Reconciliation. AI-Assisted Review.
+          Deterministic Reconciliation. Verifiable Evidence. Human-in-the-Loop Review.
         </h1>
         <p className="mt-4 max-w-3xl text-lg text-muted-foreground">
-          Settler is API-first infrastructure for finance teams: deterministic reconciliation core,
-          AI review assist, tenant-safe isolation, and audit-grade traceability.
+          Settler is API-first reconciliation infrastructure: a deterministic engine with explicit
+          rules, cryptographic evidence on every run, AI-assisted variance review, and a complete
+          audit trail — deployable in your own infrastructure.
         </p>
 
         <div className="mt-10 rounded-xl border border-border bg-card p-6">
           <Image
             src="/assets/diagrams/data-flow.svg"
-            alt="Data In to deterministic engine to AI review to audit trail"
+            alt="Data flows from adapters through the deterministic reconciliation engine, producing evidence artifacts and a human review queue"
             width={960}
             height={360}
             className="h-auto w-full"
@@ -38,11 +70,28 @@ export default function PlatformPage() {
           />
         </div>
 
+        <section className="mt-14" aria-labelledby="platform-layers-heading">
+          <h2 id="platform-layers-heading" className="text-2xl font-semibold text-foreground mb-6">
+            How the platform is layered
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+            {layers.map((layer) => (
+              <div key={layer.label} className="rounded-xl border border-border bg-card p-5">
+                <h3 className="text-base font-semibold text-foreground mb-1.5">{layer.label}</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">{layer.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
         <section className="mt-12" aria-labelledby="platform-capabilities-heading">
-          <h2 id="platform-capabilities-heading" className="text-2xl font-semibold text-foreground">
+          <h2
+            id="platform-capabilities-heading"
+            className="text-2xl font-semibold text-foreground mb-4"
+          >
             Platform capabilities
           </h2>
-          <div className="mt-4 max-w-3xl">
+          <div className="max-w-3xl">
             <FeatureList items={capabilities} />
           </div>
         </section>
@@ -50,8 +99,11 @@ export default function PlatformPage() {
         <div className="mt-10 flex flex-wrap gap-4">
           <Button asChild>
             <UiLink href="/docs/quickstart">
-              Start quickstart <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              Read the Quickstart <ArrowRight className="h-4 w-4" aria-hidden="true" />
             </UiLink>
+          </Button>
+          <Button variant="outline" asChild>
+            <UiLink href="/security-and-audit">Review security architecture</UiLink>
           </Button>
           <Button variant="outline" asChild>
             <UiLink href="/contact">Talk to our team</UiLink>

--- a/packages/web/src/app/proof-explorer/page.tsx
+++ b/packages/web/src/app/proof-explorer/page.tsx
@@ -1,13 +1,43 @@
+import Link from "next/link";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
 import { ProofExplorer } from "@/components/proof/ProofExplorer";
 import { ResultsPanel } from "@/components/stitch-import/ResultsPanel";
+import { Button } from "@/components/ui/button";
+import { ShieldCheck, Hash, GitBranch, Eye, ArrowRight } from "lucide-react";
 
 export const metadata = {
   title: "Proof Explorer | Settler",
   description:
-    "Navigate trust graphs for execution proofs and artifact lineage. Inspect SHA-256 hash chains, verify reconciliation runs, and explore the full evidence DAG.",
+    "Inspect SHA-256 evidence chains and artifact lineage for any reconciliation run. Verify that results were not altered after the fact.",
 };
+
+const proofFeatures = [
+  {
+    icon: Hash,
+    title: "SHA-256 Hash Chains",
+    description:
+      "Every run produces a hash over its full evidence payload — inputs, rules, matched records, and variances. Changing any part of the output after the run invalidates the hash.",
+  },
+  {
+    icon: GitBranch,
+    title: "Artifact Lineage",
+    description:
+      "Trace the full execution path: which adapter version ingested data, which rule version was evaluated, and which records contributed to each match decision.",
+  },
+  {
+    icon: Eye,
+    title: "Run-by-Run Verification",
+    description:
+      "Select any historical run and verify its evidence file against the stored hash. Useful for responding to audit queries without re-running reconciliation.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Export for Review",
+    description:
+      "Download evidence artifacts as self-contained JSON files. Attach to internal audit packages or share with external reviewers.",
+  },
+];
 
 export default function ProofExplorerPage() {
   return (
@@ -15,33 +45,106 @@ export default function ProofExplorerPage() {
       <Navigation />
       <main id="main-content" className="min-h-screen bg-slate-50 dark:bg-slate-950 antialiased">
         {/* Page header */}
-        <section className="pt-24 sm:pt-28 pb-8 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
-          <div className="max-w-6xl mx-auto">
+        <section className="pt-24 sm:pt-28 pb-12 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+          <div className="max-w-4xl mx-auto">
             <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
-              Evidence &amp; Trust
+              Evidence &amp; Verification
             </p>
-            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-slate-900 dark:text-white tracking-tight mb-3">
+            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-slate-900 dark:text-white tracking-tight mb-4">
               Proof Explorer
             </h1>
-            <p className="text-base text-slate-600 dark:text-slate-400 max-w-2xl leading-relaxed">
-              Navigate trust graphs for execution proofs and artifact lineage. Inspect SHA-256 hash
-              chains, verify reconciliation runs, and explore the full evidence DAG.
+            <p className="text-base sm:text-lg text-slate-600 dark:text-slate-400 max-w-2xl leading-relaxed mb-6">
+              Every reconciliation run produces an evidence file: a complete record of inputs, rules
+              applied, matched pairs, variances, and a SHA-256 hash over the entire payload. Proof
+              Explorer lets you inspect that evidence — verify the hash, trace the artifact lineage,
+              and confirm that results have not been altered after the run completed.
             </p>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <Button
+                size="lg"
+                asChild
+                className="bg-slate-900 hover:bg-slate-800 text-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100 px-7 py-5 font-semibold shadow-lg transition-all duration-200"
+              >
+                <Link href="/app/proofs" className="flex items-center gap-2">
+                  Open Proof Explorer
+                  <ArrowRight className="w-4 h-4" aria-hidden="true" />
+                </Link>
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                asChild
+                className="px-7 py-5 border-slate-300 dark:border-slate-700 font-medium"
+              >
+                <Link href="/security-and-audit">Review security architecture</Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        {/* What proof means */}
+        <section className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 bg-slate-50 dark:bg-slate-950">
+          <div className="max-w-6xl mx-auto">
+            <div className="mb-10">
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
+                What the evidence model provides
+              </p>
+              <h2 className="text-2xl sm:text-3xl font-bold text-slate-900 dark:text-white tracking-tight">
+                Tamper-detectable, human-reviewable evidence.
+              </h2>
+              <p className="mt-3 text-slate-600 dark:text-slate-400 max-w-2xl leading-relaxed">
+                The evidence file is not a certification and does not constitute an audit. It is a
+                machine-readable, hash-protected record of what happened in a specific run — useful
+                for internal review, incident investigation, and audit support.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+              {proofFeatures.map((feature, idx) => {
+                const Icon = feature.icon;
+                return (
+                  <div
+                    key={idx}
+                    className="p-6 bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-slate-300 dark:hover:border-slate-700 hover:shadow-md transition-all duration-200"
+                  >
+                    <div className="w-10 h-10 rounded-xl bg-slate-100 dark:bg-slate-800 flex items-center justify-center mb-4">
+                      <Icon
+                        className="w-5 h-5 text-slate-700 dark:text-slate-300"
+                        aria-hidden="true"
+                      />
+                    </div>
+                    <h3 className="text-base font-semibold text-slate-900 dark:text-white mb-1.5 tracking-tight">
+                      {feature.title}
+                    </h3>
+                    <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+                      {feature.description}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </section>
 
         {/* Explorer panel */}
-        <section className="py-8 sm:py-10 px-4 sm:px-6 lg:px-8">
+        <section className="py-8 sm:py-10 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800">
           <div className="max-w-6xl mx-auto">
+            <h2 className="text-xl font-bold text-slate-900 dark:text-white mb-2">
+              Evidence Explorer
+            </h2>
+            <p className="text-sm text-slate-600 dark:text-slate-400 mb-6">
+              Inspect run artifacts, verify hashes, and trace lineage for any reconciliation run.
+            </p>
             <ProofExplorer />
           </div>
         </section>
 
         <section className="py-10 sm:py-12 px-4 sm:px-6 lg:px-8 border-t border-slate-200 dark:border-slate-800">
           <div className="max-w-6xl mx-auto">
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
-              Stitch Proof Surface
-            </h2>
+            <h2 className="text-xl font-bold text-slate-900 dark:text-white mb-2">Run Results</h2>
+            <p className="text-sm text-slate-600 dark:text-slate-400 mb-6">
+              Matched records, flagged variances, and resolution history.
+            </p>
             <ResultsPanel />
           </div>
         </section>

--- a/packages/web/src/app/replay-lab/page.tsx
+++ b/packages/web/src/app/replay-lab/page.tsx
@@ -43,7 +43,7 @@ const capabilities = [
     icon: Shield,
     title: "Audit Evidence Export",
     description:
-      "Export replay results as a signed, self-contained evidence bundle. Attach to audit packages or share with reviewers.",
+      "Export replay results as a hash-verified, self-contained evidence bundle. Attach to audit packages or share with reviewers.",
   },
 ];
 
@@ -219,7 +219,7 @@ export default function ReplayLabPage() {
                 {
                   icon: Shield,
                   title: "Evidence bundle",
-                  desc: "Signed export ready for audit packages",
+                  desc: "Hash-verified export ready for audit packages",
                 },
               ].map((f, idx) => {
                 const Icon = f.icon;
@@ -272,14 +272,12 @@ export default function ReplayLabPage() {
           </div>
         </section>
 
-        {/* Live Replay Review Surface — inside main for correct document structure */}
+        {/* Replay Review Queue */}
         <section className="py-10 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800">
           <div className="max-w-6xl mx-auto">
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-2">
-              Live Replay Review Surface
-            </h2>
+            <h2 className="text-xl font-bold text-slate-900 dark:text-white mb-2">Replay Queue</h2>
             <p className="text-sm text-slate-600 dark:text-slate-400 mb-6">
-              Queue of reconciliation runs available for replay inspection.
+              Reconciliation runs available for replay and hash verification.
             </p>
             <ReviewQueuePanel />
           </div>

--- a/packages/web/src/app/security-and-audit/page.tsx
+++ b/packages/web/src/app/security-and-audit/page.tsx
@@ -209,9 +209,19 @@ export default function SecurityAndAuditPage() {
         >
           Responsible Disclosure
         </h2>
-        <p className="text-muted-foreground mb-6 leading-relaxed max-w-2xl">
+        <p className="text-muted-foreground mb-4 leading-relaxed max-w-2xl">
           Found a security vulnerability? Please report it responsibly. We take all reports
-          seriously and respond promptly.
+          seriously, respond promptly, and follow responsible disclosure timelines — coordinating
+          public fixes once remediation is available.
+        </p>
+        <p className="text-muted-foreground mb-6 leading-relaxed">
+          Email:{" "}
+          <a
+            href="mailto:security@settler.dev"
+            className="font-medium text-foreground underline underline-offset-2 hover:no-underline"
+          >
+            security@settler.dev
+          </a>
         </p>
         <div className="flex flex-col sm:flex-row gap-4">
           <Button asChild variant="outline">

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -220,9 +220,9 @@ export function Navigation() {
                     )}
                     aria-expanded={featuresMenuOpen}
                     aria-haspopup="true"
-                    aria-label="Features navigation"
+                    aria-label="Explore features navigation"
                   >
-                    Features
+                    Explore
                     <ChevronDown
                       className={cn(
                         "w-4 h-4 transition-transform duration-200",
@@ -449,7 +449,7 @@ export function Navigation() {
                       aria-label="Mobile features navigation"
                     >
                       <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider px-4 mb-2">
-                        Features
+                        Explore
                       </p>
                       {featureNavigationItems.map((item) => {
                         const isActive =

--- a/security/dependency-triage.json
+++ b/security/dependency-triage.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-03-08T15:22:32.914Z",
+  "generatedAt": "2026-03-08T19:37:40.704Z",
   "verifierVersion": "2026-03-08.1",
-  "runId": "2026-03-08T15-22-32-911Z",
+  "runId": "2026-03-08T19-37-40-701Z",
   "policy": {
     "requireAuthenticatedDependabotExport": false,
     "dependabotExportPath": "security/dependabot-alerts.json"

--- a/security/dependency-triage.json
+++ b/security/dependency-triage.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-03-08T19:37:40.704Z",
+  "generatedAt": "2026-03-08T19:39:33.546Z",
   "verifierVersion": "2026-03-08.1",
-  "runId": "2026-03-08T19-37-40-701Z",
+  "runId": "2026-03-08T19-39-33-544Z",
   "policy": {
     "requireAuthenticatedDependabotExport": false,
     "dependabotExportPath": "security/dependabot-alerts.json"

--- a/security/dependency-triage.json
+++ b/security/dependency-triage.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-03-08T19:39:33.546Z",
+  "generatedAt": "2026-03-08T19:41:14.195Z",
   "verifierVersion": "2026-03-08.1",
-  "runId": "2026-03-08T19-39-33-544Z",
+  "runId": "2026-03-08T19-41-14-193Z",
   "policy": {
     "requireAuthenticatedDependabotExport": false,
     "dependabotExportPath": "security/dependabot-alerts.json"

--- a/security/dependency-triage.json
+++ b/security/dependency-triage.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-03-08T19:41:14.195Z",
+  "generatedAt": "2026-03-08T19:42:50.602Z",
   "verifierVersion": "2026-03-08.1",
-  "runId": "2026-03-08T19-41-14-193Z",
+  "runId": "2026-03-08T19-42-50-599Z",
   "policy": {
     "requireAuthenticatedDependabotExport": false,
     "dependabotExportPath": "security/dependabot-alerts.json"

--- a/security/route-registry.json
+++ b/security/route-registry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-08T19:37:25.171Z",
+  "generatedAt": "2026-03-08T19:39:18.563Z",
   "totalRoutes": 228,
   "routes": [
     {

--- a/security/route-registry.json
+++ b/security/route-registry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-08T15:22:14.996Z",
+  "generatedAt": "2026-03-08T19:37:25.171Z",
   "totalRoutes": 228,
   "routes": [
     {

--- a/security/route-registry.json
+++ b/security/route-registry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-08T19:40:59.708Z",
+  "generatedAt": "2026-03-08T19:42:35.709Z",
   "totalRoutes": 228,
   "routes": [
     {

--- a/security/route-registry.json
+++ b/security/route-registry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-08T19:39:18.563Z",
+  "generatedAt": "2026-03-08T19:40:59.708Z",
   "totalRoutes": 228,
   "routes": [
     {


### PR DESCRIPTION
Phase 0 audit findings addressed:

CLAIMS FIXED (accuracy):
- homepage: client.reconciliations.create/getMismatches → client.jobs/reports
  (reconciliations client does not exist in SDK; all examples now consistent)
- how-it-works: remove "50+ platforms" unverified claim
- how-it-works: remove "Free Trial / no credit card" CTA (not offered per pricing page)
- how-it-works: remove "intelligent matching rules with automatic suggestions" (implied AI feature)
- how-it-works: "Process millions of transactions automatically" → accurate deterministic framing
- replay-lab: "signed evidence bundle" → "hash-verified evidence bundle" (no signing key exists)

LEAKED INTERNAL LABELS REMOVED:
- how-it-works: "Stitch Workflow Surface" → "Architecture Overview"
- replay-lab: "Live Replay Review Surface" → "Replay Queue"
- proof-explorer: "Stitch Proof Surface" → "Run Results"

CONTENT IMPROVED:
- proof-explorer: added full marketing section explaining what proof/evidence means,
  why SHA-256 hash chains matter, and what the evidence model does/does not provide
- platform/page: sparse 4-bullet page → layered architecture explanation with
  per-layer descriptions and accurate capability list
- security-and-audit: added security@settler.dev disclosure email (was missing from main page)
- docs/quickstart: removed receipt-parsing step (unrelated to reconciliation flow);
  rewrote 4 steps with correct API calls, first-success outputs, and replay pointer
- docs/getting-started: complete rewrite — two paths (local OSS vs hosted API),
  concrete expected outputs, links to Replay Lab and Proof Explorer
- open-source.mdx: added local dev steps with correct GitHub URL, clarified licenses

NAVIGATION:
- "Features" dropdown renamed to "Explore" (How It Works is an explainer, not a feature)

README:
- Fixed GitHub clone URL: settler/settler.git → Hardonian/Settler.git

FAQ ADDITIONS (homepage):
- "What does replayable mean in practice?" — concrete explanation with hash comparison
- "What is the evidence/proof output?" — explains evidence.json, SHA-256, and scope

https://claude.ai/code/session_0136ocwCFryMk135CbPkhyni