### PR TITLE
trust: strengthen developer adoption path, fix messaging clarity, and harden trust surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,59 @@
 # Settler
 
-**Settler is a deterministic workflow platform for financial reconciliation that emits verifiable proof artifacts for every run.**
+**Settler is a deterministic reconciliation engine for financial data that emits verifiable evidence artifacts for every run.**
 
-Engineering teams routinely hit the same failure mode: Stripe, bank exports, and internal ledgers diverge, but root-cause analysis is slow because execution history is incomplete or non-replayable. Settler solves this by combining deterministic execution, policy evaluation, and replay verification in one auditable path.
+Engineering teams hit the same failure mode: Stripe, bank exports, and internal ledgers diverge, but root-cause analysis is slow because execution history is incomplete or non-replayable. Settler solves this by combining deterministic execution, explicit rule evaluation, and replay verification in one auditable path.
 
-## Key capabilities
+## What it produces
 
-- **Deterministic workflow execution** for recon pipelines across normalized connector inputs.
-- **Replay with cryptographic evidence** so every run can be re-verified from stored artifacts.
-- **Policy-governed operations** that evaluate access, budgets, and guardrails as part of execution.
+Every reconciliation run writes four outputs to `examples/demo-output/` (or your configured output path):
 
-## Quick usage example
+| File | Contents |
+|------|----------|
+| `run.json` | Execution metadata: timing, adapter versions, rule set used |
+| `results.json` | Match/mismatch summary with rule path traces for every record pair |
+| `evidence.json` | SHA-256 hash-linked audit artifact — the replay-verification input |
+| `report.html` | Human-readable mismatch report for review packages |
+
+## Quick start — first run in 5 minutes
+
+No database or API keys required for the demo path.
 
 ```bash
+# Clone and install
+git clone https://github.com/Hardonian/Settler.git
+cd Settler
 pnpm install
+
+# Copy env (DATABASE_URL not required for demo)
+cp .env.example .env
+
+# Run a Stripe↔QuickBooks demo reconciliation
 pnpm demo
+
+# Inspect results and evidence
+cat examples/demo-output/results.json
+cat examples/demo-output/evidence.json
+
+# Replay verification — re-runs deterministically and confirms hash match
 pnpm settler:replay examples/demo-output/evidence.json
 ```
 
-This generates `examples/demo-output/run.json`, `results.json`, `evidence.json`, and `report.html` from a deterministic Stripe↔QuickBooks demo workflow.
+For SDK-based reconciliation against your own data sources, see [`docs/launch/QUICK_START.md`](docs/launch/QUICK_START.md).
 
-## Quick start (time-to-first-value)
+## Key capabilities
 
-1. **Clone + install**
-   ```bash
-   git clone https://github.com/settler/settler.git
-   cd settler
-   pnpm install
-   ```
-2. **Set environment values**
-   ```bash
-   cp .env.example .env
-   ```
-   For demo and replay, `DATABASE_URL` is not required.
-3. **Execute a deterministic example workflow**
-   ```bash
-   pnpm demo
-   ```
-4. **Inspect outputs + proof**
-   ```bash
-   cat examples/demo-output/results.json
-   cat examples/demo-output/evidence.json
-   ```
-5. **Replay verification**
-   ```bash
-   pnpm settler:replay examples/demo-output/evidence.json
-   ```
+- **Deterministic execution** — same inputs and rules always produce the same output.
+- **Evidence artifacts are first-class outputs** — `evidence.json` with SHA-256 fingerprints, not debug logs.
+- **Replay verification** — re-run any past reconciliation from stored artifacts to confirm results.
+- **Policy evaluation in the execution loop** — access controls and guardrails evaluated at runtime, not post-hoc.
+- **Connector normalization** — adapters normalize inputs into a canonical schema before matching, reducing non-deterministic drift.
 
-For expanded launch-oriented walkthroughs (example workflows, expected outputs, replay instructions), see [`docs/launch/QUICK_START.md`](docs/launch/QUICK_START.md).
+## Why determinism matters
 
-## Architecture at a glance
+Most reconciliation workflows fail during root-cause analysis, not during the run itself. When a variance surfaces in production, you need to know: did the rule change? Did the data change? Did the engine behave differently?
 
-See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the runtime diagram and component flow (workflow execution, event backbone, workers, artifact store, proof generation, connector integrations, policy engine).
+Settler eliminates that uncertainty. Determinism makes debugging tractable, rule testing reliable, and audit straightforward.
 
 ## Technical differentiation
 
@@ -63,6 +65,10 @@ Settler differs from generic workflow tools in five concrete ways:
 4. **Policy evaluation is in the execution loop**, not a separate post-processing stage.
 5. **Connector safety includes normalization + tenant boundaries** to reduce non-deterministic drift.
 
