### PR TITLE
Unify trace propagation and Problem+JSON error semantics across CLI and API

### DIFF
--- a/docs/architecture/execution-lifecycle.md
+++ b/docs/architecture/execution-lifecycle.md
@@ -1,0 +1,25 @@
+# Canonical Execution Lifecycle
+
+Settler uses a shared lifecycle for CLI, API, worker, and replay execution paths:
+
+1. request received
+2. input validated
+3. execution initiated
+4. policy evaluation
+5. execution steps performed
+6. outputs produced
+7. proof generated
+8. results persisted
+9. response returned
+10. event logged
+
+## Canonical states
+
+Execution state transitions are constrained to:
+
+- `PENDING`
+- `RUNNING`
+- `FAILED`
+- `COMPLETED`
+
+Any adapter-specific or route-specific statuses should be mapped to this canonical state set in receipts, logs, and replay artifacts.

--- a/docs/architecture/system-surface-map.md
+++ b/docs/architecture/system-surface-map.md
@@ -1,0 +1,32 @@
+# System Surface Map
+
+## Surfaces
+
+- **CLI**: `packages/cli/src/commands/*` invoke API endpoints and replay/export tooling.
+- **API**: `packages/api/src/index.ts` mounts v1/v2 routers, auth, tenancy, idempotency, observability, and error handling.
+- **Workers / background jobs**: `packages/api/src/jobs/*` execute scheduled retention, aggregation, SLA, and refresh tasks.
+- **Queue/execution handlers**: `packages/workhorse/src/settler_workhorse/handlers/*` process export/import/backfill tasks.
+- **Proof/evidence generation**: CLI foundry and export-integrity modules; API export routes and reconciliation reporting.
+- **Replay logic**: CLI replay/jobs replay commands + API replay route family.
+- **Storage**: Postgres via `packages/api/src/db` and query calls in route/services.
+- **Tenant isolation**: auth + tenant middleware and tenant-scoped queries.
+- **Observability**: API observability middleware + structured logger; worker observability module.
+
+## Flow topology
+
+1. Request enters CLI/API surface.
+2. Validation/auth/tenant context resolves.
+3. Execution starts in service/worker path.
+4. Policy and reconciliation logic runs.
+5. Outputs and proof artifacts are produced.
+6. Data + event logs persist.
+7. Response/report returned to caller.
+
+## Request → validation → execution → proof → storage → response
+
+- **Request**: HTTP/CLI command initiation.
+- **Validation**: schema/auth/tenant checks and idempotency gates.
+- **Execution**: reconciliation/workflow operations.
+- **Proof**: receipts/replay/export integrity artifacts.
+- **Storage**: execution, matches, exceptions, audit/event rows.
+- **Response**: JSON or problem+json with trace metadata.

