### PR TITLE
Add reconciliation lifecycle, pause/resume commands, projection invariants, and alert lifecycle

### DIFF
--- a/packages/api/src/__tests__/reconciliation/AlertLifecycle.test.ts
+++ b/packages/api/src/__tests__/reconciliation/AlertLifecycle.test.ts
@@ -1,0 +1,11 @@
+import { assertCanResolveAlert, AlertTransitionError } from "../../services/alerts/AlertLifecycle";
+
+describe("AlertLifecycle", () => {
+  it("allows resolve from open state", () => {
+    expect(() => assertCanResolveAlert("open")).not.toThrow();
+  });
+
+  it("blocks resolve from resolved state", () => {
+    expect(() => assertCanResolveAlert("resolved")).toThrow(AlertTransitionError);
+  });
+});

--- a/packages/api/src/__tests__/reconciliation/ReconciliationLifecycle.test.ts
+++ b/packages/api/src/__tests__/reconciliation/ReconciliationLifecycle.test.ts
@@ -1,0 +1,95 @@
+import type { EventEnvelope } from "../../domain/eventsourcing/EventEnvelope";
+import {
+  assertCompletionDataInvariant,
+  assertProjectionMutationInvariant,
+  deriveReconciliationLifecycle,
+} from "../../domain/eventsourcing/reconciliation/ReconciliationLifecycle";
+
+describe("ReconciliationLifecycle", () => {
+  const makeEvent = (
+    eventType: string,
+    data: Record<string, unknown>,
+    id: string
+  ): EventEnvelope => ({
+    id,
+    aggregate_id: "recon-1",
+    aggregate_type: "reconciliation",
+    event_type: eventType,
+    event_version: 1,
+    data,
+    metadata: {
+      tenant_id: "tenant-1",
+      correlation_id: "corr-1",
+      timestamp: new Date().toISOString(),
+    },
+    created_at: new Date(),
+  });
+
+  it("derives paused and resumed states from mixed event history", () => {
+    const history = [
+      makeEvent("ReconciliationStarted", { execution_id: "e1" }, "1"),
+      makeEvent("ReconciliationPaused", { paused_at: new Date().toISOString() }, "2"),
+    ];
+
+    expect(deriveReconciliationLifecycle(history)).toBe("paused");
+    expect(
+      deriveReconciliationLifecycle([...history, makeEvent("ReconciliationResumed", {}, "3")])
+    ).toBe("in_progress");
+  });
+
+  it("treats unknown terminal-unrelated event as in_progress fallback", () => {
+    const history = [
+      makeEvent("ReconciliationStarted", { execution_id: "e1" }, "1"),
+      makeEvent("UnknownEvent", {}, "2"),
+    ];
+
+    expect(deriveReconciliationLifecycle(history)).toBe("in_progress");
+  });
+
+  it("enforces completion metadata invariants", () => {
+    expect(() =>
+      assertCompletionDataInvariant(
+        makeEvent(
+          "ReconciliationCompleted",
+          {
+            reconciliation_id: "recon-1",
+            summary: { duration_ms: -1 },
+            completed_at: new Date().toISOString(),
+            finalization: { finalized_at: new Date().toISOString(), finalization_source: "saga" },
+          },
+          "1"
+        )
+      )
+    ).toThrow("duration cannot be negative");
+  });
+
+  it("blocks mutation events after completion in projection processing", () => {
+    const completed = makeEvent(
+      "ReconciliationCompleted",
+      {
+        reconciliation_id: "recon-1",
+        summary: { duration_ms: 100 },
+        completed_at: new Date().toISOString(),
+        finalization: { finalized_at: new Date().toISOString(), finalization_source: "saga" },
+      },
+      "2"
+    );
+
+    const postCompletionMutation = makeEvent(
+      "RecordMatched",
+      { reconciliation_id: "recon-1" },
+      "3"
+    );
+
+    expect(() =>
+      assertProjectionMutationInvariant(
+        [
+          makeEvent("ReconciliationStarted", { execution_id: "e1" }, "1"),
+          completed,
+          postCompletionMutation,
+        ],
+        postCompletionMutation
+      )
+    ).toThrow("Projection invariant violation");
+  });
+});

--- a/packages/api/src/__tests__/reconciliation/ReconciliationService.test.ts
+++ b/packages/api/src/__tests__/reconciliation/ReconciliationService.test.ts
@@ -3,51 +3,63 @@
  * Tests for the core reconciliation service
  */
 
-import { ReconciliationService } from '../../application/reconciliation/ReconciliationService';
-import { IEventStore } from '../../infrastructure/eventsourcing/EventStore';
-import { IEventBus } from '../../infrastructure/events/IEventBus';
-import { ShopifyAdapter } from '@settler/adapters';
-import { StripeAdapter } from '@settler/adapters';
+import { ReconciliationService } from "../../application/reconciliation/ReconciliationService";
+import { IEventStore } from "../../infrastructure/eventsourcing/EventStore";
+import { IEventBus } from "../../infrastructure/events/IEventBus";
+import { ShopifyAdapter } from "@settler/adapters";
+import { StripeAdapter } from "@settler/adapters";
 import {
   StartReconciliationCommand,
   RetryReconciliationCommand,
   CancelReconciliationCommand,
-} from '../../application/cqrs/commands/ReconciliationCommands';
-import type { EventEnvelope } from '../../domain/eventsourcing/EventEnvelope';
+  PauseReconciliationCommand,
+  ResumeReconciliationCommand,
+} from "../../application/cqrs/commands/ReconciliationCommands";
+import type { EventEnvelope } from "../../domain/eventsourcing/EventEnvelope";
+import { ReconciliationTransitionError } from "../../domain/eventsourcing/reconciliation/ReconciliationLifecycle";
 
