### PR TITLE
Harden OSS/private operator-intelligence boundaries with capability registry

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -34,3 +34,19 @@ pnpm --filter @settler/api test:tenant-safety
 
 - Stable core: health/metrics, middleware chain, v1 operational APIs.
 - Strategic/internal expansion: much of v2 surface.
+
+## OSS/private capability boundary
+
+The API now uses a capability registry to separate OSS-safe runtime behavior from optional private providers.
+
+- `services/capabilities/registry.ts` is the single loader/registry for optional capabilities.
+- OSS core **must not** hard-import private modules. Private providers are loaded only through `SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE` dynamic import.
+- Operator intelligence endpoints (`/api/v1/operator/intelligence/*`, `/platform-control-plane/*`) always return truthful capability metadata.
+- If optional storage or provider dependencies are absent, these endpoints degrade safely with deterministic empty datasets and capability state `unavailable` instead of hard 500s.
+- Capability inventory is exposed at `GET /api/v1/capabilities`.
+
+Boundary rule of thumb:
+
+1. Core reconciliation, auth, tenancy, safety invariants stay in OSS runtime.
+2. Enterprise-only modules attach via provider interfaces in `services/capabilities/providers/*`.
+3. Routes must gate behavior from provider status and expose machine-readable capability truth.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -43,7 +43,8 @@ The API now uses a capability registry to separate OSS-safe runtime behavior fro
 - OSS core **must not** hard-import private modules. Private providers are loaded only through `SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE` dynamic import.
 - Operator intelligence endpoints (`/api/v1/operator/intelligence/*`, `/platform-control-plane/*`) always return truthful capability metadata.
 - If optional storage or provider dependencies are absent, these endpoints degrade safely with deterministic empty datasets and capability state `unavailable` instead of hard 500s.
-- Capability inventory is exposed at `GET /api/v1/capabilities`.
+- Capability inventory is exposed at `GET /api/v1/capabilities` with role/scope projection at `GET /api/v1/capabilities/projected`.
+- Capability state observations are emitted to `capability_status_observed_total` Prometheus metric for operator observability.
 
 Boundary rule of thumb:
 

--- a/packages/api/src/__tests__/integration/capability-route-degradation.test.ts
+++ b/packages/api/src/__tests__/integration/capability-route-degradation.test.ts
@@ -1,0 +1,147 @@
+import express from "express";
+import request from "supertest";
+import operatorIntelligenceRouter from "../../routes/v1/operator-intelligence";
+import { platformControlPlaneRouter } from "../../routes/platform-control-plane";
+import capabilitiesRouter from "../../routes/v1/capabilities";
+
+jest.mock("../../middleware/authorization", () => ({
+  requirePermission:
+    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
+}));
+
+jest.mock("../../middleware/validation", () => ({
+  validateRequest:
+    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
+}));
+
+jest.mock("../../services/capabilities/registry", () => ({
+  getOperatorIntelligenceProvider: jest.fn(),
+  getUnavailableOperatorIntelligenceProvider: jest.fn(),
+  getCapabilityRegistry: jest.fn(),
+  getEnterpriseAnalyticsProvider: jest.fn(() => ({
+    status: () => ({
+      key: "enterprise_analytics",
+      state: "degraded",
+      available: true,
+      source: "oss",
+    }),
+  })),
+}));
+
+jest.mock("../../db", () => ({
+  query: jest.fn(),
+}));
+
+const registry = jest.requireMock("../../services/capabilities/registry") as {
+  getOperatorIntelligenceProvider: jest.Mock;
+  getUnavailableOperatorIntelligenceProvider: jest.Mock;
+  getCapabilityRegistry: jest.Mock;
+};
+
+const db = jest.requireMock("../../db") as {
+  query: jest.Mock;
+};
+
+describe("capability route degradation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function withTenant(app: express.Express): express.Express {
+    app.use((req, _res, next) => {
+      (req as any).tenantId = "tenant-1";
+      (req as any).userId = "user-1";
+      next();
+    });
+    return app;
+  }
+
+  it("degrades operator intelligence route when optional tables are absent", async () => {
+    const providerError = Object.assign(new Error("relation does not exist"), { code: "42P01" });
+    registry.getOperatorIntelligenceProvider.mockResolvedValue({
+      getSystemHealthSnapshot: jest.fn().mockRejectedValue(providerError),
+      status: () => ({
+        key: "operator_intelligence",
+        state: "available",
+        available: true,
+        source: "oss",
+      }),
+    });
+    registry.getUnavailableOperatorIntelligenceProvider.mockReturnValue({
+      getSystemHealthSnapshot: jest.fn().mockResolvedValue({ runsPerDay: 0, errorRate: 0 }),
+      status: () => ({
+        key: "operator_intelligence",
+        state: "unavailable",
+        available: false,
+        source: "oss",
+      }),
+    });
+
+    const app = withTenant(express());
+    app.use(operatorIntelligenceRouter);
+
+    const response = await request(app).get("/operator/intelligence/system-health");
+
+    expect(response.status).toBe(200);
+    expect(response.body.capability.state).toBe("unavailable");
+  });
+
+  it("degrades platform control plane route when optional tables are absent", async () => {
+    const providerError = Object.assign(new Error("relation does not exist"), { code: "42P01" });
+    registry.getOperatorIntelligenceProvider.mockResolvedValue({
+      getPlatformOverview: jest.fn().mockRejectedValue(providerError),
+      status: () => ({
+        key: "operator_intelligence",
+        state: "available",
+        available: true,
+        source: "oss",
+      }),
+    });
+    registry.getUnavailableOperatorIntelligenceProvider.mockReturnValue({
+      getPlatformOverview: jest
+        .fn()
+        .mockResolvedValue({
+          telemetry: {},
+          analytics: {},
+          costs: {},
+          autonomousOperations: {},
+          leaderboard: [],
+        }),
+      status: () => ({
+        key: "operator_intelligence",
+        state: "unavailable",
+        available: false,
+        source: "oss",
+      }),
+    });
+
+    const app = withTenant(express());
+    app.use(platformControlPlaneRouter);
+
+    const response = await request(app).get("/platform-control-plane/overview");
+
+    expect(response.status).toBe(200);
+    expect(response.body.capability.operatorIntelligence.state).toBe("unavailable");
+  });
+
+  it("projects capabilities by role/scope for consumers", async () => {
+    registry.getCapabilityRegistry.mockResolvedValue({
+      list: () => [
+        { key: "operator_intelligence", state: "available", available: true, source: "oss" },
+        { key: "support_intake", state: "available", available: true, source: "oss" },
+      ],
+    });
+    db.query.mockResolvedValueOnce([{ role: "viewer" }]);
+
+    const app = withTenant(express());
+    app.use(capabilitiesRouter);
+
+    const response = await request(app).get("/capabilities/projected");
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toHaveLength(1);
+    expect(response.body.data[0].key).toBe("support_intake");
+  });
+});

--- a/packages/api/src/routes/feedback.ts
+++ b/packages/api/src/routes/feedback.ts
@@ -11,20 +11,32 @@ import { requirePermission } from "../middleware/authorization";
 import { Permission } from "../infrastructure/security/Permissions";
 import { query } from "../db";
 import { handleRouteError } from "../utils/error-handler";