--- a/docs/architecture/traceability.md
+++ b/docs/architecture/traceability.md
@@ -1,0 +1,20 @@
+# Traceability Spine
+
+## Required identifiers
+
+All platform surfaces are required to propagate:
+
+- `trace_id`
+- `execution_id`
+- `tenant_id`
+
+## Propagation rules
+
+- CLI emits `X-Trace-Id` and `X-Execution-Id` (and `X-Tenant-Id` when known) on outbound API requests.
+- API middleware resolves/creates these IDs early and returns them as response headers.
+- Error responses include IDs in `application/problem+json` bodies.
+- Structured logs include request, trace, execution, and tenant dimensions.
+
+## Continuity objective
+
+A single execution should be traceable across command invocation, API entry, service execution, persistence, and failure handling without identifier loss.

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -1,0 +1,27 @@
+# Observability Foundation
+
+## Structured log envelope
+
+Minimum fields for operational events:
+
+- `timestamp`
+- `event_type`
+- `trace_id`
+- `execution_id`
+- `tenant_id`
+- `duration_ms` (where applicable)
+
+## Platform checkpoints
+
+- API request middleware emits tracing context and response correlation headers.
+- Error middleware returns machine-visible problem+json responses.
+- Health surfaces: `/health`, `/health/live`, `/health/ready`, `/metrics`.
+- Worker handlers log tenant-scoped events and failures.
+
+## Operational verification
+
+Run API + CLI checks to verify:
+
+- trace headers are set and returned,
+- failed requests include problem+json + trace metadata,
+- logs include trace and execution dimensions.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -138,9 +138,17 @@ if (config.features.enableRequestTimeout) {
 
 // Trace ID middleware
 app.use((req: Request, res: Response, next: NextFunction) => {
+  const authReq = req as AuthRequest;
   const traceId = (req.headers["x-trace-id"] as string) || uuidv4();
-  (req as AuthRequest).traceId = traceId;
+  const executionId = (req.headers["x-execution-id"] as string) || uuidv4();
+  authReq.traceId = traceId;
+  authReq.executionId = executionId;
+  authReq.tenantId = authReq.tenantId || (req.headers["x-tenant-id"] as string | undefined);
   res.setHeader("X-Trace-Id", traceId);
+  res.setHeader("X-Execution-Id", executionId);
+  if (authReq.tenantId) {
+    res.setHeader("X-Tenant-Id", authReq.tenantId);
+  }
   next();
 });
 

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import { query } from "../db";
 import { verifyApiKey } from "../utils/hash";
 import { logWarn, logError } from "../utils/logger";
 import { config } from "../config";
+import { sendProblemJson } from "../utils/problem-json";
 
 export interface AuthRequest extends Request {
   userId?: string;
@@ -12,18 +13,19 @@ export interface AuthRequest extends Request {
   traceId?: string;
   tenantId?: string;
   requestId?: string;
+  executionId?: string;
 }
 
 /**
  * Express middleware for API key or JWT token authentication.
- * 
+ *
  * Supports two authentication methods:
  * 1. API Key: `X-API-Key` header with `rk_` prefix
  * 2. JWT Token: `Authorization: Bearer <token>` header
- * 
+ *
  * On success, attaches `userId` and `apiKeyId` (if API key) to `req`.
  * On failure, returns 401 Unauthorized.
- * 
+ *
  * @example
  * ```typescript
  * app.use("/api/v1", authMiddleware, protectedRouter);
@@ -43,14 +45,16 @@ export const authMiddleware = async (
         return next();
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : "Invalid API key";
-        logWarn('API key validation failed', {
+        logWarn("API key validation failed", {
           ip: req.ip,
-          userAgent: req.headers['user-agent'],
+          userAgent: req.headers["user-agent"],
           error: message,
         });
-        res.status(401).json({
-          error: "Unauthorized",
-          message,
+        sendProblemJson(req, res, {
+          status: 401,
+          title: "Unauthorized",
+          detail: message,
+          code: "UNAUTHORIZED",
         });
         return;
       }
@@ -63,27 +67,32 @@ export const authMiddleware = async (
         await validateJWT(req, authHeader.substring(7));
         return next();
       } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : "The provided token is invalid or expired";
-        logWarn('JWT validation failed', {
+        const message =
+          error instanceof Error ? error.message : "The provided token is invalid or expired";
+        logWarn("JWT validation failed", {
           ip: req.ip,
-          userAgent: req.headers['user-agent'],
+          userAgent: req.headers["user-agent"],
           error: message,
         });
-        res.status(401).json({
-          error: "Invalid Token",
-          message,
+        sendProblemJson(req, res, {
+          status: 401,
+          title: "Invalid Token",
+          detail: message,
+          code: "INVALID_TOKEN",
         });
         return;
       }
     }
 
     // No auth provided
-    res.status(401).json({
-      error: "Unauthorized",
-      message: "API key or Bearer token required",
+    sendProblemJson(req, res, {
+      status: 401,
+      title: "Unauthorized",
+      detail: "API key or Bearer token required",
+      code: "UNAUTHORIZED",
     });
   } catch (error) {
-    logError('Auth middleware error', error);
+    logError("Auth middleware error", error);
     next(error);
   }
 };
@@ -95,7 +104,7 @@ async function validateApiKey(req: AuthRequest, apiKey: string): Promise<void> {
 
   // Extract prefix for database lookup
   const prefix = apiKey.substring(0, 12);
-  
+
   // Lookup API key in database
   const keys = await query<{
     id: string;
@@ -118,9 +127,9 @@ async function validateApiKey(req: AuthRequest, apiKey: string): Promise<void> {
       `INSERT INTO audit_logs (event, ip, user_agent, path, metadata)
        VALUES ($1, $2, $3, $4, $5)`,
       [
-        'api_key_auth_failed',
+        "api_key_auth_failed",
         req.ip || null,
-        req.headers['user-agent'] || null,
+        req.headers["user-agent"] || null,
         req.path,
         JSON.stringify({ keyPrefix: prefix }),
       ]
@@ -141,10 +150,10 @@ async function validateApiKey(req: AuthRequest, apiKey: string): Promise<void> {
       `INSERT INTO audit_logs (event, api_key_id, ip, user_agent, path, metadata)
        VALUES ($1, $2, $3, $4, $5, $6)`,
       [
-        'api_key_auth_failed',
+        "api_key_auth_failed",
         keyRecord.id,
         req.ip || null,
-        req.headers['user-agent'] || null,
+        req.headers["user-agent"] || null,
         req.path,
         JSON.stringify({ keyPrefix: prefix }),
       ]
@@ -162,10 +171,7 @@ async function validateApiKey(req: AuthRequest, apiKey: string): Promise<void> {
   }
 
   // Update last used timestamp
-  await query(
-    `UPDATE api_keys SET last_used_at = NOW() WHERE id = $1`,
-    [keyRecord.id]
-  );
+  await query(`UPDATE api_keys SET last_used_at = NOW() WHERE id = $1`, [keyRecord.id]);
 
   // Set request properties
   req.userId = keyRecord.user_id;
@@ -174,28 +180,28 @@ async function validateApiKey(req: AuthRequest, apiKey: string): Promise<void> {
 }
 
 async function validateJWT(req: AuthRequest, token: string): Promise<void> {
-  if (!config.jwt.secret || config.jwt.secret === 'your-secret-key-change-in-production') {
+  if (!config.jwt.secret || config.jwt.secret === "your-secret-key-change-in-production") {
     throw new Error("JWT authentication not configured");
   }
 
   try {
     const decoded = jwt.verify(token, config.jwt.secret, {
-      issuer: 'settler-api',
-      audience: 'settler-client',
+      issuer: "settler-api",
+      audience: "settler-client",
     }) as { userId: string; type?: string };
 
     // Check token type (access vs refresh)
-    if (decoded.type === 'refresh') {
+    if (decoded.type === "refresh") {
       throw new Error("Refresh tokens cannot be used for API access");
     }
 
     req.userId = decoded.userId;
   } catch (error: unknown) {
     if (error instanceof Error) {
-      if (error.name === 'TokenExpiredError') {
+      if (error.name === "TokenExpiredError") {
         throw new Error("Token has expired");
       }
-      if (error.name === 'JsonWebTokenError') {
+      if (error.name === "JsonWebTokenError") {
         throw new Error("Invalid token");
       }
     }

--- a/packages/api/src/middleware/context.ts
+++ b/packages/api/src/middleware/context.ts
@@ -29,6 +29,8 @@ export function contextMiddleware(req: Request, _res: Response, next: NextFuncti
     requestId: req.requestId,
     tenantId: (req as any).tenantId, // Set by auth middleware
     userId: (req as any).userId, // Set by auth middleware
+    traceId: (req as any).traceId,
+    executionId: (req as any).executionId,
   };
 
   // Run the rest of the request handling in this context

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -4,6 +4,7 @@ import { AuthRequest } from "./auth";
 import { config } from "../config";
 import { captureException, setSentryUser } from "./sentry";
 import { toApiError } from "../utils/typed-errors";
+import { sendProblemJson } from "../utils/problem-json";
 
 export const errorHandler = (
   err: unknown,
@@ -13,14 +14,14 @@ export const errorHandler = (
 ): void => {
   const authReq = req as AuthRequest;
   const apiError = toApiError(err);
-  
+
   // Set Sentry user context
   if (authReq.userId) {
     setSentryUser(authReq);
   }
-  
+
   // Log error with context
-  logError('Request error', err, {
+  logError("Request error", err, {
     method: req.method,
     path: req.path,
     ip: req.ip,
@@ -46,32 +47,19 @@ export const errorHandler = (
     });
   }
 
-  // Build error response
-  const response: {
-    error: string;
-    errorCode: string;
-    message: string;
-    traceId?: string;
-    stack?: string;
-    details?: unknown;
-  } = {
-    error: apiError.name,
-    errorCode: apiError.errorCode,
-    message: apiError.message,
-  };
-  if (authReq.traceId !== undefined) {
-    response.traceId = authReq.traceId;
-  }
-
-  // Include details if present
+  const extra: Record<string, unknown> = {};
   if (apiError.details) {
-    response.details = apiError.details;
+    extra.details = apiError.details;
   }
-
-  // Only include stack in development
   if (config.nodeEnv === "development" && err instanceof Error && err.stack !== undefined) {
-    response.stack = err.stack;
+    extra.stack = err.stack;
   }
 
-  res.status(statusCode).json(response);
+  sendProblemJson(authReq, res, {
+    status: statusCode,
+    title: apiError.name,
+    detail: apiError.message,
+    code: apiError.errorCode,
+    extra,
+  });
 };

--- a/packages/api/src/middleware/tenant.ts
+++ b/packages/api/src/middleware/tenant.ts
@@ -8,6 +8,7 @@ import { AuthRequest } from "./auth";
 import { ITenantRepository } from "../domain/repositories/ITenantRepository";
 import { Container } from "../infrastructure/di/Container";
 import { query } from "../db";
+import { sendProblemJson } from "../utils/problem-json";
 
 export interface TenantRequest extends AuthRequest {
   tenantId?: string;
@@ -70,18 +71,22 @@ export async function tenantMiddleware(
     }
 
     if (!tenant) {
-      res.status(403).json({
-        error: "TenantNotFound",
-        message: "Unable to determine tenant context",
+      sendProblemJson(req, res, {
+        status: 403,
+        title: "Tenant context missing",
+        detail: "Unable to determine tenant context",
+        code: "TENANT_NOT_FOUND",
       });
       return;
     }
 
     // Check tenant status
     if (tenant.status === "suspended" || tenant.status === "cancelled") {
-      res.status(403).json({
-        error: "TenantSuspended",
-        message: "Tenant account is suspended or cancelled",
+      sendProblemJson(req, res, {
+        status: 403,
+        title: "Tenant suspended",
+        detail: "Tenant account is suspended or cancelled",
+        code: "TENANT_SUSPENDED",
       });
       return;
     }

--- a/packages/api/src/utils/logger.ts
+++ b/packages/api/src/utils/logger.ts
@@ -12,6 +12,8 @@ export const requestContext = new AsyncLocalStorage<{
   requestId?: string;
   tenantId?: string;
   userId?: string;
+  traceId?: string;
+  executionId?: string;
 }>();
 
 function getTraceContext(): { trace_id?: string; span_id?: string } {
@@ -31,6 +33,8 @@ function getRequestContext(): {
   request_id?: string;
   tenant_id?: string;
   user_id?: string;
+  trace_id?: string;
+  execution_id?: string;
 } {
   const context = requestContext.getStore();
   if (!context) {
@@ -41,6 +45,8 @@ function getRequestContext(): {
     request_id: context.requestId || undefined,
     tenant_id: context.tenantId || undefined,
     user_id: context.userId || undefined,
+    trace_id: context.traceId || undefined,
+    execution_id: context.executionId || undefined,
   };
 }
 
@@ -63,6 +69,7 @@ function createPrintfFormat() {
         span_id?: string;
         tenant_id?: string;
         user_id?: string;
+        execution_id?: string;
       }
     ) => {
       const timestamp = info.timestamp as string | Date | undefined;
@@ -73,6 +80,7 @@ function createPrintfFormat() {
       const span_id = info.span_id;
       const tenant_id = info.tenant_id;
       const user_id = info.user_id;
+      const execution_id = info.execution_id;
 
       const meta = { ...(info as Record<string, unknown>) };
       delete meta.timestamp;
@@ -83,6 +91,7 @@ function createPrintfFormat() {
       delete meta.span_id;
       delete meta.tenant_id;
       delete meta.user_id;
+      delete meta.execution_id;
       const metaStr = Object.keys(meta).length ? JSON.stringify(redact(meta)) : "";
 
       const requestInfo =
@@ -93,10 +102,14 @@ function createPrintfFormat() {
         span_id && typeof span_id === "string" ? `[span=${span_id.substring(0, 8)}]` : "";
       const tenantInfo = tenant_id && typeof tenant_id === "string" ? `[tenant=${tenant_id}]` : "";
       const userInfo = user_id && typeof user_id === "string" ? `[user=${user_id}]` : "";
+      const executionInfo =
+        execution_id && typeof execution_id === "string"
+          ? `[exec=${execution_id.substring(0, 8)}]`
+          : "";
       const timestampStr = typeof timestamp === "string" ? timestamp : String(timestamp);
       const messageStr = typeof message === "string" ? message : String(message);
 
-      return `${timestampStr} [${level}]${requestInfo}${traceInfo}${spanInfo}${tenantInfo}${userInfo}: ${messageStr} ${metaStr}`;
+      return `${timestampStr} [${level}]${requestInfo}${traceInfo}${spanInfo}${tenantInfo}${userInfo}${executionInfo}: ${messageStr} ${metaStr}`;
     }
   );
 }

--- a/packages/api/src/utils/problem-json.ts
+++ b/packages/api/src/utils/problem-json.ts
@@ -1,0 +1,36 @@
+import { Response } from "express";
+import { AuthRequest } from "../middleware/auth";
+
+export interface ProblemJsonOptions {
+  status: number;
+  title: string;
+  detail: string;
+  code: string;
+  type?: string;
+  extra?: Record<string, unknown>;
+}
+
+export function sendProblemJson(
+  req: AuthRequest,
+  res: Response,
+  options: ProblemJsonOptions
+): void {
+  const problem: Record<string, unknown> = {
+    type: options.type ?? `https://docs.settler.dev/problems/${options.code.toLowerCase()}`,
+    title: options.title,
+    status: options.status,
+    detail: options.detail,
+    code: options.code,
+    timestamp: new Date().toISOString(),
+    trace_id: req.traceId,
+    execution_id: req.executionId,
+    tenant_id: req.tenantId,
+  };
+
+  if (options.extra) {
+    Object.assign(problem, options.extra);
+  }
+
+  res.setHeader("Content-Type", "application/problem+json");
+  res.status(options.status).json(problem);
+}

--- a/packages/cli/src/commands/debug.ts
+++ b/packages/cli/src/commands/debug.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { createTraceContext, withTraceHeaders } from "../lib/http";
 
 const debugCommand = new Command("debug");
 
@@ -23,14 +24,18 @@ debugCommand
       console.log(chalk.blue(`Testing connection to ${options.adapter}...`));
 
       // Use the playground endpoint to test adapter connection
+      const trace = createTraceContext();
       const response = await fetch(
         `${options.parent.parent?.baseUrl || "https://api.settler.io"}/api/v1/playground/test-adapter`,
         {
           method: "POST",
-          headers: {
-            "X-API-Key": settlerApiKey,
-            "Content-Type": "application/json",
-          },
+          headers: withTraceHeaders(
+            {
+              "X-API-Key": settlerApiKey,
+              "Content-Type": "application/json",
+            },
+            trace
+          ),
           body: JSON.stringify({
             adapter: options.adapter,
             config: options.config ? JSON.parse(options.config) : { apiKey: options.apiKey },
@@ -98,7 +103,7 @@ debugCommand
       // Basic validation
       const errors: string[] = [];
 
-      if (typeof config !== 'object' || config === null) {
+      if (typeof config !== "object" || config === null) {
         console.error(chalk.red("❌ Validation failed: Config must be an object"));
         process.exit(1);
       }
@@ -109,15 +114,27 @@ debugCommand
         errors.push("Missing required field: name");
       }
 
-      if (!configObj.source || typeof configObj.source !== 'object' || !(configObj.source as Record<string, unknown>).adapter) {
+      if (
+        !configObj.source ||
+        typeof configObj.source !== "object" ||
+        !(configObj.source as Record<string, unknown>).adapter
+      ) {
         errors.push("Missing required field: source.adapter");
       }
 
-      if (!configObj.target || typeof configObj.target !== 'object' || !(configObj.target as Record<string, unknown>).adapter) {
+      if (
+        !configObj.target ||
+        typeof configObj.target !== "object" ||
+        !(configObj.target as Record<string, unknown>).adapter
+      ) {
         errors.push("Missing required field: target.adapter");
       }
 
-      if (!configObj.rules || typeof configObj.rules !== 'object' || !Array.isArray((configObj.rules as Partial<{ matching: unknown[] }>).matching)) {
+      if (
+        !configObj.rules ||
+        typeof configObj.rules !== "object" ||
+        !Array.isArray((configObj.rules as Partial<{ matching: unknown[] }>).matching)
+      ) {
         errors.push("Missing required field: rules.matching (must be an array)");
       }
 
@@ -129,8 +146,12 @@ debugCommand
 
       console.log(chalk.green("✅ Config file is valid!"));
       console.log(chalk.gray(`   Name: ${configObj.name}`));
-      console.log(chalk.gray(`   Source: ${(configObj.source as Record<string, unknown>).adapter}`));
-      console.log(chalk.gray(`   Target: ${(configObj.target as Record<string, unknown>).adapter}`));
+      console.log(
+        chalk.gray(`   Source: ${(configObj.source as Record<string, unknown>).adapter}`)
+      );
+      console.log(
+        chalk.gray(`   Target: ${(configObj.target as Record<string, unknown>).adapter}`)
+      );
       const rules = configObj.rules as Partial<{ matching: unknown[] }>;
       console.log(chalk.gray(`   Matching rules: ${rules.matching?.length || 0}`));
     } catch (error) {
@@ -165,12 +186,16 @@ debugCommand
 
       const startTime = Date.now();
 
+      const trace = createTraceContext();
       const fetchOptions: RequestInit = {
         method: options.method,
-        headers: {
-          "X-API-Key": settlerApiKey,
-          "Content-Type": "application/json",
-        },
+        headers: withTraceHeaders(
+          {
+            "X-API-Key": settlerApiKey,
+            "Content-Type": "application/json",
+          },
+          trace
+        ),
       };
 
       if (options.data) {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -6,6 +6,7 @@ import {
   EXPORT_SCHEMA_VERSION,
   validateHashChain,
 } from "../lib/export-integrity";
+import { createTraceContext, withTraceHeaders } from "../lib/http";
 
 interface ExportDocument {
   schemaVersion: string;
@@ -38,10 +39,14 @@ exportCommand
     const baseUrl = (options.parent.baseUrl || "https://api.settler.io").replace(/\/$/, "");
     const url = `${baseUrl}/api/export?runId=${encodeURIComponent(options.runId)}`;
 
+    const trace = createTraceContext();
     const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
+      headers: withTraceHeaders(
+        {
+          Authorization: `Bearer ${apiKey}`,
+        },
+        trace
+      ),
     });
 
     if (!response.ok) {

--- a/packages/cli/src/commands/jobs.ts
+++ b/packages/cli/src/commands/jobs.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 
 import Settler from "@settler/sdk";
 import type { ReconciliationJob } from "@settler/sdk";
+import { createTraceContext, withTraceHeaders } from "../lib/http";
 
 interface CommandParentOptions {
   apiKey?: string;
@@ -206,10 +207,14 @@ jobsCommand
           params.append("since", options.since);
         }
 
+        const trace = createTraceContext();
         const response = await fetch(`${baseUrl}/api/v1/jobs/${id}/logs?${params.toString()}`, {
-          headers: {
-            "X-API-Key": apiKey,
-          },
+          headers: withTraceHeaders(
+            {
+              "X-API-Key": apiKey,
+            },
+            trace
+          ),
         });
 
         if (!response.ok) {
@@ -281,63 +286,68 @@ jobsCommand
         parent?: CommandParentOptions;
       }
     ) => {
-    try {
-      const apiKey = process.env.SETTLER_API_KEY || options.parent?.parent?.apiKey;
-      if (!apiKey) {
-        console.error(chalk.red("Error: API key required"));
+      try {
+        const apiKey = process.env.SETTLER_API_KEY || options.parent?.parent?.apiKey;
+        if (!apiKey) {
+          console.error(chalk.red("Error: API key required"));
+          process.exit(1);
+        }
+
+        const baseUrl = options.parent?.parent?.baseUrl || "https://api.settler.io";
+
+        const body: Record<string, unknown> = {
+          dryRun: options.dryRun || false,
+        };
+
+        if (options.fromDate) {
+          body.fromDate = options.fromDate;
+        }
+
+        if (options.eventId) {
+          body.eventId = options.eventId;
+        }
+
+        console.log(chalk.blue("Replaying events..."));
+
+        const trace = createTraceContext(undefined, id);
+        const response = await fetch(`${baseUrl}/api/v1/jobs/${id}/replay`, {
+          method: "POST",
+          headers: withTraceHeaders(
+            {
+              "X-API-Key": apiKey,
+              "Content-Type": "application/json",
+            },
+            trace
+          ),
+          body: JSON.stringify(body),
+        });
+
+        if (!response.ok) {
+          const error = (await response.json()) as { message?: string };
+          console.error(chalk.red(`Error: ${error.message || "Failed to replay events"}`));
+          process.exit(1);
+        }
+
+        const result = (await response.json()) as {
+          eventsProcessed?: number;
+          eventsReplayed?: number;
+        };
+
+        if (options.dryRun) {
+          console.log(chalk.yellow("Dry run mode - no events were actually replayed"));
+        } else {
+          console.log(chalk.green("✓ Events replayed successfully"));
+        }
+
+        console.log(chalk.gray(`   Events processed: ${result.eventsProcessed || 0}`));
+        console.log(chalk.gray(`   Events replayed: ${result.eventsReplayed || 0}`));
+      } catch (error) {
+        console.error(
+          chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
+        );
         process.exit(1);
       }
-
-      const baseUrl = options.parent?.parent?.baseUrl || "https://api.settler.io";
-
-      const body: Record<string, unknown> = {
-        dryRun: options.dryRun || false,
-      };
-
-      if (options.fromDate) {
-        body.fromDate = options.fromDate;
-      }
-
-      if (options.eventId) {
-        body.eventId = options.eventId;
-      }
-
-      console.log(chalk.blue("Replaying events..."));
-
-      const response = await fetch(`${baseUrl}/api/v1/jobs/${id}/replay`, {
-        method: "POST",
-        headers: {
-          "X-API-Key": apiKey,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-      });
-
-      if (!response.ok) {
-        const error = (await response.json()) as { message?: string };
-        console.error(chalk.red(`Error: ${error.message || "Failed to replay events"}`));
-        process.exit(1);
-      }
-
-      const result = (await response.json()) as {
-        eventsProcessed?: number;
-        eventsReplayed?: number;
-      };
-
-      if (options.dryRun) {
-        console.log(chalk.yellow("Dry run mode - no events were actually replayed"));
-      } else {
-        console.log(chalk.green("✓ Events replayed successfully"));
-      }
-
-      console.log(chalk.gray(`   Events processed: ${result.eventsProcessed || 0}`));
-      console.log(chalk.gray(`   Events replayed: ${result.eventsReplayed || 0}`));
-    } catch (error) {
-      console.error(
-        chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
-      );
-      process.exit(1);
     }
-  });
+  );
 
 export { jobsCommand };

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { createTraceContext, withTraceHeaders } from "../lib/http";
 
 type ReplayDiffEntry = {
   path: string;
@@ -73,9 +74,10 @@ export const replayCommand = new Command("replay")
       options: { baseUrl?: string; step: string; breakpoint?: boolean }
     ) => {
       const baseUrl = normalizeBaseUrl(options.baseUrl);
+      const trace = createTraceContext(undefined, executionId);
       const response = await fetch(`${baseUrl}/api/v1/runs/${executionId}/replay`, {
         method: "GET",
-        headers: { "content-type": "application/json" },
+        headers: withTraceHeaders({ "content-type": "application/json" }, trace),
       });
 
       if (!response.ok) {

--- a/packages/cli/src/commands/tenant-check.ts
+++ b/packages/cli/src/commands/tenant-check.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { createTraceContext, withTraceHeaders } from "../lib/http";
 
 interface TenantIntegrityResponse {
   tenantId: string;
@@ -29,17 +30,19 @@ export const tenantCheckCommand = new Command("tenant-check")
     }
 
     const baseUrl = (options.parent.baseUrl || "https://api.settler.io").replace(/\/$/, "");
+    const trace = createTraceContext();
     const response = await fetch(`${baseUrl}/api/v1/tenant/integrity-check`, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
+      headers: withTraceHeaders(
+        {
+          Authorization: `Bearer ${apiKey}`,
+        },
+        trace
+      ),
     });
 
     if (!response.ok) {
       const body = await response.text();
-      console.error(
-        chalk.red(`Error: tenant integrity check failed (${response.status}) ${body}`)
-      );
+      console.error(chalk.red(`Error: tenant integrity check failed (${response.status}) ${body}`));
       process.exit(1);
     }
 

--- a/packages/cli/src/lib/http.ts
+++ b/packages/cli/src/lib/http.ts
@@ -1,0 +1,32 @@
+import { randomUUID } from "crypto";
+
+export interface TraceContext {
+  traceId: string;
+  executionId: string;
+  tenantId?: string;
+}
+
+export function createTraceContext(tenantId?: string, executionId?: string): TraceContext {
+  return {
+    traceId: randomUUID(),
+    executionId: executionId ?? randomUUID(),
+    tenantId,
+  };
+}
+
+export function withTraceHeaders(
+  headers: Record<string, string>,
+  context: TraceContext
+): Record<string, string> {
+  const merged: Record<string, string> = {
+    ...headers,
+    "X-Trace-Id": context.traceId,
+    "X-Execution-Id": context.executionId,
+  };
+
+  if (context.tenantId) {
+    merged["X-Tenant-Id"] = context.tenantId;
+  }
+
+  return merged;
+}


### PR DESCRIPTION
### Motivation
- Establish a consistent traceability spine so every surface (CLI, API, workers) propagates `trace_id`, `execution_id`, and `tenant_id` end-to-end for reliable observability and forensics.
- Standardize error responses to `application/problem+json` so failures are machine-readable and always include trace and tenant context for auditability and automated remediation.
- Align CLI and API behavior to avoid ad-hoc headers and duplicated tracing logic, improving determinism and tenant safety across replay/export flows.
- Provide lightweight architecture/docs artifacts to capture the system surface map, canonical lifecycle, traceability rules, and observability requirements.

### Description
- Introduced a Problem+JSON helper at `packages/api/src/utils/problem-json.ts` and refactored API middleware paths (`auth`, `tenant`, `error`) to emit standardized problem documents that include `trace_id`, `execution_id`, and `tenant_id` when available.
- Normalized ingress tracing in `packages/api/src/index.ts` to resolve/create `X-Trace-Id` and `X-Execution-Id`, mirror them into response headers, and allow tenant header correlation; propagated these into request context and AsyncLocalStorage.
- Extended structured logging in `packages/api/src/utils/logger.ts` and request context middleware to include `trace_id` and `execution_id` so logs are correlated with requests and executions.
- Added a small CLI HTTP utility `packages/cli/src/lib/http.ts` and updated key CLI commands (`replay`, `debug`, `export`, `jobs`, `tenant-check`) to emit consistent trace headers on outbound API calls; added documentation files under `docs/architecture` and `docs/operations/observability.md` describing surface map, lifecycle, and observability expectations.

### Testing
- Ran API and CLI typechecks: `pnpm --filter @settler/cli typecheck` (passed) and `pnpm --filter @settler/api typecheck` (passed).
- Executed CLI unit tests: `pnpm --filter @settler/cli test` and observed all suites passing.
- Pre-commit lint tasks scoped to changed packages were executed as part of verification (`turbo run lint` via hooks) and completed without errors (warnings only where noted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae246cfc7883289d022dfc93254d8d)