### PR TITLE
Add structured GitHub issue templates, support intake API, observability & usage contracts, and triage automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security disclosure instructions
+    url: https://github.com/settler/settler/blob/main/.github/ISSUE_TEMPLATE/security_guidance.yml
+    about: Use private reporting instructions for security issues.
+  - name: Support self-help index
+    url: https://github.com/settler/settler/blob/main/docs/support/README.md
+    about: Start with support triage and diagnostics guides before filing.
+  - name: Operator triage routing guide
+    url: https://github.com/settler/settler/blob/main/docs/ops/github-triage-routing.md
+    about: Label taxonomy, routing rules, and automation-ready issue structure.

--- a/.github/ISSUE_TEMPLATE/operator_control_plane_bug.yml
+++ b/.github/ISSUE_TEMPLATE/operator_control_plane_bug.yml
@@ -1,0 +1,94 @@
+name: Operator / control-plane bug
+description: Report control-plane behavior defects (not runtime data bugs).
+title: "operator: bug "
+labels:
+  - triage
+  - operator
+  - bug
+body:
+  - type: input
+    id: tenant_id
+    attributes:
+      label: Tenant ID
+      placeholder: tenant_abc123
+    validations:
+      required: false
+
+  - type: input
+    id: run_id
+    attributes:
+      label: Run ID (if tied to an operation)
+      placeholder: run_2026_02_18_01
+    validations:
+      required: false
+
+  - type: input
+    id: route_module
+    attributes:
+      label: Route + module
+      placeholder: GET /v1/operator/daily-intelligence · routes/v1/operator-mode
+    validations:
+      required: true
+
+  - type: input
+    id: error_signature
+    attributes:
+      label: Error signature (if available)
+      placeholder: UpstreamUnavailable|GET /v1/operator/daily-intelligence|operator-mode/daily-intelligence
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - sev1_high
+        - sev2_medium
+        - sev3_low
+    validations:
+      required: true
+
+  - type: input
+    id: frequency
+    attributes:
+      label: Frequency
+      placeholder: always / intermittent / once
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Current behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: triage_snapshot
+    attributes:
+      label: Triage snapshot (automation-friendly)
+      value: |
+        ## Classification
+        - bug_class:
+        - severity:
+        - retryable:
+
+        ## Correlation
+        - tenant_id:
+        - run_id:
+        - route:
+        - module:
+
+        ## Impact
+        - affected_operator_capability:
+        - workaround:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/runtime_error_incident.yml
+++ b/.github/ISSUE_TEMPLATE/runtime_error_incident.yml
@@ -1,0 +1,129 @@
+name: Runtime error / incident
+description: Capture production/runtime failures with dedupe-friendly fields.
+title: "incident(runtime): "
+labels:
+  - triage
+  - incident
+  - runtime
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for runtime failures, degraded execution, or tenant-impacting incidents.
+        Keep customer data sanitized; include IDs and signatures, not raw PII.
+
+  - type: input
+    id: tenant_id
+    attributes:
+      label: Tenant ID
+      description: Tenant/workspace/org identifier from the failing run context.
+      placeholder: tenant_abc123
+    validations:
+      required: true
+
+  - type: input
+    id: run_id
+    attributes:
+      label: Run ID
+      description: Reconciliation run/job execution identifier.
+      placeholder: run_2026_02_18_01
+    validations:
+      required: false
+
+  - type: input
+    id: route_module
+    attributes:
+      label: Route + module
+      description: API route and module/service where failure happened.
+      placeholder: POST /v1/operator/backups/create · services/operator-mode/backups
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - sev0_critical
+        - sev1_high
+        - sev2_medium
+        - sev3_low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: retryable
+    attributes:
+      label: Retryable
+      options:
+        - unknown
+        - retryable
+        - non_retryable
+    validations:
+      required: true
+
+  - type: input
+    id: frequency
+    attributes:
+      label: Frequency
+      description: How often is this happening?
+      placeholder: 100% / 3 in 20 runs / once
+    validations:
+      required: true
+
+  - type: input
+    id: error_signature
+    attributes:
+      label: Error signature
+      description: Stable signature used for grouping/deduping.
+      placeholder: DatabaseTimeoutError|POST /v1/operator/backups/create|operator-mode/backups
+    validations:
+      required: true
+
+  - type: textarea
+    id: stack_trace_summary
+    attributes:
+      label: Stack trace summary
+      description: Top frames and concise message; redact sensitive values.
+      placeholder: |
+        ErrorName: message
+         at service.fn (file.ts:12)
+         at route.handler (route.ts:55)
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction_context
+    attributes:
+      label: Reproduction context
+      description: Inputs, preconditions, and commands to reproduce.
+      placeholder: |
+        1. Tenant configured with ...
+        2. Trigger endpoint ...
+        3. Observe failure after ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: triage_snapshot
+    attributes:
+      label: Triage snapshot (automation-friendly)
+      value: |
+        ## Classification
+        - category:
+        - severity:
+        - retryable:
+        - dedupe_key:
+
+        ## Correlation
+        - tenant_id:
+        - run_id:
+        - route:
+        - module:
+
+        ## Evidence
+        - trace_ids:
+        - logs:
+        - dashboards:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/support_issue.yml
+++ b/.github/ISSUE_TEMPLATE/support_issue.yml
@@ -1,0 +1,96 @@
+name: Support issue
+description: Capture user/operator support requests with structured context.
+title: "support: "
+labels:
+  - triage
+  - support
+body:
+  - type: input
+    id: tenant_id
+    attributes:
+      label: Tenant ID
+      placeholder: tenant_abc123
+    validations:
+      required: true
+
+  - type: input
+    id: run_id
+    attributes:
+      label: Run ID (optional)
+      placeholder: run_2026_02_18_01
+    validations:
+      required: false
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Support category
+      options:
+        - run_failure
+        - data_mismatch
+        - import_export
+        - replay_divergence
+        - auth_access
+        - performance
+        - billing_usage
+        - docs_other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - sev2_medium
+        - sev3_low
+        - sev1_high
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue description
+      description: What is the user/operator blocked on?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro_context
+    attributes:
+      label: Reproduction context
+      description: Steps, date range, source systems, and what changed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: contact_context
+    attributes:
+      label: Contact / requester context (optional)
+      description: Non-sensitive context needed for follow-up.
+      placeholder: user_id, role, timezone, preferred response channel
+    validations:
+      required: false
+
+  - type: textarea
+    id: triage_snapshot
+    attributes:
+      label: Triage snapshot (automation-friendly)
+      value: |
+        ## Classification
+        - support_category:
+        - severity:
+        - related_error_signature:
+
+        ## Correlation
+        - tenant_id:
+        - run_id:
+        - route_module:
+
+        ## Follow-up
+        - owner:
+        - target_response_sla:
+        - linked_incident_or_bug:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/telemetry_regression.yml
+++ b/.github/ISSUE_TEMPLATE/telemetry_regression.yml
@@ -1,0 +1,87 @@
+name: Telemetry regression
+description: Report missing/broken runtime telemetry or observability drift.
+title: "telemetry: regression "
+labels:
+  - triage
+  - telemetry
+body:
+  - type: input
+    id: tenant_id
+    attributes:
+      label: Tenant ID
+      placeholder: tenant_abc123
+    validations:
+      required: false
+
+  - type: input
+    id: run_id
+    attributes:
+      label: Run ID
+      placeholder: run_2026_02_18_01
+    validations:
+      required: false
+
+  - type: input
+    id: route_module
+    attributes:
+      label: Route + module
+      placeholder: POST /v1/reconciliation/run · services/reconciliation/runner
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_telemetry
+    attributes:
+      label: Expected telemetry
+      description: Expected metric/log/event names and required tags.
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed_telemetry
+    attributes:
+      label: Observed telemetry
+      description: What is missing, renamed, malformed, or cardinality-exploding?
+    validations:
+      required: true
+
+  - type: input
+    id: error_signature
+    attributes:
+      label: Related error signature (if any)
+      placeholder: ValidationError|POST /v1/reconciliation/run|services/reconciliation/runner
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - sev1_high
+        - sev2_medium
+        - sev3_low
+    validations:
+      required: true
+
+  - type: textarea
+    id: triage_snapshot
+    attributes:
+      label: Triage snapshot (automation-friendly)
+      value: |
+        ## Regression type
+        - type: missing_metric | missing_tag | bad_grouping | schema_change
+        - first_seen:
+        - suspected_change_window:
+
+        ## Correlation
+        - tenant_id:
+        - run_id:
+        - route:
+        - module:
+
+        ## Evidence
+        - query_or_dashboard:
+        - logs_or_samples:
+    validations:
+      required: true