+## Architecture at a glance
+
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the runtime diagram and component flow: workflow execution, event backbone, workers, artifact store, proof generation, connector integrations, and policy engine.
+
 ## Security evidence model
 
 Security verification artifacts are machine-readable and intentionally explicit about evidence quality:
@@ -70,28 +76,33 @@ Security verification artifacts are machine-readable and intentionally explicit 
 - `VERIFIED`: runtime or authenticated evidence confirms the claim.
 - `DEGRADED`: checks passed, but confidence is reduced (e.g., missing authenticated advisory feed).
 - `UNAVAILABLE`: evidence was not produced in this environment.
-- `SKIPPED`: verification was intentionally not executed (for example, runtime-only probes during local work).
+- `SKIPPED`: verification was intentionally not executed (e.g., runtime-only probes during local development).
 - `FAILED`: evidence demonstrates a failing control.
 
-Artifacts are emitted to:
+Artifacts are written to:
 
 - `security/dependency-evidence.json`
 - `security/rls-evidence.json`
 - `security/security-verdict.json`
 
-## Product surfaces and route map
+## Product surfaces
 
-Public routes include `/product`, `/reconciliation`, `/replay-lab`, `/proof-explorer`, `/policies`, `/security`, `/oss`, and `/enterprise`.
+**Public routes:** `/product`, `/how-it-works`, `/reconciliation`, `/replay-lab`, `/proof-explorer`, `/policies`, `/security`, `/oss`, `/enterprise`
 
-Control-plane routes include `/app/executions`, `/app/reconciliation`, `/app/replay`, `/app/proofs`, `/app/policies`, `/app/audit`, `/app/system-health`, and `/app/integrations`.
+**Control-plane routes:** `/app/executions`, `/app/reconciliation`, `/app/replay`, `/app/proofs`, `/app/policies`, `/app/audit`, `/app/system-health`, `/app/integrations`
 
 ## Contributor on-ramp
 
-- Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup and quality gates.
-- Browse launch-ready examples in [`docs/launch/EXAMPLE_WORKFLOWS.md`](docs/launch/EXAMPLE_WORKFLOWS.md).
-- Use issue/PR templates in [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE) and [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+1. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup, package layout, and quality gates.
+2. Run `pnpm demo` to verify your environment produces a working evidence artifact.
+3. Browse [`docs/launch/EXAMPLE_WORKFLOWS.md`](docs/launch/EXAMPLE_WORKFLOWS.md) for walkthrough examples with expected outputs.
+4. Check open issues for **good first issue** labels, or open a proposal before starting larger changes.
+5. Use issue/PR templates in [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE) and [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+
+Good first contributions: documentation fixes, new adapter integrations (see `packages/adapters/src/drivers/`), SDK examples, and minor UI improvements.
 
 ## License and security
 
-- License: [`LICENSE`](LICENSE)
+- License: [`LICENSE`](LICENSE) — Apache 2.0
 - Security policy: [`SECURITY.md`](SECURITY.md)
+- Report security issues: `security@settler.dev`

--- a/packages/web/content/pages/open-source.mdx
+++ b/packages/web/content/pages/open-source.mdx
@@ -1,31 +1,53 @@
 ---
 title: Open Source
-description: Governance, licenses, and fork safety for the Settler reconciliation engine.
+description: Governance, licenses, and fork guidance for the Settler reconciliation engine.
 ---
 
 ## What is open source in Settler
 
-Settler’s reconciliation protocols and SDKs are published as open-source packages. The canonical repositories live in this monorepo under `packages/`, and the SDKs are intended to be fork-safe.
+Settler is published as an open-source monorepo. The reconciliation engine, CLI, SDKs, and protocol definitions are all included. The canonical repository lives at [github.com/Hardonian/Settler](https://github.com/Hardonian/Settler).
 
 ## Licenses
 
-- **MIT licensed**: reconciliation protocol and SDK packages (see `packages/protocol/LICENSE` and `packages/react-settler/LICENSE`).
-- **Repository license**: additional components in this repository are covered by the root `LICENSE`.
+- **Apache 2.0:** the root repository, including the reconciliation engine, API, CLI, and web console. See `LICENSE` at the repository root.
+- **MIT:** select SDK and protocol packages under `packages/protocol/` and `packages/react-settler/`. See per-package `LICENSE` files.
 
-Review licenses before redistributing or deploying derivatives.
+Review the applicable license before redistributing or deploying derivatives.
 
-## Governance
+## Running it locally
 
-Changes are proposed through GitHub pull requests, reviewed by maintainers, and merged with a public changelog. Design discussions and issues live in the same repo to keep history inspectable.
+No database required for the demo path:
+
+```bash
+git clone https://github.com/Hardonian/Settler.git
+cd Settler
+pnpm install
+pnpm demo
+```
+
+This runs a deterministic Stripe↔QuickBooks example and writes outputs to `examples/demo-output/`. See the [quickstart](/docs/quickstart) for full instructions.
 
 ## Fork safety
 
-The OSS packages are structured to remain usable without the hosted service. Forks can:
+The OSS packages are structured to remain usable without the hosted service:
 
-- pin a stable protocol version,
-- maintain local adapters,
-- and control data handling without SaaS dependencies.
+- Pin a stable protocol version to avoid breaking changes from upstream.
+- Maintain local adapters in `packages/adapters/src/drivers/` without coupling to SaaS dependencies.
+- Control data handling and retention entirely within your own infrastructure.
+- The replay verification path (`pnpm settler:replay`) works offline against stored `evidence.json` artifacts.
+
+## Governance
+
+Changes are proposed through GitHub pull requests and reviewed by maintainers. The changelog is public and versioned. Design discussions and issues live in the same repository to keep history inspectable.
+
+Contributor guidance is in [`CONTRIBUTING.md`](https://github.com/Hardonian/Settler/blob/main/CONTRIBUTING.md). Good first contributions include documentation improvements, new adapter integrations, and SDK examples.
+
+## Community
+
+- **Issues:** bug reports and feature requests via GitHub Issues using the provided templates.
+- **Pull requests:** contributions welcome — see `CONTRIBUTING.md` for quality gates and local setup.
+- **Discussions:** proposals and Q&A via GitHub Discussions (if enabled on the repository).
 
 ## Code of conduct
 
-Community contributions follow the repository’s contribution guidelines and code of conduct. See `CONTRIBUTING.md` for details.
+Community contributions follow the repository's [Code of Conduct](https://github.com/Hardonian/Settler/blob/main/CODE_OF_CONDUCT.md). Respectful, constructive engagement is expected from all participants.

--- a/packages/web/content/pages/product.mdx
+++ b/packages/web/content/pages/product.mdx
@@ -1,34 +1,58 @@
 ---
 title: Product
-description: Deterministic reconciliation engine that normalizes data, applies explicit rules, and surfaces variances.
+description: Deterministic reconciliation engine that normalizes data, applies explicit rules, and surfaces variances with verifiable evidence.
 ---
 
-## Data → Normalize → Rules → Variances
+## What Settler does
 
-Settler is a reconciliation engine with a deliberate pipeline:
+Settler matches financial records across data sources — Stripe, QuickBooks, Shopify, bank exports, internal ledgers — and surfaces every mismatch with full context. Every run produces a hash-linked evidence artifact you can inspect, share, and replay.
 
-1. **Ingest data** from adapters, files, or internal pipelines.
-2. **Normalize records** into a canonical schema.
-3. **Apply explicit rules** for matching, tolerances, and transformations.
-4. **Surface variances** with evidence for human review.
+## The pipeline: Data → Normalize → Rules → Variances
 
-## Deterministic and inspectable
+Settler processes data through a fixed, inspectable pipeline:
 
-The engine is deterministic: the same inputs and rules produce the same outputs. Outputs are designed to be inspectable so teams can review evidence and rule paths.
+1. **Ingest data** from adapters, file uploads, or internal pipelines.
+2. **Normalize records** into a canonical schema so records from different sources are comparable.
+3. **Apply explicit rules** for matching criteria, numeric tolerances, and date windows.
+4. **Surface variances** with the rule path that produced them, for human review.
+
+Nothing in the pipeline is implicit. Every step is inspectable.
+
+## Why determinism matters
+
+Most reconciliation workflows fail during root-cause analysis — not during the run itself. When a mismatch surfaces in production, you need to know: did the rule change? Did the data change? Did the engine behave differently between runs?
+
+Settler eliminates this uncertainty. Given the same inputs and rules, it always produces the same output. This means:
+
+- **Debugging is tractable.** Replay a past run against current rules to isolate what changed.
+- **Testing is reliable.** Write rule tests against fixture data with known expected outputs.
+- **Audit is straightforward.** The evidence artifact for any past run can be independently re-verified.
+
+## Proof artifacts are first-class outputs
+
+Every run writes:
+
+- `evidence.json` — SHA-256 hash-linked record of inputs, rules, and outputs
+- `results.json` — structured match/mismatch data with rule path traces
+- `report.html` — human-readable mismatch summary
+
+These artifacts are the product, not a debug side-effect.
 
 ## Human-in-the-loop by design
 
-Settler does not decide outcomes for you. It provides variance sets and evidence so your team can review and resolve exceptions.
+Settler does not decide outcomes for your team. It surfaces variance sets and evidence so your team can review and resolve exceptions. AI-assisted review compresses triage time for high-volume exception queues — but final authority stays with your operators.
 
 ## Provider-agnostic core
 
-Adapters are optional. You can bring your own data model and map it into the canonical schema without coupling to a single provider.
+Adapters are optional. You can bring your own data model and normalize it into the canonical schema without coupling to a single provider. Custom adapters live in `packages/adapters/src/drivers/` and follow the same normalization contract as built-in connectors.
 
 ## Non-goals
 
 Settler is **not**:
 
 - Accounting software
-- An audit
-- Compliance tooling
+- An audit or certification tool
+- Compliance infrastructure
 - A guarantee of correctness
+
+It produces evidence that supports your team's review and your auditors' work. The judgment and accountability remain with you.

--- a/packages/web/content/pages/security-and-audit.mdx
+++ b/packages/web/content/pages/security-and-audit.mdx
@@ -5,11 +5,39 @@ description: How Settler approaches security, audit evidence, and disclosure wit
 
 ## Security posture
 
-Settler is designed to be conservative and auditable. The engine emphasizes deterministic behavior and explicit rule configuration over implicit automation.
+Settler is designed to be conservative and auditable. The engine emphasizes deterministic behavior and explicit rule configuration over implicit automation. Every run produces machine-readable evidence artifacts that can be independently inspected and replayed.
 
 ## Audit evidence, not audit results
 
-Settler produces reconciliation artifacts (inputs, rules, outputs, and variances) to support human review. It is **not** an audit, and it does not certify outcomes or compliance.
+Settler produces reconciliation artifacts — inputs, rules, outputs, and variances — to support human review. These artifacts are structured so a third party can independently verify that the run occurred as described.
+
+Settler is **not** an audit and it does not certify outcomes or compliance. Evidence generation is a tool for your team and your auditors — not a replacement for professional review.
+
+## What evidence artifacts contain
+
+Each run produces:
+
+- **`evidence.json`** — hash-linked record of inputs, rules applied, outputs, and variance summary. Includes SHA-256 fingerprints at each step.
+- **`results.json`** — structured match/mismatch output with rule path traces for every record pair.
+- **`report.html`** — human-readable summary for audit review packages.
+
+Artifact integrity is verified during replay: `pnpm settler:replay evidence.json` re-runs the workflow from stored artifacts and confirms the output hash matches the original.
+
+## Evidence quality levels
+
+Security verification artifacts use explicit confidence levels rather than binary pass/fail:
+
+- `VERIFIED` — runtime or authenticated evidence confirms the claim.
+- `DEGRADED` — checks passed, but confidence is reduced (e.g., missing authenticated advisory feed).
+- `UNAVAILABLE` — evidence was not produced in this environment.
+- `SKIPPED` — verification was intentionally not executed (e.g., runtime-only probes during local development).
+- `FAILED` — evidence demonstrates a failing control.
+
+System-level security artifacts are written to:
+
+- `security/dependency-evidence.json`
+- `security/rls-evidence.json`
+- `security/security-verdict.json`
 
 ## Non-guarantees
 
@@ -21,10 +49,19 @@ Settler does **not**:
 
 You are responsible for review, approval, and downstream reporting.
 
+## Data handling
+
+Data handling depends on your deployment model:
+
+- **Self-hosted (OSS):** your data stays in your infrastructure. You control retention, access, and configuration.
+- **Managed cloud:** data is processed in Settler's infrastructure. Review the privacy policy and DPA for your deployment.
+
+Always review configuration, retention, and access control policies for your environment before processing sensitive financial data.
+
+## Access controls
+
+The engine enforces tenant isolation through row-level security (RLS) on all data queries. Policy-based access controls gate reconciliation workflow execution. Access logs are written as part of the audit trail.
+
 ## Responsible disclosure
 
-Report security issues to `security@settler.dev`. We follow responsible disclosure timelines and coordinate public fixes once remediation is available.
-
-## Data handling expectations
-
-Data handling depends on your deployment model (self-hosted OSS vs. hosted enterprise). Always review configuration, retention, and access control policies for your environment.
+Report security issues to `security@settler.dev`. We follow responsible disclosure timelines and coordinate public fixes once remediation is available. Do not disclose vulnerabilities publicly before a fix is available.

--- a/packages/web/src/app/docs/quickstart/page.tsx
+++ b/packages/web/src/app/docs/quickstart/page.tsx
@@ -7,40 +7,86 @@ import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Quickstart - Docs',
-  description: 'Get started with Settler — reconcile financial data, find mismatches, and verify results',
+  description: 'Get started with Settler — run a deterministic reconciliation and inspect the evidence in under 5 minutes',
 };
 
-const steps = [
+const demoSteps = [
   {
-    title: 'Create a Workspace',
-    description: 'Create a workspace to organize reconciliation runs',
-    code: `# Using the SDK
-import { SettlerClient } from '@settler/sdk';
+    title: 'Clone and Install',
+    description: 'No database or API keys required for the demo path.',
+    code: `git clone https://github.com/Hardonian/Settler.git
+cd Settler
+pnpm install`,
+    action: null,
+  },
+  {
+    title: 'Copy Environment File',
+    description: 'For the demo, DATABASE_URL is not required. Leave it blank.',
+    code: `cp .env.example .env
+# DATABASE_URL is not needed for pnpm demo`,
+    action: null,
+  },
+  {
+    title: 'Run the Demo',
+    description: 'Executes a Stripe↔QuickBooks reconciliation using fixture data. Writes four output files to examples/demo-output/.',
+    code: `pnpm demo
+
+# Expected output:
+# ✓ Workflow executed deterministically
+# ✓ evidence.json written
+# ✓ results.json written
+# ✓ report.html written`,
+    action: null,
+  },
+  {
+    title: 'Inspect Results and Evidence',
+    description: 'The evidence file contains the full hash-linked audit artifact. Open report.html to browse mismatches visually.',
+    code: `# Summary: matched, unmatched, and variance counts
+cat examples/demo-output/results.json
+
+# Hash-linked audit artifact for this run
+cat examples/demo-output/evidence.json
+
+# Open in browser for a visual mismatch report
+open examples/demo-output/report.html`,
+    action: { label: 'Explore the Evidence Model', href: '/proof-explorer' },
+  },
+  {
+    title: 'Replay Verification',
+    description: 'Re-runs the reconciliation from stored artifacts and verifies the output hash matches the original. Confirms determinism.',
+    code: `pnpm settler:replay examples/demo-output/evidence.json
+
+# Expected output:
+# ✓ Replay complete — hash match confirmed`,
+    action: { label: 'Learn about Replay', href: '/docs/api' },
+  },
+];
+
+const sdkSteps = [
+  {
+    title: 'Install the SDK',
+    description: 'TypeScript and Python SDKs are available.',
+    code: `npm install @settler/sdk`,
+    action: { label: 'SDK Reference', href: '/docs/sdk' },
+  },
+  {
+    title: 'Create a Reconciliation Job',
+    description: 'Connect your data sources and define matching rules in code. Rules are version-controlled and testable.',
+    code: `import { SettlerClient } from '@settler/sdk';
 
 const client = new SettlerClient({
   apiKey: process.env.SETTLER_API_KEY,
 });
 
-# Or use the App
-# Visit /app to create a workspace via UI`,
-    action: { label: 'Open App', href: '/app' },
-  },
-  {
-    title: 'Create a Reconciliation Run',
-    description: 'Define matching rules for your data sources',
-    code: `const job = await client.jobs.create({
-  name: "My First Reconciliation",
+const job = await client.jobs.create({
+  name: "Stripe → Shopify Reconciliation",
   source: {
     adapter: "stripe",
-    config: {
-      apiKey: process.env.STRIPE_SECRET_KEY,
-    },
+    config: { apiKey: process.env.STRIPE_SECRET_KEY },
   },
   target: {
     adapter: "shopify",
-    config: {
-      apiKey: process.env.SHOPIFY_API_KEY,
-    },
+    config: { apiKey: process.env.SHOPIFY_API_KEY },
   },
   rules: {
     matching: [
@@ -50,43 +96,20 @@ const client = new SettlerClient({
   },
 });
 
-// eslint-disable-next-line no-console
 console.log("Job created:", job.id);`,
-    action: { label: 'See Integrations', href: '/docs/integrations' },
+    action: { label: 'Browse Integrations', href: '/docs/integrations' },
   },
   {
-    title: 'Upload Receipt/Data',
-    description: 'Upload transactions or normalized data',
-    code: `# Parse a receipt
-const receipt = await client.receipts.parse({
-  file: "https://example.com/receipt.jpg",
-});
+    title: 'Run and Review Results',
+    description: 'Execute the job and inspect the mismatch report. Every run produces a verifiable evidence artifact.',
+    code: `const report = await client.reports.get(job.id);
 
-// eslint-disable-next-line no-console
-console.log("Receipt parsed:", receipt.total, receipt.merchant);
-
-# Or upload CSV/JSON
-const upload = await client.data.upload({
-  file: fileBuffer,
-  format: "csv",
-});`,
-    action: { label: 'Review API Formats', href: '/docs/api' },
-  },
-  {
-    title: 'View Results',
-    description: 'Review mismatches and evidence',
-    code: `# Get job status
-const status = await client.jobs.get(job.id);
-// eslint-disable-next-line no-console
-console.log("Status:", status.status);
-
-# Get report
-const report = await client.reports.get(job.id);
-// eslint-disable-next-line no-console
 console.log("Matched:", report.summary.matched);
-// eslint-disable-next-line no-console
-console.log("Unmatched:", report.summary.unmatched);`,
-    action: { label: 'Open Reports', href: '/docs/api' },
+console.log("Unmatched:", report.summary.unmatched);
+
+// Each mismatch includes: field, expected, actual, rule applied, evidence hash
+const mismatches = await client.reconciliations.getMismatches(job.id);`,
+    action: { label: 'API Reference', href: '/docs/api' },
   },
 ];
 
@@ -94,26 +117,59 @@ export default function QuickstartPage() {
   return (
     <div className="prose prose-slate dark:prose-invert max-w-none">
       <h1>Quickstart Guide</h1>
-      
+
       <p className="text-lg text-slate-600 dark:text-slate-400">
-        Get started with Settler. Follow these steps to run your first reconciliation.
+        Two paths to your first result. The demo path requires no API keys and runs in under 5 minutes. The SDK path connects to your own data sources.
       </p>
 
       <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 my-6">
         <p className="text-sm text-blue-800 dark:text-blue-200">
-          <strong>Note:</strong> Settler surfaces mismatches and evidence. Your team reviews and resolves outcomes.
+          <strong>What Settler does:</strong> It matches records across your data sources, surfaces every variance with context, and writes a hash-linked evidence artifact you can replay and share. It does not make decisions — your team reviews the results.
         </p>
       </div>
 
-      <div className="space-y-8 my-8">
-        {steps.map((step, index) => (
+      <h2 className="text-2xl font-bold mt-10 mb-6 text-slate-900 dark:text-white">Path A — Run the Demo (No API Key Needed)</h2>
+      <p className="text-slate-600 dark:text-slate-400 mb-6">Runs a Stripe↔QuickBooks reconciliation using fixture data. Generates evidence you can inspect and replay.</p>
+
+      <div className="space-y-6 my-6">
+        {demoSteps.map((step, index) => (
           <Card key={index} className="border-2">
             <CardHeader>
               <div className="flex items-center gap-3 mb-2">
-                <div className="w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400 font-bold">
+                <div className="w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400 font-bold text-sm">
                   {index + 1}
                 </div>
-                <CardTitle className="text-xl">{step.title}</CardTitle>
+                <CardTitle className="text-lg">{step.title}</CardTitle>
+              </div>
+              <CardDescription>{step.description}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <CodeBlock code={step.code} language="bash" />
+              {step.action && (
+                <Button variant="outline" asChild>
+                  <Link href={step.action.href}>
+                    {step.action.label}
+                    <ArrowRight className="w-4 h-4 ml-2" />
+                  </Link>
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <h2 className="text-2xl font-bold mt-12 mb-6 text-slate-900 dark:text-white">Path B — Connect Your Own Data (SDK)</h2>
+      <p className="text-slate-600 dark:text-slate-400 mb-6">Connect your own Stripe, Shopify, QuickBooks, or custom data sources using the TypeScript SDK.</p>
+
+      <div className="space-y-6 my-6">
+        {sdkSteps.map((step, index) => (
+          <Card key={index} className="border-2">
+            <CardHeader>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="w-8 h-8 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center text-slate-600 dark:text-slate-400 font-bold text-sm">
+                  {index + 1}
+                </div>
+                <CardTitle className="text-lg">{step.title}</CardTitle>
               </div>
               <CardDescription>{step.description}</CardDescription>
             </CardHeader>
@@ -138,10 +194,11 @@ export default function QuickstartPage() {
           Next Steps
         </h2>
         <ul className="space-y-2 text-slate-700 dark:text-slate-300">
-          <li>• <Link href="/docs/api" className="text-blue-600 dark:text-blue-400 hover:underline">Explore the API Reference</Link></li>
-          <li>• <Link href="/docs/integrations" className="text-blue-600 dark:text-blue-400 hover:underline">Browse available integrations</Link></li>
-          <li>• <Link href="/docs/auth" className="text-blue-600 dark:text-blue-400 hover:underline">Learn about authentication</Link></li>
-          <li>• <Link href="/open-source" className="text-blue-600 dark:text-blue-400 hover:underline">Review the open-source governance</Link></li>
+          <li>• <Link href="/how-it-works" className="text-blue-600 dark:text-blue-400 hover:underline">How It Works — full architecture walkthrough</Link></li>
+          <li>• <Link href="/docs/api" className="text-blue-600 dark:text-blue-400 hover:underline">API Reference — all endpoints and response shapes</Link></li>
+          <li>• <Link href="/docs/integrations" className="text-blue-600 dark:text-blue-400 hover:underline">Available integrations — Stripe, Shopify, QuickBooks, and more</Link></li>
+          <li>• <Link href="/proof-explorer" className="text-blue-600 dark:text-blue-400 hover:underline">Proof Explorer — inspect evidence artifacts from your runs</Link></li>
+          <li>• <Link href="/docs/auth" className="text-blue-600 dark:text-blue-400 hover:underline">Authentication — API key management and scopes</Link></li>
         </ul>
       </div>
     </div>

--- a/packages/web/src/app/enterprise/page.tsx
+++ b/packages/web/src/app/enterprise/page.tsx
@@ -339,12 +339,12 @@ export default function EnterprisePage() {
             ))}
           </div>
 
-          {/* Compliance Badges */}
+          {/* Architecture and design properties */}
           <div className="flex flex-wrap justify-center gap-8 md:gap-16">
             {[
-              { label: "SOC 2 TYPE II", sublabel: "Ready" },
-              { label: "GDPR", sublabel: "Compliant" },
-              { label: "AES-256", sublabel: "Encrypted" },
+              { label: "SOC 2 TYPE II", sublabel: "Architecture aligned" },
+              { label: "GDPR", sublabel: "Data handling controls" },
+              { label: "AES-256", sublabel: "Encryption at rest" },
             ].map((badge, idx) => (
               <div key={idx} className="flex flex-col items-center gap-1">
                 <Shield
@@ -358,6 +358,9 @@ export default function EnterprisePage() {
               </div>
             ))}
           </div>
+          <p className="text-xs text-slate-400 dark:text-slate-600 mt-6 max-w-lg mx-auto">
+            Architecture alignment does not constitute certification. Review your deployment configuration and consult your compliance team for your audit requirements.
+          </p>
         </div>
       </section>
 

--- a/packages/web/src/app/how-it-works/page.tsx
+++ b/packages/web/src/app/how-it-works/page.tsx
@@ -15,25 +15,25 @@ const steps = [
   {
     number: 1,
     title: "Connect",
-    description: "Link Stripe, Shopify, QuickBooks, and 50+ platforms",
+    description: "Attach a data source — Stripe, Shopify, QuickBooks, a CSV export, or your own adapter.",
     icon: Plug,
   },
   {
     number: 2,
-    title: "Match",
-    description: "Set up intelligent matching rules with automatic suggestions",
+    title: "Define Rules",
+    description: "Write matching rules in code: field mappings, numeric tolerances, and date windows. Rules are version-controlled and testable.",
     icon: Code2,
   },
   {
     number: 3,
     title: "Run",
-    description: "Process millions of transactions automatically",
+    description: "Execute the reconciliation. The engine applies your rules deterministically — same inputs always produce the same output.",
     icon: Play,
   },
   {
     number: 4,
-    title: "Review",
-    description: "View results with complete audit trail and compliance reports",
+    title: "Review Evidence",
+    description: "Inspect every mismatch with full context: which rule matched, what the variance was, and a SHA-256 hash-linked audit trail.",
     icon: BarChart3,
   },
 ];
@@ -70,7 +70,7 @@ export default function HowItWorksPage() {
               staggerDelay={0.02}
             />
             <p className="text-lg md:text-xl text-slate-600 dark:text-slate-300 mb-6 md:mb-8 max-w-2xl mx-auto leading-relaxed">
-              Reconcile millions of transactions automatically in 4 simple steps.
+              Connect a data source, define matching rules, run the engine, review evidence. Four explicit steps with no hidden logic.
             </p>
 
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">
@@ -79,7 +79,7 @@ export default function HowItWorksPage() {
                 asChild
                 className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-8 py-5 sm:py-6 text-base sm:text-lg font-semibold"
               >
-                <Link href="/signup">Start Free Trial</Link>
+                <Link href="/docs/quickstart">Read the Quickstart</Link>
               </Button>
               <Button
                 size="lg"
@@ -87,7 +87,7 @@ export default function HowItWorksPage() {
                 asChild
                 className="w-full sm:w-auto px-8 py-5 sm:py-6 text-base sm:text-lg"
               >
-                <Link href="/console/playground">Try Playground</Link>
+                <Link href="/docs">View Documentation</Link>
               </Button>
             </div>
           </div>
@@ -127,37 +127,28 @@ export default function HowItWorksPage() {
           <SpotlightCard className="p-6 md:p-8">
             <div className="text-center mb-5 md:mb-6">
               <h2 className="text-xl md:text-2xl lg:text-3xl font-bold mb-3 md:mb-4 text-slate-900 dark:text-white">
-                Get Started in 5 Minutes
+                Run a Demo Reconciliation in 5 Minutes
               </h2>
+              <p className="text-slate-600 dark:text-slate-400 text-sm md:text-base max-w-lg mx-auto">
+                No database or API keys required for the demo. The example runs a Stripe↔QuickBooks reconciliation and writes <code className="font-mono text-xs bg-slate-800 text-green-400 px-1 rounded">evidence.json</code> and <code className="font-mono text-xs bg-slate-800 text-green-400 px-1 rounded">report.html</code> to <code className="font-mono text-xs bg-slate-800 text-green-400 px-1 rounded">examples/demo-output/</code>.
+              </p>
             </div>
 
             <div className="bg-slate-900 dark:bg-slate-800 rounded-lg p-4 md:p-6 overflow-x-auto mb-5 md:mb-6">
               <pre className="text-green-400 text-xs md:text-sm leading-relaxed">
-                <code>{`npm install @settler/sdk
+                <code>{`# Clone and install
+git clone https://github.com/Hardonian/Settler.git
+cd Settler && pnpm install
 
-import { Settler } from '@settler/sdk';
+# Run the built-in demo (no API key required)
+pnpm demo
 
-const client = new Settler({
-  apiKey: process.env.SETTLER_API_KEY,
-});
+# Inspect outputs
+cat examples/demo-output/results.json
+cat examples/demo-output/evidence.json
 
-// Create a reconciliation job
-const job = await client.jobs.create({
-  name: "Shopify-Stripe Reconciliation",
-  source: { adapter: "shopify" },
-  target: { adapter: "stripe" },
-  rules: {
-    matching: [
-      { field: "order_id", type: "exact" },
-      { field: "amount", type: "exact", tolerance: 0.01 },
-    ],
-  },
-});
-
-// Run and get results
-const report = await client.jobs.run(job.id);
-// eslint-disable-next-line no-console
-console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}</code>
+# Replay verification — re-runs deterministically from stored artifacts
+pnpm settler:replay examples/demo-output/evidence.json`}</code>
               </pre>
             </div>
 
@@ -167,7 +158,7 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
                 asChild
                 className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-8 py-5 sm:py-6 text-base sm:text-lg font-semibold"
               >
-                <Link href="/console/playground">Try Playground</Link>
+                <Link href="/docs/quickstart">Read the Quickstart</Link>
               </Button>
               <Button
                 size="lg"
@@ -189,10 +180,10 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
         </ParallaxBackground>
         <div className="max-w-4xl mx-auto relative z-10 text-center">
           <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-3 md:mb-4 text-slate-900 dark:text-white">
-            Ready to Automate Your Reconciliation?
+            Start with the Demo or Read the Docs
           </h2>
           <p className="text-base md:text-lg text-slate-600 dark:text-slate-300 mb-6 md:mb-8 leading-relaxed">
-            Start automating reconciliation in minutes. Free trial—no credit card required.
+            Run <code className="font-mono text-sm">pnpm demo</code> locally for a zero-credential first run, or read the quickstart to connect your own data sources.
           </p>
           <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
             <Button
@@ -200,7 +191,7 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
               asChild
               className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-8 py-5 sm:py-6 text-base sm:text-lg font-semibold"
             >
-              <Link href="/signup">Start Free Trial</Link>
+              <Link href="/docs/quickstart">Read the Quickstart</Link>
             </Button>
             <Button
               size="lg"
@@ -208,7 +199,7 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
               asChild
               className="w-full sm:w-auto px-8 py-5 sm:py-6 text-base sm:text-lg"
             >
-              <Link href="/pricing">View Pricing</Link>
+              <Link href="/docs">Full Documentation</Link>
             </Button>
           </div>
         </div>
@@ -217,7 +208,7 @@ console.log(\`Matched: \${report.summary.matched}/\${report.summary.total}\`);`}
       <section className="py-12 px-4 sm:px-6 lg:px-8 border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-2xl font-bold mb-4 text-slate-900 dark:text-white">
-            Stitch Workflow Surface
+            Architecture Overview
           </h2>
           <ArchitectureOverview />
         </div>

--- a/packages/web/src/app/proof-explorer/page.tsx
+++ b/packages/web/src/app/proof-explorer/page.tsx
@@ -40,7 +40,7 @@ export default function ProofExplorerPage() {
         <section className="py-10 sm:py-12 px-4 sm:px-6 lg:px-8 border-t border-slate-200 dark:border-slate-800">
           <div className="max-w-6xl mx-auto">
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
-              Stitch Proof Surface
+              Run Results
             </h2>
             <ResultsPanel />
           </div>


### PR DESCRIPTION
- README: add output file table, clearer 5-min quickstart, contributor step-by-step,
  differentiation rationale, license/security section
- how-it-works: replace unverified claims ("50+ platforms", "millions automatically",
  "intelligent automatic suggestions") with accurate descriptions; show zero-credential
  demo commands instead of SDK-first flow; remove internal "Stitch Workflow Surface" label
- quickstart: restructure into two explicit paths — demo (no API key) and SDK; remove
  eslint-disable comments from rendered code blocks; add expected output annotations
- enterprise: soften compliance badges from "SOC 2 TYPE II Ready / GDPR Compliant" to
  "Architecture aligned / Data handling controls"; add disclaimer footnote
- proof-explorer: rename "Stitch Proof Surface" internal label to "Run Results"
- security-and-audit.mdx: expand with evidence artifact contents, quality levels,
  access control model, and data handling by deployment mode
- open-source.mdx: fix license inconsistency (MIT vs Apache 2.0), add local run
  instructions, fork guidance, and community contribution paths
- product.mdx: add determinism rationale, evidence artifact table, and clearer
  pipeline explanation

https://claude.ai/code/session_014CPYSfigSCcdB2GbS35YB3