### PR TITLE
Add capability-gated Slack/Teams/Telegram notifier layer for operator alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -290,3 +290,17 @@ DEMO_USER_EMAIL=demo@settler.dev
 
 # Demo user password
 DEMO_USER_PASSWORD=DemoPassword123!
+
+# ----------------------------------------------------------------------------
+# ALERT NOTIFIER CHANNELS (OPTIONAL)
+# ----------------------------------------------------------------------------
+# External channels are optional. In-app alerting still works when unset.
+SLACK_ALERT_WEBHOOK_URL=
+TEAMS_ALERT_WEBHOOK_URL=
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
+# Optional dry-run mode for notifier dispatch
+ALERT_NOTIFIER_DRY_RUN=true
+# Optional dedupe cooldown in milliseconds (default 300000 = 5 minutes)
+ALERT_NOTIFICATION_COOLDOWN_MS=300000

--- a/.env.local.example
+++ b/.env.local.example
@@ -29,3 +29,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=local-dev-anon-key
 # RESEND_API_KEY=re_xxx
 # STRIPE_SECRET_KEY=sk_test_xxx
 # STRIPE_WEBHOOK_SECRET=whsec_xxx
+
+# Alert notifier channels (optional)
+# SLACK_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/...
+# TEAMS_ALERT_WEBHOOK_URL=https://outlook.office.com/webhook/...
+# TELEGRAM_BOT_TOKEN=123456:ABCDEF
+# TELEGRAM_CHAT_ID=-123456789
+# ALERT_NOTIFIER_DRY_RUN=true

--- a/docs/OPERATOR_MODE.md
+++ b/docs/OPERATOR_MODE.md
@@ -369,3 +369,13 @@ Operator mode metrics are exposed via Prometheus:
 - [ ] Multi-region backup replication
 - [ ] Predictive alerting based on trends
 - [ ] Cost forecasting and recommendations
+
+## Notifier Capability Gating
+
+Operator alerting now supports optional channel dispatch providers for:
+
+- Slack (`SLACK_ALERT_WEBHOOK_URL`)
+- Microsoft Teams (`TEAMS_ALERT_WEBHOOK_URL`)
+- Telegram (`TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`)
+
+When credentials are absent, external dispatch is skipped and in-app alert persistence remains active. Use `GET /api/v1/operator/alerts/capabilities` to inspect runtime channel capability status.

--- a/docs/OPERATOR_MODE_SETUP.md
+++ b/docs/OPERATOR_MODE_SETUP.md
@@ -265,3 +265,35 @@ For issues or questions:
 2. Review `docs/OPERATOR_MODE.md` for detailed documentation
 3. Check `docs/OPERATOR_MODE_QUICK_START.md` for quick reference
 4. Review `docs/INCIDENT_POSTMORTEM_TEMPLATE.md` for incident response