--- a/.github/workflows/issue-template-contracts.yml
+++ b/.github/workflows/issue-template-contracts.yml
@@ -1,0 +1,27 @@
+name: Issue Template Contracts
+
+on:
+  pull_request:
+    paths:
+      - ".github/ISSUE_TEMPLATE/**"
+      - "scripts/validate-issue-templates.mjs"
+      - ".github/workflows/issue-template-contracts.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/ISSUE_TEMPLATE/**"
+      - "scripts/validate-issue-templates.mjs"
+      - ".github/workflows/issue-template-contracts.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-templates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Validate issue template contracts
+        run: node scripts/validate-issue-templates.mjs

--- a/.github/workflows/issue-triage-runbook-comment.yml
+++ b/.github/workflows/issue-triage-runbook-comment.yml
@@ -1,0 +1,51 @@
+name: Issue Triage Runbook Comment
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  suggest-runbook:
+    if: contains(github.event.issue.labels.*.name, 'triage')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment triage runbook links
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map((l) => l.name);
+            const links = [];
+            if (labels.includes('incident') || labels.includes('runtime')) {
+              links.push('- Runtime failure triage: `docs/runbook/operator-failure-triage.md`');
+              links.push('- Error contract: `docs/ops/observability-error-contract.md`');
+            }
+            if (labels.includes('support')) {
+              links.push('- Support intake contract: `docs/support/support-intake-foundation.md`');
+            }
+            if (labels.includes('telemetry')) {
+              links.push('- Observability taxonomy: `docs/ops/observability-error-contract.md`');
+            }
+            if (labels.includes('operator')) {
+              links.push('- Operator triage routing: `docs/ops/github-triage-routing.md`');
+            }
+            if (!links.length) {
+              return;
+            }
+
+            const body = [
+              'Automated triage aid: relevant runbooks/contracts for this label set.',
+              '',
+              ...links,
+              '',
+              'If capabilities/integrations are unavailable in OSS mode, keep manual triage explicit in issue notes.'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -9,6 +9,12 @@ Operational guidance for running Settler in production.
 - Deployment notes: [`docs/deployment-notes.md`](../deployment-notes.md)
 - Incident response: [`docs/INCIDENT_RESPONSE.md`](../INCIDENT_RESPONSE.md)
 
+- GitHub triage routing: [`docs/ops/github-triage-routing.md`](./github-triage-routing.md)
+- Observability error contract: [`docs/ops/observability-error-contract.md`](./observability-error-contract.md)
+- Usage metering contract: [`docs/ops/usage-metering-contract.md`](./usage-metering-contract.md)
+- Failed run triage runbook: [`docs/runbook/operator-failure-triage.md`](../runbook/operator-failure-triage.md)
+- Operator terminology: [`docs/reference/operator-terminology.md`](../reference/operator-terminology.md)
+
 ## Reliability principles
 
 - Deterministic runs are immutable and replayable.

--- a/docs/ops/github-triage-routing.md
+++ b/docs/ops/github-triage-routing.md
@@ -1,0 +1,57 @@
+# GitHub Triage Routing (Operator + Support)
+
+This runbook defines **automation-friendly issue intake** for runtime incidents, telemetry regressions, support requests, and operator/control-plane bugs.
+
+## Issue templates
+
+Use the structured issue forms under `.github/ISSUE_TEMPLATE/`:
+
+- `runtime_error_incident.yml`
+- `support_issue.yml`
+- `telemetry_regression.yml`
+- `operator_control_plane_bug.yml`
+
+Each form captures dedupe/correlation fields:
+
+- `tenant_id`
+- `run_id` (when available)
+- `route` / `module`
+- `severity`
+- `retryable`
+- `error_signature`
+- concise reproduction + stack summary
+
+## Label taxonomy
+
+Core labels:
+
+- `triage` (all new structured issues)
+- `incident` (runtime failures/degradation)
+- `support` (customer/operator support request)
+- `telemetry` (missing/broken observability)
+- `operator` (control-plane behavior bugs)
+- `bug` (defect rather than docs/question)
+
+## Routing expectations
+
+- `incident` + `runtime` => operator on-call + runtime owners
+- `support` => support responder + module owner
+- `telemetry` => observability owner + affected module owner
+- `operator` => control-plane owner
+
+## Dedupe guidance
+
+Use this grouping key whenever possible:
+
+`{error_signature}|{tenant_id}|{route}|{module}`
+
+If `tenant_id` is unknown, dedupe by `error_signature|route|module` and include uncertainty in notes.
+
+## OSS/private boundary
+
+This repo only defines open intake standards. Future private automation (GitHub Apps, Slack routing, incident tooling) should attach through provider boundaries; do not hard-depend on private services here.
+
+## Automation hooks
+
+- CI validates issue template contracts via `scripts/validate-issue-templates.mjs`.
+- GitHub issue triage helper comments runbook links when `triage`-labeled issues are opened/labeled (`.github/workflows/issue-triage-runbook-comment.yml`).

--- a/docs/ops/observability-error-contract.md
+++ b/docs/ops/observability-error-contract.md
@@ -1,0 +1,42 @@
+# Observability Error Contract
+
+Settler runtime and operator surfaces should emit consistent error metadata for grouping and support handoff.
+
+## Error taxonomy
+
+Shared constants live in:
+
+- `packages/api/src/services/observability/error-taxonomy.ts`
+
+Defined dimensions:
+
+- `category`: authentication, authorization, validation, dependency, throttling, data_integrity, timeout, internal, configuration
+- `severity`: `sev0_critical`, `sev1_high`, `sev2_medium`, `sev3_low`
+- `retryable`: boolean
+
+## Required correlation fields
+
+Every structured error event should include:
+
+- `tenant_id`
+- `run_id` (if run-scoped)
+- `route`
+- `module`
+- `error_signature`
+
+## Signature guidance
+
+Use stable signatures for grouping/fingerprinting:
+
+`{ErrorName}|{Route}|{Module}`
+
+Do not include volatile IDs, timestamps, or user-provided strings in signatures.
+
+## Future Sentry/incident integration
+
+Sentry (or equivalent) integration should map:
+
+- fingerprint => `error_signature`
+- tags => `tenant_id`, `run_id`, `route`, `module`, `category`, `severity`, `retryable`
+
+This contract is additive and does not replace existing telemetry pipelines.

--- a/docs/ops/usage-metering-contract.md
+++ b/docs/ops/usage-metering-contract.md
@@ -1,0 +1,51 @@
+# Usage Metering Contract (Prep)
+
+Usage metering is separate from operational telemetry.
+
+- **Usage metering** answers "how much billable/product usage happened?"
+- **Telemetry** answers "how healthy is the system?"
+
+## Contract location
+
+- `packages/api/src/services/usage/usage-metering-contract.ts`
+
+## Canonical usage events
+
+- `runs_executed`
+- `records_processed`
+- `imports_processed`
+- `replay_runs`
+- `operator_actions`
+- `api_calls`
+
+## Event schema
+
+Required fields:
+
+- `tenant_id`
+- `event_name`
+- `quantity`
+- `occurred_at`
+
+Optional fields:
+
+- `run_id`
+- `metadata`
+
+## Provider boundary
+
+`UsageMeterProvider` exposes provider status:
+
+- `installed`
+- `configured`
+- `unavailable`
+- `unsupported_oss`
+
+`NoopUsageMeterProvider` keeps OSS runtime buildable when billing infrastructure is absent.
+
+Future Stripe/warehouse integrations should implement `UsageMeterProvider` without changing caller contracts.
+
+## Current provider implementation
+
+- `DatabaseUsageMeterProvider` writes validated usage events to `audit_logs` with event `usage_metered` when `USAGE_METER_DB_ENABLED=true`.
+- In default OSS mode, provider status remains `unavailable` and metering is a safe no-op.

--- a/docs/reference/operator-terminology.md
+++ b/docs/reference/operator-terminology.md
@@ -1,0 +1,13 @@
+# Operator Terminology (Canonical)
+
+Use these terms consistently across issues, docs, support, and telemetry contracts.
+
+- **run**: a single reconciliation execution instance.
+- **job**: scheduled or user-triggered unit that may create one or more runs.
+- **replay run**: deterministic re-execution of a prior run.
+- **support issue**: user/operator help request requiring investigation.
+- **incident**: runtime degradation or failure requiring operational triage.
+- **error signature**: stable grouping key (`ErrorName|Route|Module`).
+- **usage event**: contract-level meter event for analytics/billing.
+- **telemetry event**: operational health signal (logs/metrics/traces), not inherently billable.
+- **tenant**: canonical isolation boundary (workspace/org synonyms should map to tenant in technical surfaces).

--- a/docs/runbook/operator-failure-triage.md
+++ b/docs/runbook/operator-failure-triage.md
@@ -1,0 +1,43 @@
+# Operator Runbook: Failed Run + Error Spike Triage
+
+## 1) Inspect failed run
+
+Collect:
+
+- `tenant_id`
+- `run_id`
+- route + module that initiated execution
+- top error message and stack summary
+- trace/correlation identifiers
+
+## 2) Classify quickly
+
+- category (validation/dependency/timeout/internal/etc.)
+- severity (`sev0`..`sev3`)
+- retryable (`true/false`)
+
+Use `error_signature = {ErrorName}|{Route}|{Module}` to group similar failures.
+
+## 3) Check for spike pattern
+
+- Is this isolated to one tenant/run?
+- Is frequency increasing?
+- Are multiple routes/modules affected?
+
+If spike is broad, open a `runtime_error_incident` issue using the structured template.
+
+## 4) Support handoff
+
+If user-impact is present, file or link `support_issue` with:
+
+- same tenant/run correlation fields
+- short customer-safe summary
+- known workaround (if any)
+
+## 5) Capability-gating behavior
+
+If GitHub/Slack/Stripe/private connectors are unavailable:
+
+- mark capability as `unavailable` or `unsupported_oss`
+- do not claim automated routing or billing sync is active
+- keep manual triage path explicit in issue notes

--- a/docs/support/README.md
+++ b/docs/support/README.md
@@ -6,6 +6,7 @@ Use this section for first-response diagnostics before escalation.
 
 - [`api-error-guide.md`](./api-error-guide.md) — interpreting API errors, trace IDs, and tenant failures.
 - [`doctor-and-health-checks.md`](./doctor-and-health-checks.md) — what `settler doctor` and health endpoints validate.
+- [`support-intake-foundation.md`](./support-intake-foundation.md) — structured support payload contract and escalation attachment guidance.
 
 ## Most common questions
 

--- a/docs/support/support-intake-foundation.md
+++ b/docs/support/support-intake-foundation.md
@@ -1,0 +1,48 @@
+# Support Intake Foundation
+
+Support intake is intentionally minimal and contract-first in OSS mode.
+
+## Contract location
+
+- `packages/api/src/services/support/support-intake-contract.ts`
+
+## Required fields
+
+- `tenant_id`
+- `category`
+- `description` (minimum context for investigation)
+
+Optional correlation/context fields:
+
+- `run_id`
+- `route`
+- `module`
+- contact context (`user_id`, `email`, `role`)
+
+## Category set
+
+- `run_failure`
+- `data_mismatch`
+- `import_export`
+- `replay_divergence`
+- `auth_access`
+- `performance`
+- `billing_usage`
+- `docs_other`
+
+## Minimal authenticated endpoint
+
+- `POST /api/v1/support/intake`
+- requires authenticated user context and tenant resolution
+- validates payload against `supportIntakeSubmissionSchema`
+- persists submission to `audit_logs` as `support_intake_submitted` (durable store in OSS mode)
+
+## How to attach evidence later
+
+When wiring private/internal support systems, attach:
+
+1. failing request metadata (`route`, status, trace ID)
+2. run-level telemetry (`run_id`, module logs)
+3. linked GitHub triage issue (if escalation needed)
+
+No fake inbox/ticketing system is provided in OSS mode.

--- a/package.json
+++ b/package.json
@@ -253,7 +253,8 @@
     "verify:reconciliation-runtime": "pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-verify --seed 42 --profile integration --strict",
     "verify:reconciliation:strict": "node scripts/verify-reconciliation-strict.mjs",
     "reconciliation:summary": "node scripts/reconciliation-run-tools.mjs summary test-data/exports/latest",
-    "reconciliation:compare": "node scripts/reconciliation-run-tools.mjs compare test-data/exports/smoke-seed42 test-data/exports/latest"
+    "reconciliation:compare": "node scripts/reconciliation-run-tools.mjs compare test-data/exports/smoke-seed42 test-data/exports/latest",
+    "verify:issue-templates": "node scripts/validate-issue-templates.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/api/src/__tests__/services/operator-foundations-contracts.test.ts
+++ b/packages/api/src/__tests__/services/operator-foundations-contracts.test.ts
@@ -1,0 +1,77 @@
+import {
+  ERROR_CATEGORY,
+  ERROR_SEVERITY,
+  buildErrorObservabilityMetadata,
+  createErrorSignature,
+} from "../../services/observability/error-taxonomy";
+import { supportIntakeSubmissionSchema } from "../../services/support/support-intake-contract";
+import { USAGE_EVENT_NAME, usageEventSchema } from "../../services/usage/usage-metering-contract";
+import { resolveCanonicalUsageEventName } from "../../services/usage/metering";
+import { DatabaseUsageMeterProvider } from "../../services/usage/usage-meter-provider-db";
+
+describe("operator foundations contracts", () => {
+  it("creates a stable error signature", () => {
+    expect(
+      createErrorSignature({
+        errorName: "Validation Error",
+        route: "POST /v1/reconciliation/run",
+        module: "services/reconciliation/runner",
+      })
+    ).toBe("ValidationError|POST /v1/reconciliation/run|services/reconciliation/runner");
+  });
+
+  it("builds required observability metadata", () => {
+    const metadata = buildErrorObservabilityMetadata({
+      tenant_id: "tenant_a",
+      run_id: "run_1",
+      route: "POST /v1/reconciliation/run",
+      module: "services/reconciliation/runner",
+      category: ERROR_CATEGORY.VALIDATION,
+      severity: ERROR_SEVERITY.SEV2,
+      retryable: false,
+      errorName: "ValidationError",
+    });
+
+    expect(metadata.tenant_id).toBe("tenant_a");
+    expect(metadata.retryable).toBe(false);
+    expect(metadata.error_signature).toContain("ValidationError|");
+  });
+
+  it("validates support intake payload", () => {
+    const parsed = supportIntakeSubmissionSchema.parse({
+      tenant_id: "tenant_a",
+      run_id: "run_1",
+      category: "run_failure",
+      description: "Reconciliation run fails after upload validation in production env.",
+      route: "POST /v1/reconciliation/run",
+      module: "services/reconciliation/runner",
+      contact: { email: "operator@example.com" },
+    });
+
+    expect(parsed.category).toBe("run_failure");
+  });
+
+  it("maps legacy metric types to canonical usage events", () => {
+    expect(resolveCanonicalUsageEventName("reconciliations")).toBe("runs_executed");
+    expect(resolveCanonicalUsageEventName("exports")).toBe("imports_processed");
+    expect(resolveCanonicalUsageEventName("unknown_metric")).toBeNull();
+  });
+
+  it("exposes provider capability state for DB usage meter", () => {
+    expect(new DatabaseUsageMeterProvider(true).status).toBe("configured");
+    expect(new DatabaseUsageMeterProvider(false).status).toBe("unavailable");
+  });
+
+  it("validates usage metering payload", () => {
+    const parsed = usageEventSchema.parse({
+      tenant_id: "tenant_a",
+      run_id: "run_1",
+      event_name: USAGE_EVENT_NAME.RUNS_EXECUTED,
+      quantity: 1,
+      occurred_at: new Date().toISOString(),
+      metadata: { route: "POST /v1/reconciliation/run" },
+    });
+
+    expect(parsed.event_name).toBe("runs_executed");
+  });
+});

--- a/packages/api/src/routes/v1/index.ts
+++ b/packages/api/src/routes/v1/index.ts
@@ -30,6 +30,7 @@ import advancedMatchingRulesRouter from "./advanced-matching-rules";
 import customIntegrationsRouter from "./custom-integrations";
 import dedicatedInfrastructureRouter from "./dedicated-infrastructure";
 import automatedReviewRouter from "./automated-review";
+import supportRouter from "./support";
 
 export const v1Router: Router = Router();
 
@@ -51,6 +52,7 @@ v1Router.use("/ingestion", ingestionRouter);
 v1Router.use("/reconciliation", reconciliationRouter);
 v1Router.use("/ingestion/exports", ingestionExportsRouter);
 v1Router.use("/automated-review", automatedReviewRouter);
+v1Router.use("/support", supportRouter);
 
 // Phase 1: Core Features
 v1Router.use("/multi-source-reconciliation", multiSourceReconciliationRouter);

--- a/packages/api/src/routes/v1/support.ts
+++ b/packages/api/src/routes/v1/support.ts
@@ -1,0 +1,70 @@
+import { Router } from "express";
+import { z } from "zod";
+import { tenantMiddleware } from "../../middleware/tenant";
+import { AuthRequest } from "../../middleware/auth";
+import { sendError } from "../../utils/api-response";
+import { handleRouteError } from "../../utils/error-handler";
+import { submitSupportIntake } from "../../services/support/support-intake-service";
+
+const router: Router = Router();
+
+const supportIntakeRequestSchema = z.object({
+  category: z.string().min(1),
+  description: z.string().min(20),
+  run_id: z.string().optional(),
+  route: z.string().optional(),
+  module: z.string().optional(),
+  contact: z
+    .object({
+      user_id: z.string().optional(),
+      email: z.string().email().optional(),
+      role: z.string().optional(),
+    })
+    .optional(),
+});
+
+router.post("/intake", tenantMiddleware, async (req: AuthRequest, res) => {
+  try {
+    if (!req.userId) {
+      return sendError(res, 401, "UNAUTHORIZED", "Authentication required");
+    }
+
+    if (!req.tenantId) {
+      return sendError(res, 403, "TENANT_NOT_FOUND", "Tenant context required");
+    }
+
+    const parseResult = supportIntakeRequestSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendError(
+        res,
+        400,
+        "INVALID_SUPPORT_INTAKE",
+        "Support intake request is invalid",
+        parseResult.error.flatten()
+      );
+    }
+
+    const stored = await submitSupportIntake({
+      userId: req.userId,
+      tenantId: req.tenantId,
+      path: req.originalUrl,
+      body: parseResult.data,
+    });
+
+    return res.status(202).json({
+      accepted: true,
+      submission_id: stored.submissionId,
+      tenant_id: stored.tenantId,
+      created_at: stored.createdAt,
+    });
+  } catch (error) {
+    return handleRouteError(res, error, "Failed to submit support intake", 500, {
+      module: "routes/v1/support",
+      route: `${req.method} ${req.baseUrl}${req.path}`,
+      tenant_id: req.tenantId,
+      run_id: typeof req.body?.run_id === "string" ? req.body.run_id : undefined,
+    });
+  }
+});
+
+export default router;