+import { getSupportIntakeProvider } from "../services/capabilities/registry";
+import { observeCapabilityStatus } from "../services/capabilities/telemetry";
+import { isMissingOptionalCapabilityDependency } from "../services/capabilities/errors";
 import { trackEventAsync } from "../utils/event-tracker";
 
 const router: Router = Router();
 
 const createFeedbackSchema = z.object({
   body: z.object({
-    source: z.enum(["sales_call", "user_interview", "support_ticket", "github_issue", "community", "survey"]),
+    source: z.enum([
+      "sales_call",
+      "user_interview",
+      "support_ticket",
+      "github_issue",
+      "community",
+      "survey",
+    ]),
     persona: z.enum(["cto", "cfo", "finance_ops", "developer"]).optional(),
     company: z.string().max(255).optional(),
-    context: z.object({
-      stage: z.enum(["evaluating", "onboarding", "active", "churned"]).optional(),
-      useCase: z.string().optional(),
-      transactionVolume: z.string().optional(),
-    }).optional(),
+    context: z
+      .object({
+        stage: z.enum(["evaluating", "onboarding", "active", "churned"]).optional(),
+        useCase: z.string().optional(),
+        transactionVolume: z.string().optional(),
+      })
+      .optional(),
     pain: z.object({
       description: z.string().min(1),
       severity: z.enum(["high", "medium", "low"]),
@@ -34,16 +46,22 @@ const createFeedbackSchema = z.object({
       description: z.string().min(1),
       successMetric: z.string().optional(),
     }),
-    workaround: z.object({
-      description: z.string(),
-      painPoints: z.array(z.string()),
-    }).optional(),
+    workaround: z
+      .object({
+        description: z.string(),
+        painPoints: z.array(z.string()),
+      })
+      .optional(),
     quotes: z.array(z.string()).optional(),
-    featureRequests: z.array(z.object({
-      feature: z.string(),
-      priority: z.enum(["high", "medium", "low"]),
-      rationale: z.string(),
-    })).optional(),
+    featureRequests: z
+      .array(
+        z.object({
+          feature: z.string(),
+          priority: z.enum(["high", "medium", "low"]),
+          rationale: z.string(),
+        })
+      )
+      .optional(),
     tags: z.array(z.string()).optional(),
   }),
 });
@@ -68,6 +86,7 @@ router.post(
     try {
       const userId = req.userId!;
       const feedback = req.body;
+      const provider = getSupportIntakeProvider();
 
       const result = await query<{ id: string }>(
         `INSERT INTO feedback (
@@ -92,23 +111,39 @@ router.post(
       );
 
       if (!result[0]) {
-        throw new Error('Failed to create feedback');
+        throw new Error("Failed to create feedback");
       }
 
       // Track event
-      trackEventAsync(userId, 'FeedbackCreated', {
+      trackEventAsync(userId, "FeedbackCreated", {
         feedbackId: result[0].id,
         source: feedback.source,
         persona: feedback.persona,
       });
 
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/feedback");
       res.status(201).json({
         data: {
           id: result[0].id,
         },
+        capability,
         message: "Feedback created successfully",
       });
     } catch (error: unknown) {
+      if (isMissingOptionalCapabilityDependency(error)) {
+        const capability = {
+          ...getSupportIntakeProvider().status(),
+          state: "unavailable" as const,
+          available: false,
+          reason: "Support intake storage is not configured in this OSS deployment",
+        };
+        observeCapabilityStatus(capability, "/feedback");
+        res
+          .status(200)
+          .json({ data: null, capability, message: "Support intake capability unavailable" });
+        return;
+      }
       handleRouteError(res, error, "Failed to create feedback", 500, { userId: req.userId });
     }
   }
@@ -122,6 +157,7 @@ router.get(
   async (req: AuthRequest, res: Response) => {
     try {
       const userId = req.userId!;
+      const provider = getSupportIntakeProvider();
       const queryParams = listFeedbackSchema.parse({ query: req.query });
       const { persona, source, startDate, endDate, limit, offset } = queryParams.query;
 
@@ -153,7 +189,7 @@ router.get(
         values.push(new Date(endDate));
       }
 
-      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
       const feedback = await query<{
         id: string;
@@ -185,28 +221,33 @@ router.get(
       );
 
       if (!countResult[0]) {
-        throw new Error('Failed to get feedback count');
+        throw new Error("Failed to get feedback count");
       }
       const total = parseInt(countResult[0].count);
 
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/feedback");
       res.json({
-        data: feedback.map((f) => {
-          if (!f) return null;
-          return {
-            id: f.id,
-            source: f.source,
-            persona: f.persona,
-            company: f.company,
-            context: f.context,
-            pain: f.pain,
-            desiredOutcome: f.desired_outcome,
-            workaround: f.workaround,
-            quotes: f.quotes,
-            featureRequests: f.feature_requests,
-            tags: f.tags,
-            createdAt: f.created_at.toISOString(),
-          };
-        }).filter((f) => f !== null),
+        data: feedback
+          .map((f) => {
+            if (!f) return null;
+            return {
+              id: f.id,
+              source: f.source,
+              persona: f.persona,
+              company: f.company,
+              context: f.context,
+              pain: f.pain,
+              desiredOutcome: f.desired_outcome,
+              workaround: f.workaround,
+              quotes: f.quotes,
+              featureRequests: f.feature_requests,
+              tags: f.tags,
+              createdAt: f.created_at.toISOString(),
+            };
+          })
+          .filter((f) => f !== null),
+        capability,
         pagination: {
           limit,
           offset,
@@ -215,6 +256,23 @@ router.get(
         },
       });
     } catch (error: unknown) {
+      if (isMissingOptionalCapabilityDependency(error)) {
+        const capability = {
+          ...getSupportIntakeProvider().status(),
+          state: "unavailable" as const,
+          available: false,
+          reason: "Support intake storage is not configured in this OSS deployment",
+        };
+        observeCapabilityStatus(capability, "/feedback");
+        res
+          .status(200)
+          .json({
+            data: [],
+            capability,
+            pagination: { limit: 0, offset: 0, total: 0, totalPages: 0 },
+          });
+        return;
+      }
       handleRouteError(res, error, "Failed to list feedback", 500, { userId: req.userId });
     }
   }
@@ -232,7 +290,9 @@ router.get(
         endDate?: string;
       };
 
-      const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const start = startDate
+        ? new Date(startDate)
+        : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
       // Top pains by frequency
@@ -282,12 +342,12 @@ router.get(
 
       res.json({
         data: {
-          topPains: topPains.map(p => ({
+          topPains: topPains.map((p) => ({
             description: p.pain_description,
             count: parseInt(p.count),
             avgSeverity: parseFloat(p.avg_severity),
           })),
-          topFeatureRequests: topFeatureRequests.map(f => ({
+          topFeatureRequests: topFeatureRequests.map((f) => ({
             feature: f.feature,
             count: parseInt(f.count),
             avgPriority: parseFloat(f.avg_priority),

--- a/packages/api/src/routes/platform-control-plane.ts
+++ b/packages/api/src/routes/platform-control-plane.ts
@@ -2,10 +2,12 @@ import { Router, Response } from "express";
 import { AuthRequest } from "../middleware/auth";
 import { handleRouteError } from "../utils/error-handler";
 import {
+  getEnterpriseAnalyticsProvider,
   getOperatorIntelligenceProvider,
   getUnavailableOperatorIntelligenceProvider,
 } from "../services/capabilities/registry";
 import { isMissingOptionalCapabilityDependency } from "../services/capabilities/errors";
+import { observeCapabilityStatus } from "../services/capabilities/telemetry";
 
 export const platformControlPlaneRouter: Router = Router();
 
@@ -24,14 +26,19 @@ platformControlPlaneRouter.get(
     try {
       const days = Number(req.query.days || 7);
       const provider = await getOperatorIntelligenceProvider();
+      const analyticsCapability = getEnterpriseAnalyticsProvider().status();
       const overview = await provider.getPlatformOverview(
         tenantId,
         Number.isFinite(days) ? Math.max(1, days) : 7
       );
 
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/platform-control-plane/overview");
+      observeCapabilityStatus(analyticsCapability, "/platform-control-plane/overview");
+
       res.json({
         data: overview,
-        capability: provider.status(),
+        capability: { operatorIntelligence: capability, enterpriseAnalytics: analyticsCapability },
         metadata: {
           tenantId,
           generatedAt: new Date().toISOString(),
@@ -42,9 +49,16 @@ platformControlPlaneRouter.get(
         const provider = getUnavailableOperatorIntelligenceProvider(
           "Operator intelligence storage tables are not present in OSS mode"
         );
+        const capability = provider.status();
+        const analyticsCapability = getEnterpriseAnalyticsProvider().status();
+        observeCapabilityStatus(capability, "/platform-control-plane/overview");
+        observeCapabilityStatus(analyticsCapability, "/platform-control-plane/overview");
         res.status(200).json({
           data: await provider.getPlatformOverview(tenantId, 7),
-          capability: provider.status(),
+          capability: {
+            operatorIntelligence: capability,
+            enterpriseAnalytics: analyticsCapability,
+          },
           metadata: { tenantId, generatedAt: new Date().toISOString() },
         });
         return;
@@ -73,6 +87,7 @@ platformControlPlaneRouter.get(
       const format = (req.query.format as string) || "json";
       const days = Number(req.query.days || 30);
       const provider = await getOperatorIntelligenceProvider();
+      const analyticsCapability = getEnterpriseAnalyticsProvider().status();
       const telemetry = await provider.getTelemetryForExport(
         tenantId,
         Number.isFinite(days) ? Math.max(1, days) : 30
@@ -117,13 +132,18 @@ platformControlPlaneRouter.get(
           "Content-Disposition",
           `attachment; filename=tenant-${tenantId}-telemetry.csv`
         );
+        observeCapabilityStatus(provider.status(), "/platform-control-plane/analytics/export");
+        observeCapabilityStatus(analyticsCapability, "/platform-control-plane/analytics/export");
         res.send(csv);
         return;
       }
 
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/platform-control-plane/analytics/export");
+      observeCapabilityStatus(analyticsCapability, "/platform-control-plane/analytics/export");
       res.json({
         data: telemetry,
-        capability: provider.status(),
+        capability: { operatorIntelligence: capability, enterpriseAnalytics: analyticsCapability },
         metadata: {
           tenantId,
           count: telemetry.length,
@@ -135,9 +155,16 @@ platformControlPlaneRouter.get(
         const provider = getUnavailableOperatorIntelligenceProvider(
           "Operator intelligence storage tables are not present in OSS mode"
         );
+        const capability = provider.status();
+        const analyticsCapability = getEnterpriseAnalyticsProvider().status();
+        observeCapabilityStatus(capability, "/platform-control-plane/analytics/export");
+        observeCapabilityStatus(analyticsCapability, "/platform-control-plane/analytics/export");
         res.status(200).json({
           data: await provider.getTelemetryForExport(tenantId, 30),
-          capability: provider.status(),
+          capability: {
+            operatorIntelligence: capability,
+            enterpriseAnalytics: analyticsCapability,
+          },
           metadata: { tenantId, count: 0, generatedAt: new Date().toISOString() },
         });
         return;

--- a/packages/api/src/routes/platform-control-plane.ts
+++ b/packages/api/src/routes/platform-control-plane.ts
@@ -2,9 +2,10 @@ import { Router, Response } from "express";
 import { AuthRequest } from "../middleware/auth";
 import { handleRouteError } from "../utils/error-handler";
 import {
-  buildPlatformOverview,
-  loadTenantTelemetry,
-} from "../services/ops-intelligence/control-plane-analytics";
+  getOperatorIntelligenceProvider,
+  getUnavailableOperatorIntelligenceProvider,
+} from "../services/capabilities/registry";
+import { isMissingOptionalCapabilityDependency } from "../services/capabilities/errors";
 
 export const platformControlPlaneRouter: Router = Router();
 
@@ -22,21 +23,33 @@ platformControlPlaneRouter.get(
 
     try {
       const days = Number(req.query.days || 7);
-      const telemetry = await loadTenantTelemetry(
+      const provider = await getOperatorIntelligenceProvider();
+      const overview = await provider.getPlatformOverview(
         tenantId,
         Number.isFinite(days) ? Math.max(1, days) : 7
       );
-      const overview = buildPlatformOverview(telemetry);
 
       res.json({
         data: overview,
+        capability: provider.status(),
         metadata: {
           tenantId,
-          recordCount: telemetry.length,
           generatedAt: new Date().toISOString(),
         },
       });
     } catch (error) {
+      if (isMissingOptionalCapabilityDependency(error)) {
+        const provider = getUnavailableOperatorIntelligenceProvider(
+          "Operator intelligence storage tables are not present in OSS mode"
+        );
+        res.status(200).json({
+          data: await provider.getPlatformOverview(tenantId, 7),
+          capability: provider.status(),
+          metadata: { tenantId, generatedAt: new Date().toISOString() },
+        });
+        return;
+      }
+
       handleRouteError(res, error, "Failed to load platform control plane overview", 500, {
         tenantId,
         userId: req.userId,
@@ -59,7 +72,8 @@ platformControlPlaneRouter.get(
     try {
       const format = (req.query.format as string) || "json";
       const days = Number(req.query.days || 30);
-      const telemetry = await loadTenantTelemetry(
+      const provider = await getOperatorIntelligenceProvider();
+      const telemetry = await provider.getTelemetryForExport(
         tenantId,
         Number.isFinite(days) ? Math.max(1, days) : 30
       );
@@ -109,6 +123,7 @@ platformControlPlaneRouter.get(
 
       res.json({
         data: telemetry,
+        capability: provider.status(),
         metadata: {
           tenantId,
           count: telemetry.length,
@@ -116,6 +131,18 @@ platformControlPlaneRouter.get(
         },
       });
     } catch (error) {
+      if (isMissingOptionalCapabilityDependency(error)) {
+        const provider = getUnavailableOperatorIntelligenceProvider(
+          "Operator intelligence storage tables are not present in OSS mode"
+        );
+        res.status(200).json({
+          data: await provider.getTelemetryForExport(tenantId, 30),
+          capability: provider.status(),
+          metadata: { tenantId, count: 0, generatedAt: new Date().toISOString() },
+        });
+        return;
+      }
+
       handleRouteError(res, error, "Failed to export analytics dataset", 500, {
         tenantId,
         userId: req.userId,

--- a/packages/api/src/routes/v1/capabilities.ts
+++ b/packages/api/src/routes/v1/capabilities.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import { getCapabilityRegistry } from "../../services/capabilities/registry";
+import { handleRouteError } from "../../utils/error-handler";
+
+const router: Router = Router();
+
+router.get("/capabilities", async (_req, res) => {
+  try {
+    const registry = await getCapabilityRegistry();
+    res.json({ data: registry.list() });
+  } catch (error) {
+    return handleRouteError(res, error, "Failed to load capability registry", 500);
+  }
+});
+
+export default router;

--- a/packages/api/src/routes/v1/capabilities.ts
+++ b/packages/api/src/routes/v1/capabilities.ts
@@ -1,15 +1,93 @@
-import { Router } from "express";
+import { Router, Response } from "express";
+import { query } from "../../db";
+import type { AuthRequest } from "../../middleware/auth";
+import { UserRole } from "../../domain/entities/User";
+import { Permission, PermissionChecker } from "../../infrastructure/security/Permissions";
 import { getCapabilityRegistry } from "../../services/capabilities/registry";
+import { observeCapabilityStatus } from "../../services/capabilities/telemetry";
+import type { CapabilityStatus } from "../../services/capabilities/types";
 import { handleRouteError } from "../../utils/error-handler";
 
 const router: Router = Router();
 
+const capabilityPermissionMap: Record<string, Permission[]> = {
+  operator_intelligence: [Permission.ADMIN_READ],
+  alert_routing: [Permission.ADMIN_READ],
+  usage_metering: [Permission.ADMIN_READ],
+  enterprise_analytics: [Permission.ADMIN_READ],
+  enterprise_surface: [Permission.ADMIN_READ],
+  support_intake: [Permission.USERS_READ],
+};
+
+async function resolveRequestPermissions(
+  req: AuthRequest
+): Promise<{ role: UserRole; scopes: string[] }> {
+  const scopes: string[] = [];
+
+  if (req.apiKeyId) {
+    const apiKeyRows = await query<{ scopes: string[] | null }>(
+      `SELECT scopes FROM api_keys WHERE id = $1`,
+      [req.apiKeyId]
+    );
+    scopes.push(...(apiKeyRows[0]?.scopes ?? []));
+  }
+
+  if (!req.userId) {
+    return { role: UserRole.VIEWER, scopes };
+  }
+
+  const userRows = await query<{ role: string }>(`SELECT role FROM users WHERE id = $1`, [
+    req.userId,
+  ]);
+  const roleValue = userRows[0]?.role;
+  const role = Object.values(UserRole).includes(roleValue as UserRole)
+    ? (roleValue as UserRole)
+    : UserRole.VIEWER;
+
+  return { role, scopes };
+}
+
+function isCapabilityVisible(status: CapabilityStatus, role: UserRole, scopes: string[]): boolean {
+  const requiredPermissions = capabilityPermissionMap[status.key] ?? [Permission.USERS_READ];
+  return PermissionChecker.hasAnyPermission(role, scopes, requiredPermissions);
+}
+
 router.get("/capabilities", async (_req, res) => {
   try {
     const registry = await getCapabilityRegistry();
-    res.json({ data: registry.list() });
+    const data = registry.list();
+    data.forEach((status) => observeCapabilityStatus(status, "/api/v1/capabilities"));
+    res.json({ data });
   } catch (error) {
     return handleRouteError(res, error, "Failed to load capability registry", 500);
+  }
+});
+
+router.get("/capabilities/projected", async (req: AuthRequest, res: Response) => {
+  try {
+    const registry = await getCapabilityRegistry();
+    const { role, scopes } = await resolveRequestPermissions(req);
+    const projected = registry
+      .list()
+      .filter((status) => isCapabilityVisible(status, role, scopes))
+      .map((status) => ({ ...status, visible: true }));
+
+    projected.forEach((status) =>
+      observeCapabilityStatus(status, "/api/v1/capabilities/projected")
+    );
+
+    res.json({
+      data: projected,
+      metadata: {
+        role,
+        scopeCount: scopes.length,
+      },
+    });
+  } catch (error) {
+    return handleRouteError(res, error, "Failed to load projected capabilities", 500, {
+      userId: req.userId,
+      apiKeyId: req.apiKeyId,
+    });
   }
 });
 

--- a/packages/api/src/routes/v1/index.ts
+++ b/packages/api/src/routes/v1/index.ts
@@ -30,6 +30,7 @@ import advancedMatchingRulesRouter from "./advanced-matching-rules";
 import customIntegrationsRouter from "./custom-integrations";
 import dedicatedInfrastructureRouter from "./dedicated-infrastructure";
 import automatedReviewRouter from "./automated-review";
+import capabilitiesRouter from "./capabilities";
 
 export const v1Router: Router = Router();
 
@@ -73,6 +74,8 @@ v1Router.use("/dedicated-infrastructure", dedicatedInfrastructureRouter);
 // Operator mode routes
 v1Router.use("/", operatorModeRouter);
 v1Router.use("/", operatorIntelligenceRouter);
+
+v1Router.use("/", capabilitiesRouter);
 
 // Health check
 v1Router.get("/health", (_req, res) => {

--- a/packages/api/src/routes/v1/operator-intelligence.ts
+++ b/packages/api/src/routes/v1/operator-intelligence.ts
@@ -6,9 +6,10 @@ import { Permission } from "../../infrastructure/security/Permissions";
 import { validateRequest } from "../../middleware/validation";
 import { handleRouteError } from "../../utils/error-handler";
 import {
-  getRunExplorer,
-  getSystemHealthSnapshot,
-} from "../../services/ops-intelligence/runtime-events";
+  getOperatorIntelligenceProvider,
+  getUnavailableOperatorIntelligenceProvider,
+} from "../../services/capabilities/registry";
+import { isMissingOptionalCapabilityDependency } from "../../services/capabilities/errors";
 
 const router: Router = Router();
 
@@ -16,15 +17,30 @@ router.get(
   "/operator/intelligence/system-health",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
+    const tenantId = req.tenantId;
+    if (!tenantId) {
+      return res.status(400).json({ error: "Missing tenant context" });
+    }
+
     try {
-      const tenantId = req.tenantId;
-      if (!tenantId) {
-        return res.status(400).json({ error: "Missing tenant context" });
-      }
       const days = Number(req.query.days ?? 7);
-      const data = await getSystemHealthSnapshot(tenantId, Number.isFinite(days) ? days : 7);
-      return res.json({ data });
+      const provider = await getOperatorIntelligenceProvider();
+      const data = await provider.getSystemHealthSnapshot(
+        tenantId,
+        Number.isFinite(days) ? days : 7
+      );
+      return res.json({ data, capability: provider.status() });
     } catch (error: unknown) {
+      if (isMissingOptionalCapabilityDependency(error)) {
+        const provider = getUnavailableOperatorIntelligenceProvider(
+          "Operator intelligence storage tables are not present in OSS mode"
+        );
+        return res.status(200).json({
+          data: await provider.getSystemHealthSnapshot(tenantId, 7),
+          capability: provider.status(),
+        });
+      }
+
       return handleRouteError(res, error, "Failed to load system health snapshot", 500, {
         userId: req.userId,
       });
@@ -45,18 +61,30 @@ router.get(
   requirePermission(Permission.ADMIN_READ),
   validateRequest(runExplorerSchema),
   async (req: AuthRequest, res: Response) => {
+    const tenantId = req.tenantId;
+    if (!tenantId) {
+      return res.status(400).json({ error: "Missing tenant context" });
+    }
+
     try {
-      const tenantId = req.tenantId;
-      if (!tenantId) {
-        return res.status(400).json({ error: "Missing tenant context" });
-      }
-      const runs = await getRunExplorer(tenantId, {
+      const provider = await getOperatorIntelligenceProvider();
+      const runs = await provider.getRunExplorer(tenantId, {
         status: typeof req.query.status === "string" ? req.query.status : undefined,
         runId: typeof req.query.runId === "string" ? req.query.runId : undefined,
         limit: typeof req.query.limit === "string" ? Number(req.query.limit) : undefined,
       });
-      return res.json({ data: runs });
+      return res.json({ data: runs, capability: provider.status() });
     } catch (error: unknown) {
+      if (isMissingOptionalCapabilityDependency(error)) {
+        const provider = getUnavailableOperatorIntelligenceProvider(
+          "Operator intelligence storage tables are not present in OSS mode"
+        );
+        return res.status(200).json({
+          data: await provider.getRunExplorer(tenantId, {}),
+          capability: provider.status(),
+        });
+      }
+
       return handleRouteError(res, error, "Failed to load run explorer", 500, {
         userId: req.userId,
       });

--- a/packages/api/src/routes/v1/operator-intelligence.ts
+++ b/packages/api/src/routes/v1/operator-intelligence.ts
@@ -10,6 +10,7 @@ import {
   getUnavailableOperatorIntelligenceProvider,
 } from "../../services/capabilities/registry";
 import { isMissingOptionalCapabilityDependency } from "../../services/capabilities/errors";
+import { observeCapabilityStatus } from "../../services/capabilities/telemetry";
 
 const router: Router = Router();
 
@@ -29,15 +30,19 @@ router.get(
         tenantId,
         Number.isFinite(days) ? days : 7
       );
-      return res.json({ data, capability: provider.status() });
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/api/v1/operator/intelligence/system-health");
+      return res.json({ data, capability });
     } catch (error: unknown) {
       if (isMissingOptionalCapabilityDependency(error)) {
         const provider = getUnavailableOperatorIntelligenceProvider(
           "Operator intelligence storage tables are not present in OSS mode"
         );
+        const capability = provider.status();
+        observeCapabilityStatus(capability, "/api/v1/operator/intelligence/system-health");
         return res.status(200).json({
           data: await provider.getSystemHealthSnapshot(tenantId, 7),
-          capability: provider.status(),
+          capability,
         });
       }
 
@@ -73,15 +78,19 @@ router.get(
         runId: typeof req.query.runId === "string" ? req.query.runId : undefined,
         limit: typeof req.query.limit === "string" ? Number(req.query.limit) : undefined,
       });
-      return res.json({ data: runs, capability: provider.status() });
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/api/v1/operator/intelligence/run-explorer");
+      return res.json({ data: runs, capability });
     } catch (error: unknown) {
       if (isMissingOptionalCapabilityDependency(error)) {
         const provider = getUnavailableOperatorIntelligenceProvider(
           "Operator intelligence storage tables are not present in OSS mode"
         );
+        const capability = provider.status();
+        observeCapabilityStatus(capability, "/api/v1/operator/intelligence/run-explorer");
         return res.status(200).json({
           data: await provider.getRunExplorer(tenantId, {}),
-          capability: provider.status(),
+          capability,
         });
       }
 

--- a/packages/api/src/routes/v1/operator-mode.ts
+++ b/packages/api/src/routes/v1/operator-mode.ts
@@ -3,31 +3,26 @@
  * Endpoints for daily intelligence, alerts, cost controls, kill switches, and backups
  */
 
-import { Router, Response } from 'express';
-import { z } from 'zod';
-import { validateRequest } from '../../middleware/validation';
-import { AuthRequest } from '../../middleware/auth';
-import { requirePermission } from '../../middleware/authorization';
-import { Permission } from '../../infrastructure/security/Permissions';
-import { handleRouteError } from '../../utils/error-handler';
+import { Router, Response } from "express";
+import { z } from "zod";
+import { validateRequest } from "../../middleware/validation";
+import { AuthRequest } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/authorization";
+import { Permission } from "../../infrastructure/security/Permissions";
+import { handleRouteError } from "../../utils/error-handler";
 import {
   generateDailyIntelligence,
   getErrorRateSummary,
   getSlowEndpoints,
   getFailedIngestions,
   getBillingAnomalies,
-} from '../../services/operator-mode/daily-intelligence';
+} from "../../services/operator-mode/daily-intelligence";
+import { AlertThreshold } from "../../services/operator-mode/alerting";
 import {
-  checkAlertThresholds,
-  upsertAlertThreshold,
-  AlertThreshold,
-} from '../../services/operator-mode/alerting';
-import {
-  setTenantUsageCeiling,
-  getAllUsageCeilings,
-  checkUsageCeiling,
-  setBackgroundJobLimit,
-} from '../../services/operator-mode/cost-controls';
+  getAlertRoutingProvider,
+  getUsageMeteringProvider,
+} from "../../services/capabilities/registry";
+import { observeCapabilityStatus } from "../../services/capabilities/telemetry";
 import {
   setKillSwitch,
   getAllKillSwitches,
@@ -35,12 +30,8 @@ import {
   enableConnector,
   pauseBackgroundJob,
   resumeBackgroundJob,
-} from '../../services/operator-mode/kill-switches';
-import {
-  createBackup,
-  verifyBackup,
-  listBackups,
-} from '../../services/operator-mode/backups';
+} from "../../services/operator-mode/kill-switches";
+import { createBackup, verifyBackup, listBackups } from "../../services/operator-mode/backups";
 
 const router: Router = Router();
 
@@ -49,7 +40,7 @@ const router: Router = Router();
 // ============================================================================
 
 router.get(
-  '/operator/daily-intelligence',
+  "/operator/daily-intelligence",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -60,7 +51,7 @@ router.get(
 
       res.json({ data: intelligence });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to get daily intelligence', 500, {
+      handleRouteError(res, error, "Failed to get daily intelligence", 500, {
         userId: req.userId,
       });
     }
@@ -68,7 +59,7 @@ router.get(
 );
 
 router.get(
-  '/operator/error-rate',
+  "/operator/error-rate",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -79,7 +70,7 @@ router.get(
 
       res.json({ data: errorRate });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to get error rate', 500, {
+      handleRouteError(res, error, "Failed to get error rate", 500, {
         userId: req.userId,
       });
     }
@@ -87,7 +78,7 @@ router.get(
 );
 
 router.get(
-  '/operator/slow-endpoints',
+  "/operator/slow-endpoints",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -98,7 +89,7 @@ router.get(
 
       res.json({ data: slowEndpoints });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to get slow endpoints', 500, {
+      handleRouteError(res, error, "Failed to get slow endpoints", 500, {
         userId: req.userId,
       });
     }
@@ -106,7 +97,7 @@ router.get(
 );
 
 router.get(
-  '/operator/failed-ingestions',
+  "/operator/failed-ingestions",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -117,7 +108,7 @@ router.get(
 
       res.json({ data: failedIngestions });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to get failed ingestions', 500, {
+      handleRouteError(res, error, "Failed to get failed ingestions", 500, {
         userId: req.userId,
       });
     }
@@ -125,7 +116,7 @@ router.get(
 );
 
 router.get(
-  '/operator/billing-anomalies',
+  "/operator/billing-anomalies",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -136,7 +127,7 @@ router.get(
 
       res.json({ data: anomalies });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to get billing anomalies', 500, {
+      handleRouteError(res, error, "Failed to get billing anomalies", 500, {
         userId: req.userId,
       });
     }
@@ -148,18 +139,22 @@ router.get(
 // ============================================================================
 
 router.post(
-  '/operator/alerts/check',
+  "/operator/alerts/check",
   requirePermission(Permission.ADMIN_WRITE),
   async (req: AuthRequest, res: Response) => {
     try {
-      const alerts = await checkAlertThresholds();
+      const provider = getAlertRoutingProvider();
+      const alerts = await provider.checkThresholds();
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/api/v1/operator/alerts/check");
 
       res.json({
         data: alerts,
+        capability,
         message: `Checked thresholds, triggered ${alerts.length} alerts`,
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to check alert thresholds', 500, {
+      handleRouteError(res, error, "Failed to check alert thresholds", 500, {
         userId: req.userId,
       });
     }
@@ -169,17 +164,23 @@ router.post(
 const createAlertThresholdSchema = z.object({
   body: z.object({
     name: z.string().min(1).max(255),
-    metric: z.enum(['error_rate', 'slow_endpoint', 'failed_ingestion', 'billing_anomaly', 'usage_limit']),
+    metric: z.enum([
+      "error_rate",
+      "slow_endpoint",
+      "failed_ingestion",
+      "billing_anomaly",
+      "usage_limit",
+    ]),
     threshold: z.number(),
-    operator: z.enum(['gt', 'gte', 'lt', 'lte', 'eq', 'neq']),
-    severity: z.enum(['low', 'medium', 'high', 'critical']).default('medium'),
-    channels: z.array(z.enum(['email', 'slack', 'webhook'])).default([]),
+    operator: z.enum(["gt", "gte", "lt", "lte", "eq", "neq"]),
+    severity: z.enum(["low", "medium", "high", "critical"]).default("medium"),
+    channels: z.array(z.enum(["email", "slack", "webhook"])).default([]),
     enabled: z.boolean().default(true),
   }),
 });
 
 router.post(
-  '/operator/alerts/thresholds',
+  "/operator/alerts/thresholds",
   requirePermission(Permission.ADMIN_WRITE),
   validateRequest(createAlertThresholdSchema),
   async (req: AuthRequest, res: Response) => {
@@ -187,14 +188,18 @@ router.post(
       const userId = req.userId!;
       const threshold: AlertThreshold = req.body;
 
-      const thresholdId = await upsertAlertThreshold(userId, threshold);
+      const provider = getAlertRoutingProvider();
+      const thresholdId = await provider.upsertThreshold(userId, threshold);
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/api/v1/operator/alerts/thresholds");
 
       res.status(201).json({
         data: { id: thresholdId },
-        message: 'Alert threshold created',
+        capability,
+        message: "Alert threshold created",
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to create alert threshold', 500, {
+      handleRouteError(res, error, "Failed to create alert threshold", 500, {
         userId: req.userId,
       });
     }
@@ -209,26 +214,30 @@ const setUsageCeilingSchema = z.object({
   body: z.object({
     tenantId: z.string().uuid(),
     billingAccountId: z.string().uuid(),
-    usageType: z.enum(['ingestions', 'reconciliations', 'api_requests', 'storage']),
+    usageType: z.enum(["ingestions", "reconciliations", "api_requests", "storage"]),
     monthlyLimit: z.number().positive(),
   }),
 });
 
 router.post(
-  '/operator/cost-controls/usage-ceilings',
+  "/operator/cost-controls/usage-ceilings",
   requirePermission(Permission.ADMIN_WRITE),
   validateRequest(setUsageCeilingSchema),
   async (req: AuthRequest, res: Response) => {
     try {
       const { tenantId, billingAccountId, usageType, monthlyLimit } = req.body;
 
-      await setTenantUsageCeiling(tenantId, billingAccountId, usageType, monthlyLimit);
+      const provider = getUsageMeteringProvider();
+      await provider.setUsageCeiling(tenantId, billingAccountId, usageType, monthlyLimit);
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/api/v1/operator/cost-controls/usage-ceilings");
 
       res.status(201).json({
-        message: 'Usage ceiling set',
+        capability,
+        message: "Usage ceiling set",
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to set usage ceiling', 500, {
+      handleRouteError(res, error, "Failed to set usage ceiling", 500, {
         userId: req.userId,
       });
     }
@@ -236,15 +245,18 @@ router.post(
 );
 
 router.get(
-  '/operator/cost-controls/usage-ceilings',
+  "/operator/cost-controls/usage-ceilings",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
-      const ceilings = await getAllUsageCeilings();
+      const provider = getUsageMeteringProvider();
+      const ceilings = await provider.getUsageCeilings();
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/api/v1/operator/cost-controls/usage-ceilings");
 
-      res.json({ data: ceilings });
+      res.json({ data: ceilings, capability });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to get usage ceilings', 500, {
+      handleRouteError(res, error, "Failed to get usage ceilings", 500, {
         userId: req.userId,
       });
     }
@@ -252,7 +264,7 @@ router.get(
 );
 
 router.get(
-  '/operator/cost-controls/usage-ceilings/:tenantId/:usageType',
+  "/operator/cost-controls/usage-ceilings/:tenantId/:usageType",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -260,17 +272,23 @@ router.get(
 
       if (!tenantId || !usageType) {
         res.status(400).json({
-          error: 'Bad Request',
-          message: 'tenantId and usageType are required',
+          error: "Bad Request",
+          message: "tenantId and usageType are required",
         });
         return;
       }
 
-      const check = await checkUsageCeiling(tenantId, usageType as any);
+      const provider = getUsageMeteringProvider();
+      const check = await provider.checkUsageCeiling(tenantId, usageType as any);
+      const capability = provider.status();
+      observeCapabilityStatus(
+        capability,
+        "/api/v1/operator/cost-controls/usage-ceilings/:tenantId/:usageType"
+      );
 
-      res.json({ data: check });
+      res.json({ data: check, capability });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to check usage ceiling', 500, {
+      handleRouteError(res, error, "Failed to check usage ceiling", 500, {
         userId: req.userId,
       });
     }
@@ -279,27 +297,31 @@ router.get(
 
 const setJobLimitSchema = z.object({
   body: z.object({
-    jobType: z.enum(['ingestion', 'reconciliation', 'webhook', 'export']),
+    jobType: z.enum(["ingestion", "reconciliation", "webhook", "export"]),
     maxConcurrent: z.number().positive(),
     maxPerTenant: z.number().positive(),
   }),
 });
 
 router.post(
-  '/operator/cost-controls/job-limits',
+  "/operator/cost-controls/job-limits",
   requirePermission(Permission.ADMIN_WRITE),
   validateRequest(setJobLimitSchema),
   async (req: AuthRequest, res: Response) => {
     try {
       const { jobType, maxConcurrent, maxPerTenant } = req.body;
 
-      await setBackgroundJobLimit(jobType, maxConcurrent, maxPerTenant);
+      const provider = getUsageMeteringProvider();
+      await provider.setJobLimit(jobType, maxConcurrent, maxPerTenant);
+      const capability = provider.status();
+      observeCapabilityStatus(capability, "/api/v1/operator/cost-controls/job-limits");
 
       res.status(201).json({
-        message: 'Background job limit set',
+        capability,
+        message: "Background job limit set",
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to set job limit', 500, {
+      handleRouteError(res, error, "Failed to set job limit", 500, {
         userId: req.userId,
       });
     }
@@ -311,7 +333,7 @@ router.post(
 // ============================================================================
 
 router.get(
-  '/operator/kill-switches',
+  "/operator/kill-switches",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -319,7 +341,7 @@ router.get(
 
       res.json({ data: switches });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to get kill switches', 500, {
+      handleRouteError(res, error, "Failed to get kill switches", 500, {
         userId: req.userId,
       });
     }
@@ -329,7 +351,7 @@ router.get(
 const setKillSwitchSchema = z.object({
   body: z.object({
     name: z.string().min(1),
-    type: z.enum(['connector', 'background_job', 'feature', 'endpoint']),
+    type: z.enum(["connector", "background_job", "feature", "endpoint"]),
     target: z.string().min(1),
     enabled: z.boolean(),
     reason: z.string().optional(),
@@ -337,7 +359,7 @@ const setKillSwitchSchema = z.object({
 });
 
 router.post(
-  '/operator/kill-switches',
+  "/operator/kill-switches",
   requirePermission(Permission.ADMIN_WRITE),
   validateRequest(setKillSwitchSchema),
   async (req: AuthRequest, res: Response) => {
@@ -346,8 +368,8 @@ router.post(
       const userId = req.userId;
       if (!userId) {
         res.status(401).json({
-          error: 'Unauthorized',
-          message: 'User ID not found',
+          error: "Unauthorized",
+          message: "User ID not found",
         });
         return;
       }
@@ -356,10 +378,10 @@ router.post(
 
       res.status(201).json({
         data: { id: switchId },
-        message: `Kill switch ${enabled ? 'enabled' : 'disabled'}`,
+        message: `Kill switch ${enabled ? "enabled" : "disabled"}`,
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to set kill switch', 500, {
+      handleRouteError(res, error, "Failed to set kill switch", 500, {
         userId: req.userId,
       });
     }
@@ -367,24 +389,24 @@ router.post(
 );
 
 router.post(
-  '/operator/kill-switches/connectors/:connectorType/disable',
+  "/operator/kill-switches/connectors/:connectorType/disable",
   requirePermission(Permission.ADMIN_WRITE),
   async (req: AuthRequest, res: Response) => {
     try {
       const { connectorType } = req.params;
       if (!connectorType) {
         res.status(400).json({
-          error: 'Bad Request',
-          message: 'connectorType is required',
+          error: "Bad Request",
+          message: "connectorType is required",
         });
         return;
       }
-      const reason = (req.body.reason as string) || 'Manually disabled';
+      const reason = (req.body.reason as string) || "Manually disabled";
       const userId = req.userId;
       if (!userId) {
         res.status(401).json({
-          error: 'Unauthorized',
-          message: 'User ID not found',
+          error: "Unauthorized",
+          message: "User ID not found",
         });
         return;
       }
@@ -395,7 +417,7 @@ router.post(
         message: `Connector ${connectorType} disabled`,
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to disable connector', 500, {
+      handleRouteError(res, error, "Failed to disable connector", 500, {
         userId: req.userId,
       });
     }
@@ -403,15 +425,15 @@ router.post(
 );
 
 router.post(
-  '/operator/kill-switches/connectors/:connectorType/enable',
+  "/operator/kill-switches/connectors/:connectorType/enable",
   requirePermission(Permission.ADMIN_WRITE),
   async (req: AuthRequest, res: Response) => {
     try {
       const { connectorType } = req.params;
       if (!connectorType) {
         res.status(400).json({
-          error: 'Bad Request',
-          message: 'connectorType is required',
+          error: "Bad Request",
+          message: "connectorType is required",
         });
         return;
       }
@@ -422,7 +444,7 @@ router.post(
         message: `Connector ${connectorType} enabled`,
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to enable connector', 500, {
+      handleRouteError(res, error, "Failed to enable connector", 500, {
         userId: req.userId,
       });
     }
@@ -430,24 +452,24 @@ router.post(
 );
 
 router.post(
-  '/operator/kill-switches/jobs/:jobType/pause',
+  "/operator/kill-switches/jobs/:jobType/pause",
   requirePermission(Permission.ADMIN_WRITE),
   async (req: AuthRequest, res: Response) => {
     try {
       const { jobType } = req.params;
       if (!jobType) {
         res.status(400).json({
-          error: 'Bad Request',
-          message: 'jobType is required',
+          error: "Bad Request",
+          message: "jobType is required",
         });
         return;
       }
-      const reason = (req.body.reason as string) || 'Manually paused';
+      const reason = (req.body.reason as string) || "Manually paused";
       const userId = req.userId;
       if (!userId) {
         res.status(401).json({
-          error: 'Unauthorized',
-          message: 'User ID not found',
+          error: "Unauthorized",
+          message: "User ID not found",
         });
         return;
       }
@@ -458,7 +480,7 @@ router.post(
         message: `Background job ${jobType} paused`,
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to pause background job', 500, {
+      handleRouteError(res, error, "Failed to pause background job", 500, {
         userId: req.userId,
       });
     }
@@ -466,15 +488,15 @@ router.post(
 );
 
 router.post(
-  '/operator/kill-switches/jobs/:jobType/resume',
+  "/operator/kill-switches/jobs/:jobType/resume",
   requirePermission(Permission.ADMIN_WRITE),
   async (req: AuthRequest, res: Response) => {
     try {
       const { jobType } = req.params;
       if (!jobType) {
         res.status(400).json({
-          error: 'Bad Request',
-          message: 'jobType is required',
+          error: "Bad Request",
+          message: "jobType is required",
         });
         return;
       }
@@ -485,7 +507,7 @@ router.post(
         message: `Background job ${jobType} resumed`,
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to resume background job', 500, {
+      handleRouteError(res, error, "Failed to resume background job", 500, {
         userId: req.userId,
       });
     }
@@ -497,7 +519,7 @@ router.post(
 // ============================================================================
 
 router.post(
-  '/operator/backups/create',
+  "/operator/backups/create",
   requirePermission(Permission.ADMIN_WRITE),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -505,10 +527,10 @@ router.post(
 
       res.status(201).json({
         data: backup,
-        message: 'Backup created',
+        message: "Backup created",
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to create backup', 500, {
+      handleRouteError(res, error, "Failed to create backup", 500, {
         userId: req.userId,
       });
     }
@@ -516,15 +538,15 @@ router.post(
 );
 
 router.post(
-  '/operator/backups/:backupId/verify',
+  "/operator/backups/:backupId/verify",
   requirePermission(Permission.ADMIN_WRITE),
   async (req: AuthRequest, res: Response) => {
     try {
       const { backupId } = req.params;
       if (!backupId) {
         res.status(400).json({
-          error: 'Bad Request',
-          message: 'backupId is required',
+          error: "Bad Request",
+          message: "backupId is required",
         });
         return;
       }
@@ -533,10 +555,10 @@ router.post(
 
       res.json({
         data: { verified },
-        message: verified ? 'Backup verified' : 'Backup verification failed',
+        message: verified ? "Backup verified" : "Backup verification failed",
       });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to verify backup', 500, {
+      handleRouteError(res, error, "Failed to verify backup", 500, {
         userId: req.userId,
       });
     }
@@ -544,16 +566,16 @@ router.post(
 );
 
 router.get(
-  '/operator/backups',
+  "/operator/backups",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
-      const limit = parseInt((req.query.limit as string) || '10', 10);
+      const limit = parseInt((req.query.limit as string) || "10", 10);
       const backups = await listBackups(limit);
 
       res.json({ data: backups });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to list backups', 500, {
+      handleRouteError(res, error, "Failed to list backups", 500, {
         userId: req.userId,
       });
     }

--- a/packages/api/src/services/capabilities/__tests__/registry.test.ts
+++ b/packages/api/src/services/capabilities/__tests__/registry.test.ts
@@ -1,0 +1,58 @@
+import { getCapabilityRegistry, getUnavailableOperatorIntelligenceProvider } from "../registry";
+
+describe("capability registry", () => {
+  const originalModule = process.env.SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE;
+
+  beforeEach(() => {
+    delete process.env.SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE;
+  });
+
+  afterAll(() => {
+    if (originalModule) {
+      process.env.SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE = originalModule;
+      return;
+    }
+    delete process.env.SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE;
+  });
+
+  it("returns OSS capabilities when no private module is configured", async () => {
+    const registry = await getCapabilityRegistry();
+    const capabilities = registry.list();
+
+    expect(capabilities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "operator_intelligence",
+          available: true,
+          source: "oss",
+        }),
+        expect.objectContaining({
+          key: "enterprise_surface",
+          available: false,
+          state: "unavailable",
+        }),
+      ])
+    );
+  });
+
+  it("provides a deterministic unavailable provider shape", async () => {
+    const provider = getUnavailableOperatorIntelligenceProvider("missing tables in OSS mode");
+
+    expect(provider.status()).toEqual(
+      expect.objectContaining({
+        key: "operator_intelligence",
+        available: false,
+        state: "unavailable",
+      })
+    );
+
+    await expect(provider.getRunExplorer("tenant", {})).resolves.toEqual([]);
+    await expect(provider.getTelemetryForExport("tenant", 7)).resolves.toEqual([]);
+    await expect(provider.getSystemHealthSnapshot("tenant", 7)).resolves.toEqual(
+      expect.objectContaining({
+        runsPerDay: 0,
+        errorRate: 0,
+      })
+    );
+  });
+});

--- a/packages/api/src/services/capabilities/errors.ts
+++ b/packages/api/src/services/capabilities/errors.ts
@@ -1,0 +1,9 @@
+export function isMissingOptionalCapabilityDependency(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return (
+    message.includes("does not exist") ||
+    message.includes("undefined_table") ||
+    message.includes("relation")
+  );
+}

--- a/packages/api/src/services/capabilities/errors.ts
+++ b/packages/api/src/services/capabilities/errors.ts
@@ -1,9 +1,5 @@
+import { isUndefinedTableError } from "./pg-errors";
+
 export function isMissingOptionalCapabilityDependency(error: unknown): boolean {
-  const message =
-    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
-  return (
-    message.includes("does not exist") ||
-    message.includes("undefined_table") ||
-    message.includes("relation")
-  );
+  return isUndefinedTableError(error);
 }

--- a/packages/api/src/services/capabilities/pg-errors.ts
+++ b/packages/api/src/services/capabilities/pg-errors.ts
@@ -1,0 +1,11 @@
+export const PG_UNDEFINED_TABLE = "42P01";
+
+interface PgErrorLike {
+  code?: string;
+}
+
+export function isUndefinedTableError(error: unknown): boolean {
+  return Boolean(
+    error && typeof error === "object" && (error as PgErrorLike).code === PG_UNDEFINED_TABLE
+  );
+}

--- a/packages/api/src/services/capabilities/providers/alert-routing-provider.ts
+++ b/packages/api/src/services/capabilities/providers/alert-routing-provider.ts
@@ -1,0 +1,32 @@
+import {
+  checkAlertThresholds,
+  upsertAlertThreshold,
+  type AlertThreshold,
+} from "../../operator-mode/alerting";
+import type { CapabilityStatus } from "../types";
+
+export interface AlertRoutingProvider {
+  status(): CapabilityStatus;
+  checkThresholds(): ReturnType<typeof checkAlertThresholds>;
+  upsertThreshold(userId: string, threshold: AlertThreshold): Promise<string>;
+}
+
+export class OssAlertRoutingProvider implements AlertRoutingProvider {
+  public status(): CapabilityStatus {
+    return {
+      key: "alert_routing",
+      state: "available",
+      available: true,
+      source: "oss",
+      reason: "Using OSS alert routing implementation",
+    };
+  }
+
+  public checkThresholds(): ReturnType<typeof checkAlertThresholds> {
+    return checkAlertThresholds();
+  }
+
+  public upsertThreshold(userId: string, threshold: AlertThreshold): Promise<string> {
+    return upsertAlertThreshold(userId, threshold);
+  }
+}

--- a/packages/api/src/services/capabilities/providers/enterprise-analytics-provider.ts
+++ b/packages/api/src/services/capabilities/providers/enterprise-analytics-provider.ts
@@ -1,0 +1,17 @@
+import type { CapabilityStatus } from "../types";
+
+export interface EnterpriseAnalyticsProvider {
+  status(): CapabilityStatus;
+}
+
+export class OssEnterpriseAnalyticsProvider implements EnterpriseAnalyticsProvider {
+  public status(): CapabilityStatus {
+    return {
+      key: "enterprise_analytics",
+      state: "degraded",
+      available: true,
+      source: "oss",
+      reason: "OSS analytics is available; enterprise enrichment is optional",
+    };
+  }
+}

--- a/packages/api/src/services/capabilities/providers/operator-intelligence-provider.ts
+++ b/packages/api/src/services/capabilities/providers/operator-intelligence-provider.ts
@@ -1,0 +1,124 @@
+import {
+  buildPlatformOverview,
+  loadTenantTelemetry,
+  type PlatformOverview,
+  type TelemetryExecutionRecord,
+} from "../../ops-intelligence/control-plane-analytics";
+import {
+  getRunExplorer as getRunExplorerCore,
+  getSystemHealthSnapshot as getSystemHealthSnapshotCore,
+  type RunExplorerEntry,
+  type SystemHealthSnapshot,
+} from "../../ops-intelligence/runtime-events";
+import type { CapabilityStatus } from "../types";
+
+export interface OperatorIntelligenceProvider {
+  status(): CapabilityStatus;
+  getSystemHealthSnapshot(tenantId: string, days: number): Promise<SystemHealthSnapshot>;
+  getRunExplorer(
+    tenantId: string,
+    filters: { status?: string; runId?: string; limit?: number }
+  ): Promise<RunExplorerEntry[]>;
+  getPlatformOverview(tenantId: string, days: number): Promise<PlatformOverview>;
+  getTelemetryForExport(tenantId: string, days: number): Promise<TelemetryExecutionRecord[]>;
+}
+
+export class OssOperatorIntelligenceProvider implements OperatorIntelligenceProvider {
+  public status(): CapabilityStatus {
+    return {
+      key: "operator_intelligence",
+      state: "available",
+      available: true,
+      source: "oss",
+      reason: "Using OSS operator intelligence implementation",
+    };
+  }
+
+  public getSystemHealthSnapshot(tenantId: string, days: number): Promise<SystemHealthSnapshot> {
+    return getSystemHealthSnapshotCore(tenantId, days);
+  }
+
+  public getRunExplorer(
+    tenantId: string,
+    filters: { status?: string; runId?: string; limit?: number }
+  ): Promise<RunExplorerEntry[]> {
+    return getRunExplorerCore(tenantId, filters);
+  }
+
+  public async getPlatformOverview(tenantId: string, days: number): Promise<PlatformOverview> {
+    const telemetry = await loadTenantTelemetry(tenantId, days);
+    return buildPlatformOverview(telemetry);
+  }
+
+  public getTelemetryForExport(
+    tenantId: string,
+    days: number
+  ): Promise<TelemetryExecutionRecord[]> {
+    return loadTenantTelemetry(tenantId, days);
+  }
+}
+
+export class UnavailableOperatorIntelligenceProvider implements OperatorIntelligenceProvider {
+  public constructor(private readonly reason: string) {}
+
+  public status(): CapabilityStatus {
+    return {
+      key: "operator_intelligence",
+      state: "unavailable",
+      available: false,
+      source: "oss",
+      reason: this.reason,
+    };
+  }
+
+  public async getSystemHealthSnapshot(): Promise<SystemHealthSnapshot> {
+    return this.emptySnapshot();
+  }
+
+  public async getRunExplorer(): Promise<RunExplorerEntry[]> {
+    return [];
+  }
+
+  public async getPlatformOverview(): Promise<PlatformOverview> {
+    return {
+      telemetry: {
+        systemHealth: 0,
+        executionThroughputPerMinute: 0,
+        replayRate: 0,
+        policyViolations: 0,
+        failureTrends: {},
+        infrastructureUtilization: { avgLatencyMs: 0, p95LatencyMs: 0, avgQueueMs: 0 },
+      },
+      analytics: {
+        executionSuccessRate: 0,
+        mttrMinutes: 0,
+        failureRecurrenceClusters: [],
+        apiEndpointAdoption: [],
+        latencyTrend: "stable",
+        infrastructureTrend: "stable",
+      },
+      costs: { perExecutionAverageUsd: 0, totalUsd: 0, byTenantUsd: 0 },
+      autonomousOperations: { recommendations: [], controlledAutoRemediation: [] },
+      leaderboard: [],
+    };
+  }
+
+  public async getTelemetryForExport(): Promise<TelemetryExecutionRecord[]> {
+    return [];
+  }
+
+  private emptySnapshot(): SystemHealthSnapshot {
+    return {
+      runsPerDay: 0,
+      recordsProcessed: 0,
+      matchRate: 0,
+      manualReviewRate: 0,
+      runDurationMsP50: 0,
+      runDurationMsP95: 0,
+      runFailureRate: 0,
+      apiLatencyMsP50: 0,
+      apiLatencyMsP95: 0,
+      errorRate: 0,
+    };
+  }
+}

--- a/packages/api/src/services/capabilities/providers/support-intake-provider.ts
+++ b/packages/api/src/services/capabilities/providers/support-intake-provider.ts
@@ -1,0 +1,17 @@
+import type { CapabilityStatus } from "../types";
+
+export interface SupportIntakeProvider {
+  status(): CapabilityStatus;
+}
+
+export class OssSupportIntakeProvider implements SupportIntakeProvider {
+  public status(): CapabilityStatus {
+    return {
+      key: "support_intake",
+      state: "available",
+      available: true,
+      source: "oss",
+      reason: "Using OSS support intake implementation",
+    };
+  }
+}

--- a/packages/api/src/services/capabilities/providers/usage-metering-provider.ts
+++ b/packages/api/src/services/capabilities/providers/usage-metering-provider.ts
@@ -1,0 +1,67 @@
+import {
+  setTenantUsageCeiling,
+  getAllUsageCeilings,
+  checkUsageCeiling,
+  setBackgroundJobLimit,
+} from "../../operator-mode/cost-controls";
+import type { CapabilityStatus } from "../types";
+
+export interface UsageMeteringProvider {
+  status(): CapabilityStatus;
+  setUsageCeiling(
+    tenantId: string,
+    billingAccountId: string,
+    usageType: "ingestions" | "reconciliations" | "api_requests" | "storage",
+    monthlyLimit: number
+  ): Promise<void>;
+  getUsageCeilings(): ReturnType<typeof getAllUsageCeilings>;
+  checkUsageCeiling(
+    tenantId: string,
+    usageType: "ingestions" | "reconciliations" | "api_requests" | "storage"
+  ): ReturnType<typeof checkUsageCeiling>;
+  setJobLimit(
+    jobType: "ingestion" | "reconciliation" | "webhook" | "export",
+    maxConcurrent: number,
+    maxPerTenant: number
+  ): Promise<void>;
+}
+
+export class OssUsageMeteringProvider implements UsageMeteringProvider {
+  public status(): CapabilityStatus {
+    return {
+      key: "usage_metering",
+      state: "available",
+      available: true,
+      source: "oss",
+      reason: "Using OSS usage metering implementation",
+    };
+  }
+
+  public setUsageCeiling(
+    tenantId: string,
+    billingAccountId: string,
+    usageType: "ingestions" | "reconciliations" | "api_requests" | "storage",
+    monthlyLimit: number
+  ): Promise<void> {
+    return setTenantUsageCeiling(tenantId, billingAccountId, usageType, monthlyLimit);
+  }
+
+  public getUsageCeilings(): ReturnType<typeof getAllUsageCeilings> {
+    return getAllUsageCeilings();
+  }
+
+  public checkUsageCeiling(
+    tenantId: string,
+    usageType: "ingestions" | "reconciliations" | "api_requests" | "storage"
+  ): ReturnType<typeof checkUsageCeiling> {
+    return checkUsageCeiling(tenantId, usageType);
+  }
+
+  public setJobLimit(
+    jobType: "ingestion" | "reconciliation" | "webhook" | "export",
+    maxConcurrent: number,
+    maxPerTenant: number
+  ): Promise<void> {
+    return setBackgroundJobLimit(jobType, maxConcurrent, maxPerTenant);
+  }
+}

--- a/packages/api/src/services/capabilities/registry.ts
+++ b/packages/api/src/services/capabilities/registry.ts
@@ -5,6 +5,22 @@ import {
   UnavailableOperatorIntelligenceProvider,
   type OperatorIntelligenceProvider,
 } from "./providers/operator-intelligence-provider";
+import {
+  OssAlertRoutingProvider,
+  type AlertRoutingProvider,
+} from "./providers/alert-routing-provider";
+import {
+  OssUsageMeteringProvider,
+  type UsageMeteringProvider,
+} from "./providers/usage-metering-provider";
+import {
+  OssSupportIntakeProvider,
+  type SupportIntakeProvider,
+} from "./providers/support-intake-provider";
+import {
+  OssEnterpriseAnalyticsProvider,
+  type EnterpriseAnalyticsProvider,
+} from "./providers/enterprise-analytics-provider";
 
 interface PrivateOperatorIntelligenceProviderModule {
   createOperatorIntelligenceProvider: () => OperatorIntelligenceProvider;
@@ -23,6 +39,10 @@ class InMemoryCapabilityRegistry implements CapabilityRegistry {
 }
 
 let operatorIntelligenceProvider: OperatorIntelligenceProvider | null = null;
+let alertRoutingProvider: AlertRoutingProvider | null = null;
+let usageMeteringProvider: UsageMeteringProvider | null = null;
+let supportIntakeProvider: SupportIntakeProvider | null = null;
+let enterpriseAnalyticsProvider: EnterpriseAnalyticsProvider | null = null;
 
 async function loadPrivateOperatorIntelligenceProvider(): Promise<OperatorIntelligenceProvider | null> {
   const modulePath = process.env.SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE;
@@ -66,11 +86,47 @@ export async function getOperatorIntelligenceProvider(): Promise<OperatorIntelli
   return operatorIntelligenceProvider;
 }
 
+export function getAlertRoutingProvider(): AlertRoutingProvider {
+  if (!alertRoutingProvider) {
+    alertRoutingProvider = new OssAlertRoutingProvider();
+  }
+  return alertRoutingProvider;
+}
+
+export function getUsageMeteringProvider(): UsageMeteringProvider {
+  if (!usageMeteringProvider) {
+    usageMeteringProvider = new OssUsageMeteringProvider();
+  }
+  return usageMeteringProvider;
+}
+
+export function getSupportIntakeProvider(): SupportIntakeProvider {
+  if (!supportIntakeProvider) {
+    supportIntakeProvider = new OssSupportIntakeProvider();
+  }
+  return supportIntakeProvider;
+}
+
+export function getEnterpriseAnalyticsProvider(): EnterpriseAnalyticsProvider {
+  if (!enterpriseAnalyticsProvider) {
+    enterpriseAnalyticsProvider = new OssEnterpriseAnalyticsProvider();
+  }
+  return enterpriseAnalyticsProvider;
+}
+
 export async function getCapabilityRegistry(): Promise<CapabilityRegistry> {
-  const provider = await getOperatorIntelligenceProvider();
+  const operatorIntelligence = await getOperatorIntelligenceProvider();
+  const alertRouting = getAlertRoutingProvider();
+  const usageMetering = getUsageMeteringProvider();
+  const supportIntake = getSupportIntakeProvider();
+  const enterpriseAnalytics = getEnterpriseAnalyticsProvider();
 
   return new InMemoryCapabilityRegistry([
-    provider.status(),
+    operatorIntelligence.status(),
+    alertRouting.status(),
+    usageMetering.status(),
+    supportIntake.status(),
+    enterpriseAnalytics.status(),
     {
       key: "enterprise_surface",
       available: false,

--- a/packages/api/src/services/capabilities/registry.ts
+++ b/packages/api/src/services/capabilities/registry.ts
@@ -1,0 +1,88 @@
+import { logWarn } from "../../utils/logger";
+import type { CapabilityRegistry, CapabilityStatus } from "./types";
+import {
+  OssOperatorIntelligenceProvider,
+  UnavailableOperatorIntelligenceProvider,
+  type OperatorIntelligenceProvider,
+} from "./providers/operator-intelligence-provider";
+
+interface PrivateOperatorIntelligenceProviderModule {
+  createOperatorIntelligenceProvider: () => OperatorIntelligenceProvider;
+}
+
+class InMemoryCapabilityRegistry implements CapabilityRegistry {
+  public constructor(private readonly statuses: CapabilityStatus[]) {}
+
+  public list(): CapabilityStatus[] {
+    return this.statuses;
+  }
+
+  public get(key: string): CapabilityStatus | undefined {
+    return this.statuses.find((s) => s.key === key);
+  }
+}
+
+let operatorIntelligenceProvider: OperatorIntelligenceProvider | null = null;
+
+async function loadPrivateOperatorIntelligenceProvider(): Promise<OperatorIntelligenceProvider | null> {
+  const modulePath = process.env.SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE;
+  if (!modulePath) {
+    return null;
+  }
+
+  try {
+    const loadedModule = (await import(
+      modulePath
+    )) as Partial<PrivateOperatorIntelligenceProviderModule>;
+    if (typeof loadedModule.createOperatorIntelligenceProvider !== "function") {
+      logWarn("Private operator intelligence module loaded without provider factory", {
+        modulePath,
+      });
+      return null;
+    }
+
+    const provider = loadedModule.createOperatorIntelligenceProvider();
+    return {
+      ...provider,
+      status: () => ({ ...provider.status(), source: "private" }),
+    };
+  } catch (error) {
+    logWarn("Unable to load private operator intelligence provider; falling back to OSS", {
+      modulePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+export async function getOperatorIntelligenceProvider(): Promise<OperatorIntelligenceProvider> {
+  if (operatorIntelligenceProvider) {
+    return operatorIntelligenceProvider;
+  }
+
+  operatorIntelligenceProvider =
+    (await loadPrivateOperatorIntelligenceProvider()) ?? new OssOperatorIntelligenceProvider();
+
+  return operatorIntelligenceProvider;
+}
+
+export async function getCapabilityRegistry(): Promise<CapabilityRegistry> {
+  const provider = await getOperatorIntelligenceProvider();
+
+  return new InMemoryCapabilityRegistry([
+    provider.status(),
+    {
+      key: "enterprise_surface",
+      available: false,
+      state: "unavailable",
+      source: "oss",
+      reason: "Enterprise routes are disabled until private enterprise backends are configured",
+    },
+  ]);
+}
+
+export function getUnavailableOperatorIntelligenceProvider(
+  reason: string
+): OperatorIntelligenceProvider {
+  return new UnavailableOperatorIntelligenceProvider(reason);
+}

--- a/packages/api/src/services/capabilities/telemetry.ts
+++ b/packages/api/src/services/capabilities/telemetry.ts
@@ -1,0 +1,19 @@
+import { Counter } from "prom-client";
+import { register } from "../../infrastructure/observability/metrics";
+import type { CapabilityStatus } from "./types";
+
+const capabilityStatusObservedTotal = new Counter({
+  name: "capability_status_observed_total",
+  help: "Capability status observations from API routes",
+  labelNames: ["capability", "state", "source", "route"],
+  registers: [register],
+});
+
+export function observeCapabilityStatus(status: CapabilityStatus, route: string): void {
+  capabilityStatusObservedTotal.inc({
+    capability: status.key,
+    state: status.state,
+    source: status.source,
+    route,
+  });
+}

--- a/packages/api/src/services/capabilities/types.ts
+++ b/packages/api/src/services/capabilities/types.ts
@@ -1,0 +1,14 @@
+export type CapabilityState = "available" | "degraded" | "unavailable";
+
+export interface CapabilityStatus {
+  key: string;
+  state: CapabilityState;
+  source: "oss" | "private";
+  available: boolean;
+  reason?: string;
+}
+
+export interface CapabilityRegistry {
+  list(): CapabilityStatus[];
+  get(key: string): CapabilityStatus | undefined;
+}


### PR DESCRIPTION
### Motivation

- Separate OSS-safe core from optional/private operator-control-plane capabilities so the public repo stays runnable and truthful without private modules.
- Prevent hard imports of private enterprise code in core routes and enable safe dynamic attachment of private providers.
- Ensure routes that depend on optional capabilities degrade gracefully and expose truthful capability status to clients/operators.

### Description

- Add a typed capability model and registry at `packages/api/src/services/capabilities` with `CapabilityStatus`, `CapabilityRegistry` and a dynamic loader for optional private providers using `SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE`.
- Introduce a provider contract and concrete implementations (`OssOperatorIntelligenceProvider` and `UnavailableOperatorIntelligenceProvider`) under `services/capabilities/providers/operator-intelligence-provider.ts` to provide deterministic fallbacks.
- Refactor operator intelligence and platform control-plane routes to resolve a provider from the registry, return `capability` metadata in responses, and fall back to deterministic empty payloads with `capability.state = "unavailable"` when optional storage/dependencies are missing.
- Add `GET /api/v1/capabilities` for runtime capability discovery and document the OSS/private boundary in `packages/api/README.md`.

### Testing

- Ran unit tests: `pnpm --filter @settler/api exec jest src/services/capabilities/__tests__/registry.test.ts --runInBand` which passed.
- Ran combined tests: `pnpm --filter @settler/api exec jest src/services/capabilities/__tests__/registry.test.ts src/services/ops-intelligence/__tests__/control-plane-analytics.test.ts --runInBand` which passed.
- Typechecking succeeded with `pnpm --filter @settler/api typecheck` and build succeeded with `pnpm --filter @settler/api build`.
- Lint was executed via `pnpm --filter @settler/api lint` and completed with pre-existing warnings unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af841c49408328a6c691939a0f96d9)