### PR TITLE
Fix ops dashboard TypeScript error, unblock API tests, and add quality reports

### DIFF
--- a/docs/architecture/route-map.md
+++ b/docs/architecture/route-map.md
@@ -10,58 +10,58 @@ All routes must return `200` or a Problem+JSON error (`application/problem+json`
 
 ### Public Marketing Routes
 
-| Path | Status | Notes |
-|------|--------|-------|
-| `/` | ✅ 200 | Landing page |
-| `/product` | ✅ 200 | Product overview |
-| `/how-it-works` | ✅ 200 | Mechanism explainer |
+| Path              | Status | Notes                       |
+| ----------------- | ------ | --------------------------- |
+| `/`               | ✅ 200 | Landing page                |
+| `/product`        | ✅ 200 | Product overview            |
+| `/how-it-works`   | ✅ 200 | Mechanism explainer         |
 | `/reconciliation` | ✅ 200 | Reconciliation feature page |
-| `/replay-lab` | ✅ 200 | Interactive replay lab |
-| `/proof-explorer` | ✅ 200 | Proof capsule explorer |
-| `/policies` | ✅ 200 | Policy engine docs |
-| `/security` | ✅ 200 | Security posture page |
-| `/pricing` | ✅ 200 | Pricing tiers |
-| `/about` | ✅ 200 | About page |
-| `/changelog` | ✅ 200 | Changelog |
-| `/blog` | ✅ 200 | Blog index |
-| `/blog/[slug]` | ✅ 200 | Blog posts |
-| `/comparison` | ✅ 200 | Competitive comparison |
-| `/community` | ✅ 200 | Community page |
-| `/contact` | ✅ 200 | Contact form |
-| `/cookbook` | ✅ 200 | Integration cookbook |
-| `/architecture` | ✅ 200 | Architecture overview |
-| `/benchmarks` | ✅ 200 | Performance benchmarks |
+| `/replay-lab`     | ✅ 200 | Interactive replay lab      |
+| `/proof-explorer` | ✅ 200 | Proof capsule explorer      |
+| `/policies`       | ✅ 200 | Policy engine docs          |
+| `/security`       | ✅ 200 | Security posture page       |
+| `/pricing`        | ✅ 200 | Pricing tiers               |
+| `/about`          | ✅ 200 | About page                  |
+| `/changelog`      | ✅ 200 | Changelog                   |
+| `/blog`           | ✅ 200 | Blog index                  |
+| `/blog/[slug]`    | ✅ 200 | Blog posts                  |
+| `/comparison`     | ✅ 200 | Competitive comparison      |
+| `/community`      | ✅ 200 | Community page              |
+| `/contact`        | ✅ 200 | Contact form                |
+| `/cookbook`       | ✅ 200 | Integration cookbook        |
+| `/architecture`   | ✅ 200 | Architecture overview       |
+| `/benchmarks`     | ✅ 200 | Performance benchmarks      |
 
 ### Auth Routes
 
-| Path | Status | Notes |
-|------|--------|-------|
-| `/auth/login` | ✅ 200 | Supabase auth |
+| Path             | Status | Notes          |
+| ---------------- | ------ | -------------- |
+| `/auth/login`    | ✅ 200 | Supabase auth  |
 | `/auth/callback` | ✅ 200 | OAuth callback |
-| `/auth/signup` | ✅ 200 | Registration |
+| `/auth/signup`   | ✅ 200 | Registration   |
 
 ### Authenticated App Routes (`/app/*`)
 
-| Path | Status | Auth Required |
-|------|--------|--------------|
-| `/app/executions` | ✅ 200 | ✅ |
-| `/app/reconciliation` | ✅ 200 | ✅ |
-| `/app/replay` | ✅ 200 | ✅ |
-| `/app/proofs` | ✅ 200 | ✅ |
-| `/app/audit` | ✅ 200 | ✅ |
-| `/app/system-health` | ✅ 200 | ✅ |
-| `/app/billing` | ✅ 200 | ✅ |
-| `/app/settings` | ✅ 200 | ✅ |
+| Path                  | Status | Auth Required |
+| --------------------- | ------ | ------------- |
+| `/app/executions`     | ✅ 200 | ✅            |
+| `/app/reconciliation` | ✅ 200 | ✅            |
+| `/app/replay`         | ✅ 200 | ✅            |
+| `/app/proofs`         | ✅ 200 | ✅            |
+| `/app/audit`          | ✅ 200 | ✅            |
+| `/app/system-health`  | ✅ 200 | ✅            |
+| `/app/billing`        | ✅ 200 | ✅            |
+| `/app/settings`       | ✅ 200 | ✅            |
 
 ### Admin Routes (`/admin/*`)
 
-| Path | Status | Notes |
-|------|--------|-------|
-| `/admin` | ✅ 200 | Operator mode required |
-| `/admin/runs` | ✅ 200 | All runs view |
-| `/admin/audit` | ✅ 200 | Audit trail |
-| `/admin/metrics` | ✅ 200 | System metrics |
-| `/admin/health` | ✅ 200 | Health dashboard |
+| Path             | Status | Notes                  |
+| ---------------- | ------ | ---------------------- |
+| `/admin`         | ✅ 200 | Operator mode required |
+| `/admin/runs`    | ✅ 200 | All runs view          |
+| `/admin/audit`   | ✅ 200 | Audit trail            |
+| `/admin/metrics` | ✅ 200 | System metrics         |
+| `/admin/health`  | ✅ 200 | Health dashboard       |
 
 ---
 
@@ -69,71 +69,71 @@ All routes must return `200` or a Problem+JSON error (`application/problem+json`
 
 ### Health
 
-| Route | Method | Returns |
-|-------|--------|---------|
-| `/api/health` | GET | `{ ok, status, checks }` |
-| `/api/status` | GET | `{ status, timestamp }` |
+| Route         | Method | Returns                  |
+| ------------- | ------ | ------------------------ |
+| `/api/health` | GET    | `{ ok, status, checks }` |
+| `/api/status` | GET    | `{ status, timestamp }`  |
 
 ### Admin API
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `/api/admin/health` | GET | Admin JWT |
-| `/api/admin/audit` | GET | Admin JWT |
-| `/api/admin/exceptions` | GET/POST | Admin JWT |
-| `/api/admin/metrics` | GET | Admin JWT |
-| `/api/admin/jobforge` | GET | Admin JWT |
-| `/api/admin/runs` | GET | Admin JWT |
-| `/api/admin/stream` | GET | Admin JWT + SSE |
+| Route                   | Method   | Auth            |
+| ----------------------- | -------- | --------------- |
+| `/api/admin/health`     | GET      | Admin JWT       |
+| `/api/admin/audit`      | GET      | Admin JWT       |
+| `/api/admin/exceptions` | GET/POST | Admin JWT       |
+| `/api/admin/metrics`    | GET      | Admin JWT       |
+| `/api/admin/jobforge`   | GET      | Admin JWT       |
+| `/api/admin/runs`       | GET      | Admin JWT       |
+| `/api/admin/stream`     | GET      | Admin JWT + SSE |
 
 ### AI Endpoints
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `/api/ai/data-insights` | POST | User JWT |
-| `/api/ai/onboarding-assistant` | POST | User JWT |
-| `/api/ai/support-assistant` | POST | User JWT |
-| `/api/ai/troubleshooting` | POST | User JWT |
+| Route                          | Method | Auth     |
+| ------------------------------ | ------ | -------- |
+| `/api/ai/data-insights`        | POST   | User JWT |
+| `/api/ai/onboarding-assistant` | POST   | User JWT |
+| `/api/ai/support-assistant`    | POST   | User JWT |
+| `/api/ai/troubleshooting`      | POST   | User JWT |
 
 ### Billing
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `/api/billing/dispute` | POST | User JWT |
-| `/api/billing/payment-recovery` | POST | User JWT |
-| `/api/billing/retry-payment` | POST | User JWT |
+| Route                           | Method | Auth     |
+| ------------------------------- | ------ | -------- |
+| `/api/billing/dispute`          | POST   | User JWT |
+| `/api/billing/payment-recovery` | POST   | User JWT |
+| `/api/billing/retry-payment`    | POST   | User JWT |
 
 ### Connectors
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `/api/connectors/backfill` | POST | User JWT |
+| Route                      | Method   | Auth           |
+| -------------------------- | -------- | -------------- |
+| `/api/connectors/backfill` | POST     | User JWT       |
 | `/api/connectors/callback` | GET/POST | Public (OAuth) |
-| `/api/connectors/connect` | POST | User JWT |
+| `/api/connectors/connect`  | POST     | User JWT       |
 
 ### Core Operations
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `/api/runs` | GET/POST | User JWT |
-| `/api/runs/[id]/replay` | GET | User JWT |
-| `/api/receipts` | GET | User JWT |
-| `/api/exports` | GET/POST | User JWT |
-| `/api/jobs` | GET/POST | User JWT |
-| `/api/metrics` | GET | User JWT |
-| `/api/quota` | GET | User JWT |
-| `/api/workspaces` | GET | User JWT |
+| Route                   | Method   | Auth     |
+| ----------------------- | -------- | -------- |
+| `/api/runs`             | GET/POST | User JWT |
+| `/api/runs/[id]/replay` | GET      | User JWT |
+| `/api/receipts`         | GET      | User JWT |
+| `/api/exports`          | GET/POST | User JWT |
+| `/api/jobs`             | GET/POST | User JWT |
+| `/api/metrics`          | GET      | User JWT |
+| `/api/quota`            | GET      | User JWT |
+| `/api/workspaces`       | GET      | User JWT |
 
 ### Stripe Webhooks
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `/api/stripe` | POST | Stripe Signature |
+| Route         | Method | Auth             |
+| ------------- | ------ | ---------------- |
+| `/api/stripe` | POST   | Stripe Signature |
 
 ### Versioned API
 
-| Route | Method | Notes |
-|-------|--------|-------|
+| Route       | Method  | Notes                |
+| ----------- | ------- | -------------------- |
 | `/api/v1/*` | Various | Stable public API v1 |
 
 ---
@@ -142,86 +142,86 @@ All routes must return `200` or a Problem+JSON error (`application/problem+json`
 
 ### Core
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `GET /health` | GET | None |
-| `GET /api/v1/status` | GET | None |
+| Route                | Method | Auth |
+| -------------------- | ------ | ---- |
+| `GET /health`        | GET    | None |
+| `GET /api/v1/status` | GET    | None |
 
 ### Auth
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `POST /api/v1/auth/token` | POST | API Key |
-| `POST /api/v1/auth/refresh` | POST | JWT |
-| `DELETE /api/v1/auth/token` | DELETE | JWT |
+| Route                       | Method | Auth    |
+| --------------------------- | ------ | ------- |
+| `POST /api/v1/auth/token`   | POST   | API Key |
+| `POST /api/v1/auth/refresh` | POST   | JWT     |
+| `DELETE /api/v1/auth/token` | DELETE | JWT     |
 
 ### Reconciliation
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `GET /api/v1/runs` | GET | JWT |
-| `POST /api/v1/runs` | POST | JWT |
-| `GET /api/v1/runs/:id` | GET | JWT |
-| `GET /api/v1/runs/:id/replay` | GET | JWT |
-| `GET /api/v1/runs/:id/status` | GET | JWT |
-| `GET /api/v1/runs/:id/summary` | GET | JWT |
+| Route                          | Method | Auth |
+| ------------------------------ | ------ | ---- |
+| `GET /api/v1/runs`             | GET    | JWT  |
+| `POST /api/v1/runs`            | POST   | JWT  |
+| `GET /api/v1/runs/:id`         | GET    | JWT  |
+| `GET /api/v1/runs/:id/replay`  | GET    | JWT  |
+| `GET /api/v1/runs/:id/status`  | GET    | JWT  |
+| `GET /api/v1/runs/:id/summary` | GET    | JWT  |
 
 ### Reports
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `GET /api/v1/reports` | GET | JWT |
-| `POST /api/v1/reports/export` | POST | JWT |
-| `GET /api/v1/reports/:id` | GET | JWT |
+| Route                         | Method | Auth |
+| ----------------------------- | ------ | ---- |
+| `GET /api/v1/reports`         | GET    | JWT  |
+| `POST /api/v1/reports/export` | POST   | JWT  |
+| `GET /api/v1/reports/:id`     | GET    | JWT  |
 
 ### Adapters
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `GET /api/v1/adapters` | GET | JWT |
-| `POST /api/v1/adapters/test` | POST | JWT |
+| Route                        | Method | Auth |
+| ---------------------------- | ------ | ---- |
+| `GET /api/v1/adapters`       | GET    | JWT  |
+| `POST /api/v1/adapters/test` | POST   | JWT  |
 
 ### API Keys
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `GET /api/v1/api-keys` | GET | JWT |
-| `POST /api/v1/api-keys` | POST | JWT |
-| `DELETE /api/v1/api-keys/:id` | DELETE | JWT |
+| Route                         | Method | Auth |
+| ----------------------------- | ------ | ---- |
+| `GET /api/v1/api-keys`        | GET    | JWT  |
+| `POST /api/v1/api-keys`       | POST   | JWT  |
+| `DELETE /api/v1/api-keys/:id` | DELETE | JWT  |
 
 ### Dashboards
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `GET /api/v1/dashboards` | GET | JWT |
-| `GET /api/v1/dashboards/:id` | GET | JWT |
+| Route                        | Method | Auth |
+| ---------------------------- | ------ | ---- |
+| `GET /api/v1/dashboards`     | GET    | JWT  |
+| `GET /api/v1/dashboards/:id` | GET    | JWT  |
 
 ### Audit Trail
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `GET /api/v1/audit-trail` | GET | JWT |
-| `GET /api/v1/audit-trail/:runId` | GET | JWT |
+| Route                            | Method | Auth |
+| -------------------------------- | ------ | ---- |
+| `GET /api/v1/audit-trail`        | GET    | JWT  |
+| `GET /api/v1/audit-trail/:runId` | GET    | JWT  |
 
 ### Alerts & Notifications
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `GET /api/v1/alerts` | GET | JWT |
-| `POST /api/v1/alerts` | POST | JWT |
-| `GET /api/v1/notifications` | GET | JWT |
+| Route                       | Method | Auth |
+| --------------------------- | ------ | ---- |
+| `GET /api/v1/alerts`        | GET    | JWT  |
+| `POST /api/v1/alerts`       | POST   | JWT  |
+| `GET /api/v1/notifications` | GET    | JWT  |
 
 ### AI
 
-| Route | Method | Auth |
-|-------|--------|------|
-| `POST /api/v1/ai/assist` | POST | JWT |
-| `POST /api/v1/ai/edge` | POST | JWT |
+| Route                    | Method | Auth |
+| ------------------------ | ------ | ---- |
+| `POST /api/v1/ai/assist` | POST   | JWT  |
+| `POST /api/v1/ai/edge`   | POST   | JWT  |
 
 ### Versioned
 
-| Route | Method | Notes |
-|-------|--------|-------|
+| Route         | Method  | Notes          |
+| ------------- | ------- | -------------- |
 | `* /api/v2/*` | Various | v2 API surface |
 
 ---
@@ -242,6 +242,7 @@ All errors must return `application/problem+json`:
 ```
 
 Standard status codes:
+
 - `200` — Success
 - `201` — Created
 - `204` — No content
@@ -264,3 +265,9 @@ Standard status codes:
 3. Admin routes require `operator_mode=true` claim in JWT.
 4. All `POST/PUT/PATCH/DELETE` routes require CSRF token (web) or API key (API server).
 5. Tenant isolation: every authenticated route scopes to `tenant_id` from JWT claim.
+
+### Operations API
+
+| Route                | Method | Auth                       | Runtime | Error Behavior                                           |
+| -------------------- | ------ | -------------------------- | ------- | -------------------------------------------------------- |
+| `/api/ops/dashboard` | GET    | Billing-gated public route | nodejs  | Graceful degradation to zeroed metrics + trace id header |

--- a/docs/quality/repo-truth-report.md
+++ b/docs/quality/repo-truth-report.md
@@ -1,0 +1,26 @@
+# Repo Truth Report
+
+Generated: 2026-03-09
+
+## Broken Claims / Surfaces Found
+
+- Ops dashboard route typecheck failed, making claimed route health data endpoint non-buildable.
+- API runtime isolation tests failed in monorepo test run due to unresolved `@jest/globals` type import in test file.
+
+## Implemented Corrections
+
+- Fixed ops dashboard route typing for tenant usage aggregation and null-safe tenant id handling.
+- Fixed runtime isolation test to use project-standard Jest globals setup.
+- Added explicit route inventory entry for `/api/ops/dashboard` in architecture route map with runtime and error behavior notes.
+
+## Removed/Downgraded Claims
+
+- No route claims removed in this pass.
+- Coverage claim remains downgraded to "not yet proven" pending transform/instrumentation fix for coverage mode.
+
+## Final Verification Snapshot
+
+- Typecheck: pass (`pnpm -s typecheck`).
+- Route inventory generation: pass (`pnpm -s qa:routes`).
+- API tests: pass (`pnpm --filter @settler/api test`).
+- Coverage mode: fail (`pnpm --filter @settler/api exec jest --runInBand --forceExit --coverage`) due to current instrumentation stack error.

--- a/docs/quality/test-coverage-report.md
+++ b/docs/quality/test-coverage-report.md
@@ -1,0 +1,17 @@
+# Test Coverage Report
+
+Generated: 2026-03-09
+
+## Baseline and Verification Commands
+
+- `pnpm --filter @settler/api test` passes after the test typing fix.
+- `pnpm --filter @settler/api exec jest --runInBand --forceExit --coverage` currently fails due to Jest/Istanbul instrumentation runtime error (`TypeError: The "original" argument must be of type function`) in this repository's current test transform stack.
+
+## Gaps Closed in This Pass
+
+- Fixed API test suite compile blocker by removing direct `@jest/globals` import from runtime tenant isolation test and relying on existing Jest globals typing.
+
+## Remaining Coverage Truth
+
+- This pass removed a hard test failure and restored full API test execution (`pnpm --filter @settler/api test`).
+- Honest 100% repo-wide coverage is not yet proven because coverage instrumentation currently fails before collection.

--- a/docs/quality/type-safety-report.md
+++ b/docs/quality/type-safety-report.md
@@ -1,0 +1,17 @@
+# Type Safety Report
+
+Generated: 2026-03-09
+
+## Initial Error Categories
+
+- `TS2339` in `packages/web/src/app/api/ops/dashboard/route.ts`: Supabase query result inferred as `never`, causing `tenant_id` access failure.
+
+## Root Cause Fixes
+
+- Added explicit `TenantRunRow` type for dashboard tenant usage query rows.
+- Normalized nullable tenant ids to `"unknown"` before aggregation to preserve deterministic behavior and avoid null branch ambiguity.
+- Re-ran monorepo typecheck (`pnpm -s typecheck`) to confirm zero TypeScript errors across all workspaces.
+
+## Type Hardening Decisions
+
+- Chose a narrow local row type (`TenantRunRow`) instead of broadening to `any`, preserving strict typing and predictable route behavior.

--- a/packages/api/src/__tests__/multi-tenancy/runtime-isolation.test.ts
+++ b/packages/api/src/__tests__/multi-tenancy/runtime-isolation.test.ts
@@ -11,8 +11,6 @@
  * attempt cross-tenant operations, assert rejection at each layer.
  */
 
-import { describe, it, expect, beforeEach } from "@jest/globals";
-
 // ---------------------------------------------------------------------------
 // Minimal in-memory fixture types
 // ---------------------------------------------------------------------------

--- a/packages/web/src/app/api/ops/dashboard/route.ts
+++ b/packages/web/src/app/api/ops/dashboard/route.ts
@@ -84,11 +84,14 @@ interface DashboardPayload {
   aiInsights: AIInsight[];
 }
 
+type TenantRunRow = { tenant_id: string | null };
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function buildAIInsights(payload: Omit<DashboardPayload, "aiInsights" | "ok" | "traceId" | "generatedAt">): AIInsight[] {
+function buildAIInsights(
+  payload: Omit<DashboardPayload, "aiInsights" | "ok" | "traceId" | "generatedAt">
+): AIInsight[] {
   const insights: AIInsight[] = [];
 
   if (payload.replay.deterministicRate < 0.99) {
@@ -97,7 +100,8 @@ function buildAIInsights(payload: Omit<DashboardPayload, "aiInsights" | "ok" | "
       severity: "critical",
       category: "determinism",
       message: `Replay determinism rate dropped to ${(payload.replay.deterministicRate * 100).toFixed(1)}%`,
-      recommendation: "Investigate connector outputs for nondeterministic fields (timestamps, UUIDs). Enable replay breakpoints.",
+      recommendation:
+        "Investigate connector outputs for nondeterministic fields (timestamps, UUIDs). Enable replay breakpoints.",
     });
   }
 
@@ -107,7 +111,8 @@ function buildAIInsights(payload: Omit<DashboardPayload, "aiInsights" | "ok" | "
       severity: "warning",
       category: "execution",
       message: `Execution success rate is ${(payload.executions.successRate * 100).toFixed(1)}% (below 95% threshold)`,
-      recommendation: "Check failure breakdown — dependency failures suggest connector instability.",
+      recommendation:
+        "Check failure breakdown — dependency failures suggest connector instability.",
     });
   }
 
@@ -117,7 +122,8 @@ function buildAIInsights(payload: Omit<DashboardPayload, "aiInsights" | "ok" | "
       severity: "critical",
       category: "determinism",
       message: `${payload.failures.byCategory.nondeterminism} nondeterminism failures detected`,
-      recommendation: "Run `settler replay <executionId>` to inspect divergence. Check policy changes in last 24h.",
+      recommendation:
+        "Run `settler replay <executionId>` to inspect divergence. Check policy changes in last 24h.",
     });
   }
 
@@ -127,7 +133,8 @@ function buildAIInsights(payload: Omit<DashboardPayload, "aiInsights" | "ok" | "
       severity: "warning",
       category: "policy",
       message: "Policy rejection rate exceeds 5% of executions",
-      recommendation: "Run `settler policy simulate` to evaluate policy impact before next deployment.",
+      recommendation:
+        "Run `settler policy simulate` to evaluate policy impact before next deployment.",
     });
   }
 
@@ -137,7 +144,8 @@ function buildAIInsights(payload: Omit<DashboardPayload, "aiInsights" | "ok" | "
       severity: "info",
       category: "performance",
       message: "Execution throughput below 1 run/hour",
-      recommendation: "Expected for low-traffic windows. Alert if this persists during business hours.",
+      recommendation:
+        "Expected for low-traffic windows. Alert if this persists during business hours.",
     });
   }
 
@@ -147,7 +155,8 @@ function buildAIInsights(payload: Omit<DashboardPayload, "aiInsights" | "ok" | "
       severity: "info",
       category: "system",
       message: "All operational metrics within normal bounds",
-      recommendation: "Continue monitoring. Schedule next benchmark run with `pnpm benchmark:full`.",
+      recommendation:
+        "Continue monitoring. Schedule next benchmark run with `pnpm benchmark:full`.",
     });
   }
 
@@ -164,10 +173,17 @@ async function getDashboard(request: NextRequest): Promise<NextResponse> {
 
   // Authenticate
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) {
     return NextResponse.json(
-      { type: "https://settler.dev/errors/unauthorized", title: "Unauthorized", status: 401, trace_id: traceId },
+      {
+        type: "https://settler.dev/errors/unauthorized",
+        title: "Unauthorized",
+        status: 401,
+        trace_id: traceId,
+      },
       { status: 401, headers: { "content-type": "application/problem+json" } }
     );
   }
@@ -234,9 +250,7 @@ async function getDashboard(request: NextRequest): Promise<NextResponse> {
     replayHealth.totalReplays = replayTotal ?? 0;
     replayHealth.matchedReplays = replayMatched ?? 0;
     replayHealth.deterministicRate =
-      replayHealth.totalReplays > 0
-        ? replayHealth.matchedReplays / replayHealth.totalReplays
-        : 1.0;
+      replayHealth.totalReplays > 0 ? replayHealth.matchedReplays / replayHealth.totalReplays : 1.0;
   } catch {
     // Graceful degradation
   }
@@ -272,15 +286,17 @@ async function getDashboard(request: NextRequest): Promise<NextResponse> {
       .gte("created_at", since24h);
 
     if (tenantData) {
-      const tenantCounts = tenantData.reduce<Record<string, number>>((acc, row) => {
-        const tid = String(row.tenant_id);
+      const tenantRows = tenantData as TenantRunRow[];
+      const tenantCounts = tenantRows.reduce<Record<string, number>>((acc, row) => {
+        const tid = row.tenant_id ?? "unknown";
         acc[tid] = (acc[tid] ?? 0) + 1;
         return acc;
       }, {});
       const counts = Object.values(tenantCounts);
       tenantUsage.activeTenants = counts.length;
       tenantUsage.topTenantsRunCount = Math.max(0, ...counts);
-      tenantUsage.averageRunsPerTenant = counts.length > 0 ? counts.reduce((s, v) => s + v, 0) / counts.length : 0;
+      tenantUsage.averageRunsPerTenant =
+        counts.length > 0 ? counts.reduce((s, v) => s + v, 0) / counts.length : 0;
     }
   } catch {
     // Graceful degradation
@@ -293,7 +309,14 @@ async function getDashboard(request: NextRequest): Promise<NextResponse> {
     successRate,
   };
 
-  const aiInsights = buildAIInsights({ window: { hours: 24 }, executions, replay: replayHealth, failures: { totalLast24h: 0, byCategory: failureBreakdown }, policyViolations, tenantUsage });
+  const aiInsights = buildAIInsights({
+    window: { hours: 24 },
+    executions,
+    replay: replayHealth,
+    failures: { totalLast24h: 0, byCategory: failureBreakdown },
+    policyViolations,
+    tenantUsage,
+  });
 
   const payload: DashboardPayload = {
     ok: true,
@@ -317,7 +340,7 @@ async function getDashboard(request: NextRequest): Promise<NextResponse> {
   return response;
 }
 
-export const GET = withSecurity(
-  publicRoute(getDashboard),
-  { rateLimit: { windowMs: 60000, maxRequests: 60 }, requireAuth: false }
-);
+export const GET = withSecurity(publicRoute(getDashboard), {
+  rateLimit: { windowMs: 60000, maxRequests: 60 },
+  requireAuth: false,
+});


### PR DESCRIPTION
### Motivation

- Eliminate a TypeScript build error in the operations dashboard route so the `/api/ops/dashboard` route is buildable and safe to run.  
- Unblock API unit tests that were failing the monorepo test run due to an invalid test import.  
- Record verification artifacts and the current reality of coverage to preserve truth while further coverage work continues.

### Description

- Added a narrow Supabase row shape `TenantRunRow` and null-safe tenant-id normalization in `packages/web/src/app/api/ops/dashboard/route.ts` to avoid accessing properties on an inferred `never` and to make aggregation deterministic.  
- Reworked the dashboard handler formatting and call sites to preserve strict types and graceful degradation when metrics are not available.  
- Removed the direct `@jest/globals` import from `packages/api/src/__tests__/multi-tenancy/runtime-isolation.test.ts` so tests use the repository's standard Jest globals and no longer fail to compile.  
- Updated route inventory documentation in `docs/architecture/route-map.md` to include the `/api/ops/dashboard` Operations API row and error/runtime notes.  
- Added verification artifacts under `docs/quality/`: `type-safety-report.md`, `test-coverage-report.md`, and `repo-truth-report.md` that document the issues found, fixes applied, and remaining coverage/instrumentation gap.

### Testing

- Ran full TypeScript check with `pnpm -s typecheck` and confirmed it completes successfully.  
- Executed API unit tests with `pnpm --filter @settler/api test` and the suite passed.  
- Verified route discovery with `pnpm -s qa:routes` which generated the route registry successfully.  
- Attempted coverage collection with `pnpm --filter @settler/api exec jest --runInBand --forceExit --coverage`, which currently fails due to a Jest/Istanbul instrumentation runtime error (`TypeError: The "original" argument must be of type function`); this is documented in `docs/quality/test-coverage-report.md` and remains the outstanding gap toward proving repo-wide 100% coverage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae240eee608328aa39da8556a7ec82)