--- a/packages/api/src/services/observability/error-taxonomy.ts
+++ b/packages/api/src/services/observability/error-taxonomy.ts
@@ -1,0 +1,74 @@
+export const ERROR_CATEGORY = {
+  AUTHENTICATION: "authentication",
+  AUTHORIZATION: "authorization",
+  VALIDATION: "validation",
+  DEPENDENCY: "dependency",
+  THROTTLING: "throttling",
+  DATA_INTEGRITY: "data_integrity",
+  TIMEOUT: "timeout",
+  INTERNAL: "internal",
+  CONFIGURATION: "configuration",
+} as const;
+
+export type ErrorCategory = (typeof ERROR_CATEGORY)[keyof typeof ERROR_CATEGORY];
+
+export const ERROR_SEVERITY = {
+  SEV0: "sev0_critical",
+  SEV1: "sev1_high",
+  SEV2: "sev2_medium",
+  SEV3: "sev3_low",
+} as const;
+
+export type ErrorSeverity = (typeof ERROR_SEVERITY)[keyof typeof ERROR_SEVERITY];
+
+export interface ObservabilityCorrelationFields {
+  tenant_id: string;
+  run_id?: string;
+  route: string;
+  module: string;
+}
+
+export interface ErrorObservabilityMetadata extends ObservabilityCorrelationFields {
+  category: ErrorCategory;
+  severity: ErrorSeverity;
+  retryable: boolean;
+  error_signature: string;
+}
+
+export function createErrorSignature(params: {
+  errorName?: string;
+  route: string;
+  module: string;
+}): string {
+  const normalizedError = (params.errorName || "UnknownError").replace(/\s+/g, "");
+  return `${normalizedError}|${params.route}|${params.module}`;
+}
+
+export function buildErrorObservabilityMetadata(params: {
+  tenant_id: string;
+  run_id?: string;
+  route: string;
+  module: string;
+  category: ErrorCategory;
+  severity: ErrorSeverity;
+  retryable: boolean;
+  errorName?: string;
+  errorSignature?: string;
+}): ErrorObservabilityMetadata {
+  return {
+    tenant_id: params.tenant_id,
+    run_id: params.run_id,
+    route: params.route,
+    module: params.module,
+    category: params.category,
+    severity: params.severity,
+    retryable: params.retryable,
+    error_signature:
+      params.errorSignature ||
+      createErrorSignature({
+        errorName: params.errorName,
+        route: params.route,
+        module: params.module,
+      }),
+  };
+}