-describe('ReconciliationService', () => {
+describe("ReconciliationService", () => {
   let service: ReconciliationService;
   let mockEventStore: jest.Mocked<IEventStore>;
   let mockEventBus: jest.Mocked<IEventBus>;
   let mockShopifyAdapter: jest.Mocked<ShopifyAdapter>;
   let mockStripeAdapter: jest.Mocked<StripeAdapter>;
-  let baseEvent: EventEnvelope;
+  let baseStartedEvent: EventEnvelope;
+
+  const createEvent = (
+    eventType: string,
+    data: Record<string, unknown>,
+    tenantId = "tenant-123"
+  ): EventEnvelope => ({
+    id: `event-${eventType}`,
+    aggregate_id: "recon-123",
+    aggregate_type: "reconciliation",
+    event_type: eventType,
+    event_version: 1,
+    data,
+    metadata: {
+      tenant_id: tenantId,
+      correlation_id: "corr-123",
+      timestamp: new Date().toISOString(),
+    },
+    created_at: new Date(),
+  });
 
   beforeEach(() => {
-    baseEvent = {
-      id: 'event-1',
-      aggregate_id: 'recon-123',
-      aggregate_type: 'reconciliation',
-      event_type: 'reconciliation.started',
-      event_version: 1,
-      data: {
-        job_id: 'job-123',
-        source_adapter: 'shopify',
-        target_adapter: 'stripe',
-        date_range: {
-          start: new Date('2024-01-01').toISOString(),
-          end: new Date('2024-01-31').toISOString(),
-        },
+    baseStartedEvent = createEvent("ReconciliationStarted", {
+      reconciliation_id: "recon-123",
+      job_id: "job-123",
+      source_adapter: "shopify",
+      target_adapter: "stripe",
+      date_range: {
+        start: new Date("2024-01-01").toISOString(),
+        end: new Date("2024-01-31").toISOString(),
       },
-      metadata: {
-        tenant_id: 'tenant-123',
-        correlation_id: 'corr-123',
-        timestamp: new Date().toISOString(),
-      },
-      created_at: new Date(),
-    };
+      execution_id: "exec-1",
+      attempt_number: 1,
+      execution_kind: "initial",
+    });
 
-    // Mock EventStore
     mockEventStore = {
       append: jest.fn().mockResolvedValue(undefined),
       getEvents: jest.fn().mockResolvedValue([]),
@@ -55,13 +67,11 @@ describe('ReconciliationService', () => {
       saveSnapshot: jest.fn().mockResolvedValue(undefined),
     } as any;
 
-    // Mock EventBus
     mockEventBus = {
       publish: jest.fn().mockResolvedValue(undefined),
       subscribe: jest.fn(),
     } as any;
 
-    // Mock Adapters
     mockShopifyAdapter = {
       fetch: jest.fn(),
       validate: jest.fn().mockResolvedValue(true),
@@ -80,17 +90,17 @@ describe('ReconciliationService', () => {
     );
   });
 
-  describe('startReconciliation', () => {
-    it('should start a reconciliation successfully', async () => {
+  describe("startReconciliation", () => {
+    it("should start a reconciliation successfully", async () => {
       const command: StartReconciliationCommand = {
-        reconciliation_id: 'recon-123',
-        job_id: 'job-123',
-        tenant_id: 'tenant-123',
-        source_adapter: 'shopify',
-        target_adapter: 'stripe',
+        reconciliation_id: "recon-123",
+        job_id: "job-123",
+        tenant_id: "tenant-123",
+        source_adapter: "shopify",
+        target_adapter: "stripe",
         date_range: {
-          start: new Date('2024-01-01').toISOString(),
-          end: new Date('2024-01-31').toISOString(),
+          start: new Date("2024-01-01").toISOString(),
+          end: new Date("2024-01-31").toISOString(),
         },
       };
 
@@ -100,58 +110,112 @@ describe('ReconciliationService', () => {
       expect(mockEventBus.publish).toHaveBeenCalled();
     });
 
-    it('should handle errors during reconciliation start', async () => {
-      mockEventStore.append.mockRejectedValue(new Error('Database error'));
-
+    it("should reject start when reconciliation already exists", async () => {
+      mockEventStore.getEvents.mockResolvedValue([baseStartedEvent]);
       const command: StartReconciliationCommand = {
-        reconciliation_id: 'recon-123',
-        job_id: 'job-123',
-        tenant_id: 'tenant-123',
-        source_adapter: 'shopify',
-        target_adapter: 'stripe',
+        reconciliation_id: "recon-123",
+        job_id: "job-123",
+        tenant_id: "tenant-123",
+        source_adapter: "shopify",
+        target_adapter: "stripe",
         date_range: {
-          start: new Date('2024-01-01').toISOString(),
-          end: new Date('2024-01-31').toISOString(),
+          start: new Date("2024-01-01").toISOString(),
+          end: new Date("2024-01-31").toISOString(),
         },
       };
 
-      await expect(service.startReconciliation(command)).rejects.toThrow('Database error');
+      await expect(service.startReconciliation(command)).rejects.toMatchObject({
+        name: "ReconciliationTransitionError",
+        attemptedAction: "start",
+        currentState: "in_progress",
+      });
     });
   });
 
-  describe('retryReconciliation', () => {
-    it('should retry a failed reconciliation', async () => {
-      mockEventStore.getEvents.mockResolvedValue([baseEvent]);
+  describe("retryReconciliation", () => {
+    it("should retry a failed reconciliation with incremented attempt metadata", async () => {
+      const failedEvent = createEvent("ReconciliationFailed", {
+        reconciliation_id: "recon-123",
+        error: { type: "RuntimeError", message: "failed" },
+      });
+      mockEventStore.getEvents.mockResolvedValue([baseStartedEvent, failedEvent]);
+
       const command: RetryReconciliationCommand = {
-        reconciliation_id: 'recon-123',
-        tenant_id: 'tenant-123',
+        reconciliation_id: "recon-123",
+        tenant_id: "tenant-123",
       };
 
       await service.retryReconciliation(command);
 
-      expect(mockEventStore.append).toHaveBeenCalled();
+      expect(mockEventStore.append).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            attempt_number: 2,
+            execution_kind: "retry",
+            retry_of_execution_id: "exec-1",
+          }),
+        })
+      );
     });
 
-    it('should handle retry errors', async () => {
-      mockEventStore.append.mockRejectedValue(new Error('Retry failed'));
-      mockEventStore.getEvents.mockResolvedValue([baseEvent]);
+    it("should reject retry for completed reconciliation", async () => {
+      const completedEvent = createEvent("ReconciliationCompleted", {
+        reconciliation_id: "recon-123",
+      });
+      mockEventStore.getEvents.mockResolvedValue([baseStartedEvent, completedEvent]);
 
       const command: RetryReconciliationCommand = {
-        reconciliation_id: 'recon-123',
-        tenant_id: 'tenant-123',
+        reconciliation_id: "recon-123",
+        tenant_id: "tenant-123",
       };
 
-      await expect(service.retryReconciliation(command)).rejects.toThrow('Retry failed');
+      await expect(service.retryReconciliation(command)).rejects.toBeInstanceOf(
+        ReconciliationTransitionError
+      );
     });
   });
 
-  describe('cancelReconciliation', () => {
-    it('should cancel an active reconciliation', async () => {
-      mockEventStore.getEvents.mockResolvedValue([baseEvent]);
+  describe("pauseResumeReconciliation", () => {
+    it("should pause an in-progress reconciliation", async () => {
+      mockEventStore.getEvents.mockResolvedValue([baseStartedEvent]);
+      const command: PauseReconciliationCommand = {
+        reconciliation_id: "recon-123",
+        tenant_id: "tenant-123",
+      };
+
+      await service.pauseReconciliation(command);
+
+      expect(mockEventStore.append).toHaveBeenCalledWith(
+        expect.objectContaining({ event_type: "ReconciliationPaused" })
+      );
+    });
+
+    it("should resume a paused reconciliation", async () => {
+      const pausedEvent = createEvent("ReconciliationPaused", {
+        reconciliation_id: "recon-123",
+        paused_at: new Date().toISOString(),
+      });
+      mockEventStore.getEvents.mockResolvedValue([baseStartedEvent, pausedEvent]);
+      const command: ResumeReconciliationCommand = {
+        reconciliation_id: "recon-123",
+        tenant_id: "tenant-123",
+      };
+
+      await service.resumeReconciliation(command);
+
+      expect(mockEventStore.append).toHaveBeenCalledWith(
+        expect.objectContaining({ event_type: "ReconciliationResumed" })
+      );
+    });
+  });
+
+  describe("cancelReconciliation", () => {
+    it("should cancel an active reconciliation", async () => {
+      mockEventStore.getEvents.mockResolvedValue([baseStartedEvent]);
       const command: CancelReconciliationCommand = {
-        reconciliation_id: 'recon-123',
-        tenant_id: 'tenant-123',
-        reason: 'User requested cancellation',
+        reconciliation_id: "recon-123",
+        tenant_id: "tenant-123",
+        reason: "User requested cancellation",
       };
 
       await service.cancelReconciliation(command);
@@ -159,27 +223,74 @@ describe('ReconciliationService', () => {
       expect(mockEventStore.append).toHaveBeenCalled();
       expect(mockEventBus.publish).toHaveBeenCalled();
     });
+
+    it("should reject cancellation after completion", async () => {
+      const completedEvent = createEvent("ReconciliationCompleted", {
+        reconciliation_id: "recon-123",
+      });
+      mockEventStore.getEvents.mockResolvedValue([baseStartedEvent, completedEvent]);
+
+      const command: CancelReconciliationCommand = {
+        reconciliation_id: "recon-123",
+        tenant_id: "tenant-123",
+      };
+
+      await expect(service.cancelReconciliation(command)).rejects.toMatchObject({
+        name: "ReconciliationTransitionError",
+        attemptedAction: "cancel",
+        currentState: "completed",
+      });
+    });
+
+    it("should reject cross-tenant mutation attempts", async () => {
+      mockEventStore.getEvents.mockResolvedValue([
+        createEvent(
+          "ReconciliationStarted",
+          {
+            reconciliation_id: "recon-123",
+            job_id: "job-123",
+            source_adapter: "shopify",
+            target_adapter: "stripe",
+            date_range: {
+              start: new Date("2024-01-01").toISOString(),
+              end: new Date("2024-01-31").toISOString(),
+            },
+            execution_id: "exec-1",
+            attempt_number: 1,
+            execution_kind: "initial",
+          },
+          "tenant-a"
+        ),
+      ]);
+      const command: CancelReconciliationCommand = {
+        reconciliation_id: "recon-123",
+        tenant_id: "tenant-b",
+      };
+
+      await expect(service.cancelReconciliation(command)).rejects.toThrow(
+        "Tenant invariant violation"
+      );
+    });
   });
 
-  describe('saga integration', () => {
-    it('should trigger saga when reconciliation starts', async () => {
+  describe("saga integration", () => {
+    it("should trigger saga when reconciliation starts", async () => {
       const command: StartReconciliationCommand = {
-        reconciliation_id: 'recon-123',
-        job_id: 'job-123',
-        tenant_id: 'tenant-123',
-        source_adapter: 'shopify',
-        target_adapter: 'stripe',
+        reconciliation_id: "recon-123",
+        job_id: "job-123",
+        tenant_id: "tenant-123",
+        source_adapter: "shopify",
+        target_adapter: "stripe",
         date_range: {
-          start: new Date('2024-01-01').toISOString(),
-          end: new Date('2024-01-31').toISOString(),
+          start: new Date("2024-01-01").toISOString(),
+          end: new Date("2024-01-31").toISOString(),
         },
       };
 
       await service.startReconciliation(command);
 
-      // Verify saga was subscribed to reconciliation.started event
       expect(mockEventBus.subscribe).toHaveBeenCalledWith(
-        'reconciliation.started',
+        "reconciliation.started",
         expect.any(Function)
       );
     });

--- a/packages/api/src/application/cqrs/commands/ReconciliationCommandHandlers.ts
+++ b/packages/api/src/application/cqrs/commands/ReconciliationCommandHandlers.ts
@@ -3,17 +3,30 @@
  * Handle commands and emit events
  */
 
-import { IEventStore } from '../../../infrastructure/eventsourcing/EventStore';
+import { IEventStore } from "../../../infrastructure/eventsourcing/EventStore";
 import {
   StartReconciliationCommand,
   RetryReconciliationCommand,
   CancelReconciliationCommand,
   PauseReconciliationCommand,
   ResumeReconciliationCommand,
-} from './ReconciliationCommands';
-import { ReconciliationEvents, ReconciliationStartedData } from '../../../domain/eventsourcing/reconciliation/ReconciliationEvents';
-import { IEventBus } from '../../../infrastructure/events/IEventBus';
-import { DomainEvent } from '../../../domain/events/DomainEvent';
+} from "./ReconciliationCommands";
+import {
+  ReconciliationEvents,
+  ReconciliationStartedData,
+} from "../../../domain/eventsourcing/reconciliation/ReconciliationEvents";
+import {
+  assertCanCancel,
+  assertCanPause,
+  assertCanResume,
+  assertCanRetry,
+  assertCanStart,
+  assertTenantInvariant,
+  countExecutionAttempts,
+  getLatestStartedExecution,
+} from "../../../domain/eventsourcing/reconciliation/ReconciliationLifecycle";
+import { IEventBus } from "../../../infrastructure/events/IEventBus";
+import { DomainEvent } from "../../../domain/events/DomainEvent";
 
 export class ReconciliationCommandHandlers {
   constructor(
@@ -22,16 +35,22 @@ export class ReconciliationCommandHandlers {
   ) {}
 
   async handleStartReconciliation(command: StartReconciliationCommand): Promise<void> {
-    // Validate permissions and input
-    // In a real implementation, check tenant permissions, job exists, etc.
+    const existingEvents = await this.eventStore.getEvents(
+      command.reconciliation_id,
+      "reconciliation"
+    );
+    assertTenantInvariant(existingEvents, command.tenant_id);
+    assertCanStart(existingEvents);
 
-    // Create and emit ReconciliationStarted event
     const eventData: ReconciliationStartedData = {
       reconciliation_id: command.reconciliation_id,
       job_id: command.job_id,
       source_adapter: command.source_adapter,
       target_adapter: command.target_adapter,
       date_range: command.date_range,
+      execution_id: command.execution_id || crypto.randomUUID(),
+      attempt_number: 1,
+      execution_kind: "initial",
     };
     if (command.user_id) {
       eventData.initiated_by = command.user_id;
@@ -44,10 +63,8 @@ export class ReconciliationCommandHandlers {
       command.correlation_id || crypto.randomUUID()
     );
 
-    // Append to event store
     await this.eventStore.append(event);
 
-    // Publish to event bus for projections and saga orchestration
     await this.eventBus.publish(
       new ReconciliationStartedDomainEvent(
         command.reconciliation_id,
@@ -55,40 +72,40 @@ export class ReconciliationCommandHandlers {
         event.metadata.correlation_id,
         command.tenant_id,
         command.date_range,
-        command.source_adapter === 'shopify' ? { adapter: command.source_adapter } : undefined,
-        command.target_adapter === 'stripe' ? { adapter: command.target_adapter } : undefined
+        command.source_adapter === "shopify" ? { adapter: command.source_adapter } : undefined,
+        command.target_adapter === "stripe" ? { adapter: command.target_adapter } : undefined
       )
     );
   }
 
   async handleRetryReconciliation(command: RetryReconciliationCommand): Promise<void> {
-    // Get existing events to determine current state
-    const events = await this.eventStore.getEvents(
-      command.reconciliation_id,
-      'reconciliation'
-    );
+    const events = await this.eventStore.getEvents(command.reconciliation_id, "reconciliation");
 
-    if (events.length === 0) {
-      throw new Error('Reconciliation not found');
-    }
+    assertTenantInvariant(events, command.tenant_id);
+    assertCanRetry(events);
 
     const lastEvent = events[events.length - 1];
     if (!lastEvent) {
-      throw new Error('Reconciliation not found');
+      throw new Error("Reconciliation not found");
     }
-    const correlationId = command.correlation_id || lastEvent.metadata.correlation_id;
 
-    // Create retry event (could be a new event type)
+    const latestStartedExecution = getLatestStartedExecution(events);
+    if (!latestStartedExecution) {
+      throw new Error("Reconciliation invariant violation: missing started execution data");
+    }
+
+    const correlationId = command.correlation_id || crypto.randomUUID();
+
     const retryEventData: ReconciliationStartedData = {
       reconciliation_id: command.reconciliation_id,
-       
-      job_id: (lastEvent.data as any).job_id,
-       
-      source_adapter: (lastEvent.data as any).source_adapter,
-       
-      target_adapter: (lastEvent.data as any).target_adapter,
-       
-      date_range: (lastEvent.data as any).date_range,
+      job_id: latestStartedExecution.job_id,
+      source_adapter: latestStartedExecution.source_adapter,
+      target_adapter: latestStartedExecution.target_adapter,
+      date_range: latestStartedExecution.date_range,
+      execution_id: command.execution_id || crypto.randomUUID(),
+      attempt_number: countExecutionAttempts(events) + 1,
+      execution_kind: "retry",
+      retry_of_execution_id: latestStartedExecution.execution_id,
     };
     if (command.user_id) {
       retryEventData.initiated_by = command.user_id;
@@ -108,18 +125,14 @@ export class ReconciliationCommandHandlers {
   }
 
   async handleCancelReconciliation(command: CancelReconciliationCommand): Promise<void> {
-    const events = await this.eventStore.getEvents(
-      command.reconciliation_id,
-      'reconciliation'
-    );
+    const events = await this.eventStore.getEvents(command.reconciliation_id, "reconciliation");
 
-    if (events.length === 0) {
-      throw new Error('Reconciliation not found');
-    }
+    assertTenantInvariant(events, command.tenant_id);
+    assertCanCancel(events);
 
     const lastEvent = events[events.length - 1];
     if (!lastEvent) {
-      throw new Error('Reconciliation not found');
+      throw new Error("Reconciliation not found");
     }
     const correlationId = command.correlation_id || lastEvent.metadata.correlation_id;
 
@@ -128,8 +141,8 @@ export class ReconciliationCommandHandlers {
       {
         reconciliation_id: command.reconciliation_id,
         error: {
-          type: 'CancellationError',
-          message: command.reason || 'Reconciliation cancelled by user',
+          type: "CancellationError",
+          message: command.reason || "Reconciliation cancelled by user",
         },
         failed_at: new Date().toISOString(),
         retryable: false,
@@ -144,18 +157,56 @@ export class ReconciliationCommandHandlers {
     );
   }
 
-  async handlePauseReconciliation(_command: PauseReconciliationCommand): Promise<void> {
-    // Similar implementation for pause
-    // Would emit a ReconciliationPaused event
+  async handlePauseReconciliation(command: PauseReconciliationCommand): Promise<void> {
+    const events = await this.eventStore.getEvents(command.reconciliation_id, "reconciliation");
+
+    assertTenantInvariant(events, command.tenant_id);
+    assertCanPause(events);
+
+    const correlationId = command.correlation_id || crypto.randomUUID();
+    const pauseEvent = ReconciliationEvents.ReconciliationPaused(
+      command.reconciliation_id,
+      {
+        reconciliation_id: command.reconciliation_id,
+        paused_at: new Date().toISOString(),
+        reason: command.reason,
+      },
+      command.tenant_id,
+      command.user_id,
+      correlationId
+    );
+
+    await this.eventStore.append(pauseEvent);
+    await this.eventBus.publish(
+      new ReconciliationPausedDomainEvent(command.reconciliation_id, correlationId)
+    );
   }
 
-  async handleResumeReconciliation(_command: ResumeReconciliationCommand): Promise<void> {
-    // Similar implementation for resume
-    // Would emit a ReconciliationResumed event
+  async handleResumeReconciliation(command: ResumeReconciliationCommand): Promise<void> {
+    const events = await this.eventStore.getEvents(command.reconciliation_id, "reconciliation");
+
+    assertTenantInvariant(events, command.tenant_id);
+    assertCanResume(events);
+
+    const correlationId = command.correlation_id || crypto.randomUUID();
+    const resumeEvent = ReconciliationEvents.ReconciliationResumed(
+      command.reconciliation_id,
+      {
+        reconciliation_id: command.reconciliation_id,
+        resumed_at: new Date().toISOString(),
+      },
+      command.tenant_id,
+      command.user_id,
+      correlationId
+    );
+
+    await this.eventStore.append(resumeEvent);
+    await this.eventBus.publish(
+      new ReconciliationResumedDomainEvent(command.reconciliation_id, correlationId)
+    );
   }
 }
 
-// Domain events for event bus (simplified)
 class ReconciliationStartedDomainEvent extends DomainEvent {
   constructor(
     public readonly reconciliationId: string,
@@ -171,7 +222,7 @@ class ReconciliationStartedDomainEvent extends DomainEvent {
   }
 
   get eventName(): string {
-    return 'reconciliation.started';
+    return "reconciliation.started";
   }
 }
 
@@ -184,7 +235,7 @@ class ReconciliationRetryDomainEvent extends DomainEvent {
   }
 
   get eventName(): string {
-    return 'reconciliation.retry';
+    return "reconciliation.retry";
   }
 }
 
@@ -197,6 +248,32 @@ class ReconciliationCancelledDomainEvent extends DomainEvent {
   }
 
   get eventName(): string {
-    return 'reconciliation.cancelled';
+    return "reconciliation.cancelled";
+  }
+}
+
+class ReconciliationPausedDomainEvent extends DomainEvent {
+  constructor(
+    public readonly reconciliationId: string,
+    public readonly correlationId: string
+  ) {
+    super();
+  }
+
+  get eventName(): string {
+    return "reconciliation.paused";
+  }
+}
+
+class ReconciliationResumedDomainEvent extends DomainEvent {
+  constructor(
+    public readonly reconciliationId: string,
+    public readonly correlationId: string
+  ) {
+    super();
+  }
+
+  get eventName(): string {
+    return "reconciliation.resumed";
   }
 }

--- a/packages/api/src/application/cqrs/commands/ReconciliationCommands.ts
+++ b/packages/api/src/application/cqrs/commands/ReconciliationCommands.ts
@@ -14,6 +14,7 @@ export interface StartReconciliationCommand {
     start: string;
     end: string;
   };
+  execution_id?: string;
   correlation_id?: string;
 }
 
@@ -22,6 +23,7 @@ export interface RetryReconciliationCommand {
   tenant_id: string;
   user_id?: string;
   from_step?: string;
+  execution_id?: string;
   correlation_id?: string;
 }
 
@@ -37,6 +39,7 @@ export interface PauseReconciliationCommand {
   reconciliation_id: string;
   tenant_id: string;
   user_id?: string;
+  reason?: string;
   correlation_id?: string;
 }
 

--- a/packages/api/src/application/cqrs/projections/ReconciliationProjections.ts
+++ b/packages/api/src/application/cqrs/projections/ReconciliationProjections.ts
@@ -3,15 +3,15 @@
  * Event handlers that update read models
  */
 
-import { Pool } from 'pg';
-import { pool } from '../../../db';
-import { DomainEvent } from '../../../domain/events/DomainEvent';
-import { EventEnvelope } from '../../../domain/eventsourcing/EventEnvelope';
+import { Pool } from "pg";
+import { pool } from "../../../db";
+import { DomainEvent } from "../../../domain/events/DomainEvent";
+import { EventEnvelope } from "../../../domain/eventsourcing/EventEnvelope";
 
 export interface ReconciliationSummary {
   reconciliation_id: string;
   job_id: string;
-  status: 'running' | 'completed' | 'failed' | 'cancelled';
+  status: "running" | "paused" | "completed" | "failed" | "cancelled";
   total_source_records: number;
   total_target_records: number;
   matched_count: number;
@@ -70,17 +70,17 @@ export class ReconciliationProjectionHandlers {
     `;
 
     // Extract from event metadata
-     
-    const tenantId = (event as any).tenantId || 'unknown';
-     
+
+    const tenantId = (event as any).tenantId || "unknown";
+
     const reconciliationId = (event as any).reconciliationId;
-     
+
     const jobId = (event as any).jobId;
 
     await this.db.query(query, [
       reconciliationId,
       jobId,
-      'running',
+      "running",
       tenantId,
       new Date(),
       new Date(),
@@ -91,7 +91,6 @@ export class ReconciliationProjectionHandlers {
    * Handle OrdersFetched event
    */
   async handleOrdersFetched(eventEnvelope: EventEnvelope): Promise<void> {
-     
     const data = eventEnvelope.data as any;
     const query = `
       UPDATE reconciliation_summary
@@ -108,7 +107,6 @@ export class ReconciliationProjectionHandlers {
    * Handle PaymentsFetched event
    */
   async handlePaymentsFetched(eventEnvelope: EventEnvelope): Promise<void> {
-     
     const data = eventEnvelope.data as any;
     const query = `
       UPDATE reconciliation_summary
@@ -125,7 +123,6 @@ export class ReconciliationProjectionHandlers {
    * Handle RecordMatched event
    */
   async handleRecordMatched(eventEnvelope: EventEnvelope): Promise<void> {
-     
     const data = eventEnvelope.data as any;
     const query = `
       UPDATE reconciliation_summary
@@ -142,7 +139,6 @@ export class ReconciliationProjectionHandlers {
    * Handle RecordUnmatched event
    */
   async handleRecordUnmatched(eventEnvelope: EventEnvelope): Promise<void> {
-     
     const data = eventEnvelope.data as any;
     const query = `
       UPDATE reconciliation_summary
@@ -159,15 +155,46 @@ export class ReconciliationProjectionHandlers {
       WHERE reconciliation_id = $1
     `;
 
-    const unmatchedType = data.source_id ? 'source' : 'target';
+    const unmatchedType = data.source_id ? "source" : "target";
     await this.db.query(query, [data.reconciliation_id, unmatchedType]);
+  }
+
+  /**
+   * Handle ReconciliationPaused event
+   */
+  async handleReconciliationPaused(eventEnvelope: EventEnvelope): Promise<void> {
+    const data = eventEnvelope.data as { reconciliation_id: string };
+    const query = `
+      UPDATE reconciliation_summary
+      SET
+        status = 'paused',
+        updated_at = NOW()
+      WHERE reconciliation_id = $1
+    `;
+
+    await this.db.query(query, [data.reconciliation_id]);
+  }
+
+  /**
+   * Handle ReconciliationResumed event
+   */
+  async handleReconciliationResumed(eventEnvelope: EventEnvelope): Promise<void> {
+    const data = eventEnvelope.data as { reconciliation_id: string };
+    const query = `
+      UPDATE reconciliation_summary
+      SET
+        status = 'running',
+        updated_at = NOW()
+      WHERE reconciliation_id = $1
+    `;
+
+    await this.db.query(query, [data.reconciliation_id]);
   }
 
   /**
    * Handle ReconciliationCompleted event
    */
   async handleReconciliationCompleted(eventEnvelope: EventEnvelope): Promise<void> {
-     
     const data = eventEnvelope.data as any;
     const query = `
       UPDATE reconciliation_summary
@@ -203,7 +230,6 @@ export class ReconciliationProjectionHandlers {
    * Handle ReconciliationFailed event
    */
   async handleReconciliationFailed(eventEnvelope: EventEnvelope): Promise<void> {
-     
     const data = eventEnvelope.data as any;
     const query = `
       UPDATE reconciliation_summary
@@ -244,20 +270,14 @@ export class ReconciliationProjectionHandlers {
         success_count = tenant_usage_view.success_count + 1
     `;
 
-     
     const data = eventEnvelope.data as any;
-    await this.db.query(query, [
-      tenantId,
-      today,
-      data.summary?.duration_ms || 0,
-    ]);
+    await this.db.query(query, [tenantId, today, data.summary?.duration_ms || 0]);
   }
 
   /**
    * Update error hotspots view
    */
   private async updateErrorHotspots(eventEnvelope: EventEnvelope): Promise<void> {
-     
     const data = eventEnvelope.data as any;
     const tenantId = eventEnvelope.metadata.tenant_id;
 
@@ -279,10 +299,10 @@ export class ReconciliationProjectionHandlers {
 
     await this.db.query(query, [
       data.reconciliation_id,
-       
-      (data).job_id || 'unknown',
+
+      data.job_id || "unknown",
       data.error.type,
-      data.step || 'unknown',
+      data.step || "unknown",
       new Date(data.failed_at),
       tenantId,
     ]);

--- a/packages/api/src/application/eventsourcing/EventProjectionService.ts
+++ b/packages/api/src/application/eventsourcing/EventProjectionService.ts
@@ -3,11 +3,16 @@
  * Wires up event handlers to update projections
  */
 
-import { IEventBus } from '../../infrastructure/events/IEventBus';
-import { IEventStore } from '../../infrastructure/eventsourcing/EventStore';
-import { ReconciliationProjectionHandlers } from '../cqrs/projections/ReconciliationProjections';
-import { EventEnvelope } from '../../domain/eventsourcing/EventEnvelope';
-import { DomainEvent } from '../../domain/events/DomainEvent';
+import { IEventBus } from "../../infrastructure/events/IEventBus";
+import { IEventStore } from "../../infrastructure/eventsourcing/EventStore";
+import { ReconciliationProjectionHandlers } from "../cqrs/projections/ReconciliationProjections";
+import { EventEnvelope } from "../../domain/eventsourcing/EventEnvelope";
+import { DomainEvent } from "../../domain/events/DomainEvent";
+import {
+  assertCompletionDataInvariant,
+  assertProjectionMutationInvariant,
+  assertTenantInvariant,
+} from "../../domain/eventsourcing/reconciliation/ReconciliationLifecycle";
 
 export class EventProjectionService {
   private projectionHandlers: ReconciliationProjectionHandlers;
@@ -21,49 +26,57 @@ export class EventProjectionService {
   }
 
   private setupEventHandlers(): void {
-    // Subscribe to domain events from event bus
-    this.eventBus.subscribe('reconciliation.started', async (event: DomainEvent) => {
-      // Fetch full event from event store
-       
+    this.eventBus.subscribe("reconciliation.started", async (event: DomainEvent) => {
       const events = await this.eventStore.getEvents(
-        (event as any).reconciliationId,
-        'reconciliation'
+        (event as unknown as { reconciliationId: string }).reconciliationId,
+        "reconciliation"
       );
-      const startedEvent = events.find((e) => e.event_type === 'ReconciliationStarted');
+      const startedEvent = events.find((e) => e.event_type === "ReconciliationStarted");
       if (startedEvent) {
         await this.projectionHandlers.handleReconciliationStarted(event);
       }
     });
-
-    // Subscribe to event store events (for direct event envelope handling)
-    // In production, you might use a separate event stream processor
   }
 
   /**
    * Process event envelope and update projections
    */
   async processEvent(eventEnvelope: EventEnvelope): Promise<void> {
+    if (eventEnvelope.aggregate_type === "reconciliation") {
+      const history = await this.eventStore.getEvents(eventEnvelope.aggregate_id, "reconciliation");
+      assertTenantInvariant(history, eventEnvelope.metadata.tenant_id);
+      assertCompletionDataInvariant(eventEnvelope);
+      assertProjectionMutationInvariant(history, eventEnvelope);
+    }
+
     switch (eventEnvelope.event_type) {
-      case 'ReconciliationStarted':
-         
-        await this.projectionHandlers.handleReconciliationStarted(eventEnvelope as any);
+      case "ReconciliationStarted":
+        await this.projectionHandlers.handleReconciliationStarted(
+          eventEnvelope as unknown as DomainEvent
+        );
         break;
-      case 'OrdersFetched':
+      case "ReconciliationPaused":
+        await this.projectionHandlers.handleReconciliationPaused(eventEnvelope);
+        break;
+      case "ReconciliationResumed":
+        await this.projectionHandlers.handleReconciliationResumed(eventEnvelope);
+        break;
+      case "OrdersFetched":
         await this.projectionHandlers.handleOrdersFetched(eventEnvelope);
         break;
-      case 'PaymentsFetched':
+      case "PaymentsFetched":
         await this.projectionHandlers.handlePaymentsFetched(eventEnvelope);
         break;
-      case 'RecordMatched':
+      case "RecordMatched":
         await this.projectionHandlers.handleRecordMatched(eventEnvelope);
         break;
-      case 'RecordUnmatched':
+      case "RecordUnmatched":
         await this.projectionHandlers.handleRecordUnmatched(eventEnvelope);
         break;
-      case 'ReconciliationCompleted':
+      case "ReconciliationCompleted":
         await this.projectionHandlers.handleReconciliationCompleted(eventEnvelope);
         break;
-      case 'ReconciliationFailed':
+      case "ReconciliationFailed":
         await this.projectionHandlers.handleReconciliationFailed(eventEnvelope);
         break;
     }

--- a/packages/api/src/application/reconciliation/ReconciliationService.ts
+++ b/packages/api/src/application/reconciliation/ReconciliationService.ts
@@ -3,19 +3,21 @@
  * Main service that orchestrates reconciliation workflows
  */
 
-import { ReconciliationCommandHandlers } from '../cqrs/commands/ReconciliationCommandHandlers';
-import { SagaOrchestrator } from '../sagas/SagaOrchestrator';
-import { ShopifyStripeReconciliationSaga } from '../sagas/ShopifyStripeReconciliationSaga';
-import { IEventStore } from '../../infrastructure/eventsourcing/EventStore';
-import { IEventBus } from '../../infrastructure/events/IEventBus';
-import { DomainEvent } from '../../domain/events/DomainEvent';
-import { ShopifyAdapter } from '@settler/adapters';
-import { StripeAdapter } from '@settler/adapters';
+import { ReconciliationCommandHandlers } from "../cqrs/commands/ReconciliationCommandHandlers";
+import { SagaOrchestrator } from "../sagas/SagaOrchestrator";
+import { ShopifyStripeReconciliationSaga } from "../sagas/ShopifyStripeReconciliationSaga";
+import { IEventStore } from "../../infrastructure/eventsourcing/EventStore";
+import { IEventBus } from "../../infrastructure/events/IEventBus";
+import { DomainEvent } from "../../domain/events/DomainEvent";
+import { ShopifyAdapter } from "@settler/adapters";
+import { StripeAdapter } from "@settler/adapters";
 import {
   StartReconciliationCommand,
   RetryReconciliationCommand,
   CancelReconciliationCommand,
-} from '../cqrs/commands/ReconciliationCommands';
+  PauseReconciliationCommand,
+  ResumeReconciliationCommand,
+} from "../cqrs/commands/ReconciliationCommands";
 
 export class ReconciliationService {
   private commandHandlers: ReconciliationCommandHandlers;
@@ -28,7 +30,7 @@ export class ReconciliationService {
     stripeAdapter: StripeAdapter
   ) {
     this.commandHandlers = new ReconciliationCommandHandlers(eventStore, eventBus);
-    
+
     this.sagaOrchestrator = new SagaOrchestrator(
       undefined, // Will use default pool
       eventStore,
@@ -44,21 +46,33 @@ export class ReconciliationService {
     this.sagaOrchestrator.registerSaga(shopifyStripeSaga.createDefinition());
 
     // Subscribe to reconciliation started events to trigger saga
-    eventBus.subscribe('reconciliation.started', async (event: DomainEvent) => {
+    eventBus.subscribe("reconciliation.started", async (event: DomainEvent) => {
       // Type guard to check if event has required properties
-      if ('reconciliationId' in event && 'jobId' in event && 'correlationId' in event) {
+      if ("reconciliationId" in event && "jobId" in event && "correlationId" in event) {
         const reconciliationId = (event as { reconciliationId: string }).reconciliationId;
         const jobId = (event as { jobId: string }).jobId;
         const correlationId = (event as { correlationId: string }).correlationId;
-        const tenantId = 'tenantId' in event ? (event as { tenantId: string }).tenantId : 'default';
-        const dateRange = 'dateRange' in event ? (event as { dateRange?: { start: string; end: string } }).dateRange : undefined;
-        const shopifyConfig = 'shopifyConfig' in event ? (event as { shopifyConfig?: Record<string, unknown> }).shopifyConfig : undefined;
-        const stripeConfig = 'stripeConfig' in event ? (event as { stripeConfig?: Record<string, unknown> }).stripeConfig : undefined;
-        const matchingRules = 'matchingRules' in event ? (event as { matchingRules?: Record<string, unknown> }).matchingRules : undefined;
+        const tenantId = "tenantId" in event ? (event as { tenantId: string }).tenantId : "default";
+        const dateRange =
+          "dateRange" in event
+            ? (event as { dateRange?: { start: string; end: string } }).dateRange
+            : undefined;
+        const shopifyConfig =
+          "shopifyConfig" in event
+            ? (event as { shopifyConfig?: Record<string, unknown> }).shopifyConfig
+            : undefined;
+        const stripeConfig =
+          "stripeConfig" in event
+            ? (event as { stripeConfig?: Record<string, unknown> }).stripeConfig
+            : undefined;
+        const matchingRules =
+          "matchingRules" in event
+            ? (event as { matchingRules?: Record<string, unknown> }).matchingRules
+            : undefined;
 
         // Start saga
         await this.sagaOrchestrator.startSaga(
-          'shopify_stripe_monthly_reconciliation',
+          "shopify_stripe_monthly_reconciliation",
           reconciliationId,
           {
             job_id: jobId,
@@ -94,6 +108,20 @@ export class ReconciliationService {
    */
   async cancelReconciliation(command: CancelReconciliationCommand): Promise<void> {
     await this.commandHandlers.handleCancelReconciliation(command);
+  }
+
+  /**
+   * Pause a reconciliation
+   */
+  async pauseReconciliation(command: PauseReconciliationCommand): Promise<void> {
+    await this.commandHandlers.handlePauseReconciliation(command);
+  }
+
+  /**
+   * Resume a reconciliation
+   */
+  async resumeReconciliation(command: ResumeReconciliationCommand): Promise<void> {
+    await this.commandHandlers.handleResumeReconciliation(command);
   }
 
   /**

--- a/packages/api/src/application/sagas/ShopifyStripeReconciliationSaga.ts
+++ b/packages/api/src/application/sagas/ShopifyStripeReconciliationSaga.ts
@@ -3,24 +3,18 @@
  * Concrete saga implementation for monthly reconciliation between Shopify and Stripe
  */
 
-import {
-  SagaDefinition,
-  SagaStep,
-  SagaStepResult,
-  SagaState,
-} from './SagaOrchestrator';
-import { ShopifyAdapter } from '@settler/adapters';
-import { StripeAdapter } from '@settler/adapters';
-import { IEventStore } from '../../infrastructure/eventsourcing/EventStore';
-import { ReconciliationEvents } from '../../domain/eventsourcing/reconciliation/ReconciliationEvents';
-import { createCircuitBreaker } from '../../infrastructure/resilience/circuit-breaker';
-import type { CircuitBreaker } from 'opossum';
-import { logError } from '../../utils/logger';
+import { SagaDefinition, SagaStep, SagaStepResult, SagaState } from "./SagaOrchestrator";
+import { ShopifyAdapter } from "@settler/adapters";
+import { StripeAdapter } from "@settler/adapters";
+import { IEventStore } from "../../infrastructure/eventsourcing/EventStore";
+import { ReconciliationEvents } from "../../domain/eventsourcing/reconciliation/ReconciliationEvents";
+import { createCircuitBreaker } from "../../infrastructure/resilience/circuit-breaker";
+import type { CircuitBreaker } from "opossum";
+import { logError } from "../../utils/logger";
 
 export class ShopifyStripeReconciliationSaga {
-   
   private shopifyCircuitBreaker: CircuitBreaker<any>;
-   
+
   private stripeCircuitBreaker: CircuitBreaker<any>;
 
   constructor(
@@ -30,14 +24,12 @@ export class ShopifyStripeReconciliationSaga {
   ) {
     // Initialize circuit breakers
     this.shopifyCircuitBreaker = createCircuitBreaker(
-       
       async (options: any) => this.shopifyAdapter.fetch(options),
-      { name: 'shopify-api' }
+      { name: "shopify-api" }
     );
     this.stripeCircuitBreaker = createCircuitBreaker(
-       
       async (options: any) => this.stripeAdapter.fetch(options),
-      { name: 'stripe-api' }
+      { name: "stripe-api" }
     );
   }
 
@@ -46,7 +38,7 @@ export class ShopifyStripeReconciliationSaga {
    */
   createDefinition(): SagaDefinition {
     return {
-      type: 'shopify_stripe_monthly_reconciliation',
+      type: "shopify_stripe_monthly_reconciliation",
       steps: [
         this.createFetchShopifyOrdersStep(),
         this.createFetchStripePaymentsStep(),
@@ -64,7 +56,7 @@ export class ShopifyStripeReconciliationSaga {
    */
   private createFetchShopifyOrdersStep(): SagaStep {
     return {
-      name: 'fetch_shopify_orders',
+      name: "fetch_shopify_orders",
       timeoutMs: 60000, // 1 minute timeout
       retryable: true,
       maxRetries: 3,
@@ -88,21 +80,23 @@ export class ShopifyStripeReconciliationSaga {
             reconciliationId,
             {
               reconciliation_id: reconciliationId,
-              source: 'shopify',
+              source: "shopify",
               count: orders.length,
-              orders: orders.map((order: {
-                id: string;
-                amount: number;
-                currency: string;
-                date: Date;
-                metadata?: Record<string, unknown>;
-              }) => ({
-                id: order.id,
-                amount: order.amount,
-                currency: order.currency,
-                date: order.date.toISOString(),
-                metadata: order.metadata,
-              })),
+              orders: orders.map(
+                (order: {
+                  id: string;
+                  amount: number;
+                  currency: string;
+                  date: Date;
+                  metadata?: Record<string, unknown>;
+                }) => ({
+                  id: order.id,
+                  amount: order.amount,
+                  currency: order.currency,
+                  date: order.date.toISOString(),
+                  metadata: order.metadata,
+                })
+              ),
               fetch_duration_ms: Date.now() - (state.data.started_at as number),
             },
             state.tenantId,
@@ -122,7 +116,7 @@ export class ShopifyStripeReconciliationSaga {
           };
         } catch (error: unknown) {
           const errorMessage = error instanceof Error ? error.message : String(error);
-          const errorName = error instanceof Error ? error.name : 'FetchError';
+          const errorName = error instanceof Error ? error.name : "FetchError";
           return {
             success: false,
             error: {
@@ -135,7 +129,9 @@ export class ShopifyStripeReconciliationSaga {
       },
       compensate: async (state: SagaState): Promise<void> => {
         // No compensation needed for read-only fetch
-        logError(`Compensating fetch_shopify_orders for ${state.aggregateId}`, undefined, { aggregateId: state.aggregateId });
+        logError(`Compensating fetch_shopify_orders for ${state.aggregateId}`, undefined, {
+          aggregateId: state.aggregateId,
+        });
       },
     };
   }
@@ -145,7 +141,7 @@ export class ShopifyStripeReconciliationSaga {
    */
   private createFetchStripePaymentsStep(): SagaStep {
     return {
-      name: 'fetch_stripe_payments',
+      name: "fetch_stripe_payments",
       timeoutMs: 60000,
       retryable: true,
       maxRetries: 3,
@@ -168,21 +164,23 @@ export class ShopifyStripeReconciliationSaga {
             reconciliationId,
             {
               reconciliation_id: reconciliationId,
-              source: 'stripe',
+              source: "stripe",
               count: payments.length,
-              payments: payments.map((payment: {
-                id: string;
-                amount: number;
-                currency: string;
-                date: Date;
-                metadata?: Record<string, unknown>;
-              }) => ({
-                id: payment.id,
-                amount: payment.amount,
-                currency: payment.currency,
-                date: payment.date.toISOString(),
-                metadata: payment.metadata,
-              })),
+              payments: payments.map(
+                (payment: {
+                  id: string;
+                  amount: number;
+                  currency: string;
+                  date: Date;
+                  metadata?: Record<string, unknown>;
+                }) => ({
+                  id: payment.id,
+                  amount: payment.amount,
+                  currency: payment.currency,
+                  date: payment.date.toISOString(),
+                  metadata: payment.metadata,
+                })
+              ),
               fetch_duration_ms: Date.now() - (state.data.started_at as number),
             },
             state.tenantId,
@@ -201,7 +199,7 @@ export class ShopifyStripeReconciliationSaga {
           };
         } catch (error: unknown) {
           const errorMessage = error instanceof Error ? error.message : String(error);
-          const errorName = error instanceof Error ? error.name : 'FetchError';
+          const errorName = error instanceof Error ? error.name : "FetchError";
           return {
             success: false,
             error: {
@@ -214,7 +212,9 @@ export class ShopifyStripeReconciliationSaga {
       },
       compensate: async (state: SagaState): Promise<void> => {
         // No compensation needed
-        logError(`Compensating fetch_stripe_payments for ${state.aggregateId}`, undefined, { aggregateId: state.aggregateId });
+        logError(`Compensating fetch_stripe_payments for ${state.aggregateId}`, undefined, {
+          aggregateId: state.aggregateId,
+        });
       },
     };
   }
@@ -224,7 +224,7 @@ export class ShopifyStripeReconciliationSaga {
    */
   private createMatchingStep(): SagaStep {
     return {
-      name: 'perform_matching',
+      name: "perform_matching",
       timeoutMs: 300000, // 5 minutes for large datasets
       retryable: false, // Matching is idempotent but expensive
       execute: async (state: SagaState): Promise<SagaStepResult> => {
@@ -281,8 +281,7 @@ export class ShopifyStripeReconciliationSaga {
 
               // Also check metadata for order_id match
               const metadataMatch =
-                payment.metadata?.order_id === order.id ||
-                payment.referenceId === order.id;
+                payment.metadata?.order_id === order.id || payment.referenceId === order.id;
 
               return amountMatch && (dateMatch || metadataMatch);
             });
@@ -294,7 +293,7 @@ export class ShopifyStripeReconciliationSaga {
                 amount: order.amount,
                 currency: order.currency,
                 confidence: 1.0,
-                matched_fields: ['amount', 'date', 'metadata'],
+                matched_fields: ["amount", "date", "metadata"],
               });
 
               // Emit RecordMatched event
@@ -308,7 +307,7 @@ export class ShopifyStripeReconciliationSaga {
                   amount: order.amount,
                   currency: order.currency,
                   confidence: 1.0,
-                  matched_fields: ['amount', 'date', 'metadata'],
+                  matched_fields: ["amount", "date", "metadata"],
                   matched_at: new Date().toISOString(),
                 },
                 state.tenantId,
@@ -321,7 +320,7 @@ export class ShopifyStripeReconciliationSaga {
                 source_id: order.id,
                 amount: order.amount,
                 currency: order.currency,
-                reason: 'No matching payment found',
+                reason: "No matching payment found",
               });
 
               // Emit RecordUnmatched event
@@ -332,7 +331,7 @@ export class ShopifyStripeReconciliationSaga {
                   source_id: order.id,
                   amount: order.amount,
                   currency: order.currency,
-                  reason: 'No matching payment found',
+                  reason: "No matching payment found",
                   unmatched_at: new Date().toISOString(),
                 },
                 state.tenantId,
@@ -351,7 +350,7 @@ export class ShopifyStripeReconciliationSaga {
                 target_id: payment.id,
                 amount: payment.amount,
                 currency: payment.currency,
-                reason: 'No matching order found',
+                reason: "No matching order found",
               });
 
               const unmatchedEvent = ReconciliationEvents.RecordUnmatched(
@@ -361,7 +360,7 @@ export class ShopifyStripeReconciliationSaga {
                   target_id: payment.id,
                   amount: payment.amount,
                   currency: payment.currency,
-                  reason: 'No matching order found',
+                  reason: "No matching order found",
                   unmatched_at: new Date().toISOString(),
                 },
                 state.tenantId,
@@ -384,7 +383,7 @@ export class ShopifyStripeReconciliationSaga {
           };
         } catch (error: unknown) {
           const errorMessage = error instanceof Error ? error.message : String(error);
-          const errorName = error instanceof Error ? error.name : 'MatchingError';
+          const errorName = error instanceof Error ? error.name : "MatchingError";
           return {
             success: false,
             error: {
@@ -403,7 +402,7 @@ export class ShopifyStripeReconciliationSaga {
    */
   private createPersistResultsStep(): SagaStep {
     return {
-      name: 'persist_results',
+      name: "persist_results",
       timeoutMs: 30000,
       retryable: true,
       maxRetries: 3,
@@ -421,7 +420,7 @@ export class ShopifyStripeReconciliationSaga {
           };
         } catch (error: unknown) {
           const errorMessage = error instanceof Error ? error.message : String(error);
-          const errorName = error instanceof Error ? error.name : 'PersistenceError';
+          const errorName = error instanceof Error ? error.name : "PersistenceError";
           return {
             success: false,
             error: {
@@ -434,7 +433,9 @@ export class ShopifyStripeReconciliationSaga {
       },
       compensate: async (state: SagaState): Promise<void> => {
         // Could delete persisted results if needed
-        logError(`Compensating persist_results for ${state.aggregateId}`, undefined, { aggregateId: state.aggregateId });
+        logError(`Compensating persist_results for ${state.aggregateId}`, undefined, {
+          aggregateId: state.aggregateId,
+        });
       },
     };
   }
@@ -444,7 +445,7 @@ export class ShopifyStripeReconciliationSaga {
    */
   private createNotifyWebhooksStep(): SagaStep {
     return {
-      name: 'notify_webhooks',
+      name: "notify_webhooks",
       timeoutMs: 30000,
       retryable: true,
       maxRetries: 3,
@@ -452,7 +453,9 @@ export class ShopifyStripeReconciliationSaga {
         try {
           // In production, send webhooks to configured endpoints
           // For now, just log
-          logError(`Sending webhook notifications for ${state.aggregateId}`, undefined, { aggregateId: state.aggregateId });
+          logError(`Sending webhook notifications for ${state.aggregateId}`, undefined, {
+            aggregateId: state.aggregateId,
+          });
 
           return {
             success: true,
@@ -462,7 +465,7 @@ export class ShopifyStripeReconciliationSaga {
           };
         } catch (error: unknown) {
           const errorMessage = error instanceof Error ? error.message : String(error);
-          const errorName = error instanceof Error ? error.name : 'WebhookError';
+          const errorName = error instanceof Error ? error.name : "WebhookError";
           return {
             success: false,
             error: {
@@ -475,7 +478,9 @@ export class ShopifyStripeReconciliationSaga {
       },
       compensate: async (state: SagaState): Promise<void> => {
         // Webhooks are typically fire-and-forget, no compensation needed
-        logError(`Compensating notify_webhooks for ${state.aggregateId}`, undefined, { aggregateId: state.aggregateId });
+        logError(`Compensating notify_webhooks for ${state.aggregateId}`, undefined, {
+          aggregateId: state.aggregateId,
+        });
       },
     };
   }
@@ -521,9 +526,7 @@ export class ShopifyStripeReconciliationSaga {
     const unmatchedTarget = unmatched.filter((u) => u.target_id).length;
 
     const totalRecords = orders.length + payments.length;
-    const accuracy = totalRecords > 0
-      ? (matched.length / totalRecords) * 100
-      : 100;
+    const accuracy = totalRecords > 0 ? (matched.length / totalRecords) * 100 : 100;
 
     const completedEvent = ReconciliationEvents.ReconciliationCompleted(
       reconciliationId,
@@ -540,6 +543,10 @@ export class ShopifyStripeReconciliationSaga {
           accuracy_percentage: accuracy,
         },
         completed_at: new Date().toISOString(),
+        finalization: {
+          finalized_at: new Date().toISOString(),
+          finalization_source: "saga",
+        },
       },
       state.tenantId,
       state.correlationId
@@ -559,7 +566,7 @@ export class ShopifyStripeReconciliationSaga {
       {
         reconciliation_id: reconciliationId,
         error: {
-          type: error.name || 'UnknownError',
+          type: error.name || "UnknownError",
           message: error.message,
           ...(error.stack ? { stack: error.stack } : {}),
         },

--- a/packages/api/src/docs/reconciliation-lifecycle.md
+++ b/packages/api/src/docs/reconciliation-lifecycle.md
@@ -1,0 +1,41 @@
+# Reconciliation Lifecycle Kernel
+
+This document defines the canonical reconciliation aggregate lifecycle used by command handlers and projection ingestion.
+
+## States
+
+- `not_started`: no reconciliation events exist for the aggregate id.
+- `in_progress`: reconciliation has started and has not reached a terminal state.
+- `paused`: reconciliation execution is intentionally paused and resumable.
+- `completed` (terminal): reconciliation succeeded and was finalized.
+- `failed` (terminal): reconciliation failed due to execution error.
+- `cancelled` (terminal): reconciliation failed with `CancellationError`.
+
+## Allowed command transitions
+
+- `start`: only allowed from `not_started`.
+- `retry`: only allowed from `failed` or `cancelled`.
+- `cancel`: only allowed from `in_progress` or `paused`.
+- `pause`: only allowed from `in_progress`.
+- `resume`: only allowed from `paused`.
+
+All other transitions are rejected with `ReconciliationTransitionError` and surfaced to APIs as conflict errors.
+
+## Execution attempt semantics
+
+Each `ReconciliationStarted` event now carries:
+
+- `execution_id`: unique id for that run attempt.
+- `attempt_number`: monotonic attempt counter on the aggregate.
+- `execution_kind`: `initial` or `retry`.
+- `retry_of_execution_id`: the prior execution id when kind is `retry`.
+
+This makes retry history replayable and auditable per-attempt.
+
+## Invariants
+
+- Tenant invariant: all events for a reconciliation aggregate must share the same `tenant_id` as the command/projection context.
+- Finalization invariant: `completed` is terminal and cannot be retried/cancelled/restarted.
+- Completion data invariant: finalized records must include `completed_at`, `finalization.finalized_at`, and non-negative duration.
+- Projection invariant: mutating events after completion are rejected during projection processing.
+- Cancellation semantic: cancellation is represented explicitly as `ReconciliationFailed` with `error.type = CancellationError` and mapped to lifecycle state `cancelled`.

--- a/packages/api/src/domain/eventsourcing/reconciliation/ReconciliationEvents.ts
+++ b/packages/api/src/domain/eventsourcing/reconciliation/ReconciliationEvents.ts
@@ -3,7 +3,7 @@
  * Core lifecycle events for reconciliation flows
  */
 
-import { EventEnvelope, createEventEnvelope, createEventMetadata } from '../EventEnvelope';
+import { EventEnvelope, createEventEnvelope, createEventMetadata } from "../EventEnvelope";
 
 // ============================================================================
 // Event Data Types
@@ -18,12 +18,27 @@ export interface ReconciliationStartedData {
     start: string;
     end: string;
   };
+  execution_id: string;
+  attempt_number: number;
+  execution_kind: "initial" | "retry";
+  retry_of_execution_id?: string;
   initiated_by?: string;
+}
+
+export interface ReconciliationPausedData {
+  reconciliation_id: string;
+  paused_at: string;
+  reason?: string;
+}
+
+export interface ReconciliationResumedData {
+  reconciliation_id: string;
+  resumed_at: string;
 }
 
 export interface OrdersFetchedData {
   reconciliation_id: string;
-  source: 'shopify' | 'stripe' | string;
+  source: "shopify" | "stripe" | string;
   count: number;
   orders: Array<{
     id: string;
@@ -37,7 +52,7 @@ export interface OrdersFetchedData {
 
 export interface PaymentsFetchedData {
   reconciliation_id: string;
-  source: 'stripe' | 'paypal' | string;
+  source: "stripe" | "paypal" | string;
   count: number;
   payments: Array<{
     id: string;
@@ -84,6 +99,10 @@ export interface ReconciliationCompletedData {
     accuracy_percentage: number;
   };
   completed_at: string;
+  finalization: {
+    finalized_at: string;
+    finalization_source: "saga" | "operator" | "system";
+  };
 }
 
 export interface ReconciliationFailedData {
@@ -112,8 +131,42 @@ export class ReconciliationEvents {
   ): EventEnvelope<ReconciliationStartedData> {
     return createEventEnvelope(
       reconciliationId,
-      'reconciliation',
-      'ReconciliationStarted',
+      "reconciliation",
+      "ReconciliationStarted",
+      data,
+      createEventMetadata(tenantId, userId, correlationId),
+      1
+    );
+  }
+
+  static ReconciliationPaused(
+    reconciliationId: string,
+    data: ReconciliationPausedData,
+    tenantId: string,
+    userId?: string,
+    correlationId?: string
+  ): EventEnvelope<ReconciliationPausedData> {
+    return createEventEnvelope(
+      reconciliationId,
+      "reconciliation",
+      "ReconciliationPaused",
+      data,
+      createEventMetadata(tenantId, userId, correlationId),
+      1
+    );
+  }
+
+  static ReconciliationResumed(
+    reconciliationId: string,
+    data: ReconciliationResumedData,
+    tenantId: string,
+    userId?: string,
+    correlationId?: string
+  ): EventEnvelope<ReconciliationResumedData> {
+    return createEventEnvelope(
+      reconciliationId,
+      "reconciliation",
+      "ReconciliationResumed",
       data,
       createEventMetadata(tenantId, userId, correlationId),
       1
@@ -128,8 +181,8 @@ export class ReconciliationEvents {
   ): EventEnvelope<OrdersFetchedData> {
     return createEventEnvelope(
       reconciliationId,
-      'reconciliation',
-      'OrdersFetched',
+      "reconciliation",
+      "OrdersFetched",
       data,
       createEventMetadata(tenantId, undefined, correlationId),
       1
@@ -144,8 +197,8 @@ export class ReconciliationEvents {
   ): EventEnvelope<PaymentsFetchedData> {
     return createEventEnvelope(
       reconciliationId,
-      'reconciliation',
-      'PaymentsFetched',
+      "reconciliation",
+      "PaymentsFetched",
       data,
       createEventMetadata(tenantId, undefined, correlationId),
       1
@@ -160,8 +213,8 @@ export class ReconciliationEvents {
   ): EventEnvelope<RecordMatchedData> {
     return createEventEnvelope(
       reconciliationId,
-      'reconciliation',
-      'RecordMatched',
+      "reconciliation",
+      "RecordMatched",
       data,
       createEventMetadata(tenantId, undefined, correlationId),
       1
@@ -176,8 +229,8 @@ export class ReconciliationEvents {
   ): EventEnvelope<RecordUnmatchedData> {
     return createEventEnvelope(
       reconciliationId,
-      'reconciliation',
-      'RecordUnmatched',
+      "reconciliation",
+      "RecordUnmatched",
       data,
       createEventMetadata(tenantId, undefined, correlationId),
       1
@@ -192,8 +245,8 @@ export class ReconciliationEvents {
   ): EventEnvelope<ReconciliationCompletedData> {
     return createEventEnvelope(
       reconciliationId,
-      'reconciliation',
-      'ReconciliationCompleted',
+      "reconciliation",
+      "ReconciliationCompleted",
       data,
       createEventMetadata(tenantId, undefined, correlationId),
       1
@@ -208,8 +261,8 @@ export class ReconciliationEvents {
   ): EventEnvelope<ReconciliationFailedData> {
     return createEventEnvelope(
       reconciliationId,
-      'reconciliation',
-      'ReconciliationFailed',
+      "reconciliation",
+      "ReconciliationFailed",
       data,
       createEventMetadata(tenantId, undefined, correlationId),
       1

--- a/packages/api/src/domain/eventsourcing/reconciliation/ReconciliationLifecycle.ts
+++ b/packages/api/src/domain/eventsourcing/reconciliation/ReconciliationLifecycle.ts
@@ -1,0 +1,208 @@
+import { EventEnvelope } from "../EventEnvelope";
+import type {
+  ReconciliationCompletedData,
+  ReconciliationStartedData,
+} from "./ReconciliationEvents";
+
+export type ReconciliationLifecycleState =
+  | "not_started"
+  | "in_progress"
+  | "paused"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export class ReconciliationTransitionError extends Error {
+  readonly code = "INVALID_RECONCILIATION_TRANSITION";
+
+  constructor(
+    message: string,
+    public readonly currentState: ReconciliationLifecycleState,
+    public readonly attemptedAction: "start" | "retry" | "cancel" | "pause" | "resume"
+  ) {
+    super(message);
+    this.name = "ReconciliationTransitionError";
+  }
+}
+
+const START_EVENTS = new Set(["ReconciliationStarted", "reconciliation.started"]);
+const RESUME_EVENTS = new Set(["ReconciliationResumed", "reconciliation.resumed"]);
+const PAUSED_EVENTS = new Set(["ReconciliationPaused", "reconciliation.paused"]);
+const COMPLETED_EVENTS = new Set(["ReconciliationCompleted", "reconciliation.completed"]);
+const FAILED_EVENTS = new Set(["ReconciliationFailed", "reconciliation.failed"]);
+const MUTATING_EVENTS = new Set([
+  ...START_EVENTS,
+  ...RESUME_EVENTS,
+  ...PAUSED_EVENTS,
+  "OrdersFetched",
+  "PaymentsFetched",
+  "RecordMatched",
+  "RecordUnmatched",
+]);
+
+function isCancellationFailure(event: EventEnvelope): boolean {
+  if (!FAILED_EVENTS.has(event.event_type)) {
+    return false;
+  }
+
+  const maybeError = (event.data as { error?: { type?: string } }).error;
+  return maybeError?.type === "CancellationError";
+}
+
+export function deriveReconciliationLifecycle(
+  events: EventEnvelope[]
+): ReconciliationLifecycleState {
+  if (events.length === 0) {
+    return "not_started";
+  }
+
+  const lastEvent = events[events.length - 1];
+  if (!lastEvent) {
+    return "not_started";
+  }
+
+  if (COMPLETED_EVENTS.has(lastEvent.event_type)) {
+    return "completed";
+  }
+
+  if (isCancellationFailure(lastEvent)) {
+    return "cancelled";
+  }
+
+  if (FAILED_EVENTS.has(lastEvent.event_type)) {
+    return "failed";
+  }
+
+  if (PAUSED_EVENTS.has(lastEvent.event_type)) {
+    return "paused";
+  }
+
+  if (START_EVENTS.has(lastEvent.event_type) || RESUME_EVENTS.has(lastEvent.event_type)) {
+    return "in_progress";
+  }
+
+  return "in_progress";
+}
+
+export function countExecutionAttempts(events: EventEnvelope[]): number {
+  return events.filter((event) => START_EVENTS.has(event.event_type)).length;
+}
+
+export function getLatestStartedExecution(
+  events: EventEnvelope[]
+): ReconciliationStartedData | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event && START_EVENTS.has(event.event_type)) {
+      return event.data as ReconciliationStartedData;
+    }
+  }
+
+  return null;
+}
+
+export function assertCanStart(events: EventEnvelope[]): void {
+  const lifecycle = deriveReconciliationLifecycle(events);
+  if (lifecycle !== "not_started") {
+    throw new ReconciliationTransitionError(
+      `Cannot start reconciliation from state ${lifecycle}`,
+      lifecycle,
+      "start"
+    );
+  }
+}
+
+export function assertCanRetry(events: EventEnvelope[]): void {
+  const lifecycle = deriveReconciliationLifecycle(events);
+  if (lifecycle !== "failed" && lifecycle !== "cancelled") {
+    throw new ReconciliationTransitionError(
+      `Cannot retry reconciliation from state ${lifecycle}`,
+      lifecycle,
+      "retry"
+    );
+  }
+}
+
+export function assertCanCancel(events: EventEnvelope[]): void {
+  const lifecycle = deriveReconciliationLifecycle(events);
+  if (lifecycle !== "in_progress" && lifecycle !== "paused") {
+    throw new ReconciliationTransitionError(
+      `Cannot cancel reconciliation from state ${lifecycle}`,
+      lifecycle,
+      "cancel"
+    );
+  }
+}
+
+export function assertCanPause(events: EventEnvelope[]): void {
+  const lifecycle = deriveReconciliationLifecycle(events);
+  if (lifecycle !== "in_progress") {
+    throw new ReconciliationTransitionError(
+      `Cannot pause reconciliation from state ${lifecycle}`,
+      lifecycle,
+      "pause"
+    );
+  }
+}
+
+export function assertCanResume(events: EventEnvelope[]): void {
+  const lifecycle = deriveReconciliationLifecycle(events);
+  if (lifecycle !== "paused") {
+    throw new ReconciliationTransitionError(
+      `Cannot resume reconciliation from state ${lifecycle}`,
+      lifecycle,
+      "resume"
+    );
+  }
+}
+
+export function assertTenantInvariant(events: EventEnvelope[], tenantId: string): void {
+  const mismatchedTenantEvent = events.find((event) => event.metadata.tenant_id !== tenantId);
+  if (mismatchedTenantEvent) {
+    throw new Error(
+      "Tenant invariant violation: reconciliation aggregate belongs to another tenant"
+    );
+  }
+}
+
+export function assertCompletionDataInvariant(eventEnvelope: EventEnvelope): void {
+  if (!COMPLETED_EVENTS.has(eventEnvelope.event_type)) {
+    return;
+  }
+
+  const completedData = eventEnvelope.data as ReconciliationCompletedData;
+  if (!completedData.completed_at || !completedData.finalization?.finalized_at) {
+    throw new Error(
+      "Completion invariant violation: finalized reconciliation missing finalization timestamp"
+    );
+  }
+
+  if (completedData.summary.duration_ms < 0) {
+    throw new Error("Completion invariant violation: reconciliation duration cannot be negative");
+  }
+}
+
+export function assertProjectionMutationInvariant(
+  history: EventEnvelope[],
+  currentEvent: EventEnvelope
+): void {
+  const currentIndex = history.findIndex((event) => event.id === currentEvent.id);
+  const boundedHistory = currentIndex >= 0 ? history.slice(0, currentIndex + 1) : history;
+
+  const completedIndex = boundedHistory.findIndex((event) =>
+    COMPLETED_EVENTS.has(event.event_type)
+  );
+  if (completedIndex < 0) {
+    return;
+  }
+
+  const postCompletionMutation = boundedHistory
+    .slice(completedIndex + 1)
+    .find((event) => MUTATING_EVENTS.has(event.event_type));
+
+  if (postCompletionMutation) {
+    throw new Error(
+      `Projection invariant violation: mutation event ${postCompletionMutation.event_type} after completion`
+    );
+  }
+}

--- a/packages/api/src/services/alerts/AlertLifecycle.ts
+++ b/packages/api/src/services/alerts/AlertLifecycle.ts
@@ -1,0 +1,20 @@
+export type AlertLifecycleState = "open" | "resolved";
+
+export class AlertTransitionError extends Error {
+  readonly code = "INVALID_ALERT_TRANSITION";
+
+  constructor(
+    message: string,
+    public readonly currentState: AlertLifecycleState,
+    public readonly attemptedAction: "resolve"
+  ) {
+    super(message);
+    this.name = "AlertTransitionError";
+  }
+}
+
+export function assertCanResolveAlert(state: AlertLifecycleState): void {
+  if (state !== "open") {
+    throw new AlertTransitionError(`Cannot resolve alert from state ${state}`, state, "resolve");
+  }
+}

--- a/packages/api/src/services/alerts/manager.ts
+++ b/packages/api/src/services/alerts/manager.ts
@@ -5,6 +5,7 @@
 
 import { logError, logWarn, logInfo } from "../../utils/logger";
 import { query } from "../../db";
+import { assertCanResolveAlert } from "./AlertLifecycle";
 
 export enum AlertSeverity {
   LOW = "low",
@@ -81,6 +82,18 @@ export async function createAlert(
  */
 export async function resolveAlert(alertId: string): Promise<void> {
   try {
+    const current = await query<{ resolved: boolean }>(
+      `SELECT resolved FROM alerts WHERE id = $1`,
+      [alertId]
+    );
+
+    const row = current[0];
+    if (!row) {
+      throw new Error(`Alert ${alertId} not found`);
+    }
+
+    assertCanResolveAlert(row.resolved ? "resolved" : "open");
+
     await query(
       `UPDATE alerts
        SET resolved = TRUE, resolved_at = NOW()
@@ -91,6 +104,7 @@ export async function resolveAlert(alertId: string): Promise<void> {
     logInfo("Alert resolved", { alertId });
   } catch (error) {
     logError("Failed to resolve alert", error, { alertId });
+    throw error;
   }
 }
 
@@ -130,32 +144,34 @@ export async function getUnresolvedAlerts(severity?: AlertSeverity): Promise<Ale
       resolved_at: Date | null;
     }>(queryStr, params as (string | number | boolean | Date | null)[]);
 
-    return results.map((r: {
-      id: string;
-      type: string;
-      severity: string;
-      message: string;
-      details: string | null;
-      resolved: boolean;
-      created_at: Date;
-      resolved_at: Date | null;
-    }) => {
-      const alert: Alert = {
-        id: r.id,
-        type: r.type,
-        severity: r.severity as AlertSeverity,
-        message: r.message,
-        resolved: r.resolved,
-        createdAt: r.created_at,
-      };
-      if (r.details) {
-        alert.details = JSON.parse(r.details) as Record<string, unknown>;
+    return results.map(
+      (r: {
+        id: string;
+        type: string;
+        severity: string;
+        message: string;
+        details: string | null;
+        resolved: boolean;
+        created_at: Date;
+        resolved_at: Date | null;
+      }) => {
+        const alert: Alert = {
+          id: r.id,
+          type: r.type,
+          severity: r.severity as AlertSeverity,
+          message: r.message,
+          resolved: r.resolved,
+          createdAt: r.created_at,
+        };
+        if (r.details) {
+          alert.details = JSON.parse(r.details) as Record<string, unknown>;
+        }
+        if (r.resolved_at) {
+          alert.resolvedAt = r.resolved_at;
+        }
+        return alert;
       }
-      if (r.resolved_at) {
-        alert.resolvedAt = r.resolved_at;
-      }
-      return alert;
-    });
+    );
   } catch (error) {
     logError("Failed to get unresolved alerts", error);
     return [];

--- a/packages/api/src/utils/typed-errors.ts
+++ b/packages/api/src/utils/typed-errors.ts
@@ -40,7 +40,7 @@ export abstract class ApiError extends Error {
 
 export class ValidationError extends ApiError {
   readonly statusCode = 400;
-  readonly errorCode = 'VALIDATION_ERROR';
+  readonly errorCode = "VALIDATION_ERROR";
   readonly field?: string;
   declare readonly details?: Array<{
     field: string;
@@ -48,11 +48,7 @@ export class ValidationError extends ApiError {
     code: string;
   }>;
 
-  constructor(
-    message: string,
-    field?: string,
-    details?: unknown
-  ) {
+  constructor(message: string, field?: string, details?: unknown) {
     super(message, details);
     if (field !== undefined) {
       this.field = field;
@@ -66,17 +62,17 @@ export class ValidationError extends ApiError {
 
 export class AuthenticationError extends ApiError {
   readonly statusCode = 401;
-  readonly errorCode = 'AUTHENTICATION_ERROR';
+  readonly errorCode = "AUTHENTICATION_ERROR";
 }
 
 export class AuthorizationError extends ApiError {
   readonly statusCode = 403;
-  readonly errorCode = 'AUTHORIZATION_ERROR';
+  readonly errorCode = "AUTHORIZATION_ERROR";
 }
 
 export class NotFoundError extends ApiError {
   readonly statusCode = 404;
-  readonly errorCode = 'NOT_FOUND';
+  readonly errorCode = "NOT_FOUND";
   readonly resourceType?: string;
   readonly resourceId?: string;
 
@@ -93,12 +89,12 @@ export class NotFoundError extends ApiError {
 
 export class ConflictError extends ApiError {
   readonly statusCode = 409;
-  readonly errorCode = 'CONFLICT';
+  readonly errorCode = "CONFLICT";
 }
 
 export class RateLimitError extends ApiError {
   readonly statusCode = 429;
-  readonly errorCode = 'RATE_LIMIT_EXCEEDED';
+  readonly errorCode = "RATE_LIMIT_EXCEEDED";
   readonly retryAfter?: number;
   readonly limit?: number;
   readonly remaining?: number;
@@ -125,12 +121,12 @@ export class RateLimitError extends ApiError {
 
 export class InternalServerError extends ApiError {
   readonly statusCode = 500;
-  readonly errorCode = 'INTERNAL_SERVER_ERROR';
+  readonly errorCode = "INTERNAL_SERVER_ERROR";
 }
 
 export class ServiceUnavailableError extends ApiError {
   readonly statusCode = 503;
-  readonly errorCode = 'SERVICE_UNAVAILABLE';
+  readonly errorCode = "SERVICE_UNAVAILABLE";
   readonly retryAfter?: number;
 
   constructor(message: string, retryAfter?: number, details?: unknown) {
@@ -143,7 +139,7 @@ export class ServiceUnavailableError extends ApiError {
 
 export class PayloadTooLargeError extends ApiError {
   readonly statusCode = 413;
-  readonly errorCode = 'PAYLOAD_TOO_LARGE';
+  readonly errorCode = "PAYLOAD_TOO_LARGE";
 }
 
 /**
@@ -168,13 +164,27 @@ export function toApiError(error: unknown): ApiError {
       type?: string;
     };
     const status = errorWithStatus.status ?? errorWithStatus.statusCode;
-    if (status === 413 || errorWithStatus.type === 'entity.too.large') {
-      return new PayloadTooLargeError('Request entity too large', {
+    if (status === 413 || errorWithStatus.type === "entity.too.large") {
+      return new PayloadTooLargeError("Request entity too large", {
         originalError: error.name,
       });
     }
+
+    const transitionLikeError = error as Error & {
+      code?: string;
+      currentState?: string;
+      attemptedAction?: string;
+    };
+    if (transitionLikeError.code === "INVALID_RECONCILIATION_TRANSITION") {
+      return new ConflictError(error.message, {
+        code: transitionLikeError.code,
+        currentState: transitionLikeError.currentState,
+        attemptedAction: transitionLikeError.attemptedAction,
+      });
+    }
+
     return new InternalServerError(error.message, { originalError: error.name });
   }
 
-  return new InternalServerError('An unexpected error occurred', { error });
+  return new InternalServerError("An unexpected error occurred", { error });
 }


### PR DESCRIPTION
### Motivation
- Introduce a canonical, auditable reconciliation lifecycle with explicit per-execution metadata and stronger invariants to prevent invalid transitions and projection mutations. 
- Support operator control over long-running reconciliations (`pause` / `resume`) and make retries auditable per attempt. 
- Add a small alert lifecycle utility to validate alert transitions before resolving alerts.

### Description
- Add a lifecycle kernel in `domain/eventsourcing/reconciliation/ReconciliationLifecycle.ts` that derives lifecycle state, enforces transition rules (`assertCanStart`, `assertCanRetry`, `assertCanPause`, `assertCanResume`, `assertCanCancel`), tenant invariants, completion data invariants, and projection mutation invariants. 
- Extend reconciliation events and factories with execution attempt metadata and new event types (`ReconciliationPaused`, `ReconciliationResumed`) in `ReconciliationEvents.ts`, and add lifecycle documentation `docs/reconciliation-lifecycle.md`. 
- Update command APIs and handlers: add `execution_id` to `Start`/`Retry` commands, add `Pause`/`Resume` commands, and wire lifecycle checks and tenant checks into `ReconciliationCommandHandlers.ts` (including attempt counting and `retry_of_execution_id`). 
- Expose pause/resume operations and wire saga subscription updates in `ReconciliationService.ts`. 
- Enforce invariants during projection ingestion in `EventProjectionService.ts` and extend `ReconciliationProjections.ts` to handle `paused`/`resumed` statuses. 
- Update the `ShopifyStripeReconciliationSaga` to include finalization metadata on completion and small robustness/formatting fixes. 
- Add a simple alert lifecycle module `services/alerts/AlertLifecycle.ts` and apply it in `services/alerts/manager.ts` to validate resolves before updating DB. 
- Map transition errors into API-friendly conflict errors in `utils/typed-errors.ts`. 
- Add unit tests covering reconciliation lifecycle and service behaviors and an alert lifecycle test (`__tests__/reconciliation/ReconciliationLifecycle.test.ts`, `ReconciliationService.test.ts`, `AlertLifecycle.test.ts`).

### Testing
- Ran the new and updated unit tests under the API package: `packages/api/src/__tests__/reconciliation/ReconciliationLifecycle.test.ts`, `ReconciliationService.test.ts`, and `AlertLifecycle.test.ts`, and they passed. 
- Projection and command handler behaviors were exercised by the updated `ReconciliationService` unit tests which asserted event store/appends, event bus publishes, transition rejections, and tenant invariant enforcement; all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07e4279d883288dc04f025f4a0f4f)