### PR TITLE
chore(release): add deterministic packaging, release gates, and artifact verification

### DIFF
--- a/.github/workflows/release-engineering.yml
+++ b/.github/workflows/release-engineering.yml
@@ -1,0 +1,73 @@
+name: Release Engineering
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Tag to package (vX.Y.Z)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  verify-and-package:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+      - name: Dependency install (lockfile enforced)
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Unit/integration tests
+        run: pnpm run test:ci:verify
+
+      - name: Build verification
+        run: pnpm run build:all
+
+      - name: Release verification gates
+        run: pnpm run verify:release
+
+      - name: Package release artifacts
+        run: pnpm run release:artifacts
+
+      - name: Artifact validation
+        run: pnpm run verify:release:artifacts
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts/release
+
+      - name: Publish GitHub release artifacts
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            artifacts/release/checksums.sha256
+            artifacts/release/manifest.json
+            artifacts/release/sbom-metadata.json
+            artifacts/release/npm/*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Added deterministic demo and replay commands that generate evidence artifacts under `examples/demo-output` and replay fixtures under `examples/demo-output-fixtures`.
 - Added verification gates for policy boundaries and replay checks (`verify:policy`) and strengthened route smoke verification requirements.
 - Added new documentation: `docs/demo.md`, `docs/determinism.md`, `docs/policies.md`, `docs/investor.md`, and `docs/one-pager.md`.
+- Added release engineering automation with deterministic artifact packaging (`release:artifacts`), checksum verification (`verify:release:artifacts`), and release dry-run orchestration (`release:dry-run`).
+- Added a dedicated `release-engineering` GitHub Actions workflow with strict release gates and artifact publication for semver tags.
+- Added OSS packaging policy enforcement to block private-workspace dependency leakage into OSS release bundles.
 
 ### Changed
 

--- a/docs/release/RELEASE_ENGINEERING.md
+++ b/docs/release/RELEASE_ENGINEERING.md
@@ -1,0 +1,66 @@
+# Release Engineering System
+
+## Goals
+
+This release pipeline is optimized for deterministic, solo-operator shipping:
+
+- lockfile-enforced installs
+- deterministic package version propagation
+- reproducible artifact generation
+- checksum and manifest validation
+- OSS/private package boundary enforcement
+
+## Release primitives
+
+- `pnpm run version:bump <semver>`: updates root and workspace package versions in one operation.
+- `pnpm run build:clean`: clean checkout style build (`clean:all`, frozen-lockfile install, build).
+- `pnpm run release:artifacts`: creates versioned distributable tarballs under `artifacts/release/npm`.
+- `pnpm run verify:release:artifacts`: verifies generated checksums and manifest coherence.
+- `pnpm run release:dry-run`: runs release verification profile + packaging + artifact verification.
+
+## Workflow
+
+GitHub Actions workflow: `.github/workflows/release-engineering.yml`
+
+Pipeline gates:
+
+1. dependency install (`pnpm install --frozen-lockfile`)
+2. lint
+3. typecheck
+4. tests (`test:ci:verify`)
+5. build verification (`build:all`)
+6. release verification (`verify:release`)
+7. packaging (`release:artifacts`)
+8. artifact validation (`verify:release:artifacts`)
+
+Any failure blocks release publication.
+
+## Artifact outputs
+
+Generated in `artifacts/release/`:
+
+- `npm/*.tgz` publishable package tarballs
+- `checksums.sha256` deterministic checksums
+- `manifest.json` release metadata (commit, lockfile hash, version)
+- `sbom-metadata.json` dependency provenance metadata
+
+## OSS vs enterprise boundary
+
+Policy file: `release/packaging-policy.json`.
+
+`release:artifacts` enforces that OSS-packaged workspace modules do **not** depend on private workspace packages. Enterprise overlays are modeled as optional private-registry/provider-injection attachments and are intentionally excluded from OSS artifacts.
+
+## Rollback
+
+1. identify prior stable tag (`git tag --sort=-v:refname | head`)
+2. redeploy prior release assets from GitHub Releases
+3. re-run `pnpm run verify:release:artifacts` against downloaded artifacts before promotion
+4. capture incident note in release log
+
+## Operator audit checklist
+
+- Confirm tag matches `package.json` version.
+- Confirm manifest `lockfileSha256` exists.
+- Confirm checksum verification passes.
+- Confirm no OSS/private boundary violations.
+- Confirm release workflow artifacts are retained.

--- a/package.json
+++ b/package.json
@@ -253,7 +253,13 @@
     "verify:reconciliation-runtime": "pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-verify --seed 42 --profile integration --strict",
     "verify:reconciliation:strict": "node scripts/verify-reconciliation-strict.mjs",
     "reconciliation:summary": "node scripts/reconciliation-run-tools.mjs summary test-data/exports/latest",
-    "reconciliation:compare": "node scripts/reconciliation-run-tools.mjs compare test-data/exports/smoke-seed42 test-data/exports/latest"
+    "reconciliation:compare": "node scripts/reconciliation-run-tools.mjs compare test-data/exports/smoke-seed42 test-data/exports/latest",
+    "version:sync": "node scripts/release/version-manager.mjs sync",
+    "version:bump": "node scripts/release/version-manager.mjs bump",
+    "build:clean": "pnpm run clean:all && pnpm install --frozen-lockfile && pnpm run build:all",
+    "release:artifacts": "node scripts/release/package-artifacts.mjs",
+    "verify:release:artifacts": "node scripts/release/verify-artifacts.mjs",
+    "release:dry-run": "pnpm run verify:release && pnpm run release:artifacts && pnpm run verify:release:artifacts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/release/packaging-policy.json
+++ b/release/packaging-policy.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "description": "OSS packaging boundary policy for deterministic release artifact generation.",
+  "ossPackageScopes": ["@settler/", "@jobforge/adapter-settler"],
+  "enterpriseOverlay": {
+    "mode": "optional-private-overlay",
+    "delivery": ["private-registry-modules", "provider-injection"],
+    "requiredEnvVars": ["SETTLER_ENTERPRISE_REGISTRY_TOKEN"]
+  }
+}

--- a/scripts/release/package-artifacts.mjs
+++ b/scripts/release/package-artifacts.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { globSync } from "glob";
+
+const repoRoot = process.cwd();
+const outDir = path.join(repoRoot, "artifacts", "release");
+const npmDir = path.join(outDir, "npm");
+
+const policy = JSON.parse(
+  readFileSync(path.join(repoRoot, "release/packaging-policy.json"), "utf8")
+);
+
+function run(cmd, opts = {}) {
+  execSync(cmd, { cwd: repoRoot, stdio: "inherit", ...opts });
+}
+
+function runCapture(cmd) {
+  return execSync(cmd, {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  }).trim();
+}
+
+function sha256File(filePath) {
+  const hash = createHash("sha256");
+  hash.update(readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function isOssPackage(name) {
+  return policy.ossPackageScopes.some((scope) =>
+    scope.endsWith("/") ? name.startsWith(scope) : name === scope
+  );
+}
+
+function listWorkspacePackages() {
+  const files = globSync("packages/*/package.json").sort();
+  return files.map((file) => {
+    const pkg = JSON.parse(readFileSync(path.join(repoRoot, file), "utf8"));
+    return { file, dir: path.dirname(file), ...pkg };
+  });
+}
+
+function evaluateOssBoundary(packages) {
+  const map = new Map(packages.map((p) => [p.name, p]));
+  const violations = [];
+  const excludedPackages = [];
+
+  for (const pkg of packages) {
+    if (pkg.private || !isOssPackage(pkg.name)) continue;
+    const dependencySets = [
+      pkg.dependencies,
+      pkg.peerDependencies,
+      pkg.optionalDependencies,
+    ].filter(Boolean);
+    for (const deps of dependencySets) {
+      for (const depName of Object.keys(deps)) {
+        const internal = map.get(depName);
+        if (internal?.private) {
+          violations.push(`${pkg.name} depends on private workspace package ${depName}`);
+        }
+      }
+    }
+
+    if (
+      violations.some((item) => item.startsWith(`${pkg.name} depends on private workspace package`))
+    ) {
+      excludedPackages.push(pkg.name);
+    }
+  }
+
+  return { violations, excludedPackages };
+}
+
+function main() {
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(npmDir, { recursive: true });
+
+  const version = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8")).version;
+  const commit = runCapture("git rev-parse HEAD");
+  const lockfileHash = existsSync(path.join(repoRoot, "pnpm-lock.yaml"))
+    ? sha256File(path.join(repoRoot, "pnpm-lock.yaml"))
+    : null;
+
+  const packages = listWorkspacePackages();
+  const boundary = evaluateOssBoundary(packages);
+
+  const published = packages.filter(
+    (pkg) => !pkg.private && isOssPackage(pkg.name) && !boundary.excludedPackages.includes(pkg.name)
+  );
+
+  if (published.length === 0) {
+    throw new Error("No OSS-safe package candidates were found for release artifact packaging.");
+  }
+
+  for (const pkg of published) {
+    run(`pnpm --filter ${pkg.name} pack --pack-destination ${npmDir}`);
+  }
+
+  const tarballs = globSync("*.tgz", { cwd: npmDir }).sort();
+  const checksums = tarballs.map((file) => {
+    const abs = path.join(npmDir, file);
+    return { file: `npm/${file}`, sha256: sha256File(abs), bytes: readFileSync(abs).byteLength };
+  });
+
+  writeFileSync(
+    path.join(outDir, "checksums.sha256"),
+    checksums.map((entry) => `${entry.sha256}  ${entry.file}`).join("\n") + "\n",
+    "utf8"
+  );
+
+  writeFileSync(
+    path.join(outDir, "manifest.json"),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        generatedAt: new Date().toISOString(),
+        version,
+        commit,
+        lockfileSha256: lockfileHash,
+        policy: policy.enterpriseOverlay,
+        boundaryViolations: boundary.violations,
+        excludedPackages: boundary.excludedPackages,
+        artifacts: checksums,
+      },
+      null,
+      2
+    ) + "\n",
+    "utf8"
+  );
+
+  writeFileSync(
+    path.join(outDir, "sbom-metadata.json"),
+    JSON.stringify(
+      {
+        schema: "settler.release.sbom-metadata.v1",
+        generatedAt: new Date().toISOString(),
+        packageManager: runCapture("pnpm --version"),
+        nodeVersion: process.version,
+        lockfileSha256: lockfileHash,
+        workspacePackages: packages.map((pkg) => ({
+          name: pkg.name,
+          version: pkg.version,
+          private: Boolean(pkg.private),
+        })),
+      },
+      null,
+      2
+    ) + "\n",
+    "utf8"
+  );
+
+  console.log(`Created ${tarballs.length} distributable package(s) in artifacts/release/npm`);
+}
+
+main();

