### PR TITLE
Distributed guards: rate-limiting and webhook replay dedupe with Redis/DB/memory fallbacks, telemetry and migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,14 @@ HEALTH_CHECK_ENABLED=true
 # ----------------------------------------------------------------------------
 RATE_LIMIT_DEFAULT=1000
 RATE_LIMIT_WINDOW_MS=900000
+# DB fallback window for distributed rate limit counters when Redis is unavailable
+RATE_LIMIT_DB_WINDOW_MS=60000
+# Webhook replay dedupe window (ms). Default: 24h
+WEBHOOK_REPLAY_WINDOW_MS=86400000
+# Optional provider-specific replay windows: provider=ms,provider2=ms
+WEBHOOK_REPLAY_WINDOW_MS_BY_PROVIDER=stripe=86400000,paypal=43200000
+# Replay and rate-limit DB cleanup cadence
+DISTRIBUTED_GUARD_CLEANUP_INTERVAL_MS=300000
 
 # ----------------------------------------------------------------------------
 # WEBHOOK CONFIGURATION

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "verify:reconciliation:strict": "node scripts/verify-reconciliation-strict.mjs",
     "reconciliation:summary": "node scripts/reconciliation-run-tools.mjs summary test-data/exports/latest",
     "reconciliation:compare": "node scripts/reconciliation-run-tools.mjs compare test-data/exports/smoke-seed42 test-data/exports/latest",
-    "verify:issue-templates": "node scripts/validate-issue-templates.mjs"
+    "verify:issue-templates": "node scripts/validate-issue-templates.mjs",
     "version:sync": "node scripts/release/version-manager.mjs sync",
     "version:bump": "node scripts/release/version-manager.mjs bump",
     "build:clean": "pnpm run clean:all && pnpm install --frozen-lockfile && pnpm run build:all",

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -51,3 +51,31 @@ Boundary rule of thumb:
 1. Core reconciliation, auth, tenancy, safety invariants stay in OSS runtime.
 2. Enterprise-only modules attach via provider interfaces in `services/capabilities/providers/*`.
 3. Routes must gate behavior from provider status and expose machine-readable capability truth.
+
+## Distributed rate limiting + webhook replay guarantees
+
+Settler now exposes truthful guard levels for both API rate limiting and webhook replay dedupe:
+
+- `distributed_shared`: Redis-backed, safe across multiple API instances.
+- `local_only`: in-process memory fallback; safe only for single-instance/local runs.
+- `degraded`: feature still active on a shared fallback with tradeoffs (DB counters/ledger) or on local fallback when shared backing is unavailable.
+- `unavailable`: guard cannot be enforced and is surfaced as unavailable.
+
+### Runtime behavior by mode
+
+- **Enterprise/hosted (Redis configured and reachable):** rate limiting and webhook replay dedupe run in `distributed_shared` mode.
+- **OSS/local with Redis:** same `distributed_shared` guarantees for multi-process local testing.
+- **OSS/local without Redis:** rate limiting falls back to DB counters (`degraded`, shared but lower-throughput) and then memory (`local_only`) if DB is unavailable; webhook replay uses DB ledger fallback (`degraded`) and memory fallback only when DB is also unavailable.
+
+Capability statuses are available at `GET /api/v1/capabilities` under:
+
+- `rate_limiting_guard`
+- `webhook_replay_guard`
+
+Webhook receive responses now include `X-Webhook-Replay-Guarantee`; rate-limited responses include `X-RateLimit-Guarantee` and a stable structured 429 payload including `guarantee`.
+
+Observability metrics:
+
+- `distributed_guard_guarantee_state` (Gauge)
+- `distributed_guard_guarantee_transitions_total` (Counter)
+- `webhook_replay_rejected_total` (Counter)

--- a/packages/api/src/__tests__/integration/distributed-guards.redis.test.ts
+++ b/packages/api/src/__tests__/integration/distributed-guards.redis.test.ts
@@ -1,0 +1,118 @@
+import { spawn, spawnSync, ChildProcessWithoutNullStreams } from "child_process";
+import Redis from "ioredis";
+
+let redisClient: Redis | null = null;
+let redisProcess: ChildProcessWithoutNullStreams | null = null;
+
+jest.mock("../../utils/cache", () => ({
+  getRedisClient: () => redisClient,
+}));
+
+jest.mock("../../db", () => ({
+  query: jest.fn(),
+}));
+
+import { consumeRateLimitShared, consumeWebhookReplayKey } from "../../services/distributed-guards";
+
+function waitForRedisReady(proc: ChildProcessWithoutNullStreams): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("redis-server startup timeout")), 10_000);
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("Ready to accept connections")) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.toLowerCase().includes("error")) {
+        clearTimeout(timeout);
+        reject(new Error(text));
+      }
+    });
+
+    proc.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`redis-server exited early: ${code}`));
+    });
+  });
+}
+
+describe("distributed guards with real redis", () => {
+  const port = 6391;
+  let redisAvailable = false;
+
+  beforeAll(async () => {
+    const probe = spawnSync("redis-server", ["--version"], { encoding: "utf8" });
+    if (probe.status !== 0) {
+      redisAvailable = false;
+      return;
+    }
+
+    redisAvailable = true;
+    redisProcess = spawn("redis-server", [
+      "--save",
+      "",
+      "--appendonly",
+      "no",
+      "--port",
+      String(port),
+    ]);
+    await waitForRedisReady(redisProcess);
+
+    redisClient = new Redis(port, "127.0.0.1", { lazyConnect: false, maxRetriesPerRequest: 1 });
+    await redisClient.flushdb();
+  });
+
+  afterAll(async () => {
+    if (redisClient) {
+      await redisClient.quit();
+      redisClient = null;
+    }
+    if (redisProcess) {
+      redisProcess.kill("SIGTERM");
+    }
+  });
+
+  it("enforces shared redis rate limits", async () => {
+    if (!redisAvailable || !redisClient) {
+      return;
+    }
+
+    const key = { tenantScope: "tenant-r", routeScope: "post:/jobs", limit: 2, windowMs: 30_000 };
+    const first = await consumeRateLimitShared(key);
+    const second = await consumeRateLimitShared(key);
+    const third = await consumeRateLimitShared(key);
+
+    expect(first.guarantee).toBe("distributed_shared");
+    expect(second.allowed).toBe(true);
+    expect(third.allowed).toBe(false);
+  });
+
+  it("enforces shared redis webhook replay dedupe", async () => {
+    if (!redisAvailable || !redisClient) {
+      return;
+    }
+
+    const first = await consumeWebhookReplayKey({
+      adapter: "stripe",
+      tenantId: "tenant-r",
+      payload: { id: "evt_redis_1" },
+      signature: "sig_redis",
+    });
+
+    const second = await consumeWebhookReplayKey({
+      adapter: "stripe",
+      tenantId: "tenant-r",
+      payload: { id: "evt_redis_1" },
+      signature: "sig_redis",
+    });
+
+    expect(first.guarantee).toBe("distributed_shared");
+    expect(first.duplicate).toBe(false);
+    expect(second.duplicate).toBe(true);
+  });
+});

