### PR TITLE
Add Reconciliation Decision Workbench APIs and Explanation Contract

### DIFF
--- a/docs/reconciliation/decision-workbench.md
+++ b/docs/reconciliation/decision-workbench.md
@@ -1,0 +1,35 @@
+# Reconciliation Decision Workbench (v1)
+
+This document describes the first operator trust-layer contracts exposed by `/api/v1/reconciliation`.
+
+## Endpoints
+
+- `GET /api/v1/reconciliation/runs/:runId/workbench`
+  - Returns queue-oriented review items (`manual_review`, `unmatched`, `grouped`, `variance`, `status_conflict`, `matched`).
+  - Each item includes an `explanation` object grounded in runtime match fields.
+- `GET /api/v1/reconciliation/runs/:runId/compare/:otherRunId`
+  - Returns summary counts and per-item changes for classification, group membership, variance, and queue movement.
+- `GET /api/v1/reconciliation/runs/:runId/workbench/export`
+  - Returns a JSON export with `schemaVersion: reconciliation-workbench.v1` for audit and downstream consumption.
+- `PATCH /api/v1/reconciliation/matches/:matchId`
+  - Supports `reviewState` updates (`pending_review | reviewed | approved | dismissed | escalated`) and persists state under `metadata.review_state`.
+
+## Decision Explanation Contract
+
+`DecisionExplanation` includes:
+
+- classification and rationale codes
+- matched source/target record IDs
+- grouped evidence (group id and deterministic member IDs)
+- evidence fields used in runtime matching
+- amount/date comparisons, variance and tolerance outcomes
+- tolerance policy values from run metadata config
+- policy path stages
+- unresolved ambiguity markers
+- dispute/reversal relevance markers
+- manual review requirement + reason codes
+
+## Notes
+
+- Contracts are additive and tenant-scoped by existing route SQL filters.
+- Explanations are generated from runtime `reconciliation_matches` fields and per-run config metadata.

--- a/packages/api/src/__tests__/routes/reconciliation-trust-contract.test.ts
+++ b/packages/api/src/__tests__/routes/reconciliation-trust-contract.test.ts
@@ -1,0 +1,81 @@
+import {
+  buildWorkbenchItem,
+  compareWorkbenchRuns,
+} from "../../routes/v1/reconciliation-trust-contract";
+
+describe("reconciliation trust contract", () => {
+  const baseRow = {
+    id: "m-1",
+    run_id: "run-1",
+    match_type: "manual",
+    confidence: 0.62,
+    match_reason: "requires human check",
+    amount_diff: 0.25,
+    date_diff: 12,
+    reviewed: false,
+    reviewed_at: null,
+    reviewed_by: null,
+    metadata: {
+      group_id: "grp-1",
+      status_conflict: true,
+      rationale_codes: ["RULE_PATH_STATUS_CONFLICT"],
+      group_member_source_transaction_ids: ["src-2", "src-1"],
+      group_member_target_transaction_ids: ["tgt-2", "tgt-1"],
+      is_dispute_related: true,
+      review_state: "escalated",
+    },
+    source_id: "src-1",
+    source_amount: 100,
+    source_currency: "USD",
+    source_date: new Date("2026-01-01T00:00:00.000Z"),
+    source_description: "source",
+    source_external_id: "ext-1",
+    target_id: "tgt-1",
+    target_amount: 99.75,
+    target_currency: "USD",
+    target_date: new Date("2026-01-13T00:00:00.000Z"),
+    target_description: "target",
+    target_external_id: "ext-tgt-1",
+  } as const;
+
+  it("builds deterministic workbench explanations from runtime fields", () => {
+    const item = buildWorkbenchItem(baseRow as never, {
+      config: { amountTolerance: 0.01, dateWindowDays: 7, fuzzyDescriptionThreshold: 0.8 },
+    });
+
+    expect(item.queue).toBe("status_conflict");
+    expect(item.reviewState).toBe("escalated");
+    expect(item.explanation.groupedEvidence.groupMemberSourceTransactionIds).toEqual([
+      "src-1",
+      "src-2",
+    ]);
+    expect(item.explanation.manualReview.reasonCodes).toContain("AMOUNT_VARIANCE_EXCEEDED");
+    expect(item.explanation.manualReview.reasonCodes).toContain("DATE_WINDOW_EXCEEDED");
+    expect(item.explanation.disputeRelevance.isDisputeRelated).toBe(true);
+    expect(item.explanation.rationaleCodes).toEqual(["RULE_PATH_STATUS_CONFLICT"]);
+  });
+
+  it("computes run diff summaries across classifications and variances", () => {
+    const fromItem = buildWorkbenchItem(baseRow as never, { config: {} });
+    const toItem = buildWorkbenchItem(
+      {
+        ...baseRow,
+        run_id: "run-2",
+        match_type: "exact",
+        confidence: 1,
+        amount_diff: 0,
+        date_diff: 0,
+        metadata: { review_state: "reviewed" },
+      } as never,
+      { config: {} }
+    );
+
+    const comparison = compareWorkbenchRuns([fromItem], [toItem], "run-1", "run-2");
+
+    expect(comparison.summary.counts.classificationChanges).toBe(1);
+    expect(comparison.summary.counts.varianceChanges).toBe(1);
+    expect(comparison.summary.counts.newlyMatched).toBe(1);
+    expect(comparison.changes).toHaveLength(1);
+    expect(comparison.changes[0]?.classification).toEqual({ from: "manual", to: "exact" });
+  });
+});

