### PR TITLE
Operator control plane: telemetry-backed UI, anomaly alerts, GitHub triage, and support intake

### DIFF
--- a/docs/operations/operator-control-plane.md
+++ b/docs/operations/operator-control-plane.md
@@ -1,0 +1,33 @@
+# Operator Control Plane (Runtime Telemetry-Backed)
+
+The operator console at `/console/operator` is backed by runtime data from:
+
+- `reconciliation_runs`
+- `reconciliation_matches`
+- `operator_runtime_events`
+- `request_metrics`
+- `billing_accounts` + `subscriptions`
+- `ops_support_tickets`
+
+## What the control plane now includes
+
+- **System health**: run volume/day, failure rate, match rate, manual review rate, run/API latency percentiles, API error rate.
+- **Usage analytics**: active tenants (7d/30d), runs/records (30d), API-vs-UI request segmentation from `request_metrics.route`.
+- **Financial observability**:
+  - revenue proxy from active subscription metadata (`monthly_revenue_usd`) with plan fallback,
+  - compute-cost proxy from run counts,
+  - revenue-per-run and margin proxy output when revenue exists.
+- **Error intelligence**: grouped signatures with top/new/regression slices and sample run/route/module context.
+- **Anomaly alerting**: baseline-aware anomaly detection with persisted, deduplicated alert history (`operator_anomaly_alerts`).
+- **GitHub auto-triage**: signature-deduped issue creation/update with cooldown tracking (`operator_error_issue_links`).
+- **Support intake**: operator ticket creation enriched with linked run/error samples, optional signature links, and triage confidence metadata.
+
+## Capability gating + graceful degradation
+
+Capabilities are explicit in API output:
+
+- GitHub triage: `GITHUB_TOKEN` + `GITHUB_REPO`
+- Stripe revenue capability: `STRIPE_SECRET_KEY`
+- Slack alerts capability: `SLACK_WEBHOOK_URL`
+
+If external systems are unavailable, the route remains functional and returns machine-visible degraded/capability state rather than hard-failing.