+
+## Notifier Channels (Slack / Teams / Telegram)
+
+External notifier dispatch is optional and capability-gated. In-app alert records continue to work when notifier credentials are missing.
+
+### Environment variables
+
+Set any channel you want to enable:
+
+- `SLACK_ALERT_WEBHOOK_URL`
+- `TEAMS_ALERT_WEBHOOK_URL`
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_CHAT_ID`
+
+Optional controls:
+
+- `ALERT_NOTIFIER_DRY_RUN=true|false` (default recommended true for first setup validation)
+- `ALERT_NOTIFICATION_COOLDOWN_MS` (dedupe cooldown, default 300000)
+
+### Capability status API
+
+Use:
+
+- `GET /api/v1/operator/alerts/capabilities`
+
+Each channel reports one of:
+
+- `configured`
+- `unavailable`
+- `degraded`
+
+`degraded` is used for partial Telegram configuration (token without chat id or vice versa).

--- a/packages/api/src/__tests__/services/notifier-provider.test.ts
+++ b/packages/api/src/__tests__/services/notifier-provider.test.ts
@@ -1,0 +1,63 @@
+import {
+  buildAlertRouter,
+  buildNotifierCapabilities,
+  createNotifierProviders,
+  dispatchAlert,
+  type AlertPayload,
+} from '../../services/operator-mode/notifier-provider';
+
+describe('notifier provider', () => {
+  const payload: AlertPayload = {
+    alertId: 'alert_1',
+    alertType: 'run_failure_spike',
+    severity: 'critical',
+    summary: 'Run failures exceeded baseline',
+    tenantId: 'tenant_1',
+    runId: 'run_1',
+    timestamp: new Date().toISOString(),
+  };
+
+  it('reports channel capabilities from env-style config', () => {
+    const capabilities = buildNotifierCapabilities({
+      slackWebhookUrl: 'https://hooks.slack.test/abc',
+      teamsWebhookUrl: undefined,
+      telegramBotToken: 'bot_token',
+      telegramChatId: undefined,
+    });
+
+    expect(capabilities.find((c) => c.channel === 'slack')?.status).toBe('configured');
+    expect(capabilities.find((c) => c.channel === 'teams')?.status).toBe('unavailable');
+    expect(capabilities.find((c) => c.channel === 'telegram')?.status).toBe('degraded');
+  });
+
+  it('routes by severity', () => {
+    const router = buildAlertRouter(['slack', 'teams', 'telegram']);
+
+    expect(router.resolveChannels({ severity: 'info', alertType: 'x' })).toEqual(['slack']);
+    expect(router.resolveChannels({ severity: 'warning', alertType: 'x' })).toEqual(['slack', 'teams']);
+    expect(router.resolveChannels({ severity: 'critical', alertType: 'x' })).toEqual([
+      'slack',
+      'teams',
+      'telegram',
+    ]);
+  });
+
+  it('supports dry-run notification dispatch without network side effects', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    const providers = createNotifierProviders(
+      {
+        slackWebhookUrl: 'https://hooks.slack.test/abc',
+        teamsWebhookUrl: 'https://teams.test/webhook',
+        telegramBotToken: 'token',
+        telegramChatId: 'chat-id',
+        dryRun: true,
+      },
+      fetchMock as unknown as typeof fetch
+    );
+
+    const delivered = await dispatchAlert(payload, providers, buildAlertRouter(['slack', 'teams', 'telegram']));
+
+    expect(delivered).toHaveLength(3);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/alerts.ts
+++ b/packages/api/src/routes/alerts.ts
@@ -20,7 +20,7 @@ const createAlertRuleSchema = z.object({
     metric: z.string(), // e.g., "reconciliation.accuracy", "reconciliation.error_rate"
     threshold: z.number(),
     operator: z.enum(["gt", "gte", "lt", "lte", "eq", "neq"]),
-    channels: z.array(z.enum(["email", "slack", "pagerduty"])),
+    channels: z.array(z.enum(["email", "slack", "teams", "telegram", "pagerduty", "webhook"])),
     enabled: z.boolean().default(true),
   }),
 });

--- a/packages/api/src/routes/v1/operator-mode.ts
+++ b/packages/api/src/routes/v1/operator-mode.ts
@@ -19,6 +19,7 @@ import {
 } from '../../services/operator-mode/daily-intelligence';
 import {
   checkAlertThresholds,
+  getNotifierCapabilities,
   upsertAlertThreshold,
   AlertThreshold,
 } from '../../services/operator-mode/alerting';
@@ -173,7 +174,7 @@ const createAlertThresholdSchema = z.object({
     threshold: z.number(),
     operator: z.enum(['gt', 'gte', 'lt', 'lte', 'eq', 'neq']),
     severity: z.enum(['low', 'medium', 'high', 'critical']).default('medium'),
-    channels: z.array(z.enum(['email', 'slack', 'webhook'])).default([]),
+    channels: z.array(z.enum(['email', 'slack', 'teams', 'telegram', 'webhook'])).default([]),
     enabled: z.boolean().default(true),
   }),
 });
@@ -195,6 +196,21 @@ router.post(
       });
     } catch (error: unknown) {
       handleRouteError(res, error, 'Failed to create alert threshold', 500, {
+        userId: req.userId,
+      });
+    }
+  }
+);
+
+
+router.get(
+  '/operator/alerts/capabilities',
+  requirePermission(Permission.ADMIN_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      res.json({ data: getNotifierCapabilities() });
+    } catch (error: unknown) {
+      handleRouteError(res, error, 'Failed to get notifier capabilities', 500, {
         userId: req.userId,
       });
     }

--- a/packages/api/src/services/operator-mode/alerting.ts
+++ b/packages/api/src/services/operator-mode/alerting.ts
@@ -6,6 +6,15 @@
 import { query } from '../../db';
 import { logError, logWarn, logInfo } from '../../utils/logger';
 import { generateDailyIntelligence } from './daily-intelligence';
+import {
+  buildAlertRouter,
+  buildNotifierCapabilities,
+  createNotifierProviders,
+  dispatchAlert,
+  type AlertChannel,
+  type AlertPayload,
+  type NotifierCapability,
+} from './notifier-provider';
 
 export interface AlertThreshold {
   id?: string;
@@ -14,7 +23,7 @@ export interface AlertThreshold {
   threshold: number;
   operator: 'gt' | 'gte' | 'lt' | 'lte' | 'eq' | 'neq';
   severity: 'low' | 'medium' | 'high' | 'critical';
-  channels: Array<'email' | 'slack' | 'webhook'>;
+  channels: AlertChannel[];
   enabled: boolean;
   emailRecipients?: string[];
   slackWebhookUrl?: string;
@@ -33,6 +42,18 @@ export interface Alert {
   metadata?: Record<string, unknown>;
   triggeredAt: Date;
   resolvedAt?: Date;
+}
+
+const notificationCooldownMs = Number(process.env.ALERT_NOTIFICATION_COOLDOWN_MS ?? 300000);
+const notificationDedupCache = new Map<string, number>();
+
+export function getNotifierCapabilities(): NotifierCapability[] {
+  return buildNotifierCapabilities({
+    slackWebhookUrl: process.env.SLACK_ALERT_WEBHOOK_URL || process.env.SLACK_WEBHOOK_URL,
+    teamsWebhookUrl: process.env.TEAMS_ALERT_WEBHOOK_URL,
+    telegramBotToken: process.env.TELEGRAM_BOT_TOKEN,
+    telegramChatId: process.env.TELEGRAM_CHAT_ID,
+  });
 }
 
 /**
@@ -104,7 +125,7 @@ export async function checkAlertThresholds(): Promise<Alert[]> {
       metric: string;
       threshold: number;
       operator: string;
-      channels: string[];
+      channels: AlertChannel[];
       severity: string;
       user_id: string;
     }>(
@@ -188,7 +209,7 @@ export async function checkAlertThresholds(): Promise<Alert[]> {
         });
 
         // Send notifications
-        await sendAlertNotifications(alertId, rule.channels, {
+        await sendAlertNotifications(alertId, (rule.channels || []) as AlertChannel[], {
           ruleName: rule.name,
           metric: rule.metric,
           value,
@@ -269,7 +290,7 @@ async function createAlert(alert: Omit<Alert, 'id' | 'triggeredAt'>): Promise<st
  */
 async function sendAlertNotifications(
   alertId: string,
-  channels: string[],
+  channels: AlertChannel[],
   alertData: {
     ruleName: string;
     metric: string;
@@ -278,18 +299,62 @@ async function sendAlertNotifications(
     severity: string;
   }
 ): Promise<void> {
+  const dedupeKey = `${alertData.metric}:${alertData.ruleName}:${alertData.severity}`;
+  const lastSentAt = notificationDedupCache.get(dedupeKey);
+  if (lastSentAt && Date.now() - lastSentAt < notificationCooldownMs) {
+    logInfo('Alert notification suppressed due to cooldown window', {
+      alertId,
+      dedupeKey,
+      cooldownMs: notificationCooldownMs,
+    });
+    return;
+  }
+
+  const providers = createNotifierProviders({
+    slackWebhookUrl: process.env.SLACK_ALERT_WEBHOOK_URL || process.env.SLACK_WEBHOOK_URL,
+    teamsWebhookUrl: process.env.TEAMS_ALERT_WEBHOOK_URL,
+    telegramBotToken: process.env.TELEGRAM_BOT_TOKEN,
+    telegramChatId: process.env.TELEGRAM_CHAT_ID,
+    dryRun: process.env.ALERT_NOTIFIER_DRY_RUN === 'true',
+  });
+
+  const router = buildAlertRouter(channels);
+  const payload: AlertPayload = {
+    alertId,
+    alertType: alertData.metric,
+    severity: alertData.severity === 'critical' ? 'critical' : alertData.severity === 'high' ? 'warning' : 'info',
+    summary: `${alertData.ruleName} threshold crossed (${alertData.value} vs ${alertData.threshold})`,
+    timestamp: new Date().toISOString(),
+    metadata: {
+      ruleName: alertData.ruleName,
+      threshold: alertData.threshold,
+      value: alertData.value,
+      source: 'operator-mode.alerting',
+    },
+  };
+
+  const delivered = await dispatchAlert(payload, providers, router);
+
+  for (const delivery of delivered) {
+    await query(
+      `INSERT INTO alert_notifications (alert_id, notification_type, recipient, status, sent_at)
+       VALUES ($1, $2, $3, $4, NOW())`,
+      [alertId, delivery.channel, delivery.channel, 'sent']
+    );
+  }
+
+  notificationDedupCache.set(dedupeKey, Date.now());
+
   for (const channel of channels) {
+    if (channel !== 'email' && channel !== 'webhook') {
+      continue;
+    }
+
     try {
-      switch (channel) {
-        case 'email':
-          await sendEmailAlert(alertId, alertData);
-          break;
-        case 'slack':
-          await sendSlackAlert(alertId, alertData);
-          break;
-        case 'webhook':
-          await sendWebhookAlert(alertId, alertData);
-          break;
+      if (channel === 'email') {
+        await sendEmailAlert(alertId, alertData);
+      } else if (channel === 'webhook') {
+        await sendWebhookAlert(alertId, alertData);
       }
     } catch (error) {
       logError(`Failed to send ${channel} alert`, error, { alertId });
@@ -349,7 +414,7 @@ async function sendSlackAlert(
     severity: string;
   }
 ): Promise<void> {
-  const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL;
+  const slackWebhookUrl = process.env.SLACK_ALERT_WEBHOOK_URL || process.env.SLACK_WEBHOOK_URL;
   if (!slackWebhookUrl) {
     logWarn('Slack webhook URL not configured', { alertId });
     return;

--- a/packages/api/src/services/operator-mode/notifier-provider.ts
+++ b/packages/api/src/services/operator-mode/notifier-provider.ts
@@ -1,0 +1,205 @@
+export type AlertSeverityLevel = 'info' | 'warning' | 'critical';
+
+export type AlertChannel = 'slack' | 'teams' | 'telegram' | 'email' | 'webhook';
+
+export type CapabilityStatus = 'installed' | 'configured' | 'unavailable' | 'degraded' | 'unsupported';
+
+export interface AlertPayload {
+  alertId: string;
+  alertType: string;
+  severity: AlertSeverityLevel;
+  summary: string;
+  tenantId?: string;
+  runId?: string;
+  timestamp: string;
+  operatorUrl?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface NotifierCapability {
+  channel: AlertChannel;
+  status: CapabilityStatus;
+  reason?: string;
+}
+
+export interface NotifierProvider {
+  channel: AlertChannel;
+  send(payload: AlertPayload): Promise<void>;
+}
+
+export interface AlertRouter {
+  resolveChannels(input: { severity: AlertSeverityLevel; alertType: string }): AlertChannel[];
+}
+
+export interface NotifierConfig {
+  slackWebhookUrl?: string;
+  teamsWebhookUrl?: string;
+  telegramBotToken?: string;
+  telegramChatId?: string;
+  dryRun?: boolean;
+}
+
+export function buildNotifierCapabilities(config: NotifierConfig): NotifierCapability[] {
+  return [
+    {
+      channel: 'slack',
+      status: config.slackWebhookUrl ? 'configured' : 'unavailable',
+      reason: config.slackWebhookUrl ? undefined : 'SLACK_ALERT_WEBHOOK_URL is not set',
+    },
+    {
+      channel: 'teams',
+      status: config.teamsWebhookUrl ? 'configured' : 'unavailable',
+      reason: config.teamsWebhookUrl ? undefined : 'TEAMS_ALERT_WEBHOOK_URL is not set',
+    },
+    {
+      channel: 'telegram',
+      status:
+        config.telegramBotToken && config.telegramChatId
+          ? 'configured'
+          : config.telegramBotToken || config.telegramChatId
+            ? 'degraded'
+            : 'unavailable',
+      reason:
+        config.telegramBotToken && config.telegramChatId
+          ? undefined
+          : 'Both TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are required',
+    },
+  ];
+}
+
+export function buildAlertRouter(configuredChannels: AlertChannel[]): AlertRouter {
+  return {
+    resolveChannels(input) {
+      if (input.severity === 'critical') {
+        return configuredChannels;
+      }
+
+      if (input.severity === 'warning') {
+        return configuredChannels.filter((channel) => channel !== 'telegram');
+      }
+
+      return configuredChannels.filter((channel) => channel === 'slack');
+    },
+  };
+}
+
+export function createNotifierProviders(
+  config: NotifierConfig,
+  fetchImpl: typeof fetch = fetch
+): NotifierProvider[] {
+  const providers: NotifierProvider[] = [];
+
+  if (config.slackWebhookUrl) {
+    providers.push({
+      channel: 'slack',
+      async send(payload) {
+        if (config.dryRun) return;
+
+        await fetchImpl(config.slackWebhookUrl!, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            text: `🚨 [${payload.severity.toUpperCase()}] ${payload.summary}`,
+            blocks: [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text:
+                    `*Alert:* ${payload.alertType}\n` +
+                    `*Alert ID:* ${payload.alertId}\n` +
+                    `*Severity:* ${payload.severity}\n` +
+                    `*Tenant:* ${payload.tenantId ?? 'n/a'}\n` +
+                    `*Run:* ${payload.runId ?? 'n/a'}\n` +
+                    `*Summary:* ${payload.summary}`,
+                },
+              },
+            ],
+          }),
+        });
+      },
+    });
+  }
+
+  if (config.teamsWebhookUrl) {
+    providers.push({
+      channel: 'teams',
+      async send(payload) {
+        if (config.dryRun) return;
+
+        await fetchImpl(config.teamsWebhookUrl!, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            '@type': 'MessageCard',
+            '@context': 'http://schema.org/extensions',
+            summary: payload.summary,
+            themeColor: payload.severity === 'critical' ? 'FF0000' : payload.severity === 'warning' ? 'FFA500' : '0076D7',
+            sections: [
+              {
+                activityTitle: `Settler Alert: ${payload.alertType}`,
+                facts: [
+                  { name: 'Alert ID', value: payload.alertId },
+                  { name: 'Severity', value: payload.severity },
+                  { name: 'Tenant', value: payload.tenantId ?? 'n/a' },
+                  { name: 'Run', value: payload.runId ?? 'n/a' },
+                  { name: 'Timestamp', value: payload.timestamp },
+                ],
+                text: payload.summary,
+              },
+            ],
+          }),
+        });
+      },
+    });
+  }
+
+  if (config.telegramBotToken && config.telegramChatId) {
+    providers.push({
+      channel: 'telegram',
+      async send(payload) {
+        if (config.dryRun) return;
+
+        const endpoint = `https://api.telegram.org/bot${config.telegramBotToken}/sendMessage`;
+        await fetchImpl(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            chat_id: config.telegramChatId,
+            text: [
+              `🚨 Settler Alert`,
+              `Type: ${payload.alertType}`,
+              `Alert ID: ${payload.alertId}`,
+              `Severity: ${payload.severity}`,
+              `Tenant: ${payload.tenantId ?? 'n/a'}`,
+              `Run: ${payload.runId ?? 'n/a'}`,
+              `Summary: ${payload.summary}`,
+            ].join('\n'),
+          }),
+        });
+      },
+    });
+  }
+
+  return providers;
+}
+
+export async function dispatchAlert(
+  payload: AlertPayload,
+  providers: NotifierProvider[],
+  router: AlertRouter
+): Promise<Array<{ channel: AlertChannel; delivered: boolean }>> {
+  const channelSet = new Set(router.resolveChannels({ severity: payload.severity, alertType: payload.alertType }));
+  const results: Array<{ channel: AlertChannel; delivered: boolean }> = [];
+
+  for (const provider of providers) {
+    if (!channelSet.has(provider.channel)) {
+      continue;
+    }
+
+    await provider.send(payload);
+    results.push({ channel: provider.channel, delivered: true });
+  }
+
+  return results;
+}