--- a/packages/api/src/routes/v1/reconciliation-trust-contract.ts
+++ b/packages/api/src/routes/v1/reconciliation-trust-contract.ts
@@ -1,0 +1,431 @@
+export type MatchClassification = "exact" | "fuzzy" | "manual" | "unmatched";
+
+export type ReviewState = "pending_review" | "reviewed" | "approved" | "dismissed" | "escalated";
+
+export type ManualReviewReasonCode =
+  | "UNMATCHED_TRANSACTION"
+  | "LOW_CONFIDENCE_MATCH"
+  | "AMOUNT_VARIANCE_EXCEEDED"
+  | "DATE_WINDOW_EXCEEDED"
+  | "STATUS_CONFLICT"
+  | "GROUP_REQUIRES_INSPECTION"
+  | "POLICY_OVERRIDE_REQUIRED"
+  | "INSUFFICIENT_EVIDENCE";
+
+export interface ReconciliationTolerancePolicy {
+  amountTolerance: number;
+  dateWindowDays: number;
+  fuzzyDescriptionThreshold: number;
+  requireExactAmount: boolean;
+}
+
+export interface DecisionExplanation {
+  classification: MatchClassification;
+  rationaleCodes: string[];
+  matchedRecordIds: {
+    sourceTransactionId: string;
+    targetTransactionId: string | null;
+  };
+  groupedEvidence: {
+    groupId: string | null;
+    groupMemberSourceTransactionIds: string[];
+    groupMemberTargetTransactionIds: string[];
+  };
+  evidenceFieldsUsed: string[];
+  amountComparison: {
+    sourceAmount: number;
+    targetAmount: number | null;
+    amountDifference: number | null;
+    withinTolerance: boolean | null;
+  };
+  dateComparison: {
+    sourceDate: string;
+    targetDate: string | null;
+    dateDifferenceDays: number | null;
+    withinWindow: boolean | null;
+  };
+  tolerancePolicy: ReconciliationTolerancePolicy;
+  varianceSummary: {
+    hasAmountVariance: boolean;
+    hasDateVariance: boolean;
+  };
+  policyPath: string[];
+  unresolvedAmbiguity: {
+    hasAmbiguity: boolean;
+    markers: string[];
+  };
+  disputeRelevance: {
+    isDisputeRelated: boolean;
+    isReversalRelated: boolean;
+  };
+  manualReview: {
+    required: boolean;
+    reasonCodes: ManualReviewReasonCode[];
+  };
+}
+
+export interface ReconciliationWorkbenchItem {
+  id: string;
+  runId: string;
+  classification: MatchClassification;
+  confidence: number;
+  queue: "manual_review" | "unmatched" | "grouped" | "variance" | "status_conflict" | "matched";
+  reviewState: ReviewState;
+  reviewed: boolean;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+  source: {
+    id: string;
+    externalId: string | null;
+    amount: number;
+    currency: string;
+    date: string;
+    description: string | null;
+  };
+  target: {
+    id: string;
+    externalId: string | null;
+    amount: number;
+    currency: string;
+    date: string;
+    description: string | null;
+  } | null;
+  explanation: DecisionExplanation;
+}
+
+interface DbMatchRow {
+  id: string;
+  run_id: string;
+  match_type: MatchClassification;
+  confidence: number;
+  match_reason: string | null;
+  amount_diff: number | null;
+  date_diff: number | null;
+  reviewed: boolean;
+  reviewed_at: Date | null;
+  reviewed_by: string | null;
+  metadata: Record<string, unknown> | string | null;
+  source_id: string;
+  source_amount: number;
+  source_currency: string;
+  source_date: Date;
+  source_description: string | null;
+  source_external_id: string | null;
+  target_id: string | null;
+  target_amount: number | null;
+  target_currency: string | null;
+  target_date: Date | null;
+  target_description: string | null;
+  target_external_id: string | null;
+}
+
+const DEFAULT_POLICY: ReconciliationTolerancePolicy = {
+  amountTolerance: 0.01,
+  dateWindowDays: 7,
+  fuzzyDescriptionThreshold: 0.8,
+  requireExactAmount: false,
+};
+
+function parseMetadata(input: DbMatchRow["metadata"]): Record<string, unknown> {
+  if (!input) return {};
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input);
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return input;
+}
+
+function toReasonCodes(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string").sort();
+}
+
+function deriveManualReviewReasons(
+  row: DbMatchRow,
+  metadata: Record<string, unknown>,
+  tolerancePolicy: ReconciliationTolerancePolicy
+): ManualReviewReasonCode[] {
+  const reasons = new Set<ManualReviewReasonCode>();
+
+  if (row.match_type === "unmatched") reasons.add("UNMATCHED_TRANSACTION");
+  if (row.match_type === "manual") reasons.add("POLICY_OVERRIDE_REQUIRED");
+  if (row.confidence < 0.75) reasons.add("LOW_CONFIDENCE_MATCH");
+  if (typeof row.amount_diff === "number" && row.amount_diff > tolerancePolicy.amountTolerance) {
+    reasons.add("AMOUNT_VARIANCE_EXCEEDED");
+  }
+  if (
+    typeof row.date_diff === "number" &&
+    Math.abs(row.date_diff) > tolerancePolicy.dateWindowDays
+  ) {
+    reasons.add("DATE_WINDOW_EXCEEDED");
+  }
+
+  if (typeof metadata.group_id === "string") reasons.add("GROUP_REQUIRES_INSPECTION");
+  if (metadata.status_conflict === true) reasons.add("STATUS_CONFLICT");
+  if (!row.target_id) reasons.add("INSUFFICIENT_EVIDENCE");
+
+  return Array.from(reasons).sort();
+}
+
+function deriveQueue(
+  row: DbMatchRow,
+  metadata: Record<string, unknown>,
+  manualReviewReasons: ManualReviewReasonCode[]
+): ReconciliationWorkbenchItem["queue"] {
+  if (metadata.status_conflict === true) return "status_conflict";
+  if (row.match_type === "unmatched") return "unmatched";
+  if (typeof metadata.group_id === "string") return "grouped";
+  if (manualReviewReasons.length > 0) return "manual_review";
+  if ((row.amount_diff ?? 0) > 0 || (row.date_diff ?? 0) !== 0) return "variance";
+  return "matched";
+}
+
+export function buildWorkbenchItem(
+  row: DbMatchRow,
+  runMetadata: Record<string, unknown>
+): ReconciliationWorkbenchItem {
+  const metadata = parseMetadata(row.metadata);
+  const runConfig = (runMetadata.config ?? runMetadata ?? {}) as Record<string, unknown>;
+  const tolerancePolicy: ReconciliationTolerancePolicy = {
+    amountTolerance:
+      typeof runConfig.amountTolerance === "number"
+        ? runConfig.amountTolerance
+        : DEFAULT_POLICY.amountTolerance,
+    dateWindowDays:
+      typeof runConfig.dateWindowDays === "number"
+        ? runConfig.dateWindowDays
+        : DEFAULT_POLICY.dateWindowDays,
+    fuzzyDescriptionThreshold:
+      typeof runConfig.fuzzyDescriptionThreshold === "number"
+        ? runConfig.fuzzyDescriptionThreshold
+        : DEFAULT_POLICY.fuzzyDescriptionThreshold,
+    requireExactAmount:
+      typeof runConfig.requireExactAmount === "boolean"
+        ? runConfig.requireExactAmount
+        : DEFAULT_POLICY.requireExactAmount,
+  };
+
+  const manualReviewReasons = deriveManualReviewReasons(row, metadata, tolerancePolicy);
+  const evidenceFieldsUsed = ["amount", "date", "currency", "description", "external_id"];
+  const rationaleCodes =
+    toReasonCodes(metadata.rationale_codes).length > 0
+      ? toReasonCodes(metadata.rationale_codes)
+      : manualReviewReasons;
+
+  const reviewStateRaw = metadata.review_state;
+  const reviewState: ReviewState =
+    reviewStateRaw === "reviewed" ||
+    reviewStateRaw === "approved" ||
+    reviewStateRaw === "dismissed" ||
+    reviewStateRaw === "escalated"
+      ? reviewStateRaw
+      : "pending_review";
+
+  const queue = deriveQueue(row, metadata, manualReviewReasons);
+
+  return {
+    id: row.id,
+    runId: row.run_id,
+    classification: row.match_type,
+    confidence: row.confidence,
+    queue,
+    reviewState,
+    reviewed: row.reviewed,
+    reviewedAt: row.reviewed_at ? row.reviewed_at.toISOString() : null,
+    reviewedBy: row.reviewed_by,
+    source: {
+      id: row.source_id,
+      externalId: row.source_external_id,
+      amount: row.source_amount,
+      currency: row.source_currency,
+      date: row.source_date.toISOString(),
+      description: row.source_description,
+    },
+    target: row.target_id
+      ? {
+          id: row.target_id,
+          externalId: row.target_external_id,
+          amount: row.target_amount ?? 0,
+          currency: row.target_currency ?? row.source_currency,
+          date: row.target_date ? row.target_date.toISOString() : row.source_date.toISOString(),
+          description: row.target_description,
+        }
+      : null,
+    explanation: {
+      classification: row.match_type,
+      rationaleCodes,
+      matchedRecordIds: {
+        sourceTransactionId: row.source_id,
+        targetTransactionId: row.target_id,
+      },
+      groupedEvidence: {
+        groupId: typeof metadata.group_id === "string" ? metadata.group_id : null,
+        groupMemberSourceTransactionIds: Array.isArray(metadata.group_member_source_transaction_ids)
+          ? (metadata.group_member_source_transaction_ids as string[]).slice().sort()
+          : [row.source_id],
+        groupMemberTargetTransactionIds: Array.isArray(metadata.group_member_target_transaction_ids)
+          ? (metadata.group_member_target_transaction_ids as string[]).slice().sort()
+          : row.target_id
+            ? [row.target_id]
+            : [],
+      },
+      evidenceFieldsUsed,
+      amountComparison: {
+        sourceAmount: row.source_amount,
+        targetAmount: row.target_amount,
+        amountDifference: row.amount_diff,
+        withinTolerance:
+          row.amount_diff === null ? null : row.amount_diff <= tolerancePolicy.amountTolerance,
+      },
+      dateComparison: {
+        sourceDate: row.source_date.toISOString(),
+        targetDate: row.target_date ? row.target_date.toISOString() : null,
+        dateDifferenceDays: row.date_diff,
+        withinWindow:
+          row.date_diff === null ? null : Math.abs(row.date_diff) <= tolerancePolicy.dateWindowDays,
+      },
+      tolerancePolicy,
+      varianceSummary: {
+        hasAmountVariance: (row.amount_diff ?? 0) > 0,
+        hasDateVariance: (row.date_diff ?? 0) !== 0,
+      },
+      policyPath: [
+        "currency-filter",
+        "date-window-filter",
+        "amount-tolerance-filter",
+        "description-similarity-scoring",
+      ],
+      unresolvedAmbiguity: {
+        hasAmbiguity: manualReviewReasons.length > 0,
+        markers: manualReviewReasons,
+      },
+      disputeRelevance: {
+        isDisputeRelated: metadata.is_dispute_related === true,
+        isReversalRelated: metadata.is_reversal_related === true,
+      },
+      manualReview: {
+        required: queue === "manual_review" || queue === "unmatched" || queue === "status_conflict",
+        reasonCodes: manualReviewReasons,
+      },
+    },
+  };
+}
+
+export interface RunComparisonSummary {
+  fromRunId: string;
+  toRunId: string;
+  counts: {
+    classificationChanges: number;
+    groupMembershipChanges: number;
+    varianceChanges: number;
+    newlyManualReviewed: number;
+    newlyMatched: number;
+    newlyUnmatched: number;
+  };
+}
+
+export interface RunComparisonChange {
+  sourceTransactionId: string;
+  classification: { from: MatchClassification | null; to: MatchClassification | null };
+  variance: {
+    amountDiffFrom: number | null;
+    amountDiffTo: number | null;
+    dateDiffFrom: number | null;
+    dateDiffTo: number | null;
+  };
+  groupMembership: { from: string | null; to: string | null };
+  queue: {
+    from: ReconciliationWorkbenchItem["queue"] | null;
+    to: ReconciliationWorkbenchItem["queue"] | null;
+  };
+}
+
+export function compareWorkbenchRuns(
+  fromItems: ReconciliationWorkbenchItem[],
+  toItems: ReconciliationWorkbenchItem[],
+  fromRunId: string,
+  toRunId: string
+): { summary: RunComparisonSummary; changes: RunComparisonChange[] } {
+  const fromMap = new Map(
+    fromItems.map((item) => [item.source.externalId ?? item.source.id, item])
+  );
+  const toMap = new Map(toItems.map((item) => [item.source.externalId ?? item.source.id, item]));
+
+  const keys = new Set([...fromMap.keys(), ...toMap.keys()]);
+  const changes: RunComparisonChange[] = [];
+
+  let classificationChanges = 0;
+  let groupMembershipChanges = 0;
+  let varianceChanges = 0;
+  let newlyManualReviewed = 0;
+  let newlyMatched = 0;
+  let newlyUnmatched = 0;
+
+  for (const key of keys) {
+    const from = fromMap.get(key) ?? null;
+    const to = toMap.get(key) ?? null;
+    const change: RunComparisonChange = {
+      sourceTransactionId: from?.source.id ?? to?.source.id ?? key,
+      classification: { from: from?.classification ?? null, to: to?.classification ?? null },
+      variance: {
+        amountDiffFrom: from?.explanation.amountComparison.amountDifference ?? null,
+        amountDiffTo: to?.explanation.amountComparison.amountDifference ?? null,
+        dateDiffFrom: from?.explanation.dateComparison.dateDifferenceDays ?? null,
+        dateDiffTo: to?.explanation.dateComparison.dateDifferenceDays ?? null,
+      },
+      groupMembership: {
+        from: from?.explanation.groupedEvidence.groupId ?? null,
+        to: to?.explanation.groupedEvidence.groupId ?? null,
+      },
+      queue: { from: from?.queue ?? null, to: to?.queue ?? null },
+    };
+
+    const changed =
+      change.classification.from !== change.classification.to ||
+      change.groupMembership.from !== change.groupMembership.to ||
+      change.variance.amountDiffFrom !== change.variance.amountDiffTo ||
+      change.variance.dateDiffFrom !== change.variance.dateDiffTo ||
+      change.queue.from !== change.queue.to;
+
+    if (change.classification.from !== change.classification.to) classificationChanges++;
+    if (change.groupMembership.from !== change.groupMembership.to) groupMembershipChanges++;
+    if (
+      change.variance.amountDiffFrom !== change.variance.amountDiffTo ||
+      change.variance.dateDiffFrom !== change.variance.dateDiffTo
+    ) {
+      varianceChanges++;
+    }
+    if (from?.queue !== "manual_review" && to?.queue === "manual_review") newlyManualReviewed++;
+    if (
+      from?.classification !== "exact" &&
+      from?.classification !== "fuzzy" &&
+      (to?.classification === "exact" || to?.classification === "fuzzy")
+    ) {
+      newlyMatched++;
+    }
+    if (from?.classification !== "unmatched" && to?.classification === "unmatched")
+      newlyUnmatched++;
+
+    if (changed) changes.push(change);
+  }
+
+  return {
+    summary: {
+      fromRunId,
+      toRunId,
+      counts: {
+        classificationChanges,
+        groupMembershipChanges,
+        varianceChanges,
+        newlyManualReviewed,
+        newlyMatched,
+        newlyUnmatched,
+      },
+    },
+    changes,
+  };
+}

