### PR TITLE
Harden API route inventory diagnostics and verification

### DIFF
--- a/docs/api/route-coverage-policy.json
+++ b/docs/api/route-coverage-policy.json
@@ -2,5 +2,5 @@
   "version": 1,
   "maxCriticalMissing": 40,
   "maxCriticalMissingIncrease": 0,
-  "baselineCriticalMissing": 40
+  "baselineCriticalMissing": 39
 }

--- a/docs/api/route-inventory.json
+++ b/docs/api/route-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-10T03:00:20.717Z",
+  "generatedAt": "2026-03-10T03:10:03.892Z",
   "coverageModel": "route-test-mapping@v1",
   "totals": {
     "routes": 252,
@@ -8,7 +8,15 @@
     "covered": 14,
     "partial": 2,
     "missing": 236,
-    "criticalMissing": 39
+    "criticalMissing": 39,
+    "unmountedCandidates": 1,
+    "undeclaredMethodHandlers": 0,
+    "duplicateMethodPathEntries": 0
+  },
+  "diagnostics": {
+    "unmountedRouteCandidates": ["packages/web/src/app/api/console/api-keys-v2/route.ts.example"],
+    "undeclaredMethodHandlers": [],
+    "duplicateMethodPathEntries": []
   },
   "routes": [
     {

--- a/docs/api/route-inventory.md
+++ b/docs/api/route-inventory.md
@@ -1,6 +1,6 @@
 # API Route Inventory
 
-Generated: 2026-03-10T03:00:20.717Z
+Generated: 2026-03-10T03:10:03.892Z
 
 - Coverage model: **route-test-mapping@v1**
 - Total mounted method routes: **252**
@@ -8,6 +8,9 @@ Generated: 2026-03-10T03:00:20.717Z
 - Critical routes: **55**
 - Critical routes missing tests: **39**
 - Covered / Partial / Missing tests: **14 / 2 / 236**
+- Unmounted route candidates: **1**
+- Route handlers with undeclared HTTP methods: **0**
+- Duplicate mounted method/path entries: **0**
 
 | Method | Path                                                    | Group          | Auth | Tenant | Criticality | Test    | Test IDs                                                                                                                                             | Source                                                                               |
 | ------ | ------------------------------------------------------- | -------------- | ---: | -----: | ----------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
@@ -268,3 +271,4 @@ Generated: 2026-03-10T03:00:20.717Z
 
 - Inventory is generated from mounted Next.js App Router `route.ts` handlers under `packages/web/src/app/api`.
 - Test status is machine-derived from `docs/api/route-test-mapping.json` (no heuristic inference).
+- Unmounted route candidates capture `route.ts.*` variants and route-like helper files in `app/api` that are not mounted handlers.

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "verify:reconciliation:strict": "node scripts/verify-reconciliation-strict.mjs",
     "reconciliation:summary": "node scripts/reconciliation-run-tools.mjs summary test-data/exports/latest",
     "reconciliation:compare": "node scripts/reconciliation-run-tools.mjs compare test-data/exports/smoke-seed42 test-data/exports/latest",
-    "verify:issue-templates": "node scripts/validate-issue-templates.mjs"
+    "verify:issue-templates": "node scripts/validate-issue-templates.mjs",
     "version:sync": "node scripts/release/version-manager.mjs sync",
     "version:bump": "node scripts/release/version-manager.mjs bump",
     "build:clean": "pnpm run clean:all && pnpm install --frozen-lockfile && pnpm run build:all",

--- a/scripts/generate-api-route-inventory.ts
+++ b/scripts/generate-api-route-inventory.ts
@@ -22,6 +22,12 @@ type RouteEntry = {
   testIds: string[];
 };
 
+type InventoryDiagnostics = {
+  unmountedRouteCandidates: string[];
+  undeclaredMethodHandlers: Array<{ path: string; source: string }>;
+  duplicateMethodPathEntries: string[];
+};
+
 const root = process.cwd();
 const apiRoot = path.join(root, "packages", "web", "src", "app", "api");
 const outJson = path.join(root, "docs", "api", "route-inventory.json");
@@ -42,6 +48,16 @@ function walk(dir: string, matcher: (f: string) => boolean, acc: string[] = []):
     if (matcher(full)) acc.push(full);
   }
   return acc;
+}
+
+function findUnmountedCandidates(apiDir: string): string[] {
+  const candidates = walk(apiDir, (f) => {
+    const normalized = f.replace(/\\/g, "/");
+    if (/\/route\.(ts|tsx|js|jsx)$/.test(normalized)) return false;
+    if (/\/route\.(ts|tsx|js|jsx)\./.test(normalized)) return true;
+    return /\/(handler|routes?)\.(ts|tsx|js|jsx)$/.test(normalized);
+  });
+  return candidates.map((file) => path.relative(root, file).replace(/\\/g, "/")).sort();
 }
 
 function classifyRouteGroup(routePath: string): string {
@@ -97,6 +113,11 @@ function main() {
 
   const entries: RouteEntry[] = [];
   const mountedPaths = new Set<string>();
+  const diagnostics: InventoryDiagnostics = {
+    unmountedRouteCandidates: findUnmountedCandidates(apiRoot),
+    undeclaredMethodHandlers: [],
+    duplicateMethodPathEntries: [],
+  };
 
   for (const file of routeFiles) {
     const source = readFileSync(file, "utf8");
@@ -116,6 +137,13 @@ function main() {
     const tenantScoped = /tenantId|tenant/.test(source);
 
     const routeMethods = methods.length > 0 ? methods : ["UNDECLARED"];
+
+    if (methods.length === 0) {
+      diagnostics.undeclaredMethodHandlers.push({
+        path: routePath,
+        source: path.relative(root, file).replace(/\\/g, "/"),
+      });
+    }
 
     for (const method of routeMethods) {
       const exact = byMethodAndPath.get(`${method} ${routePath}`) ?? [];
@@ -140,6 +168,16 @@ function main() {
 
   entries.sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method));
 
+  const routeMethodCounts = new Map<string, number>();
+  for (const entry of entries) {
+    const key = `${entry.method} ${entry.path}`;
+    routeMethodCounts.set(key, (routeMethodCounts.get(key) ?? 0) + 1);
+  }
+  diagnostics.duplicateMethodPathEntries = [...routeMethodCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([key]) => key)
+    .sort();
+
   const criticalMissing = entries.filter(
     (e) => e.criticality === "critical" && e.testStatus === "missing"
   ).length;
@@ -155,7 +193,11 @@ function main() {
       partial: entries.filter((e) => e.testStatus === "partial").length,
       missing: entries.filter((e) => e.testStatus === "missing").length,
       criticalMissing,
+      unmountedCandidates: diagnostics.unmountedRouteCandidates.length,
+      undeclaredMethodHandlers: diagnostics.undeclaredMethodHandlers.length,
+      duplicateMethodPathEntries: diagnostics.duplicateMethodPathEntries.length,
     },
+    diagnostics,
     routes: entries,
   };
 
@@ -173,6 +215,9 @@ function main() {
     `- Critical routes: **${payload.totals.critical}**`,
     `- Critical routes missing tests: **${payload.totals.criticalMissing}**`,
     `- Covered / Partial / Missing tests: **${payload.totals.covered} / ${payload.totals.partial} / ${payload.totals.missing}**`,
+    `- Unmounted route candidates: **${payload.totals.unmountedCandidates}**`,
+    `- Route handlers with undeclared HTTP methods: **${payload.totals.undeclaredMethodHandlers}**`,
+    `- Duplicate mounted method/path entries: **${payload.totals.duplicateMethodPathEntries}**`,
     "",
     "| Method | Path | Group | Auth | Tenant | Criticality | Test | Test IDs | Source |",
     "|---|---|---|---:|---:|---|---|---|---|",
@@ -185,6 +230,7 @@ function main() {
     "",
     "- Inventory is generated from mounted Next.js App Router `route.ts` handlers under `packages/web/src/app/api`.",
     "- Test status is machine-derived from `docs/api/route-test-mapping.json` (no heuristic inference).",
+    "- Unmounted route candidates capture `route.ts.*` variants and route-like helper files in `app/api` that are not mounted handlers.",
   ].join("\n");
 
   writeFileSync(outMd, `${md}\n`, "utf8");

--- a/scripts/validate-api-routes.ts
+++ b/scripts/validate-api-routes.ts
@@ -1,84 +1,97 @@
 #!/usr/bin/env tsx
 /**
  * API Route Validation Script
- * 
+ *
  * Ensures all API routes that use cookies are marked as dynamic
  * to prevent Next.js build-time static generation errors.
  */
 
-import { readFileSync, readdirSync, statSync } from 'fs';
-import { join } from 'path';
+import { readFileSync, readdirSync, statSync, existsSync } from "fs";
+import { join, dirname } from "path";
 
 interface RouteIssue {
   file: string;
   reason: string;
 }
 
+function resolveApiDir(): string {
+  const cwdCandidate = join(process.cwd(), "packages/web/src/app/api");
+  if (existsSync(cwdCandidate)) return cwdCandidate;
+
+  const scriptRootCandidate = join(dirname(__filename), "..", "packages/web/src/app/api");
+  if (existsSync(scriptRootCandidate)) return scriptRootCandidate;
+
+  return cwdCandidate;
+}
+
 function findRouteFiles(dir: string, files: string[] = []): string[] {
   try {
     const entries = readdirSync(dir, { withFileTypes: true });
-    
+
     for (const entry of entries) {
       const fullPath = join(dir, entry.name);
-      
+
       // Skip node_modules, .next, dist, etc.
       if (entry.isDirectory()) {
-        if (!entry.name.startsWith('.') && 
-            entry.name !== 'node_modules' && 
-            entry.name !== 'dist' && 
-            entry.name !== '.next' &&
-            entry.name !== 'build') {
+        if (
+          !entry.name.startsWith(".") &&
+          entry.name !== "node_modules" &&
+          entry.name !== "dist" &&
+          entry.name !== ".next" &&
+          entry.name !== "build"
+        ) {
           findRouteFiles(fullPath, files);
         }
-      } else if (entry.isFile() && entry.name === 'route.ts') {
+      } else if (entry.isFile() && entry.name === "route.ts") {
         files.push(fullPath);
       }
     }
   } catch (error) {
     // Directory doesn't exist or can't be read - skip silently
   }
-  
+
   return files;
 }
 
 function validateApiRoutes(): { passed: boolean; issues: RouteIssue[] } {
   const issues: RouteIssue[] = [];
-  const apiDir = join(process.cwd(), 'packages/web/src/app/api');
-  
-  if (!statSync(apiDir).isDirectory()) {
-    console.log('⚠️  API directory not found, skipping validation');
+  const apiDir = resolveApiDir();
+
+  if (!existsSync(apiDir) || !statSync(apiDir).isDirectory()) {
+    console.log(`⚠️  API directory not found at ${apiDir}, skipping validation`);
     return { passed: true, issues: [] };
   }
-  
+
   const routeFiles = findRouteFiles(apiDir);
-  
+
   for (const routeFile of routeFiles) {
     try {
-      const content = readFileSync(routeFile, 'utf-8');
-      
+      const content = readFileSync(routeFile, "utf-8");
+
       // Check if route uses cookies (via createClient, cookies(), or getUser)
-      const usesCookies = 
-        content.includes('createClient') || 
-        content.includes('cookies()') ||
-        content.includes('.getUser()') ||
-        content.includes('auth.getUser()') ||
-        content.includes('getUser()');
-      
+      const usesCookies =
+        content.includes("createClient") ||
+        content.includes("cookies()") ||
+        content.includes(".getUser()") ||
+        content.includes("auth.getUser()") ||
+        content.includes("getUser()");
+
       // Check if route is marked as dynamic
-      const isDynamic = 
+      const isDynamic =
         content.includes("export const dynamic = 'force-dynamic'") ||
         content.includes('export const dynamic = "force-dynamic"');
-      
+
       // Check if route is marked as static (explicit opt-out)
-      const isStatic = 
+      const isStatic =
         content.includes("export const dynamic = 'force-static'") ||
         content.includes('export const dynamic = "force-static"');
-      
+
       if (usesCookies && !isDynamic && !isStatic) {
-        const relativePath = routeFile.replace(process.cwd() + '/', '');
+        const relativePath = routeFile.replace(process.cwd() + "/", "");
         issues.push({
           file: relativePath,
-          reason: 'Uses cookies but not marked as dynamic. Add: export const dynamic = \'force-dynamic\';'
+          reason:
+            "Uses cookies but not marked as dynamic. Add: export const dynamic = 'force-dynamic';",
         });
       }
     } catch (error) {
@@ -86,7 +99,7 @@ function validateApiRoutes(): { passed: boolean; issues: RouteIssue[] } {
       console.warn(`⚠️  Could not read ${routeFile}:`, error);
     }
   }
-  
+
   return {
     passed: issues.length === 0,
     issues,
@@ -94,25 +107,27 @@ function validateApiRoutes(): { passed: boolean; issues: RouteIssue[] } {
 }
 
 async function main() {
-  console.log('🔍 Validating API routes...\n');
-  
+  console.log("🔍 Validating API routes...\n");
+
   const result = validateApiRoutes();
-  
+
   if (result.issues.length > 0) {
-    console.log('❌ Found API routes that need to be marked as dynamic:\n');
+    console.log("❌ Found API routes that need to be marked as dynamic:\n");
     result.issues.forEach((issue) => {
       console.log(`   ${issue.file}`);
       console.log(`   → ${issue.reason}\n`);
     });
-    console.log('💡 Fix: Add `export const dynamic = \'force-dynamic\';` to routes that use cookies.\n');
+    console.log(
+      "💡 Fix: Add `export const dynamic = 'force-dynamic';` to routes that use cookies.\n"
+    );
     process.exit(1);
   }
-  
-  console.log('✅ All API routes are properly configured!\n');
+
+  console.log("✅ All API routes are properly configured!\n");
   process.exit(0);
 }
 
 main().catch((error) => {
-  console.error('❌ Validation script error:', error);
+  console.error("❌ Validation script error:", error);
   process.exit(1);
 });

--- a/scripts/verify-api-route-inventory.ts
+++ b/scripts/verify-api-route-inventory.ts
@@ -37,7 +37,17 @@ function toPath(file: string): string {
 function main() {
   const mounted = new Set(walk(apiRoot).map(toPath));
   const inv = JSON.parse(readFileSync(inventoryPath, "utf8")) as {
-    totals: { criticalMissing?: number };
+    totals: {
+      criticalMissing?: number;
+      unmountedCandidates?: number;
+      undeclaredMethodHandlers?: number;
+      duplicateMethodPathEntries?: number;
+    };
+    diagnostics?: {
+      unmountedRouteCandidates?: string[];
+      undeclaredMethodHandlers?: Array<{ path: string; source: string }>;
+      duplicateMethodPathEntries?: string[];
+    };
     routes: Array<{ path: string; method: string; criticality: string; testStatus: string }>;
   };
   const mapping = JSON.parse(readFileSync(mappingPath, "utf8")) as { mappings: MappingEntry[] };
@@ -58,6 +68,15 @@ function main() {
   const staleInInventory = [...inventoryPaths].filter((p) => !mounted.has(p));
 
   const inventoryRouteKeys = new Set(inv.routes.map((r) => `${r.method} ${r.path}`));
+
+  const duplicateRouteKeys = new Map<string, number>();
+  for (const route of inv.routes) {
+    const key = `${route.method} ${route.path}`;
+    duplicateRouteKeys.set(key, (duplicateRouteKeys.get(key) ?? 0) + 1);
+  }
+  const duplicateRoutes = [...duplicateRouteKeys.entries()].filter(([, count]) => count > 1);
+  const diagnosticDuplicates = inv.diagnostics?.duplicateMethodPathEntries ?? [];
+
   const mappingMissingRoute = mapping.mappings.filter(
     (m) => !inventoryRouteKeys.has(`${m.method} ${m.path}`)
   );
@@ -91,6 +110,18 @@ function main() {
       `Route-test mappings reference missing test IDs/files (${mappingMissingTestId.length})`
     );
   }
+
+  if (duplicateRoutes.length > 0) {
+    errors.push(
+      `Inventory contains duplicate method/path route entries (${duplicateRoutes.length})`
+    );
+  }
+  if (diagnosticDuplicates.length !== duplicateRoutes.length) {
+    errors.push(
+      `Inventory diagnostics duplicate count (${diagnosticDuplicates.length}) does not match computed duplicates (${duplicateRoutes.length})`
+    );
+  }
+
   if (criticalMissing > policy.maxCriticalMissing) {
     errors.push(
       `Critical missing routes (${criticalMissing}) exceeds policy maxCriticalMissing (${policy.maxCriticalMissing})`
@@ -114,7 +145,7 @@ function main() {
   }
 
   console.log(
-    `API route inventory verification passed. criticalMissing=${criticalMissing}, max=${policy.maxCriticalMissing}`
+    `API route inventory verification passed. criticalMissing=${criticalMissing}, max=${policy.maxCriticalMissing}, unmountedCandidates=${inv.totals.unmountedCandidates ?? 0}, undeclaredMethodHandlers=${inv.totals.undeclaredMethodHandlers ?? 0}`
   );
 }
 


### PR DESCRIPTION
### Motivation

- Improve truthfulness and operator visibility of the API route inventory by emitting actionable diagnostics instead of only counts. 
- Make inventory verification stricter so discrepancies (duplicates, stale mappings, diagnostic mismatches) fail early. 
- Fix a false-negative in the route validation helper that surfaced as an ENOENT when invoked from package-level working directories. 

### Description

- Expanded `scripts/generate-api-route-inventory.ts` with a new `InventoryDiagnostics` model and added detection for unmounted route candidates (`route.ts.*` variants), route-like helper files, handlers with undeclared HTTP methods, and duplicate `method path` entries, and included those diagnostics in the generated JSON and Markdown outputs. 
- Strengthened `scripts/verify-api-route-inventory.ts` to compute duplicate method/path keys, validate duplicates, and assert consistency between generated diagnostics and verification computations. 
- Fixed `scripts/validate-api-routes.ts` to robustly resolve the `packages/web/src/app/api` directory (works when run from package cwd), added safer `existsSync` checks, and preserved the cookie/dynamic-marker checks so real findings are surfaced. 
- Regenerated inventory artifacts (`docs/api/route-inventory.json` and `.md`) and tightened the coverage baseline in `docs/api/route-coverage-policy.json` (`baselineCriticalMissing` adjusted from `40` to `39`) to reflect measured state. 
- Corrected a JSON syntax issue in the repo root `package.json` scripts block (missing comma after `verify:issue-templates`). 

### Testing

- Ran `pnpm exec tsx scripts/generate-api-route-inventory.ts` and the generator completed and wrote `docs/api/route-inventory.json` (success). 
- Ran `pnpm exec tsx scripts/verify-api-route-inventory.ts` and the verification passed against the generated inventory (success). 
- Executed `pnpm --filter @settler/web validate:api-routes` which now resolves paths correctly and executed the dynamic-marker checks; the script surfaced existing routes that use cookies but are not marked `export const dynamic = 'force-dynamic'` (intentional findings; the run returned non-zero because real issues were reported). 
- Ran `pnpm exec prettier --write` over modified scripts and docs (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af8b20259883288c05c350a4f56a8a)