--- a/packages/web/src/app/api/console/operator/control-plane/route.ts
+++ b/packages/web/src/app/api/console/operator/control-plane/route.ts
@@ -1,0 +1,764 @@
+import { createHash, randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/api/auth-gate";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const COOLDOWN_HOURS = 6;
+
+interface ErrorSignatureRow {
+  signature: string;
+  last_seen: string;
+  occurrences: number;
+  impacted_tenants: number;
+  occurrences_24h: number;
+  first_seen: string;
+  sample_run_id: string | null;
+  sample_tenant_id: string | null;
+  sample_route: string | null;
+  sample_module: string | null;
+  sample_stack: string | null;
+}
+
+interface AlertCandidate {
+  dedupeKey: string;
+  metric: string;
+  severity: "warning" | "critical";
+  observed: number;
+  baseline: number;
+  message: string;
+}
+
+const supportSchema = z.object({
+  subject: z.string().min(3).max(180),
+  description: z.string().min(5).max(5000),
+  category: z.string().max(80).optional(),
+  tenantId: z.string().uuid().optional(),
+  runId: z.string().uuid().optional(),
+  errorSignature: z.string().max(300).optional(),
+  contact: z.string().max(180).optional(),
+});
+
+async function ensureOperatorTables(): Promise<void> {
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS operator_anomaly_alerts (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      dedupe_key TEXT NOT NULL UNIQUE,
+      metric TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open',
+      triggered_count INTEGER NOT NULL DEFAULT 1,
+      first_triggered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_triggered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_value DOUBLE PRECISION NOT NULL,
+      baseline_value DOUBLE PRECISION NOT NULL,
+      message TEXT NOT NULL,
+      payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+      acknowledged_at TIMESTAMPTZ,
+      acknowledged_by TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_operator_anomaly_alerts_last_triggered ON operator_anomaly_alerts(last_triggered_at DESC);
+
+    CREATE TABLE IF NOT EXISTS operator_error_issue_links (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      signature TEXT NOT NULL UNIQUE,
+      github_issue_number INTEGER,
+      github_issue_url TEXT,
+      github_issue_state TEXT,
+      first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_triaged_at TIMESTAMPTZ,
+      cooldown_until TIMESTAMPTZ,
+      observation_count INTEGER NOT NULL DEFAULT 0,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_operator_error_issue_links_last_seen ON operator_error_issue_links(last_seen_at DESC);
+  `);
+}
+
+function computeAnomalies(row: Record<string, number | null | undefined>): AlertCandidate[] {
+  const toNumber = (v: number | null | undefined) => Number(v ?? 0);
+  const recentFailure = toNumber(row.recent_failure_rate);
+  const baseFailure = toNumber(row.baseline_failure_rate);
+  const recentManual = toNumber(row.recent_manual_review_rate);
+  const baseManual = toNumber(row.baseline_manual_review_rate);
+  const recentP95 = toNumber(row.recent_api_p95_ms);
+  const baseP95 = toNumber(row.baseline_api_p95_ms);
+  const recentApiError = toNumber(row.recent_api_error_rate);
+  const baseApiError = toNumber(row.baseline_api_error_rate);
+
+  const anomalies: AlertCandidate[] = [];
+  if (recentFailure > Math.max(6, baseFailure * 1.75)) {
+    anomalies.push({
+      dedupeKey: "run_failure_rate",
+      metric: "run_failure_rate",
+      severity: recentFailure > Math.max(12, baseFailure * 2.2) ? "critical" : "warning",
+      observed: recentFailure,
+      baseline: baseFailure,
+      message: `Run failure rate spiked to ${recentFailure.toFixed(2)}% (baseline ${baseFailure.toFixed(2)}%).`,
+    });
+  }
+  if (recentManual > Math.max(15, baseManual * 1.6)) {
+    anomalies.push({
+      dedupeKey: "manual_review_rate",
+      metric: "manual_review_rate",
+      severity: recentManual > Math.max(25, baseManual * 2) ? "critical" : "warning",
+      observed: recentManual,
+      baseline: baseManual,
+      message: `Manual review rate spiked to ${recentManual.toFixed(2)}% (baseline ${baseManual.toFixed(2)}%).`,
+    });
+  }
+  if (recentP95 > Math.max(1200, baseP95 * 1.8)) {
+    anomalies.push({
+      dedupeKey: "api_latency_p95",
+      metric: "api_latency_p95",
+      severity: recentP95 > Math.max(2500, baseP95 * 2.5) ? "critical" : "warning",
+      observed: recentP95,
+      baseline: baseP95,
+      message: `API latency p95 rose to ${Math.round(recentP95)}ms (baseline ${Math.round(baseP95)}ms).`,
+    });
+  }
+  if (recentApiError > Math.max(2.5, baseApiError * 2)) {
+    anomalies.push({
+      dedupeKey: "api_error_rate",
+      metric: "api_error_rate",
+      severity: recentApiError > Math.max(7, baseApiError * 2.5) ? "critical" : "warning",
+      observed: recentApiError,
+      baseline: baseApiError,
+      message: `API error rate increased to ${recentApiError.toFixed(2)}% (baseline ${baseApiError.toFixed(2)}%).`,
+    });
+  }
+  return anomalies;
+}
+
+async function persistAlerts(anomalies: AlertCandidate[]): Promise<void> {
+  for (const alert of anomalies) {
+    await prisma.$executeRaw`
+      INSERT INTO operator_anomaly_alerts (
+        dedupe_key, metric, severity, status, triggered_count,
+        first_triggered_at, last_triggered_at,
+        last_value, baseline_value, message, payload, created_at, updated_at
+      )
+      VALUES (
+        ${alert.dedupeKey}, ${alert.metric}, ${alert.severity}, 'open', 1,
+        NOW(), NOW(),
+        ${alert.observed}, ${alert.baseline}, ${alert.message},
+        ${JSON.stringify({ metric: alert.metric })}::jsonb,
+        NOW(), NOW()
+      )
+      ON CONFLICT (dedupe_key)
+      DO UPDATE SET
+        severity = EXCLUDED.severity,
+        status = 'open',
+        triggered_count = operator_anomaly_alerts.triggered_count + 1,
+        last_triggered_at = NOW(),
+        last_value = EXCLUDED.last_value,
+        baseline_value = EXCLUDED.baseline_value,
+        message = EXCLUDED.message,
+        payload = EXCLUDED.payload,
+        updated_at = NOW();
+    `;
+  }
+}
+
+function parseGithubRepo(): { owner: string; repo: string } | null {
+  const raw = process.env.GITHUB_REPO;
+  if (!raw || !raw.includes("/")) return null;
+  const [owner, repo] = raw.split("/");
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+async function githubRequest<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN missing");
+
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API ${response.status}: ${body.slice(0, 400)}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function triageGithubIssues(
+  signatures: ErrorSignatureRow[]
+): Promise<{ mode: "disabled" | "active"; triaged: number; skipped: number; errors: string[] }> {
+  const repo = parseGithubRepo();
+  if (!repo || !process.env.GITHUB_TOKEN) {
+    return { mode: "disabled", triaged: 0, skipped: signatures.length, errors: [] };
+  }
+
+  const candidates = signatures.filter(
+    (s) => s.occurrences_24h >= 5 || Date.parse(s.first_seen) > Date.now() - 24 * 60 * 60 * 1000
+  );
+
+  let triaged = 0;
+  let skipped = 0;
+  const errors: string[] = [];
+
+  for (const signature of candidates) {
+    try {
+      const existing = await prisma.$queryRaw<
+        Array<{
+          github_issue_number: number | null;
+          cooldown_until: Date | null;
+          observation_count: number;
+        }>
+      >`
+        SELECT github_issue_number, cooldown_until, observation_count
+        FROM operator_error_issue_links
+        WHERE signature = ${signature.signature}
+        LIMIT 1
+      `;
+
+      const row = existing[0];
+      if (row?.cooldown_until && row.cooldown_until.getTime() > Date.now()) {
+        skipped += 1;
+        continue;
+      }
+
+      if (row?.github_issue_number) {
+        await githubRequest(
+          `/repos/${repo.owner}/${repo.repo}/issues/${row.github_issue_number}/comments`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              body: [
+                "Recurring operator error signature detected.",
+                `- Signature: \`${signature.signature}\``,
+                `- occurrences_24h: ${signature.occurrences_24h}`,
+                `- occurrences_30d: ${signature.occurrences}`,
+                `- sample_run_id: ${signature.sample_run_id ?? "n/a"}`,
+                `- sample_tenant_id: ${signature.sample_tenant_id ?? "n/a"}`,
+                `- sample_route: ${signature.sample_route ?? "n/a"}`,
+              ].join("\n"),
+            }),
+          }
+        );
+
+        await prisma.$executeRaw`
+          UPDATE operator_error_issue_links
+          SET
+            last_seen_at = NOW(),
+            last_triaged_at = NOW(),
+            cooldown_until = NOW() + (${COOLDOWN_HOURS}::text || ' hours')::interval,
+            observation_count = observation_count + ${signature.occurrences_24h},
+            updated_at = NOW()
+          WHERE signature = ${signature.signature}
+        `;
+      } else {
+        const created = await githubRequest<{ number: number; html_url: string; state: string }>(
+          `/repos/${repo.owner}/${repo.repo}/issues`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              title: `[Operator] Error signature: ${signature.signature}`,
+              labels: ["operator-triage", "runtime-error"],
+              body: [
+                "Automated operator triage created this issue from runtime telemetry.",
+                "",
+                `- Signature: \`${signature.signature}\``,
+                `- First seen: ${signature.first_seen}`,
+                `- Last seen: ${signature.last_seen}`,
+                `- Occurrences (24h): ${signature.occurrences_24h}`,
+                `- Occurrences (30d): ${signature.occurrences}`,
+                `- Impacted tenants (count): ${signature.impacted_tenants}`,
+                `- Sample run_id: ${signature.sample_run_id ?? "n/a"}`,
+                `- Sample route: ${signature.sample_route ?? "n/a"}`,
+                `- Sample module: ${signature.sample_module ?? "n/a"}`,
+                "",
+                "Stack sample:",
+                "```",
+                signature.sample_stack ?? "n/a",
+                "```",
+              ].join("\n"),
+            }),
+          }
+        );
+
+        await prisma.$executeRaw`
+          INSERT INTO operator_error_issue_links (
+            signature, github_issue_number, github_issue_url, github_issue_state,
+            first_seen_at, last_seen_at, last_triaged_at, cooldown_until,
+            observation_count, created_at, updated_at
+          ) VALUES (
+            ${signature.signature}, ${created.number}, ${created.html_url}, ${created.state},
+            NOW(), NOW(), NOW(), NOW() + (${COOLDOWN_HOURS}::text || ' hours')::interval,
+            ${signature.occurrences}, NOW(), NOW()
+          )
+          ON CONFLICT (signature)
+          DO UPDATE SET
+            github_issue_number = EXCLUDED.github_issue_number,
+            github_issue_url = EXCLUDED.github_issue_url,
+            github_issue_state = EXCLUDED.github_issue_state,
+            last_seen_at = NOW(),
+            last_triaged_at = NOW(),
+            cooldown_until = EXCLUDED.cooldown_until,
+            observation_count = operator_error_issue_links.observation_count + ${signature.occurrences_24h},
+            updated_at = NOW()
+        `;
+      }
+
+      triaged += 1;
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : "GitHub triage failed");
+    }
+  }
+
+  return { mode: "active", triaged, skipped, errors };
+}
+
+async function buildPayload(days: number) {
+  await ensureOperatorTables();
+
+  const [systemHealth] = await prisma.$queryRaw<Array<Record<string, number>>>(
+    `
+    WITH base_runs AS (
+      SELECT r.id, r.tenant_id, r.status,
+        COALESCE(r.source_count, 0)::numeric AS records_processed,
+        COALESCE(r.matched_count, 0)::numeric AS matched_count,
+        COALESCE(EXTRACT(EPOCH FROM (COALESCE(r.completed_at, NOW()) - COALESCE(r.started_at, r.created_at))) * 1000, 0)::numeric AS duration_ms,
+        (
+          SELECT COUNT(*)::numeric FROM reconciliation_matches m
+          WHERE m.run_id = r.id AND m.tenant_id = r.tenant_id AND m.reviewed = false AND m.match_type IN ('manual', 'unmatched')
+        ) AS manual_review_count
+      FROM reconciliation_runs r
+      WHERE COALESCE(r.started_at, r.created_at) >= NOW() - ($1::int || ' days')::interval
+    ), api_window AS (
+      SELECT
+        COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms), 0)::numeric AS p50_latency,
+        COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms), 0)::numeric AS p95_latency,
+        COALESCE((COUNT(*) FILTER (WHERE status_code >= 500)::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::numeric AS error_rate
+      FROM request_metrics
+      WHERE created_at >= NOW() - ($1::int || ' days')::interval
+    )
+    SELECT
+      COALESCE(COUNT(*)::numeric / GREATEST($1::numeric, 1), 0)::float8 AS runs_per_day,
+      COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS run_failure_rate,
+      COALESCE((SUM(matched_count) / NULLIF(SUM(records_processed), 0)) * 100, 0)::float8 AS match_rate,
+      COALESCE((SUM(manual_review_count) / NULLIF(SUM(records_processed), 0)) * 100, 0)::float8 AS manual_review_rate,
+      COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY duration_ms), 0)::float8 AS run_duration_p50,
+      COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms), 0)::float8 AS run_duration_p95,
+      (SELECT p50_latency::float8 FROM api_window) AS api_latency_p50,
+      (SELECT p95_latency::float8 FROM api_window) AS api_latency_p95,
+      (SELECT error_rate::float8 FROM api_window) AS api_error_rate
+    FROM base_runs;
+  `,
+    days
+  );
+
+  const [anomalyWindow] = await prisma.$queryRaw<Array<Record<string, number>>>(`
+    WITH recent_runs AS (
+      SELECT
+        COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS failure_rate,
+        COALESCE(AVG(CASE WHEN source_count > 0 THEN (
+          SELECT COUNT(*)::float8
+          FROM reconciliation_matches m
+          WHERE m.run_id = r.id
+            AND m.tenant_id = r.tenant_id
+            AND m.reviewed = false
+            AND m.match_type IN ('manual', 'unmatched')
+        ) / source_count::float8 * 100 ELSE 0 END), 0)::float8 AS manual_review_rate
+      FROM reconciliation_runs r
+      WHERE COALESCE(started_at, created_at) >= NOW() - interval '24 hours'
+    ),
+    baseline_runs AS (
+      SELECT
+        COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS failure_rate,
+        COALESCE(AVG(CASE WHEN source_count > 0 THEN (
+          SELECT COUNT(*)::float8
+          FROM reconciliation_matches m
+          WHERE m.run_id = r.id
+            AND m.tenant_id = r.tenant_id
+            AND m.reviewed = false
+            AND m.match_type IN ('manual', 'unmatched')
+        ) / source_count::float8 * 100 ELSE 0 END), 0)::float8 AS manual_review_rate
+      FROM reconciliation_runs r
+      WHERE COALESCE(started_at, created_at) >= NOW() - interval '14 days'
+        AND COALESCE(started_at, created_at) < NOW() - interval '24 hours'
+    ),
+    recent_api AS (
+      SELECT
+        COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms), 0)::float8 AS p95_ms,
+        COALESCE((COUNT(*) FILTER (WHERE status_code >= 500)::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS error_rate
+      FROM request_metrics
+      WHERE created_at >= NOW() - interval '24 hours'
+    ),
+    baseline_api AS (
+      SELECT
+        COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms), 0)::float8 AS p95_ms,
+        COALESCE((COUNT(*) FILTER (WHERE status_code >= 500)::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS error_rate
+      FROM request_metrics
+      WHERE created_at >= NOW() - interval '14 days'
+        AND created_at < NOW() - interval '24 hours'
+    )
+    SELECT
+      recent_runs.failure_rate AS recent_failure_rate,
+      baseline_runs.failure_rate AS baseline_failure_rate,
+      recent_runs.manual_review_rate AS recent_manual_review_rate,
+      baseline_runs.manual_review_rate AS baseline_manual_review_rate,
+      recent_api.p95_ms AS recent_api_p95_ms,
+      baseline_api.p95_ms AS baseline_api_p95_ms,
+      recent_api.error_rate AS recent_api_error_rate,
+      baseline_api.error_rate AS baseline_api_error_rate
+    FROM recent_runs, baseline_runs, recent_api, baseline_api;
+  `);
+
+  const anomalies = computeAnomalies(anomalyWindow ?? {});
+  await persistAlerts(anomalies);
+
+  const persistedAlerts = await prisma.$queryRaw<Array<Record<string, unknown>>>(`
+    SELECT dedupe_key, metric, severity, status, triggered_count,
+      first_triggered_at, last_triggered_at, last_value, baseline_value, message
+    FROM operator_anomaly_alerts
+    ORDER BY last_triggered_at DESC
+    LIMIT 25
+  `);
+
+  const recentRuns = await prisma.$queryRaw<Array<Record<string, unknown>>>(`
+    SELECT id::text AS run_id, tenant_id::text AS tenant_id, status, error_message,
+      COALESCE(started_at, created_at) AS started_at, completed_at,
+      COALESCE(source_count, 0) AS source_count, COALESCE(matched_count, 0) AS matched_count
+    FROM reconciliation_runs
+    ORDER BY COALESCE(started_at, created_at) DESC
+    LIMIT 20;
+  `);
+
+  const errorSignatures = await prisma.$queryRaw<ErrorSignatureRow[]>(`
+    SELECT
+      COALESCE(ore.metadata->>'signature', ore.error_id::text, 'unknown_error') AS signature,
+      MAX(ore.occurred_at)::text AS last_seen,
+      COUNT(*)::int AS occurrences,
+      COUNT(DISTINCT ore.tenant_id)::int AS impacted_tenants,
+      COUNT(*) FILTER (WHERE ore.occurred_at >= NOW() - interval '24 hours')::int AS occurrences_24h,
+      MIN(ore.occurred_at)::text AS first_seen,
+      MAX(ore.run_id)::text AS sample_run_id,
+      MAX(ore.tenant_id)::text AS sample_tenant_id,
+      MAX(ore.metadata->>'route') AS sample_route,
+      MAX(ore.metadata->>'module') AS sample_module,
+      MAX(ore.metadata->>'stack') AS sample_stack
+    FROM operator_runtime_events ore
+    WHERE ore.event_type = 'error_thrown'
+      AND ore.occurred_at >= NOW() - interval '30 days'
+    GROUP BY 1
+    ORDER BY occurrences DESC
+    LIMIT 30;
+  `);
+
+  const issueTriage = await triageGithubIssues(errorSignatures);
+
+  const usage = await prisma.$queryRaw<Array<Record<string, unknown>>>(`
+    WITH run_window AS (
+      SELECT tenant_id, COALESCE(source_count, 0)::bigint AS records
+      FROM reconciliation_runs
+      WHERE COALESCE(started_at, created_at) >= NOW() - interval '30 days'
+    ), segmented AS (
+      SELECT
+        SUM(CASE WHEN route LIKE '/api/%' THEN 1 ELSE 0 END)::bigint AS api_requests,
+        SUM(CASE WHEN route NOT LIKE '/api/%' THEN 1 ELSE 0 END)::bigint AS ui_requests
+      FROM request_metrics
+      WHERE created_at >= NOW() - interval '30 days'
+    )
+    SELECT
+      (SELECT COUNT(DISTINCT tenant_id)::int FROM reconciliation_runs WHERE COALESCE(started_at, created_at) >= NOW() - interval '7 days') AS active_tenants_7d,
+      (SELECT COUNT(DISTINCT tenant_id)::int FROM reconciliation_runs WHERE COALESCE(started_at, created_at) >= NOW() - interval '30 days') AS active_tenants_30d,
+      COALESCE(COUNT(*), 0)::int AS runs_30d,
+      COALESCE(SUM(records), 0)::bigint AS records_30d,
+      (SELECT COALESCE(api_requests, 0) FROM segmented)::bigint AS api_requests_30d,
+      (SELECT COALESCE(ui_requests, 0) FROM segmented)::bigint AS ui_requests_30d
+    FROM run_window;
+  `);
+
+  const tenantOverview = await prisma.$queryRaw<Array<Record<string, unknown>>>(`
+    SELECT tenant_id::text, COUNT(*)::int AS run_count,
+      COALESCE(SUM(source_count), 0)::bigint AS records_processed,
+      COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS failure_rate,
+      COALESCE(AVG(CASE WHEN source_count > 0 THEN (
+        SELECT COUNT(*)::float8
+        FROM reconciliation_matches m
+        WHERE m.run_id = r.id
+          AND m.tenant_id = r.tenant_id
+          AND m.reviewed = false
+          AND m.match_type IN ('manual', 'unmatched')
+      ) / source_count::float8 * 100 ELSE 0 END), 0)::float8 AS manual_review_rate
+    FROM reconciliation_runs r
+    WHERE COALESCE(started_at, created_at) >= NOW() - interval '30 days'
+    GROUP BY tenant_id
+    ORDER BY run_count DESC
+    LIMIT 10;
+  `);
+
+  const tenantEconomics = await prisma.$queryRaw<Array<Record<string, unknown>>>(`
+    WITH run_stats AS (
+      SELECT tenant_id::text AS tenant_id, COUNT(*)::int AS runs_30d, COALESCE(SUM(source_count), 0)::bigint AS records_30d
+      FROM reconciliation_runs
+      WHERE COALESCE(started_at, created_at) >= NOW() - interval '30 days'
+      GROUP BY tenant_id
+    ),
+    revenue AS (
+      SELECT
+        ba.tenant_id::text AS tenant_id,
+        MAX(CASE
+          WHEN s.status IN ('active','trialing','past_due') AND (s.metadata->>'monthly_revenue_usd') ~ '^[0-9]+(\\.[0-9]+)?$'
+          THEN (s.metadata->>'monthly_revenue_usd')::numeric
+          ELSE NULL
+        END) AS explicit_mrr,
+        MAX(CASE
+          WHEN s.status IN ('active','trialing','past_due') THEN
+            CASE s.plan_id
+              WHEN 'starter' THEN 0
+              WHEN 'growth' THEN 900
+              WHEN 'scale' THEN 9900
+              WHEN 'enterprise' THEN 0
+              WHEN 'pro' THEN 900
+              WHEN 'base' THEN 0
+              ELSE 0
+            END
+          ELSE 0
+        END)::numeric AS plan_mrr
+      FROM billing_accounts ba
+      LEFT JOIN subscriptions s ON s.billing_account_id = ba.id
+      GROUP BY ba.tenant_id
+    )
+    SELECT
+      rs.tenant_id,
+      rs.runs_30d,
+      rs.records_30d,
+      COALESCE(revenue.explicit_mrr, revenue.plan_mrr, 0)::float8 AS estimated_mrr_usd
+    FROM run_stats rs
+    LEFT JOIN revenue ON revenue.tenant_id = rs.tenant_id
+    ORDER BY rs.runs_30d DESC;
+  `);
+
+  const totalRevenue = tenantEconomics.reduce(
+    (acc, row) => acc + Number(row.estimated_mrr_usd ?? 0),
+    0
+  );
+
+  const usageRow = usage[0] ?? {};
+  const totalRuns30d = Number(usageRow.runs_30d ?? 0);
+  const estimatedCostPerRun = 0.0025;
+  const totalComputeCost = totalRuns30d * estimatedCostPerRun;
+  const marginProxy =
+    totalRevenue > 0
+      ? Number((((totalRevenue - totalComputeCost) / totalRevenue) * 100).toFixed(2))
+      : null;
+
+  const capabilities = {
+    githubIssueTriage: Boolean(process.env.GITHUB_TOKEN && parseGithubRepo()),
+    stripeRevenue: Boolean(process.env.STRIPE_SECRET_KEY),
+    slackAlerts: Boolean(process.env.SLACK_WEBHOOK_URL),
+  };
+
+  return {
+    systemHealth: systemHealth ?? null,
+    activity: {
+      recentRuns,
+      failedRuns: recentRuns.filter((r) => r.status === "failed").slice(0, 10),
+      errorSignatures,
+      githubIssueTriage: issueTriage,
+    },
+    usage: {
+      activeTenants7d: Number(usageRow.active_tenants_7d ?? 0),
+      activeTenants30d: Number(usageRow.active_tenants_30d ?? 0),
+      runs30d: totalRuns30d,
+      records30d: Number(usageRow.records_30d ?? 0),
+      apiRequests30d: Number(usageRow.api_requests_30d ?? 0),
+      uiRequests30d: Number(usageRow.ui_requests_30d ?? 0),
+    },
+    financial: {
+      estimatedComputeCostPerRunUsd: estimatedCostPerRun,
+      estimatedComputeCost30dUsd: Number(totalComputeCost.toFixed(2)),
+      realizedRevenue30dProxyUsd: Number(totalRevenue.toFixed(2)),
+      revenuePerRunUsd: totalRuns30d > 0 ? Number((totalRevenue / totalRuns30d).toFixed(4)) : null,
+      marginProxyPercent: marginProxy,
+      assumptions: [
+        "Revenue uses subscription metadata monthly_revenue_usd when available; otherwise plan defaults.",
+        "Cost proxy currently includes compute only from run volume.",
+      ],
+      tenantEconomics,
+    },
+    tenantOverview,
+    errorIntelligence: {
+      top24h: errorSignatures.filter((row) => row.occurrences_24h > 0).slice(0, 10),
+      top7d: errorSignatures.slice(0, 10),
+      newSignatures: errorSignatures.filter(
+        (row) => Date.parse(row.first_seen) > Date.now() - 24 * 60 * 60 * 1000
+      ),
+      regressions: errorSignatures.filter((row) => row.occurrences_24h >= 5).slice(0, 10),
+    },
+    alerts: persistedAlerts,
+    capabilities,
+  };
+}
+
+export const GET = withSecurity(
+  async function GET(request: NextRequest) {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isAdmin) return adminCheck.error!;
+
+    const { searchParams } = new URL(request.url);
+    const days = Math.min(30, Math.max(1, Number(searchParams.get("days") ?? 7) || 7));
+
+    try {
+      const data = await buildPayload(days);
+      return NextResponse.json({ data, generatedAt: new Date().toISOString() });
+    } catch (error) {
+      return NextResponse.json({
+        data: null,
+        degraded: true,
+        error: error instanceof Error ? error.message : "Failed",
+      });
+    }
+  },
+  { requireAuth: true }
+);
+
+export const POST = withSecurity(
+  async function POST(request: NextRequest) {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isAdmin) return adminCheck.error!;
+
+    try {
+      await ensureOperatorTables();
+      const json = await request.json();
+      const payload = supportSchema.parse(json);
+
+      const ticketNumber = `OPS-${new Date().toISOString().slice(0, 10).replaceAll("-", "")}-${createHash("sha1").update(randomUUID()).digest("hex").slice(0, 8).toUpperCase()}`;
+
+      const recentRuns = await prisma.$queryRaw<Array<Record<string, unknown>>>(
+        `
+        SELECT id::text AS run_id, tenant_id::text AS tenant_id, status, error_message,
+          COALESCE(started_at, created_at) AS started_at
+        FROM reconciliation_runs
+        WHERE ($1::text IS NULL OR tenant_id::text = $1::text)
+          AND ($2::text IS NULL OR id::text = $2::text)
+        ORDER BY COALESCE(started_at, created_at) DESC
+        LIMIT 5
+      `,
+        payload.tenantId ?? null,
+        payload.runId ?? null
+      );
+
+      const recentErrors = await prisma.$queryRaw<Array<ErrorSignatureRow>>(
+        `
+        SELECT
+          COALESCE(metadata->>'signature', error_id::text, 'unknown_error') AS signature,
+          MAX(occurred_at)::text AS last_seen,
+          COUNT(*)::int AS occurrences,
+          COUNT(DISTINCT tenant_id)::int AS impacted_tenants,
+          COUNT(*) FILTER (WHERE occurred_at >= NOW() - interval '24 hours')::int AS occurrences_24h,
+          MIN(occurred_at)::text AS first_seen,
+          MAX(run_id)::text AS sample_run_id,
+          MAX(tenant_id)::text AS sample_tenant_id,
+          MAX(metadata->>'route') AS sample_route,
+          MAX(metadata->>'module') AS sample_module,
+          MAX(metadata->>'stack') AS sample_stack
+        FROM operator_runtime_events
+        WHERE event_type = 'error_thrown'
+          AND occurred_at >= NOW() - interval '7 days'
+          AND ($1::text IS NULL OR tenant_id::text = $1::text)
+          AND ($2::text IS NULL OR run_id::text = $2::text)
+          AND ($3::text IS NULL OR COALESCE(metadata->>'signature', error_id::text, 'unknown_error') = $3::text)
+        GROUP BY 1
+        ORDER BY occurrences DESC
+        LIMIT 5
+      `,
+        payload.tenantId ?? null,
+        payload.runId ?? null,
+        payload.errorSignature ?? null
+      );
+
+      const linkedIssue = payload.errorSignature
+        ? (
+            await prisma.$queryRaw<
+              Array<{ github_issue_number: number | null; github_issue_url: string | null }>
+            >`
+              SELECT github_issue_number, github_issue_url
+              FROM operator_error_issue_links
+              WHERE signature = ${payload.errorSignature}
+              LIMIT 1
+            `
+          )[0]
+        : null;
+
+      const confidence = Math.min(
+        0.98,
+        0.35 +
+          (recentRuns.length > 0 ? 0.2 : 0) +
+          (recentErrors.length > 0 ? 0.25 : 0) +
+          (linkedIssue?.github_issue_number ? 0.15 : 0)
+      );
+
+      const triage = {
+        confidence,
+        score: Math.round(confidence * 100),
+        linkedRunCount: recentRuns.length,
+        linkedErrorCount: recentErrors.length,
+        linkedGithubIssue: linkedIssue?.github_issue_number ?? null,
+      };
+
+      await prisma.$executeRaw`
+        INSERT INTO ops_support_tickets (
+          ticket_number, user_id, subject, description, status, priority, category,
+          triage_result, context, created_at, updated_at
+        ) VALUES (
+          ${ticketNumber}, ${adminCheck.user!.id}, ${payload.subject}, ${payload.description},
+          'open',
+          ${confidence >= 0.75 ? "high" : "medium"},
+          ${payload.category ?? "operator"},
+          ${JSON.stringify(triage)}::jsonb,
+          ${JSON.stringify({
+            tenantId: payload.tenantId ?? null,
+            runId: payload.runId ?? null,
+            errorSignature: payload.errorSignature ?? null,
+            contact: payload.contact ?? null,
+            recentRuns,
+            recentErrors,
+            linkedIssue,
+          })}::jsonb,
+          NOW(), NOW()
+        )
+      `;
+
+      return NextResponse.json({
+        success: true,
+        ticketNumber,
+        triage,
+        linkedIssue,
+      });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return NextResponse.json({
+          success: false,
+          error: "Invalid payload",
+          details: error.issues,
+        });
+      }
+      return NextResponse.json({
+        success: false,
+        error: error instanceof Error ? error.message : "Failed",
+      });
+    }
+  },
+  { requireAuth: true }
+);

