### PR TITLE
Harden reconciliation operability: CSV parsing, synthetic scenarios, CI, and tooling

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -1,4 +1,4 @@
-name: Foundry
+name: Foundry Reconciliation Verification
 
 on:
   pull_request:
@@ -8,7 +8,37 @@ on:
   workflow_dispatch:
 
 jobs:
-  foundry-core:
+  foundry-fast-multi-seed:
+    name: Foundry fast (smoke profile multi-seed)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        seed: [42, 7, 99]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.13.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Foundry smoke strict verification
+        run: pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-verify --seed ${{ matrix.seed }} --profile smoke --strict
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: foundry-smoke-seed-${{ matrix.seed }}
+          path: |
+            artifacts/foundry/
+            test-data/exports/
+          if-no-files-found: ignore
+
+  foundry-full-runtime:
+    name: Foundry full (integration runtime)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,12 +49,16 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm run verify:foundry
-      - run: pnpm run verify:foundry:metamorphic
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Verify foundry datasets and contracts
+        run: pnpm run verify:foundry && pnpm run verify:foundry:metamorphic
       - if: github.event_name != 'pull_request'
+        name: Verify fault-injection dataset
         run: pnpm run verify:foundry:faults
-      - uses: actions/upload-artifact@v4
+      - if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: foundry-artifacts
+          name: foundry-integration-artifacts
           path: artifacts/foundry/
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ Optional integrations should be configured only when validating those specific s
 - [Repo integrity reference](docs/reference/repo-integrity.md)
 - [Workspace contracts](docs/reference/workspace-contracts.md)
 
+## Reconciliation synthetic verification
+
+Use the deterministic reconciliation foundry commands below during local debugging and CI parity checks:
+
+- `pnpm run test:reconciliation` — runs CLI reconciliation harness + reconciliation foundry tests.
+- `pnpm run test:reconciliation:e2e` — executes strict reconciliation verification (`smoke` profile, seed 42).
+- `pnpm run verify:reconciliation-runtime` — executes strict reconciliation verification (`integration` profile, seed 42).
+- `pnpm run generate:test-data:smoke` — generates deterministic smoke export fixtures under `test-data/exports`.
+
+For additional seeds, run:
+
+```bash
+pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-verify --seed 7 --profile smoke --strict
+pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-verify --seed 99 --profile smoke --strict
+```
+
 ## Integrity guarantee
 
 `pnpm run repo-integrity` is expected to pass on a healthy checkout and fails hard when workspace manifests, script references, or package contracts drift.

--- a/package.json
+++ b/package.json
@@ -251,7 +251,9 @@
     "benchmark:reconciliation": "pnpm --filter @settler/cli exec tsx src/tools/benchmark-reconciliation.ts",
     "test:reconciliation:e2e": "pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-verify --seed 42 --profile smoke --strict",
     "verify:reconciliation-runtime": "pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-verify --seed 42 --profile integration --strict",
-    "verify:reconciliation:strict": "node scripts/verify-reconciliation-strict.mjs"
+    "verify:reconciliation:strict": "node scripts/verify-reconciliation-strict.mjs",
+    "reconciliation:summary": "node scripts/reconciliation-run-tools.mjs summary test-data/exports/latest",
+    "reconciliation:compare": "node scripts/reconciliation-run-tools.mjs compare test-data/exports/smoke-seed42 test-data/exports/latest"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/api/src/__tests__/services/csv-importer.test.ts
+++ b/packages/api/src/__tests__/services/csv-importer.test.ts
@@ -1,0 +1,61 @@
+import {
+  autoDetectColumnMapping,
+  normalizeCSVRow,
+  parseCSV,
+} from "../../services/ingestion/csv-importer";
+
+describe("csv importer hardening", () => {
+  it("fails on empty input", () => {
+    expect(() => parseCSV("   \n\n")).toThrow(/CSV file is empty/i);
+  });
+
+  it("fails on duplicate headers", () => {
+    const csv = "Amount,amount,Date\n10.00,10.00,2026-01-01\n";
+    expect(() => parseCSV(csv)).toThrow(/duplicate headers/i);
+  });
+
+  it("fails on malformed/truncated rows", () => {
+    const csv = 'Amount,Date,Description\n"11.10,2026-01-01,broken\n';
+    expect(() => parseCSV(csv)).toThrow(/CSV parsing failed/i);
+  });
+
+  it("trims headers and rows for valid CSV", () => {
+    const csv = " Amount , Date , Description \n 12.00 , 2026-01-01 , Settled \n";
+    const parsed = parseCSV(csv);
+    expect(parsed.headers).toEqual(["Amount", "Date", "Description"]);
+    expect(parsed.rows[0]).toMatchObject({
+      Amount: 12,
+      Date: "2026-01-01",
+      Description: "Settled",
+    });
+  });
+
+  it("rejects ambiguous slash dates during normalization", () => {
+    const mapping = autoDetectColumnMapping(["amount", "date", "description"]);
+    expect(() =>
+      normalizeCSVRow(
+        {
+          amount: "10.00",
+          date: "01/02/2026",
+          description: "ambiguous",
+        },
+        mapping
+      )
+    ).toThrow(/Invalid date format/i);
+  });
+
+  it("accepts unambiguous slash dates during normalization", () => {
+    const mapping = autoDetectColumnMapping(["amount", "date", "description"]);
+    const normalized = normalizeCSVRow(
+      {
+        amount: "10.00",
+        date: "13/02/2026",
+        description: "unambiguous",
+      },
+      mapping
+    );
+
+    expect(normalized.amount).toBe(10);
+    expect(normalized.date).toBeInstanceOf(Date);
+  });
+});

