### PR TITLE
Harden operator control‑plane queries and add scale indexes

### DIFF
--- a/packages/api/src/db/migrations/performance-indexes.sql
+++ b/packages/api/src/db/migrations/performance-indexes.sql
@@ -49,6 +49,42 @@ CREATE INDEX IF NOT EXISTS idx_audit_logs_tenant_timestamp
 CREATE INDEX IF NOT EXISTS idx_audit_logs_tenant_event_timestamp 
   ON audit_logs(tenant_id, event, timestamp DESC);
 
+-- Reconciliation runs: Operator/control-plane windows and list queries
+CREATE INDEX IF NOT EXISTS idx_reconciliation_runs_started_created_id
+  ON reconciliation_runs((COALESCE(started_at, created_at)) DESC, id DESC);
+
+-- Reconciliation runs: Tenant activity and health lookups
+CREATE INDEX IF NOT EXISTS idx_reconciliation_runs_tenant_started_created
+  ON reconciliation_runs(tenant_id, (COALESCE(started_at, created_at)) DESC);
+
+-- Reconciliation runs: Failed-run scans in operator anomaly checks
+CREATE INDEX IF NOT EXISTS idx_reconciliation_runs_status_started_created
+  ON reconciliation_runs(status, (COALESCE(started_at, created_at)) DESC);
+
+-- Reconciliation matches: Join/group path used to compute manual review rates
+CREATE INDEX IF NOT EXISTS idx_reconciliation_matches_manual_review_rollup
+  ON reconciliation_matches(run_id, tenant_id)
+  WHERE reviewed = false AND match_type IN ('manual', 'unmatched');
+
+-- Runtime event stream: hot query for error signatures in control plane
+CREATE INDEX IF NOT EXISTS idx_operator_runtime_events_error_signature_recent
+  ON operator_runtime_events(event_type, occurred_at DESC)
+  INCLUDE (error_id, tenant_id, run_id, metadata)
+  WHERE event_type = 'error_thrown';
+
+-- request_metrics may be absent in slim deployments, so guard creation.
+DO $$
+BEGIN
+  IF to_regclass('public.request_metrics') IS NOT NULL THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_request_metrics_created_route_status
+      ON request_metrics(created_at DESC, route, status_code)';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_request_metrics_created_api
+      ON request_metrics(created_at DESC)
+      WHERE route LIKE ''/api/%''';
+  END IF;
+END
+$$;
+
 -- ============================================================================
 -- 2. PARTIAL INDEXES FOR HOT SUBSETS
 -- ============================================================================

--- a/packages/web/src/app/api/console/operator/control-plane/route.ts
+++ b/packages/web/src/app/api/console/operator/control-plane/route.ts
@@ -332,16 +332,22 @@ async function buildPayload(days: number) {
 
   const [systemHealth] = await prisma.$queryRaw<Array<Record<string, number>>>(
     `
-    WITH base_runs AS (
+    WITH manual_review_counts AS (
+      SELECT m.run_id, m.tenant_id, COUNT(*)::numeric AS manual_review_count
+      FROM reconciliation_matches m
+      WHERE m.reviewed = false
+        AND m.match_type IN ('manual', 'unmatched')
+      GROUP BY m.run_id, m.tenant_id
+    ), base_runs AS (
       SELECT r.id, r.tenant_id, r.status,
         COALESCE(r.source_count, 0)::numeric AS records_processed,
         COALESCE(r.matched_count, 0)::numeric AS matched_count,
         COALESCE(EXTRACT(EPOCH FROM (COALESCE(r.completed_at, NOW()) - COALESCE(r.started_at, r.created_at))) * 1000, 0)::numeric AS duration_ms,
-        (
-          SELECT COUNT(*)::numeric FROM reconciliation_matches m
-          WHERE m.run_id = r.id AND m.tenant_id = r.tenant_id AND m.reviewed = false AND m.match_type IN ('manual', 'unmatched')
-        ) AS manual_review_count
+        COALESCE(mrc.manual_review_count, 0)::numeric AS manual_review_count
       FROM reconciliation_runs r
+      LEFT JOIN manual_review_counts mrc
+        ON mrc.run_id = r.id
+       AND mrc.tenant_id = r.tenant_id
       WHERE COALESCE(r.started_at, r.created_at) >= NOW() - ($1::int || ' days')::interval
     ), api_window AS (
       SELECT
@@ -367,32 +373,36 @@ async function buildPayload(days: number) {
   );
 
   const [anomalyWindow] = await prisma.$queryRaw<Array<Record<string, number>>>(`
-    WITH recent_runs AS (
+    WITH manual_review_counts AS (
+      SELECT m.run_id, m.tenant_id, COUNT(*)::float8 AS manual_review_count
+      FROM reconciliation_matches m
+      WHERE m.reviewed = false
+        AND m.match_type IN ('manual', 'unmatched')
+      GROUP BY m.run_id, m.tenant_id
+    ), recent_runs AS (
       SELECT
         COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS failure_rate,
-        COALESCE(AVG(CASE WHEN source_count > 0 THEN (
-          SELECT COUNT(*)::float8
-          FROM reconciliation_matches m
-          WHERE m.run_id = r.id
-            AND m.tenant_id = r.tenant_id
-            AND m.reviewed = false
-            AND m.match_type IN ('manual', 'unmatched')
-        ) / source_count::float8 * 100 ELSE 0 END), 0)::float8 AS manual_review_rate
+        COALESCE(AVG(CASE WHEN source_count > 0
+          THEN COALESCE(mrc.manual_review_count, 0) / source_count::float8 * 100
+          ELSE 0
+        END), 0)::float8 AS manual_review_rate
       FROM reconciliation_runs r
+      LEFT JOIN manual_review_counts mrc
+        ON mrc.run_id = r.id
+       AND mrc.tenant_id = r.tenant_id
       WHERE COALESCE(started_at, created_at) >= NOW() - interval '24 hours'
     ),
     baseline_runs AS (
       SELECT
         COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS failure_rate,
-        COALESCE(AVG(CASE WHEN source_count > 0 THEN (
-          SELECT COUNT(*)::float8
-          FROM reconciliation_matches m
-          WHERE m.run_id = r.id
-            AND m.tenant_id = r.tenant_id
-            AND m.reviewed = false
-            AND m.match_type IN ('manual', 'unmatched')
-        ) / source_count::float8 * 100 ELSE 0 END), 0)::float8 AS manual_review_rate
+        COALESCE(AVG(CASE WHEN source_count > 0
+          THEN COALESCE(mrc.manual_review_count, 0) / source_count::float8 * 100
+          ELSE 0
+        END), 0)::float8 AS manual_review_rate
       FROM reconciliation_runs r
+      LEFT JOIN manual_review_counts mrc
+        ON mrc.run_id = r.id
+       AND mrc.tenant_id = r.tenant_id
       WHERE COALESCE(started_at, created_at) >= NOW() - interval '14 days'
         AND COALESCE(started_at, created_at) < NOW() - interval '24 hours'
     ),
@@ -439,7 +449,7 @@ async function buildPayload(days: number) {
       COALESCE(started_at, created_at) AS started_at, completed_at,
       COALESCE(source_count, 0) AS source_count, COALESCE(matched_count, 0) AS matched_count
     FROM reconciliation_runs
-    ORDER BY COALESCE(started_at, created_at) DESC
+    ORDER BY COALESCE(started_at, created_at) DESC, id DESC
     LIMIT 20;
   `);
 
@@ -489,20 +499,26 @@ async function buildPayload(days: number) {
   `);
 
   const tenantOverview = await prisma.$queryRaw<Array<Record<string, unknown>>>(`
-    SELECT tenant_id::text, COUNT(*)::int AS run_count,
+    WITH manual_review_counts AS (
+      SELECT m.run_id, m.tenant_id, COUNT(*)::float8 AS manual_review_count
+      FROM reconciliation_matches m
+      WHERE m.reviewed = false
+        AND m.match_type IN ('manual', 'unmatched')
+      GROUP BY m.run_id, m.tenant_id
+    )
+    SELECT r.tenant_id::text, COUNT(*)::int AS run_count,
       COALESCE(SUM(source_count), 0)::bigint AS records_processed,
       COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS failure_rate,
-      COALESCE(AVG(CASE WHEN source_count > 0 THEN (
-        SELECT COUNT(*)::float8
-        FROM reconciliation_matches m
-        WHERE m.run_id = r.id
-          AND m.tenant_id = r.tenant_id
-          AND m.reviewed = false
-          AND m.match_type IN ('manual', 'unmatched')
-      ) / source_count::float8 * 100 ELSE 0 END), 0)::float8 AS manual_review_rate
+      COALESCE(AVG(CASE WHEN source_count > 0
+        THEN COALESCE(mrc.manual_review_count, 0) / source_count::float8 * 100
+        ELSE 0
+      END), 0)::float8 AS manual_review_rate
     FROM reconciliation_runs r
+    LEFT JOIN manual_review_counts mrc
+      ON mrc.run_id = r.id
+     AND mrc.tenant_id = r.tenant_id
     WHERE COALESCE(started_at, created_at) >= NOW() - interval '30 days'
-    GROUP BY tenant_id
+    GROUP BY r.tenant_id
     ORDER BY run_count DESC
     LIMIT 10;
   `);


### PR DESCRIPTION
### Motivation
- Reduce expensive correlated subqueries and unstable ordering in operator/control-plane dashboards that scan `reconciliation_matches`, `reconciliation_runs`, and runtime event streams under high write rates. 
- Make operator telemetry and anomaly windows deterministic and less likely to cause broad scans or page-drift on hot tables. 
- Skills used: none (no external SKILL.md workflow required for this change). 

### Description
- Refactored the control-plane analytics SQL in `packages/web/src/app/api/console/operator/control-plane/route.ts` to pre-aggregate manual-review counts via a `manual_review_counts` CTE and `LEFT JOIN`, replacing repeated correlated `SELECT COUNT(*)` subqueries. 
- Made recent-run listing deterministic by adding an `id` tie-breaker in `ORDER BY COALESCE(started_at, created_at) DESC, id DESC` to reduce pagination drift. 
- Added targeted index hardening in `packages/api/src/db/migrations/performance-indexes.sql`, including expression indexes on `reconciliation_runs` for recency windows, a partial index on `reconciliation_matches(run_id, tenant_id)` for unresolved manual/unmatched rollups, a partial covering index for `operator_runtime_events` where `event_type = 'error_thrown'`, and guarded `request_metrics` index creation wrapped in a `to_regclass` existence check. 
- All new indexes are additive and created with `IF NOT EXISTS` (and guarded execution where appropriate) to keep migrations safe and idempotent. 

### Testing
- Ran type-checking with `pnpm --filter @settler/web typecheck` which completed successfully. 
- Linted the modified frontend file with `pnpm exec eslint src/app/api/console/operator/control-plane/route.ts` which passed for the changed file. 
- Pre-commit verification (lint-staged + package lint via the repo’s turbo pipeline) completed successfully with only pre-existing warnings and no blocking errors. 
- No runtime or DB migration application was executed in CI here; migration SQL uses `IF NOT EXISTS` and guarded `DO $$ ... END $$` to avoid failures in slim deployments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07e4e0d5c8328ba7b00cf8b901927)