### PR TITLE
Ignore local-only financial planning docs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,10 @@ completion-reports/
 # Uncomment below to ignore them:
 # AGENTS.md
 # CLAUDE.md
+
+# local-only financial planning docs (private)
+docs/business/operating-cost-model.md
+docs/business/pricing-strategy.md
+docs/business/breakeven-analysis.md
+docs/business/revenue-projections.md
+docs/business/api-rate-limit-strategy.md


### PR DESCRIPTION
### Motivation
- Prevent private or local financial planning artifacts from being committed by ignoring business planning docs in the repository.

### Description
- Update `.gitignore` to add `docs/business/operating-cost-model.md`, `docs/business/pricing-strategy.md`, `docs/business/breakeven-analysis.md`, `docs/business/revenue-projections.md`, and `docs/business/api-rate-limit-strategy.md` to the ignore list.

### Testing
- No automated tests were required or run for this trivial `.gitignore` change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae2439a6448328bc6d8febd24a32ea)