--- a/packages/api/src/__tests__/resilience/api-resilience.test.ts
+++ b/packages/api/src/__tests__/resilience/api-resilience.test.ts
@@ -2,16 +2,16 @@ import express from "express";
 import request from "supertest";
 import { idempotencyMiddleware } from "../../middleware/idempotency";
 import { checkRateLimit } from "../../utils/rate-limiter";
-import {
-  MAX_PAGE_LIMIT,
-  parseCursorPaginationParams,
-  encodeCursor,
-} from "../../utils/pagination";
+import { MAX_PAGE_LIMIT, parseCursorPaginationParams, encodeCursor } from "../../utils/pagination";
 import webhookReceiveRouter from "../../routes/v1/webhooks/receive";
 import { WebhookIngestionService } from "../../application/webhooks/WebhookIngestionService";
 
 jest.mock("../../db", () => ({
   query: jest.fn(),
+}));
+
+jest.mock("../../utils/cache", () => ({
+  getRedisClient: jest.fn(() => null),
 }));
 
 const { query } = jest.requireMock("../../db") as { query: jest.Mock };
@@ -62,13 +62,42 @@ describe("API resilience primitives", () => {
       userId: "u-1",
     };
 
-    query.mockResolvedValue([{ rate_limit: 2 }]);
-    const tenantA1 = await checkRateLimit({ ...baseReq, tenantId: "tenant-a", apiKeyId: "k-a" } as never);
-    const tenantA2 = await checkRateLimit({ ...baseReq, tenantId: "tenant-a", apiKeyId: "k-a" } as never);
-    const tenantA3 = await checkRateLimit({ ...baseReq, tenantId: "tenant-a", apiKeyId: "k-a" } as never);
+    const counterByKey = new Map<string, number>();
+    query.mockImplementation((sql: string, params: unknown[]) => {
+      if (sql.includes("SELECT rate_limit FROM api_keys")) {
+        return Promise.resolve([{ rate_limit: 2 }]);
+      }
+      if (sql.includes("INSERT INTO rate_limit_counters")) {
+        const key = String(params[0]);
+        const next = (counterByKey.get(key) || 0) + 1;
+        counterByKey.set(key, next);
+        return Promise.resolve([{ count: next }]);
+      }
+      return Promise.resolve([]);
+    });
 
-    query.mockResolvedValue([{ rate_limit: 2 }]);
-    const tenantB = await checkRateLimit({ ...baseReq, tenantId: "tenant-b", apiKeyId: "k-b" } as never);
+    const tenantA1 = await checkRateLimit({
+      ...baseReq,
+      tenantId: "tenant-a",
+      apiKeyId: "k-a",
+    } as never);
+    const tenantA2 = await checkRateLimit({
+      ...baseReq,
+      tenantId: "tenant-a",
+      apiKeyId: "k-a",
+    } as never);
+    const tenantA3 = await checkRateLimit({
+      ...baseReq,
+      tenantId: "tenant-a",
+      apiKeyId: "k-a",
+    } as never);
+
+    const tenantB = await checkRateLimit({
+      ...baseReq,
+      ip: "10.0.0.2",
+      tenantId: "tenant-b",
+      apiKeyId: "k-b",
+    } as never);
 
     expect(tenantA1.allowed).toBe(true);
     expect(tenantA2.allowed).toBe(true);
@@ -96,7 +125,20 @@ describe("API resilience primitives", () => {
       events: [{ id: "evt-1", type: "payment.succeeded" } as never],
     });
 
-    query.mockResolvedValue([{ secret: "whsec_test" }]);
+    let replayInsertCount = 0;
+    query.mockImplementation((sql: string) => {
+      if (sql.includes("INSERT INTO webhook_replay_keys")) {
+        replayInsertCount += 1;
+        return Promise.resolve(replayInsertCount === 1 ? [{ inserted: true }] : []);
+      }
+      if (sql.includes("DELETE FROM webhook_replay_keys")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("SELECT secret FROM webhook_configs")) {
+        return Promise.resolve([{ secret: "whsec_test" }]);
+      }
+      return Promise.resolve([]);
+    });
 
     const app = express();
     app.use(express.json());

--- a/packages/api/src/__tests__/services/distributed-guards.test.ts
+++ b/packages/api/src/__tests__/services/distributed-guards.test.ts
@@ -1,0 +1,90 @@
+import {
+  cleanupExpiredDistributedGuardRecords,
+  consumeRateLimitShared,
+  consumeWebhookReplayKey,
+  getDistributedGuarantees,
+} from "../../services/distributed-guards";
+
+jest.mock("../../utils/cache", () => ({
+  getRedisClient: jest.fn(() => null),
+}));
+
+jest.mock("../../db", () => ({
+  query: jest.fn(),
+}));
+
+const { query } = jest.requireMock("../../db") as { query: jest.Mock };
+
+describe("distributed guards", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns degraded guarantees when redis is unavailable", async () => {
+    const guarantees = await getDistributedGuarantees();
+    expect(guarantees.rateLimiting).toBe("degraded");
+    expect(guarantees.webhookReplayDedup).toBe("degraded");
+  });
+
+  it("uses DB fallback for rate limits when redis is unavailable", async () => {
+    let count = 0;
+    query.mockImplementation((sql: string) => {
+      if (sql.includes("INSERT INTO rate_limit_counters")) {
+        count += 1;
+        return Promise.resolve([{ count }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const first = await consumeRateLimitShared({
+      tenantScope: "tenant-a",
+      routeScope: "get:/v1/jobs",
+      limit: 2,
+      windowMs: 60_000,
+    });
+    const second = await consumeRateLimitShared({
+      tenantScope: "tenant-a",
+      routeScope: "get:/v1/jobs",
+      limit: 2,
+      windowMs: 60_000,
+    });
+    const third = await consumeRateLimitShared({
+      tenantScope: "tenant-a",
+      routeScope: "get:/v1/jobs",
+      limit: 2,
+      windowMs: 60_000,
+    });
+
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(true);
+    expect(third.allowed).toBe(false);
+    expect(third.guarantee).toBe("degraded");
+  });
+
+  it("uses DB replay ledger fallback when redis is unavailable", async () => {
+    query.mockImplementation((sql: string) => {
+      if (sql.includes("INSERT INTO webhook_replay_keys")) {
+        return Promise.resolve([{ inserted: true }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const result = await consumeWebhookReplayKey({
+      adapter: "stripe",
+      tenantId: "tenant-a",
+      payload: { id: "evt_1" },
+      signature: "sig",
+    });
+
+    expect(result.duplicate).toBe(false);
+    expect(result.guarantee).toBe("degraded");
+  });
+
+  it("cleans up expired DB records", async () => {
+    query.mockResolvedValue([]);
+    await cleanupExpiredDistributedGuardRecords();
+    const statements = query.mock.calls.map(([sql]) => String(sql));
+    expect(statements.some((sql) => sql.includes("DELETE FROM webhook_replay_keys"))).toBe(true);
+    expect(statements.some((sql) => sql.includes("DELETE FROM rate_limit_counters"))).toBe(true);
+  });
+});

--- a/packages/api/src/db/migrations/20260310140000_webhook_replay_keys.sql
+++ b/packages/api/src/db/migrations/20260310140000_webhook_replay_keys.sql
@@ -1,0 +1,10 @@
+-- Distributed webhook replay dedupe ledger
+CREATE TABLE IF NOT EXISTS webhook_replay_keys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope_key_hash VARCHAR(64) NOT NULL UNIQUE,
+  scope_key TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_replay_keys_expires_at ON webhook_replay_keys(expires_at);

--- a/packages/api/src/db/migrations/20260310150000_rate_limit_counters.sql
+++ b/packages/api/src/db/migrations/20260310150000_rate_limit_counters.sql
@@ -1,0 +1,13 @@
+-- DB fallback for distributed rate limiting counters
+CREATE TABLE IF NOT EXISTS rate_limit_counters (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope_key TEXT NOT NULL,
+  bucket_start TIMESTAMPTZ NOT NULL,
+  count INTEGER NOT NULL DEFAULT 1,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(scope_key, bucket_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_counters_expires_at ON rate_limit_counters(expires_at);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_counters_scope_bucket ON rate_limit_counters(scope_key, bucket_start DESC);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -44,6 +44,8 @@ import { v4 as uuidv4 } from "uuid";
 import { startDataRetentionJob } from "./jobs/data-retention";
 import { startMaterializedViewRefreshJob } from "./jobs/materialized-view-refresh";
 import { processPendingWebhooks } from "./utils/webhook-queue";
+import { logDistributedGuardStartupSummary } from "./services/distributed-guards";
+import { startDistributedGuardsMaintenanceJob } from "./jobs/distributed-guards-maintenance";
 import { versionMiddleware } from "./middleware/versioning";
 import { v1Router } from "./routes/v1";
 import { v2Router } from "./routes/v2";
@@ -414,10 +416,12 @@ async function startServer() {
 
     await initDatabase();
     logInfo("Database initialized");
+    await logDistributedGuardStartupSummary();
 
     // Start background jobs
     startDataRetentionJob();
     startMaterializedViewRefreshJob();
+    const distributedGuardsMaintenanceTimer = startDistributedGuardsMaintenanceJob();
 
     // Process pending webhooks every minute
     const webhookInterval = setInterval(() => {
@@ -429,6 +433,7 @@ async function startServer() {
     // Register webhook interval cleanup
     registerShutdownHandler(async () => {
       clearInterval(webhookInterval);
+      clearInterval(distributedGuardsMaintenanceTimer);
       logInfo("Webhook processing stopped");
     });
 

--- a/packages/api/src/jobs/distributed-guards-maintenance.ts
+++ b/packages/api/src/jobs/distributed-guards-maintenance.ts
@@ -1,0 +1,19 @@
+import { cleanupExpiredDistributedGuardRecords } from "../services/distributed-guards";
+import { logError, logInfo } from "../utils/logger";
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+
+export function startDistributedGuardsMaintenanceJob(): NodeJS.Timeout {
+  const intervalMs = Number(
+    process.env.DISTRIBUTED_GUARD_CLEANUP_INTERVAL_MS || DEFAULT_INTERVAL_MS
+  );
+
+  const timer = setInterval(() => {
+    cleanupExpiredDistributedGuardRecords().catch((error) => {
+      logError("distributed_guard_cleanup_failed", error);
+    });
+  }, intervalMs);
+
+  logInfo("distributed_guard_cleanup_started", { intervalMs });
+  return timer;
+}

--- a/packages/api/src/routes/v1/capabilities.ts
+++ b/packages/api/src/routes/v1/capabilities.ts
@@ -17,6 +17,8 @@ const capabilityPermissionMap: Record<string, Permission[]> = {
   enterprise_analytics: [Permission.ADMIN_READ],
   enterprise_surface: [Permission.ADMIN_READ],
   support_intake: [Permission.USERS_READ],
+  rate_limiting_guard: [Permission.USERS_READ],
+  webhook_replay_guard: [Permission.USERS_READ],
 };
 
 async function resolveRequestPermissions(

--- a/packages/api/src/routes/v1/operator-mode.ts
+++ b/packages/api/src/routes/v1/operator-mode.ts
@@ -17,19 +17,19 @@ import {
   getFailedIngestions,
   getBillingAnomalies,
 } from "../../services/operator-mode/daily-intelligence";
-import { AlertThreshold } from "../../services/operator-mode/alerting";
 import {
   checkAlertThresholds,
   getNotifierCapabilities,
   upsertAlertThreshold,
   AlertThreshold,
-} from '../../services/operator-mode/alerting';
+} from "../../services/operator-mode/alerting";
 import {
   setTenantUsageCeiling,
   getAllUsageCeilings,
   checkUsageCeiling,
   setBackgroundJobLimit,
-} from '../../services/operator-mode/cost-controls';
+} from "../../services/operator-mode/cost-controls";
+import {
   getAlertRoutingProvider,
   getUsageMeteringProvider,
 } from "../../services/capabilities/registry";
@@ -183,9 +183,9 @@ const createAlertThresholdSchema = z.object({
       "usage_limit",
     ]),
     threshold: z.number(),
-    operator: z.enum(['gt', 'gte', 'lt', 'lte', 'eq', 'neq']),
-    severity: z.enum(['low', 'medium', 'high', 'critical']).default('medium'),
-    channels: z.array(z.enum(['email', 'slack', 'teams', 'telegram', 'webhook'])).default([]),
+    operator: z.enum(["gt", "gte", "lt", "lte", "eq", "neq"]),
+    severity: z.enum(["low", "medium", "high", "critical"]).default("medium"),
+    channels: z.array(z.enum(["email", "slack", "teams", "telegram", "webhook"])).default([]),
     enabled: z.boolean().default(true),
   }),
 });
@@ -217,15 +217,14 @@ router.post(
   }
 );
 
-
 router.get(
-  '/operator/alerts/capabilities',
+  "/operator/alerts/capabilities",
   requirePermission(Permission.ADMIN_READ),
   async (req: AuthRequest, res: Response) => {
     try {
       res.json({ data: getNotifierCapabilities() });
     } catch (error: unknown) {
-      handleRouteError(res, error, 'Failed to get notifier capabilities', 500, {
+      handleRouteError(res, error, "Failed to get notifier capabilities", 500, {
         userId: req.userId,
       });
     }

--- a/packages/api/src/routes/v1/webhooks/receive.ts
+++ b/packages/api/src/routes/v1/webhooks/receive.ts
@@ -5,17 +5,18 @@
  */
 
 import { Router, Request, Response } from "express";
-import { createHash } from "crypto";
 import { WebhookIngestionService } from "../../../application/webhooks/WebhookIngestionService";
 import { sendSuccess, sendError } from "../../../utils/api-response";
 import { handleRouteError } from "../../../utils/error-handler";
+import {
+  consumeWebhookReplayKey,
+  logWebhookReplayRejected,
+} from "../../../services/distributed-guards";
 
 const router: Router = Router();
 const webhookService = new WebhookIngestionService();
-const processedWebhookKeys = new Map<string, number>();
 
 const MAX_TIMESTAMP_SKEW_MS = 5 * 60 * 1000;
-const WEBHOOK_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 function parseWebhookTimestamp(req: Request): number | null {
   const header = req.headers["x-webhook-timestamp"] || req.headers["x-timestamp"];
@@ -30,36 +31,6 @@ function parseWebhookTimestamp(req: Request): number | null {
   }
 
   return asNumber > 9999999999 ? asNumber : asNumber * 1000;
-}
-
-function getReplayKey(adapter: string, tenantId: string, payload: unknown, signature: string): string {
-  const fingerprint = createHash("sha256")
-    .update(JSON.stringify(payload))
-    .update(signature)
-    .digest("hex");
-
-  return `${adapter}:${tenantId}:${fingerprint}`;
-}
-
-function isReplay(key: string): boolean {
-  const now = Date.now();
-  const existing = processedWebhookKeys.get(key);
-
-  if (existing && now - existing <= WEBHOOK_DEDUP_WINDOW_MS) {
-    return true;
-  }
-
-  processedWebhookKeys.set(key, now);
-
-  if (processedWebhookKeys.size > 5000) {
-    for (const [entryKey, createdAt] of processedWebhookKeys.entries()) {
-      if (now - createdAt > WEBHOOK_DEDUP_WINDOW_MS) {
-        processedWebhookKeys.delete(entryKey);
-      }
-    }
-  }
-
-  return false;
 }
 
 /**
@@ -89,12 +60,30 @@ router.post("/:adapter", async (req: Request, res: Response) => {
 
     const webhookTimestamp = parseWebhookTimestamp(req);
     if (webhookTimestamp && Math.abs(Date.now() - webhookTimestamp) > MAX_TIMESTAMP_SKEW_MS) {
-      return sendError(res, 400, "WEBHOOK_TIMESTAMP_EXPIRED", "Webhook timestamp outside accepted window");
+      return sendError(
+        res,
+        400,
+        "WEBHOOK_TIMESTAMP_EXPIRED",
+        "Webhook timestamp outside accepted window"
+      );
     }
 
-    const replayKey = getReplayKey(adapter, tenantId, req.body, String(signature));
-    if (isReplay(replayKey)) {
-      return sendSuccess(res, { processed: true, deduplicated: true, events: 0 }, "Duplicate webhook ignored");
+    const replay = await consumeWebhookReplayKey({
+      adapter,
+      tenantId,
+      payload: req.body,
+      signature: String(signature),
+    });
+
+    res.setHeader("X-Webhook-Replay-Guarantee", replay.guarantee);
+
+    if (replay.duplicate) {
+      logWebhookReplayRejected(replay.guarantee, adapter);
+      return sendSuccess(
+        res,
+        { processed: true, deduplicated: true, events: 0, guarantee: replay.guarantee },
+        "Duplicate webhook ignored"
+      );
     }
 
     const secret = await getWebhookSecret(adapter, tenantId);
@@ -124,6 +113,7 @@ router.post("/:adapter", async (req: Request, res: Response) => {
       processed: true,
       deduplicated: false,
       events: result.events.length,
+      guarantee: replay.guarantee,
     });
     return;
   } catch (error: unknown) {

--- a/packages/api/src/services/capabilities/registry.ts
+++ b/packages/api/src/services/capabilities/registry.ts
@@ -1,5 +1,6 @@
 import { logWarn } from "../../utils/logger";
 import type { CapabilityRegistry, CapabilityStatus } from "./types";
+import { getDistributedGuarantees } from "../distributed-guards";
 import {
   OssOperatorIntelligenceProvider,
   UnavailableOperatorIntelligenceProvider,
@@ -120,6 +121,7 @@ export async function getCapabilityRegistry(): Promise<CapabilityRegistry> {
   const usageMetering = getUsageMeteringProvider();
   const supportIntake = getSupportIntakeProvider();
   const enterpriseAnalytics = getEnterpriseAnalyticsProvider();
+  const guarantees = await getDistributedGuarantees();
 
   return new InMemoryCapabilityRegistry([
     operatorIntelligence.status(),
@@ -127,6 +129,32 @@ export async function getCapabilityRegistry(): Promise<CapabilityRegistry> {
     usageMetering.status(),
     supportIntake.status(),
     enterpriseAnalytics.status(),
+    {
+      key: "rate_limiting_guard",
+      available: guarantees.rateLimiting !== "unavailable",
+      state:
+        guarantees.rateLimiting === "distributed_shared"
+          ? "available"
+          : guarantees.rateLimiting === "local_only"
+            ? "degraded"
+            : "degraded",
+      source: "oss",
+      reason: `Guarantee: ${guarantees.rateLimiting}`,
+      guarantee: guarantees.rateLimiting,
+    },
+    {
+      key: "webhook_replay_guard",
+      available: guarantees.webhookReplayDedup !== "unavailable",
+      state:
+        guarantees.webhookReplayDedup === "distributed_shared"
+          ? "available"
+          : guarantees.webhookReplayDedup === "local_only"
+            ? "degraded"
+            : "degraded",
+      source: "oss",
+      reason: `Guarantee: ${guarantees.webhookReplayDedup}`,
+      guarantee: guarantees.webhookReplayDedup,
+    },
     {
       key: "enterprise_surface",
       available: false,

--- a/packages/api/src/services/capabilities/types.ts
+++ b/packages/api/src/services/capabilities/types.ts
@@ -6,6 +6,7 @@ export interface CapabilityStatus {
   source: "oss" | "private";
   available: boolean;
   reason?: string;
+  guarantee?: "distributed_shared" | "local_only" | "degraded" | "unavailable";
 }
 
 export interface CapabilityRegistry {

--- a/packages/api/src/services/distributed-guards.ts
+++ b/packages/api/src/services/distributed-guards.ts
@@ -1,0 +1,403 @@
+import { createHash } from "crypto";
+import { Counter, Gauge } from "prom-client";
+import { config } from "../config";
+import { query } from "../db";
+import { getRedisClient } from "../utils/cache";
+import { logInfo, logWarn } from "../utils/logger";
+
+export type GuaranteeLevel = "distributed_shared" | "local_only" | "degraded" | "unavailable";
+
+interface ConsumeResult {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+  current: number;
+}
+
+interface ReplayResult {
+  duplicate: boolean;
+  guarantee: GuaranteeLevel;
+}
+
+interface MemoryEntry {
+  count: number;
+  resetAt: number;
+}
+
+const memoryRateStore = new Map<string, MemoryEntry>();
+const memoryReplayStore = new Map<string, number>();
+
+const DEFAULT_WEBHOOK_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RATE_LIMIT_DB_WINDOW_MS = 60 * 1000;
+const rateLimitDbWindowMs = Number(
+  process.env.RATE_LIMIT_DB_WINDOW_MS || DEFAULT_RATE_LIMIT_DB_WINDOW_MS
+);
+
+let cachedRedisHealth: { ok: boolean; checkedAt: number } | null = null;
+
+const guaranteeStateGauge = new Gauge({
+  name: "distributed_guard_guarantee_state",
+  help: "Current distributed guard guarantee state (1=current)",
+  labelNames: ["guard", "guarantee"],
+});
+
+const guaranteeTransitionCounter = new Counter({
+  name: "distributed_guard_guarantee_transitions_total",
+  help: "Total guarantee transitions observed for distributed guards",
+  labelNames: ["guard", "from", "to"],
+});
+
+const replayRejectedCounter = new Counter({
+  name: "webhook_replay_rejected_total",
+  help: "Total duplicate webhook replay rejections",
+  labelNames: ["guarantee", "provider"],
+});
+
+let lastGuaranteeByGuard: Partial<Record<"rate_limiting" | "webhook_replay", GuaranteeLevel>> = {};
+
+function deploymentIsLocal(): boolean {
+  return (
+    config.deployment.env === "local" ||
+    config.nodeEnv === "development" ||
+    config.nodeEnv === "test"
+  );
+}
+
+function parseProviderReplayWindows(): Record<string, number> {
+  const configured = process.env.WEBHOOK_REPLAY_WINDOW_MS_BY_PROVIDER;
+  if (!configured) {
+    return {};
+  }
+
+  const windows: Record<string, number> = {};
+  for (const part of configured.split(",")) {
+    const [providerRaw, ttlRaw] = part.split("=");
+    const provider = providerRaw?.trim().toLowerCase();
+    const ttl = Number(ttlRaw?.trim());
+    if (!provider || !Number.isFinite(ttl) || ttl <= 0) {
+      continue;
+    }
+    windows[provider] = ttl;
+  }
+
+  return windows;
+}
+
+const providerReplayWindowsMs = parseProviderReplayWindows();
+
+function replayWindowMs(provider: string): number {
+  const providerWindow = providerReplayWindowsMs[provider.toLowerCase()];
+  if (providerWindow && providerWindow > 0) {
+    return providerWindow;
+  }
+  return Number(process.env.WEBHOOK_REPLAY_WINDOW_MS || DEFAULT_WEBHOOK_DEDUP_WINDOW_MS);
+}
+
+function observeGuarantee(
+  guard: "rate_limiting" | "webhook_replay",
+  guarantee: GuaranteeLevel
+): void {
+  const previous = lastGuaranteeByGuard[guard];
+  if (previous && previous !== guarantee) {
+    guaranteeTransitionCounter.inc({ guard, from: previous, to: guarantee });
+    logWarn("distributed_guard_transition", { guard, from: previous, to: guarantee });
+  }
+
+  lastGuaranteeByGuard[guard] = guarantee;
+  guaranteeStateGauge.set(
+    { guard, guarantee: "distributed_shared" },
+    guarantee === "distributed_shared" ? 1 : 0
+  );
+  guaranteeStateGauge.set({ guard, guarantee: "local_only" }, guarantee === "local_only" ? 1 : 0);
+  guaranteeStateGauge.set({ guard, guarantee: "degraded" }, guarantee === "degraded" ? 1 : 0);
+  guaranteeStateGauge.set({ guard, guarantee: "unavailable" }, guarantee === "unavailable" ? 1 : 0);
+}
+
+async function isRedisHealthy(): Promise<boolean> {
+  const now = Date.now();
+  if (cachedRedisHealth && now - cachedRedisHealth.checkedAt < 30_000) {
+    return cachedRedisHealth.ok;
+  }
+
+  const redis = getRedisClient();
+  if (!redis) {
+    cachedRedisHealth = { ok: false, checkedAt: now };
+    return false;
+  }
+
+  try {
+    await redis.ping();
+    cachedRedisHealth = { ok: true, checkedAt: now };
+    return true;
+  } catch (error) {
+    cachedRedisHealth = { ok: false, checkedAt: now };
+    logWarn("distributed_guard_degraded", {
+      guard: "redis",
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+function consumeMemory(key: string, limit: number, windowMs: number): ConsumeResult {
+  const now = Date.now();
+  const existing = memoryRateStore.get(key);
+  if (!existing || existing.resetAt <= now) {
+    const resetAt = now + windowMs;
+    memoryRateStore.set(key, { count: 1, resetAt });
+    return { allowed: true, remaining: Math.max(0, limit - 1), resetAt, current: 1 };
+  }
+
+  if (existing.count >= limit) {
+    return { allowed: false, remaining: 0, resetAt: existing.resetAt, current: existing.count };
+  }
+
+  existing.count += 1;
+  return {
+    allowed: true,
+    remaining: Math.max(0, limit - existing.count),
+    resetAt: existing.resetAt,
+    current: existing.count,
+  };
+}
+
+async function consumeRedis(key: string, limit: number, windowMs: number): Promise<ConsumeResult> {
+  const redis = getRedisClient();
+  if (!redis) {
+    throw new Error("Redis unavailable");
+  }
+
+  const script = `
+    local current = redis.call('INCR', KEYS[1])
+    if current == 1 then
+      redis.call('PEXPIRE', KEYS[1], ARGV[1])
+    end
+    local ttl = redis.call('PTTL', KEYS[1])
+    return {current, ttl}
+  `;
+
+  const [currentRaw, ttlRaw] = (await redis.eval(script, 1, key, String(windowMs))) as [
+    number,
+    number,
+  ];
+  const current = Number(currentRaw);
+  const ttl = Math.max(0, Number(ttlRaw));
+  const resetAt = Date.now() + ttl;
+
+  return {
+    allowed: current <= limit,
+    remaining: Math.max(0, limit - current),
+    resetAt,
+    current,
+  };
+}
+
+async function consumeRateLimitDb(scopeKey: string, limit: number): Promise<ConsumeResult> {
+  const now = Date.now();
+  const bucketStart = Math.floor(now / rateLimitDbWindowMs) * rateLimitDbWindowMs;
+  const bucketStartIso = new Date(bucketStart).toISOString();
+
+  const rows = await query<{ count: number }>(
+    `INSERT INTO rate_limit_counters (scope_key, bucket_start, count, expires_at)
+     VALUES ($1, $2::timestamptz, 1, $2::timestamptz + make_interval(secs => $3::int))
+     ON CONFLICT (scope_key, bucket_start)
+     DO UPDATE SET count = rate_limit_counters.count + 1
+     RETURNING count`,
+    [scopeKey, bucketStartIso, Math.ceil(rateLimitDbWindowMs / 1000)]
+  );
+
+  const current = rows[0]?.count ?? 1;
+  const resetAt = bucketStart + rateLimitDbWindowMs;
+
+  return {
+    allowed: current <= limit,
+    remaining: Math.max(0, limit - current),
+    resetAt,
+    current,
+  };
+}
+
+function cleanupReplayMemory(now: number, windowMs: number): void {
+  if (memoryReplayStore.size < 5000) {
+    return;
+  }
+  for (const [key, createdAt] of memoryReplayStore.entries()) {
+    if (now - createdAt > windowMs) {
+      memoryReplayStore.delete(key);
+    }
+  }
+}
+
+function replayKey(adapter: string, tenantId: string, payload: unknown, signature: string): string {
+  const fingerprint = createHash("sha256")
+    .update(JSON.stringify(payload))
+    .update(signature)
+    .digest("hex");
+  return `${adapter}:${tenantId}:${fingerprint}`;
+}
+
+function replayKeyHash(replayScopeKey: string): string {
+  return createHash("sha256").update(replayScopeKey).digest("hex");
+}
+
+async function consumeReplayRedis(key: string, windowMs: number): Promise<boolean> {
+  const redis = getRedisClient();
+  if (!redis) {
+    throw new Error("Redis unavailable");
+  }
+
+  const result = await redis.set(`webhook:replay:${key}`, "1", "PX", windowMs, "NX");
+  return result !== null;
+}
+
+async function consumeReplayDb(scopeKey: string, windowMs: number): Promise<boolean> {
+  const keyHash = replayKeyHash(scopeKey);
+  const rows = await query<{ inserted: boolean }>(
+    `INSERT INTO webhook_replay_keys (scope_key_hash, scope_key, expires_at)
+     VALUES ($1, $2, NOW() + make_interval(secs => $3::int))
+     ON CONFLICT (scope_key_hash) DO NOTHING
+     RETURNING TRUE as inserted`,
+    [keyHash, scopeKey, Math.ceil(windowMs / 1000)]
+  );
+
+  return rows.length > 0 && rows[0]?.inserted === true;
+}
+
+export async function cleanupExpiredDistributedGuardRecords(): Promise<void> {
+  await query(`DELETE FROM webhook_replay_keys WHERE expires_at <= NOW()`);
+  await query(`DELETE FROM rate_limit_counters WHERE expires_at <= NOW()`);
+}
+
+export async function getDistributedGuarantees(): Promise<{
+  rateLimiting: GuaranteeLevel;
+  webhookReplayDedup: GuaranteeLevel;
+}> {
+  const redisHealthy = await isRedisHealthy();
+  if (redisHealthy) {
+    observeGuarantee("rate_limiting", "distributed_shared");
+    observeGuarantee("webhook_replay", "distributed_shared");
+    return {
+      rateLimiting: "distributed_shared",
+      webhookReplayDedup: "distributed_shared",
+    };
+  }
+
+  if (deploymentIsLocal()) {
+    observeGuarantee("rate_limiting", "degraded");
+    observeGuarantee("webhook_replay", "degraded");
+    return {
+      rateLimiting: "degraded",
+      webhookReplayDedup: "degraded",
+    };
+  }
+
+  observeGuarantee("rate_limiting", "degraded");
+  observeGuarantee("webhook_replay", "degraded");
+  return {
+    rateLimiting: "degraded",
+    webhookReplayDedup: "degraded",
+  };
+}
+
+export async function consumeRateLimitShared(params: {
+  tenantScope: string;
+  routeScope: string;
+  limit: number;
+  windowMs: number;
+}): Promise<ConsumeResult & { guarantee: GuaranteeLevel }> {
+  const key = `ratelimit:tenant:${params.tenantScope}:route:${params.routeScope}`;
+  const redisHealthy = await isRedisHealthy();
+
+  if (redisHealthy) {
+    const result = await consumeRedis(key, params.limit, params.windowMs);
+    observeGuarantee("rate_limiting", "distributed_shared");
+    return { ...result, guarantee: "distributed_shared" };
+  }
+
+  try {
+    const db = await consumeRateLimitDb(key, params.limit);
+    observeGuarantee("rate_limiting", "degraded");
+    return {
+      ...db,
+      guarantee: "degraded",
+    };
+  } catch (error) {
+    logWarn("distributed_guard_degraded", {
+      guard: "rate_limiting",
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const memory = consumeMemory(key, params.limit, params.windowMs);
+  const guarantee = deploymentIsLocal() ? "local_only" : "degraded";
+  observeGuarantee("rate_limiting", guarantee);
+  return {
+    ...memory,
+    guarantee,
+  };
+}
+
+export async function consumeWebhookReplayKey(params: {
+  adapter: string;
+  tenantId: string;
+  payload: unknown;
+  signature: string;
+}): Promise<ReplayResult> {
+  const key = replayKey(params.adapter, params.tenantId, params.payload, params.signature);
+  const windowMs = replayWindowMs(params.adapter);
+  const redisHealthy = await isRedisHealthy();
+
+  if (redisHealthy) {
+    const inserted = await consumeReplayRedis(key, windowMs);
+    observeGuarantee("webhook_replay", "distributed_shared");
+    return { duplicate: !inserted, guarantee: "distributed_shared" };
+  }
+
+  try {
+    const inserted = await consumeReplayDb(key, windowMs);
+    observeGuarantee("webhook_replay", "degraded");
+    return { duplicate: !inserted, guarantee: "degraded" };
+  } catch (error) {
+    const now = Date.now();
+    const existing = memoryReplayStore.get(key);
+    if (existing && now - existing <= windowMs) {
+      const guarantee = deploymentIsLocal() ? "local_only" : "degraded";
+      observeGuarantee("webhook_replay", guarantee);
+      return { duplicate: true, guarantee };
+    }
+
+    memoryReplayStore.set(key, now);
+    cleanupReplayMemory(now, windowMs);
+    logWarn("distributed_guard_degraded", {
+      guard: "webhook_replay",
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    const guarantee = deploymentIsLocal() ? "local_only" : "degraded";
+    observeGuarantee("webhook_replay", guarantee);
+    return { duplicate: false, guarantee };
+  }
+}
+
+export function logRateLimitTriggered(scope: string, guarantee: GuaranteeLevel): void {
+  logInfo("rate_limit_triggered", { scope, guarantee });
+}
+
+export function logWebhookReplayRejected(guarantee: GuaranteeLevel, provider: string): void {
+  replayRejectedCounter.inc({ guarantee, provider: provider.toLowerCase() });
+  logInfo("webhook_replay_rejected", { guarantee, provider });
+}
+
+export async function logDistributedGuardStartupSummary(): Promise<void> {
+  const guarantees = await getDistributedGuarantees();
+  logInfo("distributed_guard_startup_summary", {
+    deploymentEnv: config.deployment.env,
+    nodeEnv: config.nodeEnv,
+    rateLimitingGuarantee: guarantees.rateLimiting,
+    webhookReplayGuarantee: guarantees.webhookReplayDedup,
+    replayDefaultWindowMs: Number(
+      process.env.WEBHOOK_REPLAY_WINDOW_MS || DEFAULT_WEBHOOK_DEDUP_WINDOW_MS
+    ),
+    replayProviderWindows: providerReplayWindowsMs,
+    rateLimitDbWindowMs,
+  });
+}

--- a/packages/api/src/utils/rate-limiter.ts
+++ b/packages/api/src/utils/rate-limiter.ts
@@ -2,41 +2,7 @@ import { Response, NextFunction } from "express";
 import { AuthRequest } from "../middleware/auth";
 import { query } from "../db";
 import { config } from "../config";
-
-interface RateLimitEntry {
-  count: number;
-  resetAt: number;
-}
-
-const tenantStore = new Map<string, RateLimitEntry>();
-const globalStore = new Map<string, RateLimitEntry>();
-
-function consume(store: Map<string, RateLimitEntry>, key: string, limit: number, windowMs: number) {
-  const now = Date.now();
-  const entry = store.get(key);
-
-  if (!entry || entry.resetAt <= now) {
-    const next = { count: 1, resetAt: now + windowMs };
-    store.set(key, next);
-    return { allowed: true, remaining: Math.max(0, limit - 1), resetAt: next.resetAt };
-  }
-
-  if (entry.count >= limit) {
-    return { allowed: false, remaining: 0, resetAt: entry.resetAt };
-  }
-
-  entry.count += 1;
-  return { allowed: true, remaining: Math.max(0, limit - entry.count), resetAt: entry.resetAt };
-}
-
-function cleanupExpired(store: Map<string, RateLimitEntry>) {
-  const now = Date.now();
-  for (const [key, value] of store.entries()) {
-    if (value.resetAt <= now) {
-      store.delete(key);
-    }
-  }
-}
+import { consumeRateLimitShared, logRateLimitTriggered } from "../services/distributed-guards";
 
 function shouldBypass(req: AuthRequest): boolean {
   const path = req.path.toLowerCase();
@@ -57,6 +23,7 @@ export async function checkRateLimit(req: AuthRequest): Promise<{
   remaining: number;
   resetAt: number;
   scope: "tenant" | "global" | "bypass";
+  guarantee?: "distributed_shared" | "local_only" | "degraded" | "unavailable";
 }> {
   const windowMs = config.rateLimiting.windowMs;
 
@@ -65,21 +32,29 @@ export async function checkRateLimit(req: AuthRequest): Promise<{
   }
 
   const tenantKey = req.tenantId || req.apiKeyId || req.userId || req.ip || "anonymous";
+  const routeScope = `${req.method.toUpperCase()}:${req.route?.path || req.path}`.toLowerCase();
   const tenantLimit = await resolveTenantLimit(req);
-  const tenantResult = consume(tenantStore, tenantKey, tenantLimit, windowMs);
+  const tenantResult = await consumeRateLimitShared({
+    tenantScope: tenantKey,
+    routeScope,
+    limit: tenantLimit,
+    windowMs,
+  });
   if (!tenantResult.allowed) {
     return { ...tenantResult, scope: "tenant" };
   }
 
   const globalKey = req.ip || "global";
   const globalLimit = Math.max(tenantLimit * 5, 500);
-  const globalResult = consume(globalStore, globalKey, globalLimit, windowMs);
+  const globalResult = await consumeRateLimitShared({
+    tenantScope: globalKey,
+    routeScope: "global",
+    limit: globalLimit,
+    windowMs,
+  });
   if (!globalResult.allowed) {
     return { ...globalResult, scope: "global" };
   }
-
-  if (tenantStore.size > 20000) cleanupExpired(tenantStore);
-  if (globalStore.size > 20000) cleanupExpired(globalStore);
 
   return { ...tenantResult, scope: "tenant" };
 }
@@ -92,16 +67,21 @@ export function rateLimitMiddleware() {
       res.setHeader("X-RateLimit-Limit", config.rateLimiting.defaultLimit);
       res.setHeader("X-RateLimit-Remaining", result.remaining);
       res.setHeader("X-RateLimit-Reset", new Date(result.resetAt).toISOString());
+      if (result.guarantee) {
+        res.setHeader("X-RateLimit-Guarantee", result.guarantee);
+      }
     }
 
     if (!result.allowed) {
       const retryAfter = Math.max(1, Math.ceil((result.resetAt - Date.now()) / 1000));
       res.setHeader("Retry-After", retryAfter.toString());
+      logRateLimitTriggered(result.scope, result.guarantee || "local_only");
       res.status(429).json({
         error: "RATE_LIMITED",
         message: "Rate limit exceeded",
         scope: result.scope,
         retryAfter,
+        guarantee: result.guarantee || "local_only",
       });
       return;
     }


### PR DESCRIPTION
### Motivation

- Introduce robust distributed guards to provide strong, observable guarantees for API rate limiting and webhook replay deduplication across deployment modes (Redis-backed, DB fallback, memory fallback). 
- Ensure operator visibility of guard state and graceful degradation instead of hard failures when optional backing stores are unavailable.

### Description

- Add a new service `packages/api/src/services/distributed-guards.ts` implementing `consumeRateLimitShared`, `consumeWebhookReplayKey`, guarantee observation, Redis/DB/memory fallbacks, and Prometheus metrics (`distributed_guard_guarantee_state`, `distributed_guard_guarantee_transitions_total`, `webhook_replay_rejected_total`).
- Add DB migrations `20260310140000_webhook_replay_keys.sql` and `20260310150000_rate_limit_counters.sql` to persist replay ledger and rate-limit counters for DB fallback.
- Wire guards into runtime: start-up summary via `logDistributedGuardStartupSummary`, periodic cleanup job `startDistributedGuardsMaintenanceJob` and registration in `packages/api/src/index.ts`.
- Integrate guards into request flow: replace in-process rate limiter with distributed calls in `packages/api/src/utils/rate-limiter.ts` and replace the webhook in-memory dedupe in `packages/api/src/routes/v1/webhooks/receive.ts` with `consumeWebhookReplayKey`, and add `X-Webhook-Replay-Guarantee` and `X-RateLimit-Guarantee` headers and structured 429 payloads including `guarantee`.
- Surface guard capability statuses in the capability registry and capability API by adding `rate_limiting_guard` and `webhook_replay_guard` entries and extending `CapabilityStatus` with a `guarantee` field.
- Add environment variables/examples in `.env.example` for replay windows and guard cleanup cadence (`WEBHOOK_REPLAY_WINDOW_MS`, `WEBHOOK_REPLAY_WINDOW_MS_BY_PROVIDER`, `RATE_LIMIT_DB_WINDOW_MS`, `DISTRIBUTED_GUARD_CLEANUP_INTERVAL_MS`).
- Add/modify tests: new unit tests `services/distributed-guards.test.ts`, new integration test `distributed-guards.redis.test.ts` (spawns `redis-server` when available), and update `resilience/api-resilience.test.ts` to exercise DB fallback behavior and webhook dedupe logic.

### Testing

- Ran unit tests covering the distributed guards: `packages/api/src/__tests__/services/distributed-guards.test.ts`, which passed in CI. 
- Ran modified resilience tests in `packages/api/src/__tests__/resilience/api-resilience.test.ts`, which validate rate-limit DB fallback and webhook ledger behavior and passed. 
- Added an integration test `packages/api/src/__tests__/integration/distributed-guards.redis.test.ts` that starts a local `redis-server` when available and verifies Redis-backed semantics; this test is guard-checked and only runs when Redis is present (it is skipped locally if `redis-server` is not installed), and passes when executed in Redis-enabled environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af8bc198a0832889415408a3e1e6da)