--- a/packages/api/src/routes/v1/reconciliation.ts
+++ b/packages/api/src/routes/v1/reconciliation.ts
@@ -9,6 +9,11 @@ import { logError, logInfo } from "../../utils/logger";
 import { runReconciliation } from "../../services/ingestion/reconciliation-matcher";
 import { query } from "../../db";
 import { ReconciliationConfig } from "../../services/ingestion/types";
+import {
+  buildWorkbenchItem,
+  compareWorkbenchRuns,
+  ReviewState,
+} from "./reconciliation-trust-contract";
 
 const router: Router = Router();
 
@@ -37,12 +42,7 @@ router.post("/run", async (req: AuthRequest, res: Response) => {
       requireExactAmount: config?.requireExactAmount || false,
     };
 
-    const runId = await runReconciliation(
-      ingestionId,
-      tenantId,
-      userId,
-      reconciliationConfig
-    );
+    const runId = await runReconciliation(ingestionId, tenantId, userId, reconciliationConfig);
 
     logInfo("Reconciliation run started", { runId, ingestionId, traceId: req.traceId });
 
@@ -107,10 +107,7 @@ router.get("/runs/:runId", async (req: AuthRequest, res: Response) => {
       confidenceAvg: run.confidence_avg as number | null,
       errorMessage: run.error_message as string | null,
       traceId: run.trace_id as string | null,
-      metadata:
-        typeof run.metadata === "string"
-          ? JSON.parse(run.metadata)
-          : run.metadata,
+      metadata: typeof run.metadata === "string" ? JSON.parse(run.metadata) : run.metadata,
     });
   } catch (error) {
     logError("Failed to get reconciliation run", error, {
@@ -224,6 +221,188 @@ router.get("/runs/:runId/matches", async (req: AuthRequest, res: Response) => {
   }
 });
 
+router.get("/runs/:runId/workbench", async (req: AuthRequest, res: Response) => {
+  try {
+    const { runId } = req.params;
+    const tenantId = req.tenantId!;
+    const limit = parseInt(req.query.limit as string) || 100;
+    const offset = parseInt(req.query.offset as string) || 0;
+    const queue = req.query.queue as string | undefined;
+
+    const runs = await query(
+      `SELECT metadata FROM reconciliation_runs WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+      [runId || "", tenantId]
+    );
+
+    if (runs.length === 0) {
+      return res.status(404).json({
+        error: "Not Found",
+        message: "Reconciliation run not found",
+        traceId: req.traceId,
+      });
+    }
+
+    const runMetadataRaw = (runs[0] as { metadata: unknown }).metadata;
+    const runMetadata =
+      typeof runMetadataRaw === "string"
+        ? (JSON.parse(runMetadataRaw) as Record<string, unknown>)
+        : ((runMetadataRaw as Record<string, unknown>) ?? {});
+
+    const rows = await query(
+      `SELECT
+        rm.id, rm.run_id, rm.match_type, rm.confidence, rm.match_reason,
+        rm.amount_diff, rm.date_diff, rm.reviewed, rm.reviewed_at, rm.reviewed_by, rm.metadata,
+        st.id as source_id, st.amount as source_amount, st.currency as source_currency,
+        st.date as source_date, st.description as source_description, st.external_id as source_external_id,
+        tt.id as target_id, tt.amount as target_amount, tt.currency as target_currency,
+        tt.date as target_date, tt.description as target_description, tt.external_id as target_external_id
+      FROM reconciliation_matches rm
+      JOIN normalized_transactions st ON st.id = rm.source_transaction_id
+      LEFT JOIN normalized_transactions tt ON tt.id = rm.target_transaction_id
+      WHERE rm.run_id = $1 AND rm.tenant_id = $2
+      ORDER BY rm.confidence ASC, st.date DESC
+      LIMIT $3 OFFSET $4`,
+      [runId || "", tenantId, limit.toString(), offset.toString()]
+    );
+
+    const items = rows
+      .map((row) => buildWorkbenchItem(row as never, runMetadata))
+      .filter((item) => (queue ? item.queue === queue : true));
+
+    const queueCounts = items.reduce<Record<string, number>>((acc, item) => {
+      acc[item.queue] = (acc[item.queue] || 0) + 1;
+      return acc;
+    }, {});
+
+    return res.json({
+      runId,
+      queue: queue ?? null,
+      summary: {
+        totalItems: items.length,
+        queueCounts,
+      },
+      items,
+      pagination: { limit, offset, total: items.length },
+    });
+  } catch (error) {
+    logError("Failed to load reconciliation workbench", error, { traceId: req.traceId });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: "Failed to load reconciliation workbench",
+      traceId: req.traceId,
+    });
+  }
+});
+
+router.get("/runs/:runId/compare/:otherRunId", async (req: AuthRequest, res: Response) => {
+  try {
+    const { runId, otherRunId } = req.params;
+    const tenantId = req.tenantId!;
+
+    const fetchRunItems = async (targetRunId: string) => {
+      const runRows = await query(
+        `SELECT metadata FROM reconciliation_runs WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+        [targetRunId, tenantId]
+      );
+      if (runRows.length === 0) {
+        throw new Error(`Run not found: ${targetRunId}`);
+      }
+
+      const runMetadataRaw = (runRows[0] as { metadata: unknown }).metadata;
+      const runMetadata =
+        typeof runMetadataRaw === "string"
+          ? (JSON.parse(runMetadataRaw) as Record<string, unknown>)
+          : ((runMetadataRaw as Record<string, unknown>) ?? {});
+
+      const rows = await query(
+        `SELECT
+          rm.id, rm.run_id, rm.match_type, rm.confidence, rm.match_reason,
+          rm.amount_diff, rm.date_diff, rm.reviewed, rm.reviewed_at, rm.reviewed_by, rm.metadata,
+          st.id as source_id, st.amount as source_amount, st.currency as source_currency,
+          st.date as source_date, st.description as source_description, st.external_id as source_external_id,
+          tt.id as target_id, tt.amount as target_amount, tt.currency as target_currency,
+          tt.date as target_date, tt.description as target_description, tt.external_id as target_external_id
+        FROM reconciliation_matches rm
+        JOIN normalized_transactions st ON st.id = rm.source_transaction_id
+        LEFT JOIN normalized_transactions tt ON tt.id = rm.target_transaction_id
+        WHERE rm.run_id = $1 AND rm.tenant_id = $2`,
+        [targetRunId, tenantId]
+      );
+
+      return rows.map((row) => buildWorkbenchItem(row as never, runMetadata));
+    };
+
+    const fromItems = await fetchRunItems(runId || "");
+    const toItems = await fetchRunItems(otherRunId || "");
+    const comparison = compareWorkbenchRuns(fromItems, toItems, runId || "", otherRunId || "");
+
+    return res.json(comparison);
+  } catch (error) {
+    logError("Failed to compare reconciliation runs", error, { traceId: req.traceId });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: "Failed to compare reconciliation runs",
+      traceId: req.traceId,
+    });
+  }
+});
+
+router.get("/runs/:runId/workbench/export", async (req: AuthRequest, res: Response) => {
+  try {
+    const { runId } = req.params;
+    const tenantId = req.tenantId!;
+
+    const runRows = await query(
+      `SELECT metadata FROM reconciliation_runs WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+      [runId || "", tenantId]
+    );
+
+    if (runRows.length === 0) {
+      return res.status(404).json({
+        error: "Not Found",
+        message: "Reconciliation run not found",
+        traceId: req.traceId,
+      });
+    }
+
+    const runMetadataRaw = (runRows[0] as { metadata: unknown }).metadata;
+    const runMetadata =
+      typeof runMetadataRaw === "string"
+        ? (JSON.parse(runMetadataRaw) as Record<string, unknown>)
+        : ((runMetadataRaw as Record<string, unknown>) ?? {});
+    const rows = await query(
+      `SELECT
+        rm.id, rm.run_id, rm.match_type, rm.confidence, rm.match_reason,
+        rm.amount_diff, rm.date_diff, rm.reviewed, rm.reviewed_at, rm.reviewed_by, rm.metadata,
+        st.id as source_id, st.amount as source_amount, st.currency as source_currency,
+        st.date as source_date, st.description as source_description, st.external_id as source_external_id,
+        tt.id as target_id, tt.amount as target_amount, tt.currency as target_currency,
+        tt.date as target_date, tt.description as target_description, tt.external_id as target_external_id
+      FROM reconciliation_matches rm
+      JOIN normalized_transactions st ON st.id = rm.source_transaction_id
+      LEFT JOIN normalized_transactions tt ON tt.id = rm.target_transaction_id
+      WHERE rm.run_id = $1 AND rm.tenant_id = $2
+      ORDER BY st.date DESC`,
+      [runId || "", tenantId]
+    );
+
+    const items = rows.map((row) => buildWorkbenchItem(row as never, runMetadata));
+    return res.json({
+      runId,
+      exportedAt: new Date().toISOString(),
+      schemaVersion: "reconciliation-workbench.v1",
+      items,
+    });
+  } catch (error) {
+    logError("Failed to export reconciliation workbench", error, { traceId: req.traceId });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: "Failed to export reconciliation workbench",
+      traceId: req.traceId,
+    });
+  }
+});
+
 /**
  * PATCH /api/v1/reconciliation/matches/:matchId
  * Update match (e.g., mark as reviewed)
@@ -231,23 +410,35 @@ router.get("/runs/:runId/matches", async (req: AuthRequest, res: Response) => {
 router.patch("/matches/:matchId", async (req: AuthRequest, res: Response) => {
   try {
     const { matchId } = req.params;
-    const { reviewed } = req.body;
+    const { reviewed, reviewState } = req.body as { reviewed?: boolean; reviewState?: ReviewState };
     const tenantId = req.tenantId!;
     const userId = req.userId!;
+
+    const normalizedReviewState: ReviewState =
+      reviewState === "reviewed" ||
+      reviewState === "approved" ||
+      reviewState === "dismissed" ||
+      reviewState === "escalated"
+        ? reviewState
+        : reviewed === true
+          ? "reviewed"
+          : "pending_review";
 
     await query(
       `UPDATE reconciliation_matches SET
         reviewed = $1,
         reviewed_by = $2,
         reviewed_at = NOW(),
+        metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{review_state}', to_jsonb($3::text), true),
         updated_at = NOW()
-      WHERE id = $3 AND tenant_id = $4`,
-      [reviewed === true, userId || "", matchId || "", tenantId]
+      WHERE id = $4 AND tenant_id = $5`,
+      [reviewed === true, userId || "", normalizedReviewState, matchId || "", tenantId]
     );
 
     return res.json({
       id: matchId,
       reviewed: reviewed === true,
+      reviewState: normalizedReviewState,
       reviewedAt: new Date().toISOString(),
     });
   } catch (error) {


### PR DESCRIPTION
### Motivation

- Provide operators and auditors with runtime-grounded, auditable explanations for reconciliation decisions rather than ad-hoc prose.  
- Surface structured evidence and triage queues so manual-review workflows are inspectable and actionable.  
- Enable run-to-run diffing and a serializable export so policy changes and regressions are visible and consumable by downstream audit tooling.

### Description

- Added a typed explanation contract and transformation utilities in `packages/api/src/routes/v1/reconciliation-trust-contract.ts` including `DecisionExplanation`, `ReconciliationWorkbenchItem`, deterministic normalization (sorted members/reason codes) and `compareWorkbenchRuns` for run diffs.  
- Implemented operator workbench APIs in `packages/api/src/routes/v1/reconciliation.ts`: `GET /runs/:runId/workbench`, `GET /runs/:runId/compare/:otherRunId`, and `GET /runs/:runId/workbench/export`, which are tenant-scoped and return the structured workbench items and summaries.  
- Extended `PATCH /matches/:matchId` to accept and persist a normalized `reviewState` (`pending_review|reviewed|approved|dismissed|escalated`) into match `metadata` while preserving the existing `reviewed` flag.  
- Added unit/contract tests and documentation: `packages/api/src/__tests__/routes/reconciliation-trust-contract.test.ts` to validate deterministic explanation derivation and run diff semantics, and `docs/reconciliation/decision-workbench.md` describing endpoints and the export contract.

### Testing

- Ran the targeted unit/contract tests with: `pnpm --filter @settler/api exec jest src/__tests__/routes/reconciliation-trust-contract.test.ts src/__tests__/routes/recon-results-serializer.contract.test.ts src/__tests__/routes/recon-results-endpoint.contract.test.ts --runInBand --forceExit`, and all suites passed.  
- Performed TypeScript verification with: `pnpm --filter @settler/api run typecheck`, and the typecheck completed successfully.  
- Pre-commit lint/format tasks ran as part of the commit flow (ESLint/Prettier) with only non-blocking warnings reported; no test failures observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6b39010c832887aea27b78277412)