--- a/packages/web/src/app/api/console/operator/control-plane/route.ts
+++ b/packages/web/src/app/api/console/operator/control-plane/route.ts
@@ -566,7 +566,9 @@ async function buildPayload(days: number) {
   const capabilities = {
     githubIssueTriage: Boolean(process.env.GITHUB_TOKEN && parseGithubRepo()),
     stripeRevenue: Boolean(process.env.STRIPE_SECRET_KEY),
-    slackAlerts: Boolean(process.env.SLACK_WEBHOOK_URL),
+    slackAlerts: Boolean(process.env.SLACK_ALERT_WEBHOOK_URL || process.env.SLACK_WEBHOOK_URL),
+    teamsAlerts: Boolean(process.env.TEAMS_ALERT_WEBHOOK_URL),
+    telegramAlerts: Boolean(process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_CHAT_ID),
   };
 
   return {


### PR DESCRIPTION
### Motivation
- Provide a safe, capability-gated notifier layer so operator alerts can be dispatched to external channels (Slack, Teams, Telegram) without breaking in-app alerting when credentials are absent.
- Reduce alert spam and support severity-based routing and dry-run dispatch for safe operator validation and onboarding.
- Expose runtime capability/state to operator surfaces so the control-plane UI and operators see truthful capability status.

### Description
- Added a typed notifier provider abstraction `packages/api/src/services/operator-mode/notifier-provider.ts` with `AlertPayload`, `NotifierProvider`, `AlertRouter`, capability model, and concrete Slack/Teams/Telegram providers with dry-run support. 
- Integrated provider dispatch into operator alerting in `packages/api/src/services/operator-mode/alerting.ts` with dedupe/cooldown suppression (`ALERT_NOTIFICATION_COOLDOWN_MS`), provider creation, routing, and persistence of notification deliveries in `alert_notifications`.
- Added an operator API to surface runtime notifier capabilities at `GET /api/v1/operator/alerts/capabilities` and expanded alert-rule channel schema to include `teams` and `telegram` (`packages/api/src/routes/v1/operator-mode.ts` and `packages/api/src/routes/alerts.ts`).
- Added a unit test for the notifier provider behavior (`packages/api/src/__tests__/services/notifier-provider.test.ts`) and updated operator control-plane capability booleans in the web payload plus docs and example env files to document `SLACK_ALERT_WEBHOOK_URL`, `TEAMS_ALERT_WEBHOOK_URL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `ALERT_NOTIFIER_DRY_RUN`, and `ALERT_NOTIFICATION_COOLDOWN_MS`.

### Testing
- Ran the new unit test with `npm exec jest src/__tests__/services/notifier-provider.test.ts --runInBand` from `packages/api` and it passed (3 tests, all green). 
- Ran TypeScript checks with `npm run typecheck` from `packages/api` and the API package typecheck passed.
- Noted workspace-level `pnpm` pretypecheck path surfaced a root `package.json` parse warning, but it did not affect the `packages/api` test/typecheck runs and no runtime changes require external credentials (dry-run is default).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af879e03c4832883f72876ac00156a)