### PR TITLE
Add operator runtime event stream and operator intelligence APIs

### DIFF
--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -120,6 +120,7 @@ const TENANT_SCOPED_TABLES = new Set([
   "audit_exports",
   "alert_rules",
   "alert_history",
+  "operator_runtime_events",
 ]);
 
 /**

--- a/packages/api/src/db/migrations/018-operator-runtime-events.sql
+++ b/packages/api/src/db/migrations/018-operator-runtime-events.sql
@@ -1,0 +1,23 @@
+-- Operator runtime event stream for control plane intelligence
+
+CREATE TABLE IF NOT EXISTS operator_runtime_events (
+  id BIGSERIAL PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  tenant_id UUID NOT NULL,
+  run_id UUID,
+  records_processed INTEGER,
+  duration_ms INTEGER,
+  classification_counts JSONB NOT NULL DEFAULT '{}'::jsonb,
+  manual_review_count INTEGER,
+  error_id TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_runtime_events_tenant_time
+  ON operator_runtime_events (tenant_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_operator_runtime_events_type_time
+  ON operator_runtime_events (event_type, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_operator_runtime_events_run
+  ON operator_runtime_events (tenant_id, run_id, occurred_at DESC);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -69,6 +69,7 @@ import cookieParser from "cookie-parser";
 import { initializeWebSocket } from "./infrastructure/websocket";
 import { createServer } from "http";
 import { scanJsonDepth } from "./utils/json-depth";
+import { emitOperatorRuntimeEvent } from "./services/ops-intelligence/runtime-events";
 
 const app: Express = express();
 const PORT = config.port;
@@ -150,6 +151,39 @@ app.use((req: Request, res: Response, next: NextFunction) => {
   if (authReq.tenantId) {
     res.setHeader("X-Tenant-Id", authReq.tenantId);
   }
+  next();
+});
+
+// Runtime operator event stream (best-effort, non-blocking)
+app.use((req: Request, res: Response, next: NextFunction) => {
+  const startedAt = Date.now();
+  res.on("finish", () => {
+    const tenantId =
+      (req as AuthRequest).tenantId || (req.headers["x-tenant-id"] as string | undefined);
+    if (!tenantId || !req.path.startsWith("/api/")) return;
+
+    void emitOperatorRuntimeEvent({
+      eventType: "api_request",
+      tenantId,
+      recordsProcessed: 1,
+      durationMs: Date.now() - startedAt,
+      errorId: res.statusCode >= 500 ? (req as AuthRequest).traceId || null : null,
+      metadata: {
+        method: req.method,
+        path: req.path,
+        statusCode: res.statusCode,
+      },
+    });
+
+    if (res.statusCode >= 500) {
+      void emitOperatorRuntimeEvent({
+        eventType: "error_thrown",
+        tenantId,
+        errorId: (req as AuthRequest).traceId || null,
+        metadata: { method: req.method, path: req.path, statusCode: res.statusCode },
+      });
+    }
+  });
   next();
 });
 

--- a/packages/api/src/routes/v1/index.ts
+++ b/packages/api/src/routes/v1/index.ts
@@ -17,6 +17,7 @@ import ingestionRouter from "./ingestion";
 import reconciliationRouter from "./reconciliation";
 import ingestionExportsRouter from "./ingestion-exports";
 import { operatorModeRouter } from "./operator-mode";
+import operatorIntelligenceRouter from "./operator-intelligence";
 import multiSourceReconciliationRouter from "./multi-source-reconciliation";
 import approvalsRouter from "./approvals";
 import progressRouter from "./progress";
@@ -71,6 +72,7 @@ v1Router.use("/dedicated-infrastructure", dedicatedInfrastructureRouter);
 
 // Operator mode routes
 v1Router.use("/", operatorModeRouter);
+v1Router.use("/", operatorIntelligenceRouter);
 
 // Health check
 v1Router.get("/health", (_req, res) => {

--- a/packages/api/src/routes/v1/operator-intelligence.ts
+++ b/packages/api/src/routes/v1/operator-intelligence.ts
@@ -1,0 +1,67 @@
+import { Router, Response } from "express";
+import { z } from "zod";
+import { AuthRequest } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/authorization";
+import { Permission } from "../../infrastructure/security/Permissions";
+import { validateRequest } from "../../middleware/validation";
+import { handleRouteError } from "../../utils/error-handler";
+import {
+  getRunExplorer,
+  getSystemHealthSnapshot,
+} from "../../services/ops-intelligence/runtime-events";
+
+const router: Router = Router();
+
+router.get(
+  "/operator/intelligence/system-health",
+  requirePermission(Permission.ADMIN_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({ error: "Missing tenant context" });
+      }
+      const days = Number(req.query.days ?? 7);
+      const data = await getSystemHealthSnapshot(tenantId, Number.isFinite(days) ? days : 7);
+      return res.json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load system health snapshot", 500, {
+        userId: req.userId,
+      });
+    }
+  }
+);
+
+const runExplorerSchema = z.object({
+  query: z.object({
+    status: z.string().optional(),
+    runId: z.string().uuid().optional(),
+    limit: z.coerce.number().int().min(1).max(200).optional(),
+  }),
+});
+
+router.get(
+  "/operator/intelligence/run-explorer",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(runExplorerSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({ error: "Missing tenant context" });
+      }
+      const runs = await getRunExplorer(tenantId, {
+        status: typeof req.query.status === "string" ? req.query.status : undefined,
+        runId: typeof req.query.runId === "string" ? req.query.runId : undefined,
+        limit: typeof req.query.limit === "string" ? Number(req.query.limit) : undefined,
+      });
+      return res.json({ data: runs });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load run explorer", 500, {
+        userId: req.userId,
+      });
+    }
+  }
+);
+
+export default router;

--- a/packages/api/src/services/ingestion/reconciliation-matcher.ts
+++ b/packages/api/src/services/ingestion/reconciliation-matcher.ts
@@ -11,6 +11,7 @@ import { MatchResult, ReconciliationConfig } from "./types";
 import { mlMatchingEngine } from "../matching/ml-matching-engine";
 import { enhancedCrossCustomerIntelligence } from "../matching/enhanced-cross-customer-intelligence";
 import { appendRunIntegrityEntry } from "../reconciliation/integrity";
+import { emitOperatorRuntimeEvent } from "../ops-intelligence/runtime-events";
 
 const DEFAULT_CONFIG: Required<ReconciliationConfig> = {
   dateWindowDays: 7,
@@ -365,6 +366,13 @@ export async function runReconciliation(
       [runId, ingestionId, tenantId, userId, "running", traceId, JSON.stringify(config)]
     );
 
+    await emitOperatorRuntimeEvent({
+      eventType: "reconciliation_run_started",
+      tenantId,
+      runId,
+      metadata: { ingestionId, traceId },
+    });
+
     // Get source transactions (from this ingestion)
     const sourceTransactions = await query(
       `SELECT id FROM normalized_transactions
@@ -466,6 +474,17 @@ export async function runReconciliation(
 
     await appendRunIntegrityEntry(runId, tenantId);
 
+    await emitOperatorRuntimeEvent({
+      eventType: "reconciliation_run_completed",
+      tenantId,
+      runId,
+      recordsProcessed: sourceIds.length,
+      durationMs: undefined,
+      classificationCounts: { matched: matchedCount, unmatched: unmatchedCount },
+      manualReviewCount: unmatchedCount,
+      metadata: { traceId, avgConfidence },
+    });
+
     logInfo("Reconciliation completed", {
       runId,
       matchedCount,
@@ -542,6 +561,13 @@ export async function runReconciliation(
       WHERE id = $2`,
       [error instanceof Error ? error.message : String(error), runId]
     );
+    await emitOperatorRuntimeEvent({
+      eventType: "reconciliation_run_failed",
+      tenantId,
+      runId,
+      errorId: traceId,
+      metadata: { message: error instanceof Error ? error.message : String(error), traceId },
+    });
     await appendRunIntegrityEntry(runId, tenantId);
     throw error;
   }

--- a/packages/api/src/services/ops-intelligence/runtime-events.ts
+++ b/packages/api/src/services/ops-intelligence/runtime-events.ts
@@ -1,0 +1,227 @@
+import { query, queryWithTenant } from "../../db";
+import { logError } from "../../utils/logger";
+
+export type OperatorRuntimeEventType =
+  | "reconciliation_run_started"
+  | "reconciliation_run_completed"
+  | "reconciliation_run_failed"
+  | "record_processed"
+  | "match_group_created"
+  | "manual_review_flagged"
+  | "api_request"
+  | "import_started"
+  | "import_failed"
+  | "replay_triggered"
+  | "error_thrown";
+
+export interface OperatorRuntimeEvent {
+  eventType: OperatorRuntimeEventType;
+  tenantId: string;
+  runId?: string | null;
+  recordsProcessed?: number;
+  durationMs?: number;
+  classificationCounts?: Record<string, number>;
+  manualReviewCount?: number;
+  errorId?: string | null;
+  metadata?: Record<string, unknown>;
+  occurredAt?: Date;
+}
+
+export async function emitOperatorRuntimeEvent(event: OperatorRuntimeEvent): Promise<void> {
+  try {
+    await query(
+      `INSERT INTO operator_runtime_events (
+        event_type,
+        tenant_id,
+        run_id,
+        records_processed,
+        duration_ms,
+        classification_counts,
+        manual_review_count,
+        error_id,
+        metadata,
+        occurred_at,
+        created_at
+      ) VALUES ($1,$2,$3,$4,$5,$6::jsonb,$7,$8,$9::jsonb,$10,NOW())`,
+      [
+        event.eventType,
+        event.tenantId,
+        event.runId ?? null,
+        event.recordsProcessed ?? null,
+        event.durationMs ?? null,
+        JSON.stringify(event.classificationCounts ?? {}),
+        event.manualReviewCount ?? null,
+        event.errorId ?? null,
+        JSON.stringify(event.metadata ?? {}),
+        event.occurredAt ?? new Date(),
+      ]
+    );
+  } catch (error) {
+    logError("Failed to persist operator runtime event", error, {
+      eventType: event.eventType,
+      tenantId: event.tenantId,
+      runId: event.runId,
+    });
+  }
+}
+
+export interface RunExplorerEntry {
+  runId: string;
+  tenantId: string;
+  recordsProcessed: number;
+  matchRate: number;
+  manualReviewCount: number;
+  durationMs: number;
+  executionStatus: string;
+  startedAt: string;
+  completedAt: string | null;
+  errorMessage: string | null;
+}
+
+export async function getRunExplorer(
+  tenantId: string,
+  filters: { status?: string; runId?: string; limit?: number }
+): Promise<RunExplorerEntry[]> {
+  const rows = await queryWithTenant<{
+    run_id: string;
+    tenant_id: string;
+    records_processed: number;
+    match_rate: number;
+    manual_review_count: number;
+    duration_ms: number;
+    execution_status: string;
+    started_at: Date;
+    completed_at: Date | null;
+    error_message: string | null;
+  }>(
+    tenantId,
+    `SELECT
+      r.id::text as run_id,
+      r.tenant_id::text as tenant_id,
+      COALESCE(r.source_count, 0) as records_processed,
+      CASE WHEN COALESCE(r.source_count, 0) > 0 THEN ROUND((COALESCE(r.matched_count, 0)::numeric / r.source_count::numeric) * 100, 2) ELSE 0 END as match_rate,
+      (
+        SELECT COUNT(*)::int
+        FROM reconciliation_matches m
+        WHERE m.run_id = r.id
+          AND m.tenant_id = r.tenant_id
+          AND m.reviewed = false
+          AND m.match_type IN ('manual', 'unmatched')
+      ) as manual_review_count,
+      COALESCE(
+        EXTRACT(EPOCH FROM (COALESCE(r.completed_at, NOW()) - COALESCE(r.started_at, r.created_at))) * 1000,
+        0
+      )::int as duration_ms,
+      r.status as execution_status,
+      COALESCE(r.started_at, r.created_at) as started_at,
+      r.completed_at,
+      r.error_message
+    FROM reconciliation_runs r
+    WHERE r.tenant_id = $1
+      AND ($2::text IS NULL OR r.status = $2::text)
+      AND ($3::text IS NULL OR r.id::text = $3::text)
+    ORDER BY COALESCE(r.started_at, r.created_at) DESC
+    LIMIT $4`,
+    [tenantId, filters.status ?? null, filters.runId ?? null, Math.min(filters.limit ?? 50, 200)]
+  );
+
+  return rows.map((r) => ({
+    runId: r.run_id,
+    tenantId: r.tenant_id,
+    recordsProcessed: r.records_processed,
+    matchRate: Number(r.match_rate),
+    manualReviewCount: r.manual_review_count,
+    durationMs: r.duration_ms,
+    executionStatus: r.execution_status,
+    startedAt: r.started_at.toISOString(),
+    completedAt: r.completed_at ? r.completed_at.toISOString() : null,
+    errorMessage: r.error_message,
+  }));
+}
+
+export interface SystemHealthSnapshot {
+  runsPerDay: number;
+  recordsProcessed: number;
+  matchRate: number;
+  manualReviewRate: number;
+  runDurationMsP50: number;
+  runDurationMsP95: number;
+  runFailureRate: number;
+  apiLatencyMsP50: number;
+  apiLatencyMsP95: number;
+  errorRate: number;
+}
+
+export async function getSystemHealthSnapshot(
+  tenantId: string,
+  days = 7
+): Promise<SystemHealthSnapshot> {
+  const [runStats] = await queryWithTenant<{
+    runs_per_day: number;
+    records_processed: number;
+    match_rate: number;
+    manual_review_rate: number;
+    run_duration_p50: number;
+    run_duration_p95: number;
+    run_failure_rate: number;
+  }>(
+    tenantId,
+    `WITH base_runs AS (
+      SELECT
+        r.id,
+        r.status,
+        COALESCE(r.source_count, 0) as records_processed,
+        COALESCE(r.matched_count, 0) as matched_count,
+        COALESCE(EXTRACT(EPOCH FROM (COALESCE(r.completed_at, NOW()) - COALESCE(r.started_at, r.created_at))) * 1000, 0)::numeric as duration_ms,
+        (
+          SELECT COUNT(*)::numeric
+          FROM reconciliation_matches m
+          WHERE m.run_id = r.id
+            AND m.tenant_id = r.tenant_id
+            AND m.reviewed = false
+            AND m.match_type IN ('manual', 'unmatched')
+        ) as manual_review_count
+      FROM reconciliation_runs r
+      WHERE r.tenant_id = $1
+        AND COALESCE(r.started_at, r.created_at) >= NOW() - ($2::int || ' days')::interval
+    )
+    SELECT
+      COALESCE(COUNT(*)::numeric / GREATEST($2::numeric, 1), 0) as runs_per_day,
+      COALESCE(SUM(records_processed), 0)::numeric as records_processed,
+      COALESCE((SUM(matched_count)::numeric / NULLIF(SUM(records_processed), 0)) * 100, 0) as match_rate,
+      COALESCE((SUM(manual_review_count)::numeric / NULLIF(SUM(records_processed), 0)) * 100, 0) as manual_review_rate,
+      COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY duration_ms), 0) as run_duration_p50,
+      COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms), 0) as run_duration_p95,
+      COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0) as run_failure_rate
+    FROM base_runs`,
+    [tenantId, days]
+  );
+
+  const [apiStats] = await query<{
+    p50_latency: number;
+    p95_latency: number;
+    error_rate: number;
+  }>(
+    `SELECT
+      COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms), 0) as p50_latency,
+      COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms), 0) as p95_latency,
+      COALESCE((COUNT(*) FILTER (WHERE status_code >= 500)::numeric / NULLIF(COUNT(*), 0)) * 100, 0) as error_rate
+    FROM request_metrics
+    WHERE tenant_id = $1
+      AND created_at >= NOW() - ($2::int || ' days')::interval`,
+    [tenantId, days]
+  );
+
+  return {
+    runsPerDay: Number(runStats?.runs_per_day ?? 0),
+    recordsProcessed: Number(runStats?.records_processed ?? 0),
+    matchRate: Number(runStats?.match_rate ?? 0),
+    manualReviewRate: Number(runStats?.manual_review_rate ?? 0),
+    runDurationMsP50: Number(runStats?.run_duration_p50 ?? 0),
+    runDurationMsP95: Number(runStats?.run_duration_p95 ?? 0),
+    runFailureRate: Number(runStats?.run_failure_rate ?? 0),
+    apiLatencyMsP50: Number(apiStats?.p50_latency ?? 0),
+    apiLatencyMsP95: Number(apiStats?.p95_latency ?? 0),
+    errorRate: Number(apiStats?.error_rate ?? 0),
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a concrete, tenant-scoped runtime event substrate so operator tooling can rely on real execution signals (reconciliation runs, API requests, errors) without changing the core reconciliation engine. 
- Enable basic operator workflows: system health snapshots and a run explorer to inspect reconciliation metadata and triage incidents. 
- Make event capture non-blocking and best-effort so production latency/behaviour is preserved while creating a foundation for alerting, analytics, and replay tooling.

### Description
- Persist a unified runtime event stream by adding the `operator_runtime_events` migration with indexes and a JSON-friendly schema for classification and metadata (`packages/api/src/db/migrations/018-operator-runtime-events.sql`).
- Implement the runtime-events service with `emitOperatorRuntimeEvent`, `getSystemHealthSnapshot`, and `getRunExplorer` to persist events and derive tenant-safe KPIs and run explorer rows (`packages/api/src/services/ops-intelligence/runtime-events.ts`).
- Instrument reconciliation lifecycle to emit `reconciliation_run_started`, `reconciliation_run_completed`, and `reconciliation_run_failed` events from the existing matcher flow, and emit `api_request` / `error_thrown` events via request-finish middleware for `/api/*` (`packages/api/src/services/ingestion/reconciliation-matcher.ts`, `packages/api/src/index.ts`).
- Expose operator intelligence HTTP endpoints mounted on v1: `GET /api/v1/operator/intelligence/system-health` and `GET /api/v1/operator/intelligence/run-explorer` with permission enforcement (`packages/api/src/routes/v1/operator-intelligence.ts`, `packages/api/src/routes/v1/index.ts`).
- Extend tenant query guard coverage to include the new runtime events table to reduce accidental unscoped access (`packages/api/src/db/index.ts`).

### Testing
- Ran lint: `pnpm --filter @settler/api lint` and it completed successfully (warnings only). 
- Ran typecheck: `pnpm --filter @settler/api typecheck` and it completed successfully with no TypeScript errors. 
- Ran unit test: `pnpm --filter @settler/api test -- src/services/ops-intelligence/__tests__/control-plane-analytics.test.ts` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af7d64469083288b5955d272342231)