--- a/scripts/release/verify-artifacts.mjs
+++ b/scripts/release/verify-artifacts.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const artifactsDir = path.join(repoRoot, "artifacts/release");
+
+function sha256(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+if (!existsSync(path.join(artifactsDir, "manifest.json")))
+  fail("Missing artifacts/release/manifest.json");
+if (!existsSync(path.join(artifactsDir, "checksums.sha256")))
+  fail("Missing artifacts/release/checksums.sha256");
+
+const manifest = JSON.parse(readFileSync(path.join(artifactsDir, "manifest.json"), "utf8"));
+const checksumsText = readFileSync(path.join(artifactsDir, "checksums.sha256"), "utf8").trim();
+if (!checksumsText) fail("checksums.sha256 is empty");
+
+const lines = checksumsText.split("\n").filter(Boolean);
+for (const line of lines) {
+  const [expected, rel] = line.split(/\s+/).filter(Boolean);
+  const artifactPath = path.join(artifactsDir, rel);
+  if (!existsSync(artifactPath)) fail(`Missing artifact listed in checksum file: ${rel}`);
+  const actual = sha256(artifactPath);
+  if (actual !== expected) fail(`Checksum mismatch for ${rel}`);
+}
+
+if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length !== lines.length) {
+  fail("Manifest artifact count does not match checksum file entries");
+}
+
+console.log(`✅ Verified ${lines.length} release artifact checksums.`);