--- a/packages/api/src/services/ops-intelligence/runtime-events.ts
+++ b/packages/api/src/services/ops-intelligence/runtime-events.ts
@@ -12,7 +12,8 @@ export type OperatorRuntimeEventType =
   | "import_started"
   | "import_failed"
   | "replay_triggered"
-  | "error_thrown";
+  | "error_thrown"
+  | "support_intake_submitted";
 
 export interface OperatorRuntimeEvent {
   eventType: OperatorRuntimeEventType;

--- a/packages/api/src/services/support/support-intake-contract.ts
+++ b/packages/api/src/services/support/support-intake-contract.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+export const SUPPORT_ISSUE_CATEGORY = {
+  RUN_FAILURE: "run_failure",
+  DATA_MISMATCH: "data_mismatch",
+  IMPORT_EXPORT: "import_export",
+  REPLAY_DIVERGENCE: "replay_divergence",
+  AUTH_ACCESS: "auth_access",
+  PERFORMANCE: "performance",
+  BILLING_USAGE: "billing_usage",
+  DOCS_OTHER: "docs_other",
+} as const;
+
+export type SupportIssueCategory =
+  (typeof SUPPORT_ISSUE_CATEGORY)[keyof typeof SUPPORT_ISSUE_CATEGORY];
+
+export const supportIntakeSubmissionSchema = z.object({
+  tenant_id: z.string().min(1),
+  run_id: z.string().min(1).optional(),
+  category: z.enum([
+    SUPPORT_ISSUE_CATEGORY.RUN_FAILURE,
+    SUPPORT_ISSUE_CATEGORY.DATA_MISMATCH,
+    SUPPORT_ISSUE_CATEGORY.IMPORT_EXPORT,
+    SUPPORT_ISSUE_CATEGORY.REPLAY_DIVERGENCE,
+    SUPPORT_ISSUE_CATEGORY.AUTH_ACCESS,
+    SUPPORT_ISSUE_CATEGORY.PERFORMANCE,
+    SUPPORT_ISSUE_CATEGORY.BILLING_USAGE,
+    SUPPORT_ISSUE_CATEGORY.DOCS_OTHER,
+  ]),
+  description: z.string().min(20).max(5000),
+  route: z.string().min(1).optional(),
+  module: z.string().min(1).optional(),
+  contact: z
+    .object({
+      user_id: z.string().min(1).optional(),
+      email: z.string().email().optional(),
+      role: z.string().min(1).optional(),
+    })
+    .optional(),
+});
+
+export type SupportIntakeSubmission = z.infer<typeof supportIntakeSubmissionSchema>;

--- a/packages/api/src/services/support/support-intake-service.ts
+++ b/packages/api/src/services/support/support-intake-service.ts
@@ -1,0 +1,75 @@
+import crypto from "crypto";
+import { query } from "../../db";
+import { logError } from "../../utils/logger";
+import { supportIntakeSubmissionSchema, SupportIntakeSubmission } from "./support-intake-contract";
+
+export interface StoredSupportIntake {
+  submissionId: string;
+  tenantId: string;
+  createdAt: string;
+}
+
+export async function submitSupportIntake(params: {
+  userId: string;
+  tenantId: string;
+  path: string;
+  body: unknown;
+}): Promise<StoredSupportIntake> {
+  const parsed = supportIntakeSubmissionSchema.parse({
+    ...(typeof params.body === "object" && params.body ? params.body : {}),
+    tenant_id: params.tenantId,
+  });
+
+  const submissionId = crypto.randomUUID();
+
+  try {
+    await persistSupportIntakeToAuditLog({
+      userId: params.userId,
+      tenantId: params.tenantId,
+      path: params.path,
+      submissionId,
+      payload: parsed,
+    });
+  } catch (error) {
+    logError("Failed to persist support intake submission", error, {
+      tenantId: params.tenantId,
+      userId: params.userId,
+      submissionId,
+    });
+    throw error;
+  }
+
+  return {
+    submissionId,
+    tenantId: params.tenantId,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+async function persistSupportIntakeToAuditLog(params: {
+  submissionId: string;
+  userId: string;
+  tenantId: string;
+  path: string;
+  payload: SupportIntakeSubmission;
+}): Promise<void> {
+  await query(
+    `INSERT INTO audit_logs (event, user_id, tenant_id, path, metadata)
+     VALUES ($1, $2, $3, $4, $5::jsonb)`,
+    [
+      "support_intake_submitted",
+      params.userId,
+      params.tenantId,
+      params.path,
+      JSON.stringify({
+        submission_id: params.submissionId,
+        category: params.payload.category,
+        run_id: params.payload.run_id ?? null,
+        route: params.payload.route ?? null,
+        module: params.payload.module ?? null,
+        description: params.payload.description,
+        contact: params.payload.contact ?? {},
+      }),
+    ]
+  );
+}

--- a/packages/api/src/services/usage/index.ts
+++ b/packages/api/src/services/usage/index.ts
@@ -2,4 +2,22 @@
  * Usage Tracking Services Index
  */
 
-export { ReconUsageTracker, type UsageEvent } from './recon-usage-tracker';
+export { ReconUsageTracker, type UsageEvent as LegacyUsageEvent } from "./recon-usage-tracker";
+export {
+  NoopUsageMeterProvider,
+  USAGE_EVENT_NAME,
+  usageEventSchema,
+  type UsageEvent,
+  type UsageEventName,
+  type UsageMeterProvider,
+} from "./usage-metering-contract";
+
+export {
+  DatabaseUsageMeterProvider,
+  createDatabaseUsageMeterProviderFromEnv,
+} from "./usage-meter-provider-db";
+export {
+  meterFromLegacyUsageMetric,
+  meterValidatedUsageEvent,
+  resolveCanonicalUsageEventName,
+} from "./metering";

--- a/packages/api/src/services/usage/metering.ts
+++ b/packages/api/src/services/usage/metering.ts
@@ -1,0 +1,61 @@
+import { logError } from "../../utils/logger";
+import { createDatabaseUsageMeterProviderFromEnv } from "./usage-meter-provider-db";
+import {
+  UsageEvent,
+  USAGE_EVENT_NAME,
+  UsageEventName,
+  usageEventSchema,
+} from "./usage-metering-contract";
+
+const usageMeterProvider = createDatabaseUsageMeterProviderFromEnv();
+
+const LEGACY_METRIC_TO_CANONICAL: Record<string, UsageEventName> = {
+  reconciliations: USAGE_EVENT_NAME.RUNS_EXECUTED,
+  exports: USAGE_EVENT_NAME.IMPORTS_PROCESSED,
+  playground_runs: USAGE_EVENT_NAME.OPERATOR_ACTIONS,
+};
+
+export function resolveCanonicalUsageEventName(metricType: string): UsageEventName | null {
+  return LEGACY_METRIC_TO_CANONICAL[metricType] ?? null;
+}
+
+export async function meterValidatedUsageEvent(event: UsageEvent): Promise<void> {
+  const parsed = usageEventSchema.safeParse(event);
+  if (!parsed.success) {
+    logError("Invalid usage metering event payload", new Error(parsed.error.message), {
+      event,
+    });
+    return;
+  }
+
+  try {
+    await usageMeterProvider.meter(parsed.data);
+  } catch {
+    // metering is non-blocking by contract
+  }
+}
+
+export async function meterFromLegacyUsageMetric(params: {
+  tenantId: string;
+  runId?: string;
+  metricType: string;
+  quantity: number;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  const eventName = resolveCanonicalUsageEventName(params.metricType);
+  if (!eventName) {
+    return;
+  }
+
+  await meterValidatedUsageEvent({
+    tenant_id: params.tenantId,
+    run_id: params.runId,
+    event_name: eventName,
+    quantity: params.quantity,
+    occurred_at: new Date().toISOString(),
+    metadata: {
+      metric_type: params.metricType,
+      ...(params.metadata ?? {}),
+    },
+  });
+}

--- a/packages/api/src/services/usage/tracker.ts
+++ b/packages/api/src/services/usage/tracker.ts
@@ -6,6 +6,7 @@
 import { query } from "../../db";
 import { logInfo } from "../../utils/logger";
 import { trackUsageEvent } from "../analytics/events";
+import { meterFromLegacyUsageMetric } from "./metering";
 
 export interface UsageTracking {
   userId: string;
@@ -42,6 +43,13 @@ export async function trackUsage(
 
     // Also track as analytics event
     await trackUsageEvent(userId, metricType, increment, { tenantId });
+
+    await meterFromLegacyUsageMetric({
+      tenantId,
+      metricType,
+      quantity: increment,
+      metadata: { user_id: userId },
+    });
 
     logInfo("Usage tracked", { userId, tenantId, metricType, increment });
   } catch (error) {

--- a/packages/api/src/services/usage/usage-meter-provider-db.ts
+++ b/packages/api/src/services/usage/usage-meter-provider-db.ts
@@ -1,0 +1,50 @@
+import { query } from "../../db";
+import { logError } from "../../utils/logger";
+import { UsageEvent, UsageMeterProvider } from "./usage-metering-contract";
+
+export class DatabaseUsageMeterProvider implements UsageMeterProvider {
+  readonly providerName = "database_audit_log";
+  readonly status: "configured" | "unavailable";
+
+  constructor(private readonly enabled: boolean) {
+    this.status = enabled ? "configured" : "unavailable";
+  }
+
+  async meter(event: UsageEvent): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+
+    try {
+      await query(
+        `INSERT INTO audit_logs (event, tenant_id, metadata, path)
+         VALUES ($1, $2, $3::jsonb, $4)`,
+        [
+          "usage_metered",
+          event.tenant_id,
+          JSON.stringify({
+            usage_event_name: event.event_name,
+            run_id: event.run_id ?? null,
+            quantity: event.quantity,
+            occurred_at: event.occurred_at,
+            metadata: event.metadata ?? {},
+          }),
+          "/internal/usage-meter",
+        ]
+      );
+    } catch (error) {
+      logError("Failed to persist usage metering event", error, {
+        tenantId: event.tenant_id,
+        eventName: event.event_name,
+      });
+      throw error;
+    }
+  }
+}
+
+export function createDatabaseUsageMeterProviderFromEnv(): DatabaseUsageMeterProvider {
+  const enabled =
+    process.env.USAGE_METER_DB_ENABLED === "1" || process.env.USAGE_METER_DB_ENABLED === "true";
+
+  return new DatabaseUsageMeterProvider(enabled);
+}

--- a/packages/api/src/services/usage/usage-metering-contract.ts
+++ b/packages/api/src/services/usage/usage-metering-contract.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+export const USAGE_EVENT_NAME = {
+  RUNS_EXECUTED: "runs_executed",
+  RECORDS_PROCESSED: "records_processed",
+  IMPORTS_PROCESSED: "imports_processed",
+  REPLAY_RUNS: "replay_runs",
+  OPERATOR_ACTIONS: "operator_actions",
+  API_CALLS: "api_calls",
+} as const;
+
+export type UsageEventName = (typeof USAGE_EVENT_NAME)[keyof typeof USAGE_EVENT_NAME];
+
+export const usageEventSchema = z.object({
+  tenant_id: z.string().min(1),
+  run_id: z.string().optional(),
+  event_name: z.enum([
+    USAGE_EVENT_NAME.RUNS_EXECUTED,
+    USAGE_EVENT_NAME.RECORDS_PROCESSED,
+    USAGE_EVENT_NAME.IMPORTS_PROCESSED,
+    USAGE_EVENT_NAME.REPLAY_RUNS,
+    USAGE_EVENT_NAME.OPERATOR_ACTIONS,
+    USAGE_EVENT_NAME.API_CALLS,
+  ]),
+  quantity: z.number().nonnegative(),
+  occurred_at: z.string().datetime(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type UsageEvent = z.infer<typeof usageEventSchema>;
+
+export interface UsageMeterProvider {
+  readonly providerName: string;
+  readonly status: "installed" | "configured" | "unavailable" | "unsupported_oss";
+  meter(event: UsageEvent): Promise<void>;
+}
+
+export class NoopUsageMeterProvider implements UsageMeterProvider {
+  readonly providerName = "noop";
+  readonly status = "unavailable" as const;
+
+  async meter(_event: UsageEvent): Promise<void> {
+    return;
+  }
+}

--- a/packages/api/src/utils/error-handler.ts
+++ b/packages/api/src/utils/error-handler.ts
@@ -7,9 +7,21 @@ import { Response } from "express";
 import { sendError } from "./api-response";
 import { logError } from "./logger";
 import { isApiError, toApiError } from "./typed-errors";
+import {
+  buildErrorObservabilityMetadata,
+  ERROR_CATEGORY,
+  ERROR_SEVERITY,
+  ErrorCategory,
+  ErrorSeverity,
+} from "../services/observability/error-taxonomy";
+import { emitOperatorRuntimeEvent } from "../services/ops-intelligence/runtime-events";
 
 interface RequestWithTraceId {
   traceId?: string;
+  tenantId?: string;
+  method?: string;
+  route?: { path?: string };
+  originalUrl?: string;
 }
 
 /**
@@ -61,19 +73,109 @@ export function handleRouteError(
   res: Response,
   error: unknown,
   defaultMessage: string = "An error occurred",
-  _defaultStatusCode: number = 500,
+  defaultStatusCode: number = 500,
   context?: Record<string, unknown>
 ): void {
   const apiError = toApiError(error);
   const message = apiError.message || defaultMessage;
-  const statusCode = apiError.statusCode ?? _defaultStatusCode;
+  const statusCode = apiError.statusCode ?? defaultStatusCode;
   const errorCode = apiError.errorCode || "INTERNAL_ERROR";
   const details = apiError.details;
 
   logError(defaultMessage, error, context);
 
+  emitStructuredRouteError(res, error, statusCode, context);
+
   // Extract traceId from request if available
   const traceId = (res.req as RequestWithTraceId).traceId;
 
   sendError(res, statusCode, errorCode, message, details, traceId);
+}
+
+function emitStructuredRouteError(
+  res: Response,
+  error: unknown,
+  statusCode: number,
+  context?: Record<string, unknown>
+): void {
+  const req = res.req as RequestWithTraceId;
+  const tenantId = typeof context?.tenant_id === "string" ? context.tenant_id : req.tenantId;
+  if (!tenantId) {
+    return;
+  }
+
+  const routePath = typeof context?.route === "string" ? context.route : deriveRoute(req);
+  const moduleName = typeof context?.module === "string" ? context.module : "routes/unknown-module";
+
+  const { category, severity, retryable } = classifyStatusCode(statusCode);
+  const metadata = buildErrorObservabilityMetadata({
+    tenant_id: tenantId,
+    run_id: typeof context?.run_id === "string" ? context.run_id : undefined,
+    route: routePath,
+    module: moduleName,
+    category,
+    severity,
+    retryable,
+    errorName: error instanceof Error ? error.name : "RouteError",
+  });
+
+  void emitOperatorRuntimeEvent({
+    eventType: "error_thrown",
+    tenantId,
+    runId: metadata.run_id,
+    metadata: {
+      ...metadata,
+      status_code: statusCode,
+    },
+  });
+}
+
+function deriveRoute(req: RequestWithTraceId): string {
+  const method = req.method || "UNKNOWN";
+  const route = req.route?.path || req.originalUrl || "unknown_route";
+  return `${method} ${route}`;
+}
+
+function classifyStatusCode(statusCode: number): {
+  category: ErrorCategory;
+  severity: ErrorSeverity;
+  retryable: boolean;
+} {
+  if (statusCode >= 500) {
+    return {
+      category: ERROR_CATEGORY.INTERNAL,
+      severity: ERROR_SEVERITY.SEV1,
+      retryable: true,
+    };
+  }
+
+  if (statusCode === 429) {
+    return {
+      category: ERROR_CATEGORY.THROTTLING,
+      severity: ERROR_SEVERITY.SEV2,
+      retryable: true,
+    };
+  }
+
+  if (statusCode === 401) {
+    return {
+      category: ERROR_CATEGORY.AUTHENTICATION,
+      severity: ERROR_SEVERITY.SEV3,
+      retryable: false,
+    };
+  }
+
+  if (statusCode === 403) {
+    return {
+      category: ERROR_CATEGORY.AUTHORIZATION,
+      severity: ERROR_SEVERITY.SEV3,
+      retryable: false,
+    };
+  }
+
+  return {
+    category: ERROR_CATEGORY.VALIDATION,
+    severity: ERROR_SEVERITY.SEV3,
+    retryable: false,
+  };
 }

--- a/scripts/validate-issue-templates.mjs
+++ b/scripts/validate-issue-templates.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const ISSUE_TEMPLATE_DIR = path.join(process.cwd(), ".github", "ISSUE_TEMPLATE");
+
+const REQUIRED_FILES = [
+  "runtime_error_incident.yml",
+  "support_issue.yml",
+  "telemetry_regression.yml",
+  "operator_control_plane_bug.yml",
+];
+
+const REQUIRED_RUNTIME_FIELDS = ["tenant_id", "route_module", "severity", "error_signature"];
+const REQUIRED_SUPPORT_FIELDS = ["tenant_id", "category", "description", "triage_snapshot"];
+const REQUIRED_SEVERITIES = ["sev0_critical", "sev1_high", "sev2_medium", "sev3_low"];
+
+function assertIncludes(fileName, content, token) {
+  if (!content.includes(token)) {
+    throw new Error(`${fileName} missing required token: ${token}`);
+  }
+}
+
+function validateFileExists(fileName) {
+  const filePath = path.join(ISSUE_TEMPLATE_DIR, fileName);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing issue template file: ${fileName}`);
+  }
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function main() {
+  for (const file of REQUIRED_FILES) {
+    validateFileExists(file);
+  }
+
+  const runtimeTemplate = validateFileExists("runtime_error_incident.yml");
+  const supportTemplate = validateFileExists("support_issue.yml");
+
+  for (const field of REQUIRED_RUNTIME_FIELDS) {
+    assertIncludes("runtime_error_incident.yml", runtimeTemplate, `id: ${field}`);
+  }
+
+  for (const severity of REQUIRED_SEVERITIES) {
+    assertIncludes("runtime_error_incident.yml", runtimeTemplate, `- ${severity}`);
+  }
+
+  for (const field of REQUIRED_SUPPORT_FIELDS) {
+    assertIncludes("support_issue.yml", supportTemplate, `id: ${field}`);
+  }
+
+  console.log("Issue template contracts validated.");
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
### Motivation

- Provide automation-friendly, structured issue intake for runtime incidents, support requests, telemetry regressions, and operator/control-plane bugs.  
- Establish lightweight OSS contracts for observability, support intake, and usage metering to enable consistent grouping, routing, and downstream automation.  
- Surface runtime/operator events and enrich error handling so incidents and errors are recorded with stable signatures and correlation fields.  

### Description

- Add GitHub issue templates under `.github/ISSUE_TEMPLATE/` (`runtime_error_incident.yml`, `support_issue.yml`, `telemetry_regression.yml`, `operator_control_plane_bug.yml`) and a template `config.yml` with contact links.  
- Add CI validation for templates via `scripts/validate-issue-templates.mjs` and a workflow `/.github/workflows/issue-template-contracts.yml`, and wire up an npm script `verify:issue-templates`.  
- Add triage helper workflow `/.github/workflows/issue-triage-runbook-comment.yml` to comment runbook links when `triage`-labeled issues are opened/labeled.  
- Add operational docs and runbooks under `docs/ops/` and `docs/support/` describing triage routing, observability error contract, usage metering contract, and support intake guidance.  
- Implement observability primitives: `packages/api/src/services/observability/error-taxonomy.ts` with `createErrorSignature` and `buildErrorObservabilityMetadata`, and integrate structured error emission in `utils/error-handler.ts` to emit operator runtime events on route errors.  
- Add operator runtime events type extension and event emitter usage in `packages/api/src/services/ops-intelligence/runtime-events.ts`.  
- Implement support intake API and backend: `routes/v1/support.ts`, `services/support/support-intake-contract.ts`, and `services/support/support-intake-service.ts`, which validate payloads and persist submissions to `audit_logs`.  
- Add usage metering contracts and provider implementations: `usage/usage-metering-contract.ts`, `usage/usage-meter-provider-db.ts`, `usage/metering.ts`, and integrate legacy metric mapping in `usage/tracker.ts` and exports in `usage/index.ts`.  
- Add unit tests `packages/api/src/__tests__/services/operator-foundations-contracts.test.ts` validating signature creation, observability metadata, support intake schema, usage event mapping, and DB provider status.  

### Testing

- Ran the new unit test file `packages/api/src/__tests__/services/operator-foundations-contracts.test.ts` via the repository test suite and the tests passed.  
- Added a CI job `Issue Template Contracts` that runs `node scripts/validate-issue-templates.mjs` to validate presence and fields of the issue templates; this script is included and will fail CI if templates are missing or malformed.  
- Manual smoke checks: the support intake route and usage metering code are structured to be non-blocking when DB/provider is disabled, and the `DatabaseUsageMeterProvider` exposes `status` for guarded runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af81a2e0b883288529227e08729c92)