--- a/packages/web/src/app/console/operator/page.tsx
+++ b/packages/web/src/app/console/operator/page.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+
+interface OperatorPayload {
+  data: {
+    systemHealth: Record<string, number> | null;
+    usage: {
+      activeTenants7d: number;
+      activeTenants30d: number;
+      runs30d: number;
+      records30d: number;
+      apiRequests30d: number;
+      uiRequests30d: number;
+    };
+    financial: {
+      estimatedComputeCostPerRunUsd: number;
+      estimatedComputeCost30dUsd: number;
+      realizedRevenue30dProxyUsd: number;
+      revenuePerRunUsd: number | null;
+      marginProxyPercent: number | null;
+      assumptions: string[];
+      tenantEconomics: Array<{
+        tenant_id: string;
+        runs_30d: number;
+        records_30d: number;
+        estimated_mrr_usd: number;
+      }>;
+    };
+    activity: {
+      errorSignatures: Array<{ signature: string; occurrences_24h: number }>;
+      githubIssueTriage: { mode: string; triaged: number; skipped: number; errors: string[] };
+    };
+    tenantOverview: Array<{
+      tenant_id: string;
+      run_count: number;
+      failure_rate: number;
+      manual_review_rate: number;
+    }>;
+    errorIntelligence: {
+      top24h: Array<{ signature: string; occurrences_24h: number }>;
+      newSignatures: Array<{ signature: string }>;
+      regressions: Array<{ signature: string; occurrences_24h: number }>;
+    };
+    alerts: Array<{
+      dedupe_key: string;
+      metric: string;
+      severity: string;
+      triggered_count: number;
+      message: string;
+      last_value: number;
+      baseline_value: number;
+      last_triggered_at: string;
+    }>;
+    capabilities: { githubIssueTriage: boolean; stripeRevenue: boolean; slackAlerts: boolean };
+  } | null;
+  degraded?: boolean;
+  error?: string;
+}
+
+export default function OperatorControlPlanePage() {
+  const [payload, setPayload] = useState<OperatorPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [ticketResult, setTicketResult] = useState<string>("");
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function load() {
+    setLoading(true);
+    const res = await fetch("/api/console/operator/control-plane?days=7");
+    const data = (await res.json()) as OperatorPayload;
+    setPayload(data);
+    setLoading(false);
+  }
+
+  async function submitTicket(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    const body = {
+      subject: String(form.get("subject") ?? ""),
+      description: String(form.get("description") ?? ""),
+      tenantId: String(form.get("tenantId") || "") || undefined,
+      runId: String(form.get("runId") || "") || undefined,
+      errorSignature: String(form.get("errorSignature") || "") || undefined,
+      category: "operator",
+    };
+    const res = await fetch("/api/console/operator/control-plane", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const result = (await res.json()) as {
+      success: boolean;
+      ticketNumber?: string;
+      error?: string;
+    };
+    setTicketResult(
+      result.success ? `Ticket created: ${result.ticketNumber}` : `Ticket failed: ${result.error}`
+    );
+  }
+
+  if (loading) return <div className="p-6">Loading operator control plane…</div>;
+  if (!payload?.data)
+    return (
+      <div className="p-6">Operator control plane unavailable: {payload?.error ?? "unknown"}</div>
+    );
+
+  const {
+    systemHealth,
+    usage,
+    financial,
+    tenantOverview,
+    errorIntelligence,
+    capabilities,
+    alerts,
+    activity,
+  } = payload.data;
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Operator Control Plane</h1>
+      {payload.degraded ? (
+        <p className="text-sm text-amber-600">Degraded mode: partial data available.</p>
+      ) : null}
+
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Metric label="Runs/day" value={systemHealth?.runs_per_day ?? 0} />
+        <Metric
+          label="Failure rate"
+          value={`${Number(systemHealth?.run_failure_rate ?? 0).toFixed(2)}%`}
+        />
+        <Metric label="Match rate" value={`${Number(systemHealth?.match_rate ?? 0).toFixed(2)}%`} />
+        <Metric
+          label="Manual review"
+          value={`${Number(systemHealth?.manual_review_rate ?? 0).toFixed(2)}%`}
+        />
+        <Metric label="Run p95" value={`${Math.round(systemHealth?.run_duration_p95 ?? 0)}ms`} />
+        <Metric label="API p95" value={`${Math.round(systemHealth?.api_latency_p95 ?? 0)}ms`} />
+        <Metric
+          label="API error"
+          value={`${Number(systemHealth?.api_error_rate ?? 0).toFixed(2)}%`}
+        />
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Usage analytics</h2>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <Metric label="Active tenants (7d)" value={usage.activeTenants7d} />
+          <Metric label="Active tenants (30d)" value={usage.activeTenants30d} />
+          <Metric label="Runs (30d)" value={usage.runs30d} />
+          <Metric label="Records (30d)" value={usage.records30d} />
+          <Metric label="API requests (30d)" value={usage.apiRequests30d} />
+          <Metric label="UI requests (30d)" value={usage.uiRequests30d} />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Financial / unit economics</h2>
+        <p>Revenue proxy (30d): ${financial.realizedRevenue30dProxyUsd}</p>
+        <p>Compute cost proxy (30d): ${financial.estimatedComputeCost30dUsd}</p>
+        <p>Revenue / run: {financial.revenuePerRunUsd ?? "n/a"}</p>
+        <p>
+          Margin proxy:{" "}
+          {financial.marginProxyPercent === null
+            ? "unavailable"
+            : `${financial.marginProxyPercent}%`}
+        </p>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Alert history (deduped)</h2>
+        <ul className="text-sm space-y-1">
+          {alerts.map((alert) => (
+            <li key={alert.dedupe_key}>
+              [{alert.severity}] {alert.message} · seen {alert.triggered_count}x ·{" "}
+              {new Date(alert.last_triggered_at).toLocaleString()}
+            </li>
+          ))}
+          {!alerts.length ? <li>No active anomalies.</li> : null}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Error intelligence</h2>
+        <p>New signatures (24h): {errorIntelligence.newSignatures.length}</p>
+        <p>Regressions: {errorIntelligence.regressions.length}</p>
+        <ul className="text-sm space-y-1 mt-2">
+          {errorIntelligence.top24h.map((err) => (
+            <li key={err.signature}>
+              {err.signature} — {err.occurrences_24h} in 24h
+            </li>
+          ))}
+          {!errorIntelligence.top24h.length ? <li>No signatures in last 24h.</li> : null}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">GitHub triage automation</h2>
+        <p>Mode: {activity.githubIssueTriage.mode}</p>
+        <p>Triaged this cycle: {activity.githubIssueTriage.triaged}</p>
+        <p>Skipped (dedupe/cooldown): {activity.githubIssueTriage.skipped}</p>
+        {activity.githubIssueTriage.errors.length ? (
+          <p className="text-red-600">{activity.githubIssueTriage.errors[0]}</p>
+        ) : null}
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Top tenants by run volume</h2>
+        <ul className="text-sm space-y-1">
+          {tenantOverview.map((t) => (
+            <li key={t.tenant_id}>
+              {t.tenant_id} — {t.run_count} runs, failure {t.failure_rate.toFixed(2)}%, manual
+              review {t.manual_review_rate.toFixed(2)}%
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Capability status</h2>
+        <p>GitHub triage: {capabilities.githubIssueTriage ? "available" : "unavailable"}</p>
+        <p>Stripe revenue: {capabilities.stripeRevenue ? "available" : "unavailable"}</p>
+        <p>Slack alerts: {capabilities.slackAlerts ? "available" : "unavailable"}</p>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Support intake</h2>
+        <form className="space-y-2 max-w-xl" onSubmit={submitTicket}>
+          <input
+            className="border rounded px-2 py-1 w-full"
+            name="subject"
+            placeholder="Subject"
+            required
+          />
+          <textarea
+            className="border rounded px-2 py-1 w-full"
+            name="description"
+            placeholder="Description"
+            required
+            rows={4}
+          />
+          <input
+            className="border rounded px-2 py-1 w-full"
+            name="tenantId"
+            placeholder="tenant UUID (optional)"
+          />
+          <input
+            className="border rounded px-2 py-1 w-full"
+            name="runId"
+            placeholder="run UUID (optional)"
+          />
+          <input
+            className="border rounded px-2 py-1 w-full"
+            name="errorSignature"
+            placeholder="error signature (optional)"
+          />
+          <button className="border px-3 py-1 rounded" type="submit">
+            Create support ticket
+          </button>
+        </form>
+        {ticketResult ? <p className="text-sm mt-2">{ticketResult}</p> : null}
+      </section>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded border p-3">
+      <p className="text-xs text-slate-500">{label}</p>
+      <p className="text-lg font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/prisma/migrations/20260310103000_operator_control_plane_intelligence/migration.sql
+++ b/prisma/migrations/20260310103000_operator_control_plane_intelligence/migration.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS operator_anomaly_alerts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  dedupe_key TEXT NOT NULL UNIQUE,
+  metric TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open',
+  triggered_count INTEGER NOT NULL DEFAULT 1,
+  first_triggered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_triggered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_value DOUBLE PRECISION NOT NULL,
+  baseline_value DOUBLE PRECISION NOT NULL,
+  message TEXT NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  acknowledged_at TIMESTAMPTZ,
+  acknowledged_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_anomaly_alerts_last_triggered
+  ON operator_anomaly_alerts (last_triggered_at DESC);
+
+CREATE TABLE IF NOT EXISTS operator_error_issue_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  signature TEXT NOT NULL UNIQUE,
+  github_issue_number INTEGER,
+  github_issue_url TEXT,
+  github_issue_state TEXT,
+  first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_triaged_at TIMESTAMPTZ,
+  cooldown_until TIMESTAMPTZ,
+  observation_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_error_issue_links_last_seen
+  ON operator_error_issue_links (last_seen_at DESC);


### PR DESCRIPTION
### Motivation

- Provide a runtime-telemetry backed operator console that surfaces system health, usage, financial proxies, error intelligence, and alert history.  
- Automate error triage into GitHub and allow operators to create enriched support tickets from runtime context.  
- Persist alerts and triage state to enable deduplication, cooldowns and historical visibility.

### Description

- Adds a new API route `GET/POST /api/console/operator/control-plane` that aggregates telemetry (`reconciliation_runs`, `reconciliation_matches`, `operator_runtime_events`, `request_metrics`, `billing_accounts`/`subscriptions`) and implements baseline-aware anomaly detection and persistence (`operator_anomaly_alerts`).
- Implements GitHub triage automation with dedupe/cooldown tracking persisted in `operator_error_issue_links`, and capability gating via `GITHUB_TOKEN`/`GITHUB_REPO`, `STRIPE_SECRET_KEY`, and `SLACK_WEBHOOK_URL` to gracefully degrade when external systems are unavailable.
- Adds operator UI at `/console/operator` that displays system health, usage, financial/unit-economics proxies, alert history, error intelligence, capability status, and a support intake form which creates enriched `ops_support_tickets` entries.
- Adds a Prisma migration SQL file to create `operator_anomaly_alerts` and `operator_error_issue_links`, and an internal `ensureOperatorTables` helper to create those tables when the API runs; includes server-side triage, alert persistence, and ticket creation logic.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af80f1caa8832898c8ab6711389723)