--- a/scripts/release/version-manager.mjs
+++ b/scripts/release/version-manager.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { globSync } from "glob";
+
+const repoRoot = process.cwd();
+const semverPattern =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+
+function readJson(rel) {
+  return JSON.parse(readFileSync(path.join(repoRoot, rel), "utf8"));
+}
+
+function writeJson(rel, data) {
+  writeFileSync(path.join(repoRoot, rel), `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+function assertSemver(version) {
+  if (!semverPattern.test(version)) {
+    throw new Error(`Invalid semantic version: ${version}`);
+  }
+}
+
+function allWorkspacePackages() {
+  return globSync("packages/*/package.json").sort();
+}
+
+function syncVersions(targetVersion) {
+  assertSemver(targetVersion);
+
+  const touched = [];
+  const rootPkg = readJson("package.json");
+  if (rootPkg.version !== targetVersion) {
+    rootPkg.version = targetVersion;
+    writeJson("package.json", rootPkg);
+    touched.push("package.json");
+  }
+
+  for (const pkgPath of allWorkspacePackages()) {
+    const pkg = readJson(pkgPath);
+    if (pkg.version !== targetVersion) {
+      pkg.version = targetVersion;
+      writeJson(pkgPath, pkg);
+      touched.push(pkgPath);
+    }
+  }
+
+  console.log(JSON.stringify({ version: targetVersion, touched }, null, 2));
+}
+
+const [command, arg] = process.argv.slice(2);
+
+if (!command || command === "help") {
+  console.log("Usage: node scripts/release/version-manager.mjs <sync|bump> <version>");
+  process.exit(0);
+}
+
+if (command === "sync" || command === "bump") {
+  if (!arg) {
+    throw new Error(`Missing version for '${command}'`);
+  }
+  syncVersions(arg);
+} else {
+  throw new Error(`Unknown command: ${command}`);
+}


### PR DESCRIPTION
### Motivation
- Enforce deterministic, reproducible releases with automated verification gates to allow a single operator to produce trusted artifacts.
- Prevent accidental leakage of private workspace modules into OSS-distributed packages by modeling and enforcing an OSS/private packaging boundary.
- Provide simple operator primitives for version propagation, packaging, checksum/SBOM provenance, and CI-driven artifact publication. 

### Description
- Add GitHub Actions workflow `.github/workflows/release-engineering.yml` that runs install (lockfile), lint, typecheck, tests, build, release verification, packaging, and artifact validation on semver tags. 
- Add packaging policy file `release/packaging-policy.json` and packaging tooling `scripts/release/package-artifacts.mjs` which: pack OSS-safe workspace packages, compute `pnpm-lock.yaml` SHA256, generate `artifacts/release/checksums.sha256`, `manifest.json` (includes `boundaryViolations` and `excludedPackages`), and `sbom-metadata.json`.
- Add `scripts/release/version-manager.mjs` for semver-validated root + workspace version sync and `scripts/release/verify-artifacts.mjs` to validate manifest/coherence and checksums. 
- Wire root npm scripts (`version:sync`, `version:bump`, `build:clean`, `release:artifacts`, `verify:release:artifacts`, `release:dry-run`) and add operator documentation `docs/release/RELEASE_ENGINEERING.md` and changelog entries for the release system. 

### Testing
- Ran `node scripts/release/version-manager.mjs help` which printed usage and returned success. 
- Executed `pnpm run release:artifacts` which produced distributable tarballs under `artifacts/release/npm` (6 packages in the local run) and emitted `manifest.json` and `checksums.sha256`. 
- Executed `pnpm run verify:release:artifacts` which validated checksums and manifest coherence and returned success. 
- Performed static checks with `node --check` for the new release scripts which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af82476d948328acdde40f4e0fae50)