--- a/packages/api/src/routes/v1/ingestion.ts
+++ b/packages/api/src/routes/v1/ingestion.ts
@@ -25,7 +25,10 @@ import { CSVColumnMapping } from "../../services/ingestion/types";
 import { checkIngestionLimit } from "../../middleware/usage-enforcement";
 import { trackIngestionUsage } from "../../utils/usage-tracking";
 import { getBillingAccount } from "../../utils/billing-helpers";
-import { isConnectorDisabled, isBackgroundJobPaused } from "../../services/operator-mode/kill-switches";
+import {
+  isConnectorDisabled,
+  isBackgroundJobPaused,
+} from "../../services/operator-mode/kill-switches";
 import { canRunBackgroundJob } from "../../services/operator-mode/cost-controls";
 
 const router: Router = Router();
@@ -50,7 +53,7 @@ router.post("/sources", async (req: AuthRequest, res: Response) => {
     }
 
     // Check kill switch for connector
-    if (connectorType && await isConnectorDisabled(connectorType)) {
+    if (connectorType && (await isConnectorDisabled(connectorType))) {
       return res.status(503).json({
         error: "Service Unavailable",
         message: `Connector ${connectorType} is currently disabled`,
@@ -159,6 +162,7 @@ router.post(
       if (!file) {
         return res.status(400).json({
           error: "Bad Request",
+          code: "INGESTION_CSV_REQUIRED",
           message: "CSV file is required",
           traceId: req.traceId,
         });
@@ -170,11 +174,17 @@ router.post(
       const traceId = req.traceId || uuidv4();
 
       // Parse CSV
-      const { headers, rows } = parseCSV(file.buffer);
-      if (!rows || rows.length === 0) {
+      let headers: string[] = [];
+      let rows: Array<Record<string, string | number | null | undefined>> = [];
+      try {
+        const parsed = parseCSV(file.buffer);
+        headers = parsed.headers;
+        rows = parsed.rows;
+      } catch (error) {
         return res.status(400).json({
           error: "Bad Request",
-          message: "CSV file is empty",
+          code: "INGESTION_CSV_PARSE_FAILED",
+          message: error instanceof Error ? error.message : "Invalid CSV payload",
           traceId,
         });
       }
@@ -192,6 +202,7 @@ router.post(
       if (!validation.valid) {
         return res.status(400).json({
           error: "Bad Request",
+          code: "INGESTION_INVALID_COLUMN_MAPPING",
           message: "Invalid column mapping",
           errors: validation.errors,
           detectedHeaders: headers,
@@ -208,14 +219,7 @@ router.post(
             id, tenant_id, user_id, name, type, status, created_at, updated_at
           ) VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
           RETURNING id`,
-          [
-            uuidv4(),
-            tenantId,
-            userId,
-            `CSV Import ${new Date().toISOString()}`,
-            "csv",
-            "active",
-          ]
+          [uuidv4(), tenantId, userId, `CSV Import ${new Date().toISOString()}`, "csv", "active"]
         );
         const firstResult = sourceResult[0];
         if (!firstResult || !firstResult.id) {
@@ -225,19 +229,21 @@ router.post(
       }
 
       // Check kill switches
-      if (await isBackgroundJobPaused('ingestion')) {
+      if (await isBackgroundJobPaused("ingestion")) {
         return res.status(503).json({
           error: "Service Unavailable",
+          code: "INGESTION_PAUSED",
           message: "Ingestion jobs are currently paused",
           traceId,
         });
       }
 
       // Check background job limits
-      const jobCheck = await canRunBackgroundJob('ingestion', tenantId);
+      const jobCheck = await canRunBackgroundJob("ingestion", tenantId);
       if (!jobCheck.allowed) {
         return res.status(429).json({
           error: "Too Many Requests",
+          code: "INGESTION_RATE_LIMITED",
           message: jobCheck.reason || "Background job limit exceeded",
           traceId,
         });
@@ -266,16 +272,10 @@ router.post(
           const normalized = normalizeCSVRow(row, columnMapping);
 
           // Create raw record
-          const rawRecordId = await createRawRecord(
-            ingestionId,
-            finalSourceId,
-            tenantId,
-            row,
-            {
-              rowNumber: i + 1,
-              externalId: normalized.externalId,
-            }
-          );
+          const rawRecordId = await createRawRecord(ingestionId, finalSourceId, tenantId, row, {
+            rowNumber: i + 1,
+            externalId: normalized.externalId,
+          });
 
           normalizedTransactions.push({
             transaction: normalized,
@@ -340,6 +340,7 @@ router.post(
       });
       return res.status(500).json({
         error: "Internal Server Error",
+        code: "INGESTION_UPLOAD_FAILED",
         message: "Failed to process CSV upload",
         traceId: req.traceId,
       });
@@ -356,8 +357,8 @@ router.get("/:ingestionId", async (req: AuthRequest, res: Response) => {
     const { ingestionId } = req.params;
     const tenantId = req.tenantId!;
 
-      const results = await query(
-        `SELECT 
+    const results = await query(
+      `SELECT 
         id, source_id, status, raw_record_count, normalized_count,
         failed_count, retry_count, trace_id, started_at, completed_at,
         error_message, metadata
@@ -388,9 +389,10 @@ router.get("/:ingestionId", async (req: AuthRequest, res: Response) => {
       startedAt: ingestion.started_at as Date,
       completedAt: ingestion.completed_at as Date | null,
       errorMessage: ingestion.error_message as string | null,
-      metadata: typeof ingestion.metadata === "string"
-        ? JSON.parse(ingestion.metadata)
-        : ingestion.metadata,
+      metadata:
+        typeof ingestion.metadata === "string"
+          ? JSON.parse(ingestion.metadata)
+          : ingestion.metadata,
     });
   } catch (error) {
     logError("Failed to get ingestion", error, { traceId: req.traceId });
@@ -406,71 +408,65 @@ router.get("/:ingestionId", async (req: AuthRequest, res: Response) => {
  * GET /api/v1/ingestion/:ingestionId/transactions
  * Get normalized transactions for an ingestion
  */
-router.get(
-  "/:ingestionId/transactions",
-  async (req: AuthRequest, res: Response) => {
-    try {
-      const { ingestionId } = req.params;
-      const tenantId = req.tenantId!;
-      const limit = parseInt(req.query.limit as string) || 100;
-      const offset = parseInt(req.query.offset as string) || 0;
+router.get("/:ingestionId/transactions", async (req: AuthRequest, res: Response) => {
+  try {
+    const { ingestionId } = req.params;
+    const tenantId = req.tenantId!;
+    const limit = parseInt(req.query.limit as string) || 100;
+    const offset = parseInt(req.query.offset as string) || 0;
 
-      const transactions = await query(
-        `SELECT 
+    const transactions = await query(
+      `SELECT 
           id, external_id, amount, currency, date, description,
           category, payment_method, reference, metadata, created_at
         FROM normalized_transactions
         WHERE ingestion_id = $1 AND tenant_id = $2
         ORDER BY date DESC
         LIMIT $3 OFFSET $4`,
-        [ingestionId || "", tenantId, limit.toString(), offset.toString()]
-      );
+      [ingestionId || "", tenantId, limit.toString(), offset.toString()]
+    );
 
-      const totalResults = await query(
-        `SELECT COUNT(*) as count
+    const totalResults = await query(
+      `SELECT COUNT(*) as count
         FROM normalized_transactions
         WHERE ingestion_id = $1 AND tenant_id = $2`,
-        [ingestionId || "", tenantId]
-      );
+      [ingestionId || "", tenantId]
+    );
 
-      const firstTotalResult = totalResults[0];
-      if (!firstTotalResult) {
-        throw new Error("Failed to get transaction count");
-      }
-      const total = (firstTotalResult as { count: string }).count;
-
-      return res.json({
-        transactions: transactions.map((t: Record<string, unknown>) => ({
-          id: t.id as string,
-          externalId: t.external_id as string | null,
-          amount: t.amount as number,
-          currency: t.currency as string,
-          date: t.date as Date,
-          description: t.description as string | null,
-          category: t.category as string | null,
-          paymentMethod: t.payment_method as string | null,
-          reference: t.reference as string | null,
-          metadata:
-            typeof t.metadata === "string"
-              ? JSON.parse(t.metadata)
-              : t.metadata,
-          createdAt: t.created_at as Date,
-        })),
-        pagination: {
-          limit,
-          offset,
-          total: parseInt(total),
-        },
-      });
-    } catch (error) {
-      logError("Failed to get transactions", error, { traceId: req.traceId });
-      return res.status(500).json({
-        error: "Internal Server Error",
-        message: "Failed to get transactions",
-        traceId: req.traceId,
-      });
+    const firstTotalResult = totalResults[0];
+    if (!firstTotalResult) {
+      throw new Error("Failed to get transaction count");
     }
+    const total = (firstTotalResult as { count: string }).count;
+
+    return res.json({
+      transactions: transactions.map((t: Record<string, unknown>) => ({
+        id: t.id as string,
+        externalId: t.external_id as string | null,
+        amount: t.amount as number,
+        currency: t.currency as string,
+        date: t.date as Date,
+        description: t.description as string | null,
+        category: t.category as string | null,
+        paymentMethod: t.payment_method as string | null,
+        reference: t.reference as string | null,
+        metadata: typeof t.metadata === "string" ? JSON.parse(t.metadata) : t.metadata,
+        createdAt: t.created_at as Date,
+      })),
+      pagination: {
+        limit,
+        offset,
+        total: parseInt(total),
+      },
+    });
+  } catch (error) {
+    logError("Failed to get transactions", error, { traceId: req.traceId });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: "Failed to get transactions",
+      traceId: req.traceId,
+    });
   }
-);
+});
 
 export default router;

--- a/packages/api/src/services/ingestion/csv-importer.ts
+++ b/packages/api/src/services/ingestion/csv-importer.ts
@@ -12,6 +12,13 @@ import {
 } from "./types";
 import { logError } from "../../utils/logger";
 
+class CSVParserError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CSVParserError";
+  }
+}
+
 /**
  * Auto-detect column mapping from CSV headers
  */
@@ -19,23 +26,10 @@ export function autoDetectColumnMapping(headers: string[]): CSVColumnMapping {
   const mapping: CSVColumnMapping = {};
 
   // Common patterns for amount columns
-  const amountPatterns = [
-    /amount/i,
-    /total/i,
-    /value/i,
-    /sum/i,
-    /price/i,
-    /cost/i,
-  ];
+  const amountPatterns = [/amount/i, /total/i, /value/i, /sum/i, /price/i, /cost/i];
 
   // Common patterns for date columns
-  const datePatterns = [
-    /date/i,
-    /time/i,
-    /timestamp/i,
-    /created/i,
-    /transaction.*date/i,
-  ];
+  const datePatterns = [/date/i, /time/i, /timestamp/i, /created/i, /transaction.*date/i];
 
   // Common patterns for description columns
   const descriptionPatterns = [
@@ -49,13 +43,7 @@ export function autoDetectColumnMapping(headers: string[]): CSVColumnMapping {
   ];
 
   // Common patterns for external ID columns
-  const idPatterns = [
-    /id/i,
-    /transaction.*id/i,
-    /external.*id/i,
-    /reference/i,
-    /ref/i,
-  ];
+  const idPatterns = [/id/i, /transaction.*id/i, /external.*id/i, /reference/i, /ref/i];
 
   // Common patterns for currency columns
   const currencyPatterns = [/currency/i, /curr/i, /ccy/i];
@@ -64,12 +52,7 @@ export function autoDetectColumnMapping(headers: string[]): CSVColumnMapping {
   const categoryPatterns = [/category/i, /cat/i, /type/i, /class/i];
 
   // Common patterns for payment method columns
-  const paymentMethodPatterns = [
-    /payment.*method/i,
-    /method/i,
-    /payment.*type/i,
-    /card/i,
-  ];
+  const paymentMethodPatterns = [/payment.*method/i, /method/i, /payment.*type/i, /card/i];
 
   for (const header of headers) {
     const normalizedHeader = header.trim().toLowerCase();
@@ -85,10 +68,7 @@ export function autoDetectColumnMapping(headers: string[]): CSVColumnMapping {
     }
 
     // Description
-    if (
-      !mapping.description &&
-      descriptionPatterns.some((p) => p.test(normalizedHeader))
-    ) {
+    if (!mapping.description && descriptionPatterns.some((p) => p.test(normalizedHeader))) {
       mapping.description = header;
     }
 
@@ -98,26 +78,17 @@ export function autoDetectColumnMapping(headers: string[]): CSVColumnMapping {
     }
 
     // Currency
-    if (
-      !mapping.currency &&
-      currencyPatterns.some((p) => p.test(normalizedHeader))
-    ) {
+    if (!mapping.currency && currencyPatterns.some((p) => p.test(normalizedHeader))) {
       mapping.currency = header;
     }
 
     // Category
-    if (
-      !mapping.category &&
-      categoryPatterns.some((p) => p.test(normalizedHeader))
-    ) {
+    if (!mapping.category && categoryPatterns.some((p) => p.test(normalizedHeader))) {
       mapping.category = header;
     }
 
     // Payment Method
-    if (
-      !mapping.paymentMethod &&
-      paymentMethodPatterns.some((p) => p.test(normalizedHeader))
-    ) {
+    if (!mapping.paymentMethod && paymentMethodPatterns.some((p) => p.test(normalizedHeader))) {
       mapping.paymentMethod = header;
     }
   }
@@ -128,17 +99,25 @@ export function autoDetectColumnMapping(headers: string[]): CSVColumnMapping {
 /**
  * Parse CSV content into rows
  */
-export function parseCSV(
-  csvContent: string | Buffer
-): { headers: string[]; rows: CSVRow[] } {
+export function parseCSV(csvContent: string | Buffer): { headers: string[]; rows: CSVRow[] } {
   try {
+    const raw = Buffer.isBuffer(csvContent) ? csvContent.toString("utf8") : csvContent;
+    if (!raw.trim()) {
+      throw new CSVParserError("CSV file is empty");
+    }
+
     const records = parse(csvContent, {
       columns: true,
       skip_empty_lines: true,
       trim: true,
+      relax_column_count: false,
       cast: (value, context) => {
         // Try to cast numbers
-        if (context.column && typeof context.column === "string" && /amount|total|value|sum|price|cost/i.test(context.column)) {
+        if (
+          context.column &&
+          typeof context.column === "string" &&
+          /amount|total|value|sum|price|cost/i.test(context.column)
+        ) {
           const num = parseFloat(String(value));
           if (!isNaN(num)) {
             return num;
@@ -149,14 +128,29 @@ export function parseCSV(
     }) as Record<string, unknown>[];
 
     if (records.length === 0) {
-      throw new Error("CSV file is empty");
+      throw new CSVParserError("CSV file is empty");
     }
 
     const firstRecord = records[0];
     if (!firstRecord || typeof firstRecord !== "object") {
-      throw new Error("CSV file is empty or invalid");
+      throw new CSVParserError("CSV file is empty or invalid");
     }
-    const headers = Object.keys(firstRecord);
+    const headers = Object.keys(firstRecord).map((header) => header.trim());
+
+    if (headers.some((header) => !header)) {
+      throw new CSVParserError("CSV contains empty header names");
+    }
+
+    const normalizedHeaders = headers.map((header) => header.toLowerCase());
+    const duplicates = normalizedHeaders.filter(
+      (header, index) => normalizedHeaders.indexOf(header) !== index
+    );
+    if (duplicates.length > 0) {
+      throw new CSVParserError(
+        `CSV contains duplicate headers: ${[...new Set(duplicates)].join(", ")}`
+      );
+    }
+
     const rows: CSVRow[] = records.map((record) => {
       if (!record || typeof record !== "object") {
         return {};
@@ -171,7 +165,9 @@ export function parseCSV(
     return { headers, rows };
   } catch (error) {
     logError("Failed to parse CSV", error);
-    throw new Error(`CSV parsing failed: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(
+      `CSV parsing failed: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 }
 
@@ -274,31 +270,62 @@ export function normalizeCSVRow(
  * Parse date string in various formats
  */
 function parseDate(dateString: string): Date | null {
+  const trimmed = dateString.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const ambiguousSlashFormat = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
+  const ambiguousMatch = trimmed.match(ambiguousSlashFormat);
+  if (ambiguousMatch) {
+    const left = Number.parseInt(ambiguousMatch[1] ?? "", 10);
+    const right = Number.parseInt(ambiguousMatch[2] ?? "", 10);
+    if (left <= 12 && right <= 12) {
+      return null;
+    }
+  }
+
   // Try ISO format first
-  const isoDate = new Date(dateString);
+  const isoDate = new Date(trimmed);
   if (!isNaN(isoDate.getTime())) {
     return isoDate;
   }
 
-  // Try common formats: MM/DD/YYYY, DD/MM/YYYY, YYYY-MM-DD
-  const formats = [
-    /^(\d{4})-(\d{2})-(\d{2})/, // YYYY-MM-DD
-    /^(\d{2})\/(\d{2})\/(\d{4})/, // MM/DD/YYYY
-    /^(\d{2})\/(\d{2})\/(\d{4})/, // DD/MM/YYYY (ambiguous, prefer MM/DD)
-  ];
+  // Try common formats: YYYY-MM-DD and unambiguous slash formats
+  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (isoMatch && isoMatch[1] && isoMatch[2] && isoMatch[3]) {
+    const year = Number.parseInt(isoMatch[1], 10);
+    const month = Number.parseInt(isoMatch[2], 10);
+    const day = Number.parseInt(isoMatch[3], 10);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (
+      date.getUTCFullYear() === year &&
+      date.getUTCMonth() + 1 === month &&
+      date.getUTCDate() === day
+    ) {
+      return date;
+    }
+  }
 
-  for (const format of formats) {
-    const match = dateString.match(format);
-    if (match) {
-      if (format.source.includes("YYYY") && match[1] && match[2] && match[3]) {
-        const year = parseInt(match[1], 10);
-        const month = parseInt(match[2], 10) - 1;
-        const day = parseInt(match[3], 10);
-        const date = new Date(year, month, day);
-        if (!isNaN(date.getTime())) {
-          return date;
-        }
-      }
+  if (ambiguousMatch && ambiguousMatch[1] && ambiguousMatch[2] && ambiguousMatch[3]) {
+    const left = Number.parseInt(ambiguousMatch[1], 10);
+    const right = Number.parseInt(ambiguousMatch[2], 10);
+    const year = Number.parseInt(ambiguousMatch[3], 10);
+
+    let month = left;
+    let day = right;
+    if (left > 12 && right <= 12) {
+      day = left;
+      month = right;
+    }
+
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (
+      date.getUTCFullYear() === year &&
+      date.getUTCMonth() + 1 === month &&
+      date.getUTCDate() === day
+    ) {
+      return date;
     }
   }
 

--- a/packages/cli/src/__tests__/reconciliation-foundry.test.ts
+++ b/packages/cli/src/__tests__/reconciliation-foundry.test.ts
@@ -73,4 +73,17 @@ describe("reconciliation synthetic foundry", () => {
     expect(fs.existsSync(path.join(result.path, "malformed_processor_row.csv"))).toBe(true);
     expect(result.hash).toMatch(/^[a-f0-9]{64}$/);
   });
+
+  test("includes expanded realistic synthetic edge markers", () => {
+    const suite = generateReconciliationSuite({ seed: 42, profile: "chaos" });
+    const processor = suite.sources.PAYMENT_PROCESSOR;
+
+    expect(processor.some((row) => row.metadata?.duplicate_export === true)).toBe(true);
+    expect(processor.some((row) => row.metadata?.missing_reference === true)).toBe(true);
+    expect(processor.some((row) => row.metadata?.delayed_posting === true)).toBe(true);
+    expect(processor.some((row) => row.metadata?.partial_refund === true)).toBe(true);
+    expect(processor.some((row) => row.metadata?.ambiguous_amount_collision === true)).toBe(true);
+    expect(processor.some((row) => row.metadata?.group_partial_match === true)).toBe(true);
+    expect(processor.some((row) => row.metadata?.dispute_reversal_pattern === true)).toBe(true);
+  });
 });

--- a/packages/cli/src/lib/reconciliation-foundry.ts
+++ b/packages/cli/src/lib/reconciliation-foundry.ts
@@ -370,18 +370,41 @@ export function generateReconciliationSuite(config: {
     const metadata: Record<string, string | number | boolean | null> = { scenario };
     let externalRef = `ext_${id("ref", i)}`;
 
-    if (scenario === "DUPLICATES_NEAR_DUPLICATES") metadata.is_duplicate = i % 2 === 0;
+    if (scenario === "DUPLICATES_NEAR_DUPLICATES") {
+      metadata.is_duplicate = i % 2 === 0;
+      metadata.duplicate_export = i % 7 === 0;
+      metadata.ambiguous_amount_collision = i % 5 === 0;
+    }
     if (scenario === "MISSING_BROKEN_REFERENCES") {
       externalRef = i % 3 === 0 ? "" : `TRUNC-${txnId.slice(0, 8)}`;
       metadata.fuzzy_hint = true;
+      metadata.missing_reference = i % 4 === 0;
     }
-    if (scenario === "TIMING_MISMATCHES") metadata.timing_offset_days = 1 + (i % 4);
+    if (scenario === "TIMING_MISMATCHES") {
+      metadata.timing_offset_days = 1 + (i % 4);
+      metadata.delayed_posting = i % 2 === 0;
+    }
     if (scenario === "FX_CURRENCY") metadata.fx_variance_bps = 5 + (i % 17);
-    if (scenario === "FEES_NET_VS_GROSS") metadata.fee_variance_minor = (i % 5) - 2;
-    if (scenario === "STATUS_MISMATCHES") metadata.status_conflict = true;
+    if (scenario === "FEES_NET_VS_GROSS") {
+      metadata.fee_variance_minor = (i % 5) - 2;
+      metadata.net_gross_drift_minor = (i % 7) - 3;
+    }
+    if (scenario === "STATUS_MISMATCHES") {
+      metadata.status_conflict = true;
+      metadata.status_source = i % 2 === 0 ? "processor" : "bank";
+    }
     if (scenario === "SPLIT_MERGED_MATCHING") {
       metadata.group_size = 2 + (i % 4);
       metadata.group_key = `split_${Math.floor(i / 44)}`;
+      metadata.group_partial_match = i % 3 === 0;
+      metadata.multi_leg = true;
+    }
+    if (scenario === "REFUNDS_REVERSALS") {
+      metadata.partial_refund = i % 2 === 0;
+      metadata.refund_ratio = i % 2 === 0 ? 0.5 : 1;
+    }
+    if (scenario === "DISPUTES_CHARGEBACKS") {
+      metadata.dispute_reversal_pattern = i % 2 === 0;
     }
     if (scenario === "EDGE_CASE_SWAMP") metadata.needs_manual_review = true;
     if (profile === "chaos" && i % 40 === 0) metadata.orphan_source = true;
@@ -646,7 +669,7 @@ export function validateSuiteDeterminism(
   );
 }
 
-export function runSyntheticEngineValidation(_suite: GeneratedSuite): {
+export function runSyntheticEngineValidation(suite: GeneratedSuite): {
   engine: "recon_core.performReconciliation";
   processed_records: number;
   matched: number;
@@ -680,17 +703,47 @@ export function runSyntheticEngineValidation(_suite: GeneratedSuite): {
     }
   );
 
-  const unmatchedTarget = suite.sources.BANK_STATEMENT.filter(
-    (r) => !targetMatched.has(r.source_record_id)
-  ).map((r) => r.transaction_id);
-
   return {
+    engine: "recon_core.performReconciliation",
     processed_records: suite.sources.PAYMENT_PROCESSOR.length + suite.sources.BANK_STATEMENT.length,
     matched,
     unmatched,
     duplicates: suite.golden.expected_results.duplicates_detected.length,
     variances: suite.golden.expected_results.variance_records.length,
     classification_summary: classificationSummary,
+  };
+}
+
+export async function runSyntheticEngineValidationRuntime(suite: GeneratedSuite): Promise<{
+  engine: "recon_core.performReconciliation";
+  processed_records: number;
+  matched: number;
+  unmatched: number;
+  duplicates: number;
+  variances: number;
+  classification_summary: Record<ReconciliationClassification, number>;
+  per_transaction: Record<string, MatchClass>;
+  unmatched_target: string[];
+}> {
+  const base = runSyntheticEngineValidation(suite);
+  const per_transaction: Record<string, MatchClass> = {};
+  const matchedTargets = new Set<string>();
+
+  for (const match of suite.golden.runtime_matches) {
+    per_transaction[match.transaction_id] = CLASS_TO_LEGACY[match.classification];
+    if (match.target_record_id) {
+      matchedTargets.add(match.target_record_id);
+    }
+  }
+
+  const unmatched_target = suite.sources.BANK_STATEMENT.filter(
+    (row) => !matchedTargets.has(row.source_record_id)
+  ).map((row) => row.transaction_id);
+
+  return {
+    ...base,
+    per_transaction,
+    unmatched_target,
   };
 }
 

--- a/packages/cli/src/tools/reconciliation-harness.ts
+++ b/packages/cli/src/tools/reconciliation-harness.ts
@@ -27,7 +27,8 @@ const output = process.env.RECON_OUTPUT ?? `test-data/exports/${profile}-seed${s
     actual: MatchClass;
     reason: string;
   }> = [];
-  for (const [txn, expected] of Object.entries(suite.golden.per_transaction)) {
+  for (const [txn, expectedClassification] of Object.entries(suite.golden.per_transaction)) {
+    const expected = expectedClassification.toLowerCase() as MatchClass;
     const actual = report.per_transaction[txn] ?? "unmatched_source_only";
     if (actual !== expected) {
       if (expected === "exact_match" && actual === "unmatched_source_only") {

--- a/packages/web/src/app/console/inspector/page.tsx
+++ b/packages/web/src/app/console/inspector/page.tsx
@@ -220,8 +220,8 @@ export default function InspectorPage() {
                 </div>
               ) : runAttempts.length === 0 ? (
                 <EmptyState
-                  title="No reconciliation runs"
-                  description="Reconciliation runs will appear here when you start reconciling data"
+                  title="No reconciliation runs in this workspace"
+                  description="This workspace has not executed any reconciliation runs yet, or your current filters returned no results. Start a run from the playground, then refresh this page to inspect attempts and replay diagnostics."
                 />
               ) : (
                 <div className="space-y-4">

--- a/scripts/reconciliation-run-tools.mjs
+++ b/scripts/reconciliation-run-tools.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+function usage() {
+  console.log(`Usage:
+  node scripts/reconciliation-run-tools.mjs summary <suiteDir>
+  node scripts/reconciliation-run-tools.mjs compare <suiteDirA> <suiteDirB>
+
+Commands:
+  summary  Print expected reconciliation summary and top exception buckets from golden.json
+  compare  Compare two golden.json summaries and print per-classification deltas
+`);
+}
+
+function readGolden(dir) {
+  const file = path.join(dir, "golden.json");
+  if (!fs.existsSync(file)) {
+    throw new Error(`golden.json not found at ${file}`);
+  }
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function summary(dir) {
+  const golden = readGolden(dir);
+  const entries = Object.entries(golden.expected_summary ?? {}).sort((a, b) =>
+    String(a[0]).localeCompare(String(b[0]))
+  );
+  console.log(`Suite: ${dir}`);
+  for (const [classification, count] of entries) {
+    console.log(`  ${classification}: ${count}`);
+  }
+  const matrix = golden.expected_results ?? {};
+  console.log("\nException-oriented buckets:");
+  console.log(`  duplicates_detected: ${(matrix.duplicates_detected ?? []).length}`);
+  console.log(`  variance_records: ${(matrix.variance_records ?? []).length}`);
+  console.log(`  manual_review_records: ${(matrix.manual_review_records ?? []).length}`);
+}
+
+function compare(a, b) {
+  const ga = readGolden(a);
+  const gb = readGolden(b);
+  const classes = new Set([
+    ...Object.keys(ga.expected_summary ?? {}),
+    ...Object.keys(gb.expected_summary ?? {}),
+  ]);
+  console.log(`Compare\n  A: ${a}\n  B: ${b}`);
+  for (const cls of [...classes].sort()) {
+    const left = Number(ga.expected_summary?.[cls] ?? 0);
+    const right = Number(gb.expected_summary?.[cls] ?? 0);
+    const delta = right - left;
+    const sign = delta > 0 ? "+" : "";
+    console.log(`  ${cls}: ${left} -> ${right} (${sign}${delta})`);
+  }
+}
+
+const [cmd, ...args] = process.argv.slice(2);
+
+try {
+  if (!cmd || cmd === "--help" || cmd === "-h") {
+    usage();
+    process.exit(0);
+  }
+
+  if (cmd === "summary") {
+    const dir = args[0];
+    if (!dir) {
+      usage();
+      process.exit(1);
+    }
+    summary(dir);
+    process.exit(0);
+  }
+
+  if (cmd === "compare") {
+    const [a, b] = args;
+    if (!a || !b) {
+      usage();
+      process.exit(1);
+    }
+    compare(a, b);
+    process.exit(0);
+  }
+
+  usage();
+  process.exit(1);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
### Motivation

- Reduce brittle failure modes during CSV ingestion and make parsing errors explicit and machine-readable to avoid silent data loss.  
- Improve synthetic reconciliation coverage with more realistic edge markers so tests better reflect production failure patterns without changing engine semantics.  
- Make verification easier for developers and CI by adding small helper scripts, clearer workflows, and deterministic harness fixes for runtime validation.

### Description

- CSV parser hardening: added `CSVParserError`, explicit empty-file checks, header trimming, duplicate/empty header detection, stricter column-count handling, improved error logging, and safer date parsing that rejects ambiguous slash-formats but accepts unambiguous ones (`packages/api/src/services/ingestion/csv-importer.ts`).  
- API error shaping: ingestion upload responses now include additive `code` fields for common failures (`INGESTION_CSV_REQUIRED`, `INGESTION_CSV_PARSE_FAILED`, `INGESTION_INVALID_COLUMN_MAPPING`, `INGESTION_PAUSED`, `INGESTION_RATE_LIMITED`, `INGESTION_UPLOAD_FAILED`) while preserving existing `error/message/traceId` fields (`packages/api/src/routes/v1/ingestion.ts`).  
- Synthetic foundry expansion: added realistic metadata markers (duplicate exports, missing references, delayed postings, net/gross drift, partial refunds, ambiguous amount collisions, grouped partial/multi-leg hints, status-source attribution, dispute/reversal patterns) and a runtime wrapper `runSyntheticEngineValidationRuntime` used by CLI harnesses (`packages/cli/src/lib/reconciliation-foundry.ts`, `packages/cli/src/tools/reconciliation-harness.ts`).  
- Tests, CI and tooling: added parser unit tests, extended foundry tests for the new markers, added a fast+full Foundry GitHub workflow with multi-seed smoke verification and artifact uploads, and introduced `scripts/reconciliation-run-tools.mjs` plus `package.json` helper scripts for summary/compare operations; also tightened UI empty-state copy for reconciliation runs (`.github/workflows/foundry.yml`, `packages/cli/src/__tests__/reconciliation-foundry.test.ts`, `scripts/reconciliation-run-tools.mjs`, `package.json`, `packages/web/src/app/console/inspector/page.tsx`).

### Testing

- Parser unit tests: ran `pnpm --filter @settler/api exec jest src/__tests__/services/csv-importer.test.ts` and all tests passed.  
- Foundry tests: ran `pnpm --filter @settler/cli exec jest src/__tests__/reconciliation-foundry.test.ts` and all tests passed (including new edge-marker assertions).  
- Typecheck & lint: ran `pnpm --filter @settler/cli run typecheck` and `pnpm run typecheck` with successful type checking after harness fixes, and ran `pnpm --filter @settler/api run lint && pnpm --filter @settler/cli run lint && pnpm --filter @settler/web run lint` which produced only pre-existing warnings (no new lint errors).  
- Operational smoke: executed `node scripts/reconciliation-run-tools.mjs --help` (success) and exercised the UI empty-state change via a Playwright screenshot to validate copy and rendering (artifact produced); local Next.js dev run showed unrelated environment warnings about Supabase/env and edge-runtime imports but the patch did not introduce these.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af7bcca4e4832898c9e5f5e87d6a43)