### PR TITLE
Add Import Workbench preview, diagnostics, quality gates, and control-plane links

### DIFF
--- a/contracts/ingestion/import-workbench.schema.json
+++ b/contracts/ingestion/import-workbench.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://settler.dev/contracts/ingestion/import-workbench.schema.json",
+  "title": "Settler Import Workbench Preview Contract",
+  "type": "object",
+  "required": [
+    "sourceSummary",
+    "mapping",
+    "normalization",
+    "diagnostics",
+    "qualityGates",
+    "sourceProfile",
+    "canProceed",
+    "contract"
+  ],
+  "properties": {
+    "sourceSummary": { "type": "object" },
+    "mapping": { "type": "object" },
+    "normalization": { "type": "object" },
+    "diagnostics": { "type": "array" },
+    "qualityGates": { "type": "array" },
+    "schemaDrift": { "type": "object" },
+    "sourceProfile": {
+      "type": "string",
+      "enum": ["csv_generic", "bank_statement", "processor_export"]
+    },
+    "canProceed": { "type": "boolean" },
+    "contract": {
+      "type": "object",
+      "required": ["schemaUri", "version"],
+      "properties": {
+        "schemaUri": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/INGESTION.md
+++ b/docs/INGESTION.md
@@ -65,6 +65,40 @@ If auto-detection fails, you can provide a manual mapping:
 }
 ```
 
+### Import Workbench Preview (Truthful Raw → Mapped → Normalized)
+
+Before running `/upload`, operators can call `/api/v1/ingestion/preview` with the same file/mapping payload.
+The preview executes the same parser + mapping + normalization logic and returns:
+
+- `sourceSummary`: filename, size, headers, duplicate header detection, total rows
+- `mapping`: provided mapping, auto-detected mapping, effective mapping, missing required mappings
+- `normalization`: attempted/normalized/failed row counts, dropped rows, defaulted fields, sample normalized records
+- `diagnostics`: structured stage-aware diagnostics (`raw|parse|mapping|normalize|quality_gate`) and severity (`info|warning|blocking`), each with machine-readable remediation hints for blocking codes
+- `qualityGates`: lightweight pre-reconciliation gates (required mapping, non-empty import, normalization success ratio, duplicate row ratio, currency distribution)
+- `schemaDrift`: drift comparison against last completed ingestion for the same source (when `sourceId` is provided) plus historical drift-trend escalation over the recent window
+- `canProceed`: machine-visible go/no-go decision based on blocking diagnostics/gates
+
+Example:
+
+```bash
+curl -X POST https://api.settler.dev/api/v1/ingestion/preview \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: multipart/form-data" \
+  -F "file=@transactions.csv" \
+  -F "columnMapping={\"amount\":\"Total\",\"date\":\"Transaction Date\"}"
+```
+
+`/upload` now returns a preview summary as part of the ingestion response and stores import workbench metadata on the ingestion record (`ingestions.metadata.importWorkbench`) for diagnostics/recovery.
+
+Additional operator endpoints:
+
+- `GET /api/v1/ingestion/workbench/recent`: recent ingestion workbench summaries + deep links for control-plane surfaces.
+- `POST /api/v1/ingestion/:ingestionId/retry`: remap-and-retry from stored `raw_records` (`dryRun` defaults to `true`).
+
+The workbench metadata now stores bounded diagnostic samples (`diagnosticsSample`) to speed support/debug triage without unbounded payload growth.
+
+All workbench payloads include a shared runtime-neutral contract reference (`contracts/ingestion/import-workbench.schema.json`, versioned) so API and workhorse outputs can be validated against the same artifact.
+
 ### API Usage
 
 #### Upload CSV
@@ -327,6 +361,7 @@ Full API documentation available at `/api/v1` endpoint.
 ## Support
 
 For issues or questions:
+
 - Check trace IDs in error responses
 - Review logs with trace ID
 - Contact support with trace ID for debugging

--- a/packages/api/src/routes/platform-control-plane.ts
+++ b/packages/api/src/routes/platform-control-plane.ts
@@ -8,8 +8,65 @@ import {
 } from "../services/capabilities/registry";
 import { isMissingOptionalCapabilityDependency } from "../services/capabilities/errors";
 import { observeCapabilityStatus } from "../services/capabilities/telemetry";
+import { query } from "../db";
 
 export const platformControlPlaneRouter: Router = Router();
+
+async function getRecentImportWorkbenchSummary(tenantId: string): Promise<{
+  totalImports: number;
+  importsWithBlockingDiagnostics: number;
+  latest?: {
+    ingestionId: string;
+    completedAt: string | null;
+    canProceed?: boolean;
+  };
+}> {
+  const rows = await query(
+    `SELECT id, completed_at, metadata
+       FROM ingestions
+      WHERE tenant_id = $1
+      ORDER BY created_at DESC
+      LIMIT 20`,
+    [tenantId]
+  );
+
+  let importsWithBlockingDiagnostics = 0;
+  const first = rows[0] as Record<string, unknown> | undefined;
+
+  for (const row of rows as Record<string, unknown>[]) {
+    const metadata =
+      typeof row.metadata === "string"
+        ? (JSON.parse(row.metadata) as Record<string, unknown>)
+        : ((row.metadata as Record<string, unknown> | undefined) || {});
+    const workbench = (metadata.importWorkbench || {}) as Record<string, unknown>;
+    const diagnosticsSummary = (workbench.diagnosticsSummary || {}) as Record<string, unknown>;
+    const blocking = Number(diagnosticsSummary.blocking || 0);
+    if (blocking > 0) {
+      importsWithBlockingDiagnostics += 1;
+    }
+  }
+
+  let latest: { ingestionId: string; completedAt: string | null; canProceed?: boolean } | undefined;
+  if (first && typeof first.id === "string") {
+    const metadata =
+      typeof first.metadata === "string"
+        ? (JSON.parse(first.metadata) as Record<string, unknown>)
+        : ((first.metadata as Record<string, unknown> | undefined) || {});
+    const workbench = (metadata.importWorkbench || {}) as Record<string, unknown>;
+    latest = {
+      ingestionId: first.id,
+      completedAt: first.completed_at instanceof Date ? first.completed_at.toISOString() : null,
+      canProceed: typeof workbench.canProceed === "boolean" ? (workbench.canProceed as boolean) : undefined,
+    };
+  }
+
+  return {
+    totalImports: rows.length,
+    importsWithBlockingDiagnostics,
+    latest,
+  };
+}
+
 
 platformControlPlaneRouter.get(
   "/platform-control-plane/overview",
@@ -31,13 +88,17 @@ platformControlPlaneRouter.get(
         tenantId,
         Number.isFinite(days) ? Math.max(1, days) : 7
       );
+      const importWorkbench = await getRecentImportWorkbenchSummary(tenantId);
 
       const capability = provider.status();
       observeCapabilityStatus(capability, "/platform-control-plane/overview");
       observeCapabilityStatus(analyticsCapability, "/platform-control-plane/overview");
 
       res.json({
-        data: overview,
+        data: {
+          ...overview,
+          importWorkbench,
+        },
         capability: { operatorIntelligence: capability, enterpriseAnalytics: analyticsCapability },
         metadata: {
           tenantId,
@@ -54,7 +115,10 @@ platformControlPlaneRouter.get(
         observeCapabilityStatus(capability, "/platform-control-plane/overview");
         observeCapabilityStatus(analyticsCapability, "/platform-control-plane/overview");
         res.status(200).json({
-          data: await provider.getPlatformOverview(tenantId, 7),
+          data: {
+            ...(await provider.getPlatformOverview(tenantId, 7)),
+            importWorkbench: await getRecentImportWorkbenchSummary(tenantId),
+          },
           capability: {
             operatorIntelligence: capability,
             enterpriseAnalytics: analyticsCapability,

--- a/packages/api/src/routes/v1/__tests__/ingestion-preview.route.test.ts
+++ b/packages/api/src/routes/v1/__tests__/ingestion-preview.route.test.ts
@@ -1,0 +1,149 @@
+import express from "express";
+import request from "supertest";
+import ingestionRouter from "../ingestion";
+
+const mockQuery = jest.fn();
+
+jest.mock("../../../db", () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+jest.mock("../../../middleware/usage-enforcement", () => ({
+  checkIngestionLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../../../services/operator-mode/kill-switches", () => ({
+  isConnectorDisabled: jest.fn().mockResolvedValue(false),
+  isBackgroundJobPaused: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock("../../../services/operator-mode/cost-controls", () => ({
+  canRunBackgroundJob: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
+describe("ingestion preview route", () => {
+  function buildApp(tenantId?: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).tenantId = tenantId;
+      (req as any).userId = "user-1";
+      (req as any).traceId = "trace-1";
+      next();
+    });
+    app.use("/api/v1/ingestion", ingestionRouter);
+    return app;
+  }
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("returns 400 when tenant context is missing", async () => {
+    const app = buildApp(undefined);
+
+    const response = await request(app)
+      .post("/api/v1/ingestion/preview")
+      .attach("file", Buffer.from("Date,Amount\n2026-01-01,12.00"), "sample.csv");
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe("TENANT_CONTEXT_REQUIRED");
+  });
+
+  it("returns 400 when columnMapping is malformed JSON", async () => {
+    const app = buildApp("tenant-1");
+
+    const response = await request(app)
+      .post("/api/v1/ingestion/preview")
+      .field("columnMapping", "{invalid")
+      .attach("file", Buffer.from("Date,Amount\n2026-01-01,12.00"), "sample.csv");
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe("INGESTION_INVALID_COLUMN_MAPPING");
+  });
+
+  it("uses tenant-scoped baseline query when sourceId is provided", async () => {
+    const app = buildApp("tenant-abc");
+    mockQuery.mockResolvedValue([
+      {
+        id: "ing-prev",
+        completed_at: new Date("2026-01-01T00:00:00.000Z"),
+        metadata: JSON.stringify({
+          importWorkbench: {
+            sourceSummary: {
+              headers: ["Date", "Amount"],
+            },
+          },
+        }),
+      },
+    ]);
+
+    const response = await request(app)
+      .post("/api/v1/ingestion/preview")
+      .field("sourceId", "source-1")
+      .attach("file", Buffer.from("Date,Amount\n2026-01-01,12.00"), "sample.csv");
+
+    expect(response.status).toBe(200);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const args = mockQuery.mock.calls[0];
+    expect(args[1]).toEqual(["tenant-abc", "source-1"]);
+    expect(response.body.preview.schemaDrift).toBeDefined();
+  });
+
+  it("returns 400 for recent workbench without tenant", async () => {
+    const app = buildApp(undefined);
+    const response = await request(app).get("/api/v1/ingestion/workbench/recent");
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe("TENANT_CONTEXT_REQUIRED");
+  });
+
+  it("queries recent workbench with tenant filter", async () => {
+    const app = buildApp("tenant-recent");
+    mockQuery.mockResolvedValue([
+      {
+        id: "ing-1",
+        source_id: "source-1",
+        status: "completed",
+        completed_at: new Date("2026-01-03T00:00:00.000Z"),
+        metadata: JSON.stringify({ importWorkbench: { canProceed: true } }),
+      },
+    ]);
+
+    const response = await request(app).get("/api/v1/ingestion/workbench/recent?limit=5");
+
+    expect(response.status).toBe(200);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0]?.[1]).toEqual(["tenant-recent", "5"]);
+    expect(response.body.items).toHaveLength(1);
+  });
+
+  it("returns 400 for retry without tenant", async () => {
+    const app = buildApp(undefined);
+    const response = await request(app).post("/api/v1/ingestion/ing-1/retry").send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe("TENANT_CONTEXT_REQUIRED");
+  });
+
+  it("uses tenant-scoped raw-record query for retry", async () => {
+    const app = buildApp("tenant-retry");
+    mockQuery.mockResolvedValueOnce([
+      {
+        source_id: "source-1",
+        row_number: 1,
+        raw_data: JSON.stringify({ Date: "2026-01-01", Amount: "12.00" }),
+      },
+    ]);
+    mockQuery.mockResolvedValueOnce([]); // drift baseline lookup
+
+    const response = await request(app)
+      .post("/api/v1/ingestion/ing-retry/retry")
+      .send({ dryRun: true, columnMapping: { date: "Date", amount: "Amount" } });
+
+    expect(response.status).toBe(200);
+    expect(mockQuery.mock.calls[0]?.[1]).toEqual(["ing-retry", "tenant-retry"]);
+    expect(response.body.mode).toBe("dry_run");
+  });
+
+});

--- a/packages/api/src/routes/v1/ingestion.ts
+++ b/packages/api/src/routes/v1/ingestion.ts
@@ -13,6 +13,7 @@ import {
   autoDetectColumnMapping,
   normalizeCSVRow,
   validateMapping,
+  buildImportWorkbenchPreview,
 } from "../../services/ingestion/csv-importer";
 import {
   createIngestion,
@@ -33,6 +34,107 @@ import { canRunBackgroundJob } from "../../services/operator-mode/cost-controls"
 
 const router: Router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
+
+function parseColumnMappingOverride(rawValue: unknown): {
+  mapping?: CSVColumnMapping;
+  error?: string;
+} {
+  if (!rawValue) {
+    return {};
+  }
+
+  if (typeof rawValue === "object") {
+    return { mapping: rawValue as CSVColumnMapping };
+  }
+
+  if (typeof rawValue !== "string") {
+    return { error: "columnMapping must be a JSON object or JSON string" };
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { error: "columnMapping must be a JSON object" };
+    }
+    return { mapping: parsed as CSVColumnMapping };
+  } catch {
+    return { error: "columnMapping is not valid JSON" };
+  }
+}
+
+async function loadSchemaDriftBaseline(
+  tenantId: string,
+  sourceId: string
+): Promise<
+  | {
+      baseline?: { ingestionId: string; capturedAt: string; headers: string[] };
+      history: Array<{ headers: string[]; hasDrift: boolean }>;
+    }
+  | undefined
+> {
+  const previous = await query(
+    `SELECT id, completed_at, metadata
+       FROM ingestions
+      WHERE tenant_id = $1
+        AND source_id = $2
+        AND status = 'completed'
+      ORDER BY completed_at DESC NULLS LAST, created_at DESC
+      LIMIT 6`,
+    [tenantId, sourceId]
+  );
+
+  if (previous.length === 0) {
+    return undefined;
+  }
+
+  const parsed = previous
+    .map((row) => {
+      const record = row as Record<string, unknown>;
+      const metadataValue = record.metadata;
+      const metadata =
+        typeof metadataValue === "string"
+          ? (JSON.parse(metadataValue) as Record<string, unknown>)
+          : (metadataValue as Record<string, unknown> | null);
+      const workbench = (metadata?.importWorkbench || {}) as Record<string, unknown>;
+      const sourceSummary = (workbench.sourceSummary || {}) as Record<string, unknown>;
+      const headers = Array.isArray(sourceSummary.headers)
+        ? sourceSummary.headers.filter((header): header is string => typeof header === "string")
+        : [];
+
+      if (headers.length === 0 || typeof record.id !== "string") {
+        return null;
+      }
+
+      const schemaDriftValue = (workbench.schemaDrift || {}) as Record<string, unknown>;
+      const hasDrift = Boolean(schemaDriftValue.hasDrift);
+      return {
+        ingestionId: record.id,
+        capturedAt:
+          record.completed_at instanceof Date
+            ? record.completed_at.toISOString()
+            : new Date().toISOString(),
+        headers,
+        hasDrift,
+      };
+    })
+    .filter((item): item is { ingestionId: string; capturedAt: string; headers: string[]; hasDrift: boolean } => Boolean(item));
+
+  if (parsed.length === 0) {
+    return undefined;
+  }
+
+  const [first, ...rest] = parsed;
+  return {
+    baseline: first
+      ? {
+          ingestionId: first.ingestionId,
+          capturedAt: first.capturedAt,
+          headers: first.headers,
+        }
+      : undefined,
+    history: rest.map((item) => ({ headers: item.headers, hasDrift: item.hasDrift })),
+  };
+}
 
 /**
  * POST /api/v1/ingestion/sources
@@ -149,6 +251,93 @@ router.get("/sources", async (req: AuthRequest, res: Response) => {
 });
 
 /**
+ * POST /api/v1/ingestion/preview
+ * Build truthful ingestion preview without persisting records
+ */
+router.post("/preview", upload.single("file"), async (req: AuthRequest, res: Response) => {
+  try {
+    const tenantId = req.tenantId;
+    if (!tenantId) {
+      return res.status(400).json({
+        error: "Bad Request",
+        code: "TENANT_CONTEXT_REQUIRED",
+        message: "Tenant context is required",
+        traceId: req.traceId,
+      });
+    }
+
+    const file = req.file;
+    if (!file) {
+      return res.status(400).json({
+        error: "Bad Request",
+        code: "INGESTION_CSV_REQUIRED",
+        message: "CSV file is required",
+        traceId: req.traceId,
+      });
+    }
+
+    const traceId = req.traceId || uuidv4();
+    const columnMappingOverride = req.body.columnMapping;
+
+    let headers: string[] = [];
+    let rows: Array<Record<string, string | number | null | undefined>> = [];
+
+    try {
+      const parsed = parseCSV(file.buffer);
+      headers = parsed.headers;
+      rows = parsed.rows;
+    } catch (error) {
+      return res.status(400).json({
+        error: "Bad Request",
+        code: "INGESTION_CSV_PARSE_FAILED",
+        message: error instanceof Error ? error.message : "Invalid CSV payload",
+        traceId,
+      });
+    }
+
+    const mappingParse = parseColumnMappingOverride(columnMappingOverride);
+    if (mappingParse.error) {
+      return res.status(400).json({
+        error: "Bad Request",
+        code: "INGESTION_INVALID_COLUMN_MAPPING",
+        message: mappingParse.error,
+        traceId,
+      });
+    }
+
+    const sourceId = typeof req.body.sourceId === "string" ? req.body.sourceId : undefined;
+    const schemaDriftBaselineData = sourceId
+      ? await loadSchemaDriftBaseline(tenantId, sourceId)
+      : undefined;
+
+    const preview = buildImportWorkbenchPreview({
+      fileName: file.originalname,
+      fileSizeBytes: file.size,
+      headers,
+      rows,
+      providedMapping: mappingParse.mapping,
+      schemaDriftBaseline: schemaDriftBaselineData?.baseline,
+      schemaDriftHistory: schemaDriftBaselineData?.history,
+      sourceProfile:
+        typeof req.body.sourceProfile === "string" ? req.body.sourceProfile : undefined,
+    });
+
+    return res.status(200).json({
+      preview,
+      traceId,
+    });
+  } catch (error) {
+    logError("Failed to build ingestion preview", error, { traceId: req.traceId });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      code: "INGESTION_PREVIEW_FAILED",
+      message: "Failed to build ingestion preview",
+      traceId: req.traceId,
+    });
+  }
+});
+
+/**
  * POST /api/v1/ingestion/upload
  * Upload CSV file for ingestion
  */
@@ -169,9 +358,18 @@ router.post(
       }
 
       const { sourceId, columnMapping: columnMappingOverride } = req.body;
-      const tenantId = req.tenantId!;
-      const userId = req.userId!;
+      const tenantId = req.tenantId;
+      const userId = req.userId;
       const traceId = req.traceId || uuidv4();
+
+      if (!tenantId || !userId) {
+        return res.status(400).json({
+          error: "Bad Request",
+          code: "TENANT_CONTEXT_REQUIRED",
+          message: "Tenant and user context are required",
+          traceId,
+        });
+      }
 
       // Parse CSV
       let headers: string[] = [];
@@ -189,24 +387,47 @@ router.post(
         });
       }
 
-      // Auto-detect or use provided column mapping
-      let columnMapping: CSVColumnMapping;
-      if (columnMappingOverride) {
-        columnMapping = JSON.parse(columnMappingOverride);
-      } else {
-        columnMapping = autoDetectColumnMapping(headers);
-      }
-
-      // Validate mapping
-      const validation = validateMapping(columnMapping);
-      if (!validation.valid) {
+      const mappingParse = parseColumnMappingOverride(columnMappingOverride);
+      if (mappingParse.error) {
         return res.status(400).json({
           error: "Bad Request",
           code: "INGESTION_INVALID_COLUMN_MAPPING",
-          message: "Invalid column mapping",
+          message: mappingParse.error,
+          traceId,
+        });
+      }
+
+      // Auto-detect or use provided column mapping
+      const columnMapping: CSVColumnMapping =
+        mappingParse.mapping || autoDetectColumnMapping(headers);
+
+      const schemaDriftBaselineData = sourceId
+        ? await loadSchemaDriftBaseline(tenantId, sourceId)
+        : undefined;
+
+      const preview = buildImportWorkbenchPreview({
+        fileName: file.originalname,
+        fileSizeBytes: file.size,
+        headers,
+        rows,
+        providedMapping: mappingParse.mapping,
+        schemaDriftBaseline: schemaDriftBaselineData?.baseline,
+      schemaDriftHistory: schemaDriftBaselineData?.history,
+        sourceProfile:
+          typeof req.body.sourceProfile === "string" ? req.body.sourceProfile : undefined,
+      });
+
+      // Validate mapping
+      const validation = validateMapping(columnMapping);
+      if (!validation.valid || !preview.canProceed) {
+        return res.status(400).json({
+          error: "Bad Request",
+          code: "INGESTION_INVALID_COLUMN_MAPPING",
+          message: "Import preview found blocking issues",
           errors: validation.errors,
           detectedHeaders: headers,
           detectedMapping: columnMapping,
+          preview,
           traceId,
         });
       }
@@ -306,6 +527,37 @@ router.post(
         completedAt: new Date(),
       });
 
+      await query(
+        `UPDATE ingestions SET metadata = $2, updated_at = NOW() WHERE id = $1 AND tenant_id = $3`,
+        [
+          ingestionId,
+          JSON.stringify({
+            importWorkbench: {
+              sourceSummary: preview.sourceSummary,
+              mapping: preview.mapping,
+              normalization: {
+                attemptedRows: preview.normalization.attemptedRows,
+                normalizedRows: preview.normalization.normalizedRows,
+                failedRows: preview.normalization.failedRows,
+                droppedRows: preview.normalization.droppedRows,
+                defaultedFieldCounts: preview.normalization.defaultedFieldCounts,
+              },
+              qualityGates: preview.qualityGates,
+              schemaDrift: preview.schemaDrift,
+              sourceProfile: preview.sourceProfile,
+              contract: preview.contract,
+              diagnosticsSample: preview.diagnostics.slice(0, 25),
+              diagnosticsSummary: {
+                info: preview.diagnostics.filter((d) => d.severity === "info").length,
+                warning: preview.diagnostics.filter((d) => d.severity === "warning").length,
+                blocking: preview.diagnostics.filter((d) => d.severity === "blocking").length,
+              },
+            },
+          }),
+          tenantId,
+        ]
+      );
+
       // Track usage
       const billingAccount = await getBillingAccount(userId, tenantId);
       if (billingAccount) {
@@ -332,6 +584,21 @@ router.post(
         normalizedCount: transactionIds.length,
         failedCount,
         columnMapping,
+        preview: {
+          sourceSummary: preview.sourceSummary,
+          mapping: preview.mapping,
+          normalization: preview.normalization,
+          qualityGates: preview.qualityGates,
+          schemaDrift: preview.schemaDrift,
+          sourceProfile: preview.sourceProfile,
+          diagnosticsSample: preview.diagnostics.slice(0, 25),
+          contract: preview.contract,
+          canProceed: preview.canProceed,
+        },
+        recovery: {
+          retryEndpoint: `/api/v1/ingestion/${ingestionId}/retry`,
+          retryPreviewEndpoint: `/api/v1/ingestion/${ingestionId}/retry?dryRun=true`,
+        },
         traceId,
       });
     } catch (error) {
@@ -464,6 +731,235 @@ router.get("/:ingestionId/transactions", async (req: AuthRequest, res: Response)
     return res.status(500).json({
       error: "Internal Server Error",
       message: "Failed to get transactions",
+      traceId: req.traceId,
+    });
+  }
+});
+
+/**
+ * GET /api/v1/ingestion/workbench/recent
+ * Get recent ingestion workbench summaries for control-plane linking
+ */
+router.get("/workbench/recent", async (req: AuthRequest, res: Response) => {
+  try {
+    const tenantId = req.tenantId;
+    if (!tenantId) {
+      return res.status(400).json({
+        error: "Bad Request",
+        code: "TENANT_CONTEXT_REQUIRED",
+        message: "Tenant context is required",
+        traceId: req.traceId,
+      });
+    }
+
+    const limit = Math.min(Math.max(parseInt(req.query.limit as string, 10) || 20, 1), 100);
+    const ingestions = await query(
+      `SELECT id, source_id, status, completed_at, metadata
+         FROM ingestions
+        WHERE tenant_id = $1
+        ORDER BY created_at DESC
+        LIMIT $2`,
+      [tenantId, limit.toString()]
+    );
+
+    return res.json({
+      items: ingestions.map((row: Record<string, unknown>) => {
+        const metadata =
+          typeof row.metadata === "string"
+            ? (JSON.parse(row.metadata) as Record<string, unknown>)
+            : (row.metadata as Record<string, unknown> | undefined) || {};
+        const workbench = (metadata.importWorkbench || {}) as Record<string, unknown>;
+        return {
+          ingestionId: row.id as string,
+          sourceId: row.source_id as string,
+          status: row.status as string,
+          completedAt: row.completed_at as Date | null,
+          workbench,
+          links: {
+            ingestionDetail: `/api/v1/ingestion/${row.id as string}`,
+            retry: `/api/v1/ingestion/${row.id as string}/retry`,
+          },
+        };
+      }),
+    });
+  } catch (error) {
+    logError("Failed to get recent ingestion workbench summaries", error, {
+      traceId: req.traceId,
+    });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      code: "INGESTION_WORKBENCH_RECENT_FAILED",
+      message: "Failed to load recent ingestion workbench summaries",
+      traceId: req.traceId,
+    });
+  }
+});
+
+/**
+ * POST /api/v1/ingestion/:ingestionId/retry
+ * Retry ingestion with remapped fields using original raw records
+ */
+router.post("/:ingestionId/retry", async (req: AuthRequest, res: Response) => {
+  try {
+    const tenantId = req.tenantId;
+    const userId = req.userId;
+    if (!tenantId || !userId) {
+      return res.status(400).json({
+        error: "Bad Request",
+        code: "TENANT_CONTEXT_REQUIRED",
+        message: "Tenant and user context are required",
+        traceId: req.traceId,
+      });
+    }
+
+    const { ingestionId } = req.params;
+    const mappingParse = parseColumnMappingOverride(req.body.columnMapping);
+    if (mappingParse.error) {
+      return res.status(400).json({
+        error: "Bad Request",
+        code: "INGESTION_INVALID_COLUMN_MAPPING",
+        message: mappingParse.error,
+        traceId: req.traceId,
+      });
+    }
+
+    const dryRun = req.body.dryRun !== false;
+    const originalRows = await query(
+      `SELECT i.source_id, r.row_number, r.raw_data
+         FROM ingestions i
+         JOIN raw_records r ON r.ingestion_id = i.id
+        WHERE i.id = $1 AND i.tenant_id = $2
+        ORDER BY r.row_number ASC`,
+      [ingestionId || "", tenantId]
+    );
+
+    if (originalRows.length === 0) {
+      return res.status(404).json({
+        error: "Not Found",
+        code: "INGESTION_RETRY_SOURCE_NOT_FOUND",
+        message: "No raw records found for ingestion retry",
+        traceId: req.traceId,
+      });
+    }
+
+    const first = originalRows[0] as Record<string, unknown>;
+    const sourceId = first.source_id as string;
+    const rows = originalRows.map((row: Record<string, unknown>) => {
+      const value = row.raw_data;
+      return typeof value === "string"
+        ? (JSON.parse(value) as Record<string, string | number | null | undefined>)
+        : (value as Record<string, string | number | null | undefined>);
+    });
+    const headers = Object.keys(rows[0] || {});
+
+    const schemaDriftBaselineData = await loadSchemaDriftBaseline(tenantId, sourceId);
+    const preview = buildImportWorkbenchPreview({
+      fileName: `retry-${ingestionId}.csv`,
+      fileSizeBytes: 0,
+      headers,
+      rows,
+      providedMapping: mappingParse.mapping,
+      schemaDriftBaseline: schemaDriftBaselineData?.baseline,
+      schemaDriftHistory: schemaDriftBaselineData?.history,
+    });
+
+    if (dryRun) {
+      return res.status(200).json({
+        mode: "dry_run",
+        preview,
+        traceId: req.traceId,
+      });
+    }
+
+    if (!preview.canProceed) {
+      return res.status(400).json({
+        error: "Bad Request",
+        code: "INGESTION_RETRY_BLOCKED",
+        message: "Retry blocked by import workbench diagnostics",
+        preview,
+        traceId: req.traceId,
+      });
+    }
+
+    const retryIngestionId = await createIngestion({
+      sourceId,
+      tenantId,
+      userId,
+      idempotencyKey: req.headers["idempotency-key"] as string | undefined,
+      traceId: req.traceId,
+      metadata: {
+        retryOfIngestionId: ingestionId,
+        importWorkbench: {
+          sourceSummary: preview.sourceSummary,
+          mapping: preview.mapping,
+          normalization: preview.normalization,
+          qualityGates: preview.qualityGates,
+          schemaDrift: preview.schemaDrift,
+          diagnosticsSample: preview.diagnostics.slice(0, 25),
+          contract: preview.contract,
+        },
+      },
+    });
+
+    const normalizedTransactions: Array<{
+      transaction: ReturnType<typeof normalizeCSVRow>;
+      rawRecordId?: string;
+    }> = [];
+    let failedCount = 0;
+
+    const columnMapping = mappingParse.mapping || autoDetectColumnMapping(headers);
+    for (let index = 0; index < rows.length; index++) {
+      const row = rows[index];
+      if (!row) {
+        failedCount += 1;
+        continue;
+      }
+
+      const rowNumber = index + 1;
+      const rawRecordId = await createRawRecord(retryIngestionId, sourceId, tenantId, row, {
+        rowNumber,
+      });
+
+      try {
+        const normalized = normalizeCSVRow(row, columnMapping);
+        normalizedTransactions.push({ transaction: normalized, rawRecordId });
+      } catch {
+        failedCount += 1;
+        await query(
+          `UPDATE raw_records SET status = 'failed', updated_at = NOW() WHERE id = $1 AND tenant_id = $2`,
+          [rawRecordId, tenantId]
+        );
+      }
+    }
+
+    const created = await batchCreateNormalizedTransactions(
+      retryIngestionId,
+      sourceId,
+      tenantId,
+      normalizedTransactions
+    );
+
+    await updateIngestionStatus(retryIngestionId, "completed", {
+      rawRecordCount: rows.length,
+      normalizedCount: created.length,
+      failedCount,
+      completedAt: new Date(),
+    });
+
+    return res.status(201).json({
+      retryIngestionId,
+      sourceIngestionId: ingestionId,
+      normalizedCount: created.length,
+      failedCount,
+      preview,
+      traceId: req.traceId,
+    });
+  } catch (error) {
+    logError("Failed ingestion retry", error, { traceId: req.traceId });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      code: "INGESTION_RETRY_FAILED",
+      message: "Failed to retry ingestion",
       traceId: req.traceId,
     });
   }

--- a/packages/api/src/services/ingestion/__tests__/csv-importer.test.ts
+++ b/packages/api/src/services/ingestion/__tests__/csv-importer.test.ts
@@ -8,6 +8,7 @@ import {
   autoDetectColumnMapping,
   normalizeCSVRow,
   validateMapping,
+  buildImportWorkbenchPreview,
 } from "../csv-importer";
 import { CSVColumnMapping } from "../types";
 
@@ -41,13 +42,7 @@ describe("CSV Importer", () => {
 
   describe("autoDetectColumnMapping", () => {
     it("should detect common column names", () => {
-      const headers = [
-        "Date",
-        "Description",
-        "Amount",
-        "Currency",
-        "Transaction ID",
-      ];
+      const headers = ["Date", "Description", "Amount", "Currency", "Transaction ID"];
       const mapping = autoDetectColumnMapping(headers);
 
       expect(mapping.date).toBe("Date");
@@ -84,7 +79,6 @@ describe("CSV Importer", () => {
     it("should reject missing required fields", () => {
       const mapping: CSVColumnMapping = {
         amount: "Amount",
-        // Missing date
       };
       const result = validateMapping(mapping);
 
@@ -146,14 +140,13 @@ describe("CSV Importer", () => {
 
       const normalized = normalizeCSVRow(row, mapping);
 
-      expect(normalized.amount).toBe(100); // Always positive
+      expect(normalized.amount).toBe(100);
     });
 
     it("should throw error for missing required fields", () => {
       const row = {
         Description: "Test",
         Amount: 100,
-        // Missing date
       };
       const mapping: CSVColumnMapping = {
         date: "Date",
@@ -161,6 +154,88 @@ describe("CSV Importer", () => {
       };
 
       expect(() => normalizeCSVRow(row, mapping)).toThrow();
+    });
+  });
+
+  describe("buildImportWorkbenchPreview", () => {
+    it("should produce preview diagnostics and normalized sample records", () => {
+      const parsed = parseCSV(sampleCSV);
+      const preview = buildImportWorkbenchPreview({
+        fileName: "sample.csv",
+        fileSizeBytes: Buffer.byteLength(sampleCSV),
+        headers: parsed.headers,
+        rows: parsed.rows,
+      });
+
+      expect(preview.canProceed).toBe(true);
+      expect(preview.normalization.normalizedRows).toBe(2);
+      expect(preview.normalization.failedRows).toBe(0);
+      expect(preview.normalization.sampleNormalizedRecords).toHaveLength(2);
+      expect(preview.mapping.requiredMissing).toHaveLength(0);
+      expect(preview.qualityGates.find((g) => g.gate === "required_mapping_present")?.passed).toBe(
+        true
+      );
+    });
+
+    it("should block when required mappings are missing", () => {
+      const csv = `Memo,Total\nSubscription payment,100`;
+      const parsed = parseCSV(csv);
+
+      const preview = buildImportWorkbenchPreview({
+        fileName: "bad.csv",
+        fileSizeBytes: Buffer.byteLength(csv),
+        headers: parsed.headers,
+        rows: parsed.rows,
+      });
+
+      expect(preview.canProceed).toBe(false);
+      expect(preview.mapping.requiredMissing).toContain("date");
+      expect(
+        preview.diagnostics.some((d) => d.code === "required_mapping_missing" && d.field === "date")
+      ).toBe(true);
+    });
+
+
+
+    it("should include remediation hints and contract metadata for blocking diagnostics", () => {
+      const csv = `Memo,Total
+Subscription payment,100`;
+      const parsed = parseCSV(csv);
+
+      const preview = buildImportWorkbenchPreview({
+        fileName: "bad.csv",
+        fileSizeBytes: Buffer.byteLength(csv),
+        headers: parsed.headers,
+        rows: parsed.rows,
+      });
+
+      const missingDateDiagnostic = preview.diagnostics.find(
+        (d) => d.code === "required_mapping_missing" && d.field === "date"
+      );
+      expect(missingDateDiagnostic?.remediation).toBeDefined();
+      expect(preview.contract.schemaUri).toContain("contracts/ingestion/import-workbench.schema.json");
+      expect(preview.contract.version).toBe("1.0.0");
+    });
+
+    it("should surface ambiguous slash date warnings", () => {
+      const csv = `Date,Amount\n01/02/2024,125.00`;
+      const parsed = parseCSV(csv);
+
+      const preview = buildImportWorkbenchPreview({
+        fileName: "ambiguous.csv",
+        fileSizeBytes: Buffer.byteLength(csv),
+        headers: parsed.headers,
+        rows: parsed.rows,
+      });
+
+      expect(preview.canProceed).toBe(true);
+      expect(preview.normalization.failedRows).toBe(1);
+      expect(
+        preview.diagnostics.some((d) => d.code === "ambiguous_date" && d.severity === "warning")
+      ).toBe(true);
+      expect(
+        preview.qualityGates.find((g) => g.gate === "normalization_success_ratio")?.passed
+      ).toBe(false);
     });
   });
 });

--- a/packages/api/src/services/ingestion/csv-importer.ts
+++ b/packages/api/src/services/ingestion/csv-importer.ts
@@ -7,6 +7,10 @@ import { parse } from "csv-parse/sync";
 import {
   CSVColumnMapping,
   CSVRow,
+  ImportWorkbenchPreview,
+  IngestionDiagnostic,
+  IngestionQualityGate,
+  ImportSourceProfile,
   NormalizedTransactionInput,
   NormalizedTransactionSchema,
 } from "./types";
@@ -18,6 +22,66 @@ class CSVParserError extends Error {
     this.name = "CSVParserError";
   }
 }
+
+const REQUIRED_MAPPING_FIELDS: Array<keyof CSVColumnMapping> = ["amount", "date"];
+
+
+const IMPORT_WORKBENCH_CONTRACT = {
+  schemaUri: "contracts/ingestion/import-workbench.schema.json",
+  version: "1.0.0",
+} as const;
+
+const DIAGNOSTIC_REMEDIATION: Record<
+  string,
+  {
+    action: string;
+    hint: string;
+  }
+> = {
+  duplicate_headers: {
+    action: "Rename duplicate columns in source file",
+    hint: "Ensure each header is unique and retry preview",
+  },
+  required_mapping_missing: {
+    action: "Provide explicit column mapping",
+    hint: "Map required canonical fields (amount, date) before upload",
+  },
+  invalid_amount: {
+    action: "Fix amount formatting",
+    hint: "Use numeric values without text and consistent decimal separators",
+  },
+  ambiguous_date: {
+    action: "Normalize date format",
+    hint: "Use YYYY-MM-DD or unambiguous day/month values",
+  },
+  invalid_date: {
+    action: "Correct date values",
+    hint: "Provide parseable dates and verify mapped date column",
+  },
+  schema_drift_detected: {
+    action: "Review schema changes against previous import",
+    hint: "Compare added/removed headers and update mapping/profile as needed",
+  },
+};
+
+const PROFILE_GATE_CONFIG: Record<
+  ImportSourceProfile,
+  {
+    normalizationThreshold: number;
+    duplicateRowThreshold: number;
+    currencySeverity: "warning" | "blocking";
+  }
+> = {
+  csv_generic: { normalizationThreshold: 0.8, duplicateRowThreshold: 0.25, currencySeverity: "warning" },
+  bank_statement: { normalizationThreshold: 0.9, duplicateRowThreshold: 0.15, currencySeverity: "warning" },
+  processor_export: { normalizationThreshold: 0.95, duplicateRowThreshold: 0.1, currencySeverity: "blocking" },
+};
+
+function withRemediation(diagnostic: IngestionDiagnostic): IngestionDiagnostic {
+  const remediation = DIAGNOSTIC_REMEDIATION[diagnostic.code];
+  return remediation ? { ...diagnostic, remediation } : diagnostic;
+}
+
 
 /**
  * Auto-detect column mapping from CSV headers
@@ -171,6 +235,97 @@ export function parseCSV(csvContent: string | Buffer): { headers: string[]; rows
   }
 }
 
+function normalizeAmountWithReason(rawValue: unknown): { amount: number | null; reason?: string } {
+  if (typeof rawValue === "number") {
+    return Number.isFinite(rawValue)
+      ? { amount: Math.abs(rawValue) }
+      : { amount: null, reason: "non_finite_number" };
+  }
+
+  if (typeof rawValue === "string") {
+    const cleaned = rawValue.replace(/[^\d.,()\-]/g, "").trim();
+    if (!cleaned) {
+      return { amount: null, reason: "empty_string" };
+    }
+
+    let candidate = cleaned;
+    if (candidate.includes("(") && candidate.includes(")")) {
+      candidate = `-${candidate.replace(/[()]/g, "")}`;
+    }
+
+    if (candidate.includes(",") && candidate.includes(".")) {
+      if (candidate.lastIndexOf(",") > candidate.lastIndexOf(".")) {
+        candidate = candidate.replace(/\./g, "").replace(/,/g, ".");
+      } else {
+        candidate = candidate.replace(/,/g, "");
+      }
+    } else if (candidate.includes(",")) {
+      const parts = candidate.split(",");
+      candidate =
+        parts.length === 2 && (parts[1]?.length ?? 0) <= 2
+          ? candidate.replace(",", ".")
+          : candidate.replace(/,/g, "");
+    }
+
+    const parsed = parseFloat(candidate);
+    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+      return { amount: Math.abs(parsed) };
+    }
+
+    return { amount: null, reason: "parse_failed" };
+  }
+
+  return { amount: null, reason: "unsupported_type" };
+}
+
+function parseDateWithReason(rawValue: unknown): {
+  date: Date | null;
+  reason?: string;
+  ambiguous?: boolean;
+} {
+  if (rawValue === undefined || rawValue === null) {
+    return { date: null, reason: "missing" };
+  }
+
+  if (rawValue instanceof Date) {
+    return Number.isNaN(rawValue.getTime())
+      ? { date: null, reason: "invalid_date_object" }
+      : { date: rawValue };
+  }
+
+  if (typeof rawValue === "number") {
+    const parsed = new Date(rawValue * 1000);
+    return Number.isNaN(parsed.getTime())
+      ? { date: null, reason: "invalid_unix_timestamp" }
+      : { date: parsed };
+  }
+
+  if (typeof rawValue === "string") {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return { date: null, reason: "empty_string" };
+    }
+
+    const slashMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    if (slashMatch && slashMatch[1] && slashMatch[2]) {
+      const left = Number.parseInt(slashMatch[1], 10);
+      const right = Number.parseInt(slashMatch[2], 10);
+      if (left <= 12 && right <= 12) {
+        return { date: null, reason: "ambiguous_date_format", ambiguous: true };
+      }
+    }
+
+    const parsed = parseDate(trimmed);
+    if (parsed) {
+      return { date: parsed };
+    }
+
+    return { date: null, reason: "parse_failed" };
+  }
+
+  return { date: null, reason: "unsupported_type" };
+}
+
 /**
  * Normalize CSV row to internal transaction format
  */
@@ -184,17 +339,8 @@ export function normalizeCSVRow(
 
   // Extract amount
   if (mapping.amount && row[mapping.amount] !== undefined) {
-    const amountValue = row[mapping.amount];
-    if (typeof amountValue === "number") {
-      normalized.amount = Math.abs(amountValue); // Always positive
-    } else if (typeof amountValue === "string") {
-      // Remove currency symbols and whitespace
-      const cleaned = amountValue.replace(/[^\d.-]/g, "");
-      const parsed = parseFloat(cleaned);
-      if (!isNaN(parsed)) {
-        normalized.amount = Math.abs(parsed);
-      }
-    }
+    const amountNormalization = normalizeAmountWithReason(row[mapping.amount]);
+    normalized.amount = amountNormalization.amount ?? undefined;
   }
 
   if (!normalized.amount || normalized.amount <= 0) {
@@ -219,7 +365,6 @@ export function normalizeCSVRow(
     if (dateValue && typeof dateValue === "object" && "getTime" in dateValue) {
       normalized.date = dateValue as Date;
     } else if (typeof dateValue === "string") {
-      // Try multiple date formats
       const parsed = parseDate(dateValue);
       if (parsed) {
         normalized.date = parsed;
@@ -227,7 +372,6 @@ export function normalizeCSVRow(
         throw new Error(`Invalid date format: ${dateValue}`);
       }
     } else if (typeof dateValue === "number") {
-      // Unix timestamp
       normalized.date = new Date(dateValue * 1000);
     }
   } else {
@@ -264,6 +408,357 @@ export function normalizeCSVRow(
 
   // Validate using zod schema
   return NormalizedTransactionSchema.parse(normalized);
+}
+
+export function buildImportWorkbenchPreview(params: {
+  fileName?: string;
+  fileSizeBytes: number;
+  headers: string[];
+  rows: CSVRow[];
+  providedMapping?: CSVColumnMapping;
+  sourceProfile?: ImportSourceProfile;
+  schemaDriftBaseline?: {
+    ingestionId: string;
+    capturedAt: string;
+    headers: string[];
+  };
+  schemaDriftHistory?: Array<{
+    headers: string[];
+    hasDrift: boolean;
+  }>;
+}): ImportWorkbenchPreview {
+  const { fileName, fileSizeBytes, headers, rows, providedMapping, sourceProfile } = params;
+  const detectedMapping = autoDetectColumnMapping(headers);
+  const effectiveMapping = { ...detectedMapping, ...(providedMapping || {}) };
+
+  const diagnostics: IngestionDiagnostic[] = [];
+  const resolvedSourceProfile: ImportSourceProfile =
+    sourceProfile ||
+    (headers.some((h) => /account|statement|balance/i.test(h)) ? "bank_statement" : "csv_generic");
+  const profileGates = PROFILE_GATE_CONFIG[resolvedSourceProfile];
+
+  const normalizedHeaders = headers.map((h) => h.toLowerCase());
+  const duplicateHeaders = [
+    ...new Set(normalizedHeaders.filter((h, i) => normalizedHeaders.indexOf(h) !== i)),
+  ];
+  if (duplicateHeaders.length > 0) {
+    diagnostics.push(withRemediation({
+      severity: "blocking",
+      stage: "parse",
+      code: "duplicate_headers",
+      message: `Duplicate headers detected: ${duplicateHeaders.join(", ")}`,
+      details: { duplicateHeaders },
+    }));
+  }
+
+  const baseline = params.schemaDriftBaseline;
+  let schemaDrift: ImportWorkbenchPreview["schemaDrift"];
+  if (baseline) {
+    const current = new Set(headers.map((header) => header.toLowerCase()));
+    const prior = new Set(baseline.headers.map((header) => header.toLowerCase()));
+    const addedHeaders = [...current].filter((header) => !prior.has(header));
+    const removedHeaders = [...prior].filter((header) => !current.has(header));
+    const hasDrift = addedHeaders.length > 0 || removedHeaders.length > 0;
+    schemaDrift = {
+      hasDrift,
+      baselineIngestionId: baseline.ingestionId,
+      baselineCapturedAt: baseline.capturedAt,
+      addedHeaders,
+      removedHeaders,
+      severity: hasDrift ? "warning" : "info",
+    };
+
+    if (hasDrift) {
+      diagnostics.push(withRemediation({
+        severity: "warning",
+        stage: "mapping",
+        code: "schema_drift_detected",
+        message: "Schema drift detected against baseline ingestion",
+        details: {
+          baselineIngestionId: baseline.ingestionId,
+          addedHeaders,
+          removedHeaders,
+        },
+      }));
+    }
+  }
+
+  if (schemaDrift && params.schemaDriftHistory && params.schemaDriftHistory.length > 0) {
+    const driftedRuns = params.schemaDriftHistory.filter((item) => item.hasDrift).length + (schemaDrift.hasDrift ? 1 : 0);
+    const historyWindow = params.schemaDriftHistory.length + 1;
+    const churnRate = driftedRuns / historyWindow;
+    schemaDrift.trend = {
+      historyWindow,
+      driftedRuns,
+      churnRate,
+      escalationThreshold: 0.5,
+    };
+
+    if (schemaDrift.hasDrift && churnRate >= 0.5) {
+      schemaDrift.severity = "blocking";
+      diagnostics.push(
+        withRemediation({
+          severity: "blocking",
+          stage: "mapping",
+          code: "schema_drift_detected",
+          message: "Schema drift trend exceeded escalation threshold",
+          details: { churnRate, historyWindow, driftedRuns },
+        })
+      );
+    }
+  }
+
+  const requiredMissing = REQUIRED_MAPPING_FIELDS.filter((field) => !effectiveMapping[field]);
+  for (const missing of requiredMissing) {
+    diagnostics.push(withRemediation({
+      severity: "blocking",
+      stage: "mapping",
+      code: "required_mapping_missing",
+      message: `Required mapping missing for ${missing}`,
+      field: missing,
+    }));
+  }
+
+  let normalizedRows = 0;
+  let failedRows = 0;
+  const defaultedFieldCounts: Record<string, number> = {};
+  const sampleNormalizedRecords: NormalizedTransactionInput[] = [];
+
+  for (let index = 0; index < rows.length; index++) {
+    const row = rows[index];
+    if (!row) {
+      failedRows += 1;
+      diagnostics.push(withRemediation({
+        severity: "warning",
+        stage: "parse",
+        code: "empty_row_object",
+        message: "Encountered empty row object",
+        rowNumber: index + 1,
+      }));
+      continue;
+    }
+
+    if (!effectiveMapping.amount || !effectiveMapping.date) {
+      failedRows += 1;
+      continue;
+    }
+
+    const amountRaw = row[effectiveMapping.amount];
+    const amountNormalization = normalizeAmountWithReason(amountRaw);
+    if (amountNormalization.amount === null || amountNormalization.amount <= 0) {
+      failedRows += 1;
+      diagnostics.push(withRemediation({
+        severity: "blocking",
+        stage: "normalize",
+        code: "invalid_amount",
+        message: `Amount could not be normalized`,
+        rowNumber: index + 1,
+        field: effectiveMapping.amount,
+        details: { raw: amountRaw, reason: amountNormalization.reason },
+      }));
+      continue;
+    }
+
+    const dateRaw = row[effectiveMapping.date];
+    const dateNormalization = parseDateWithReason(dateRaw);
+    if (!dateNormalization.date) {
+      failedRows += 1;
+      diagnostics.push(withRemediation({
+        severity: dateNormalization.ambiguous ? "warning" : "blocking",
+        stage: "normalize",
+        code: dateNormalization.ambiguous ? "ambiguous_date" : "invalid_date",
+        message: dateNormalization.ambiguous
+          ? "Date format is ambiguous; use YYYY-MM-DD or unambiguous slash format"
+          : "Date could not be parsed",
+        rowNumber: index + 1,
+        field: effectiveMapping.date,
+        details: { raw: dateRaw, reason: dateNormalization.reason },
+      }));
+      continue;
+    }
+
+    const currencyColumn = effectiveMapping.currency;
+    let currency = "USD";
+    if (currencyColumn && row[currencyColumn] !== undefined) {
+      const parsedCurrency = String(row[currencyColumn] ?? "")
+        .trim()
+        .toUpperCase();
+      if (parsedCurrency.length === 3) {
+        currency = parsedCurrency;
+      } else {
+        defaultedFieldCounts.currency = (defaultedFieldCounts.currency ?? 0) + 1;
+        diagnostics.push(withRemediation({
+          severity: "info",
+          stage: "normalize",
+          code: "currency_defaulted",
+          message: "Currency defaulted to USD due to malformed value",
+          rowNumber: index + 1,
+          field: currencyColumn,
+          details: { raw: row[currencyColumn] },
+        }));
+      }
+    } else {
+      defaultedFieldCounts.currency = (defaultedFieldCounts.currency ?? 0) + 1;
+      diagnostics.push(withRemediation({
+        severity: "info",
+        stage: "normalize",
+        code: "currency_defaulted",
+        message: "Currency defaulted to USD due to missing mapping/value",
+        rowNumber: index + 1,
+      }));
+    }
+
+    const normalized = NormalizedTransactionSchema.parse({
+      amount: amountNormalization.amount,
+      currency,
+      date: dateNormalization.date,
+      description: effectiveMapping.description
+        ? String(row[effectiveMapping.description] ?? "").trim() || undefined
+        : undefined,
+      externalId: effectiveMapping.externalId
+        ? String(row[effectiveMapping.externalId] ?? "").trim() || undefined
+        : undefined,
+      category: effectiveMapping.category
+        ? String(row[effectiveMapping.category] ?? "").trim() || undefined
+        : undefined,
+      paymentMethod: effectiveMapping.paymentMethod
+        ? String(row[effectiveMapping.paymentMethod] ?? "").trim() || undefined
+        : undefined,
+      reference: effectiveMapping.reference
+        ? String(row[effectiveMapping.reference] ?? "").trim() || undefined
+        : undefined,
+      metadata: { ...row },
+    });
+
+    normalizedRows += 1;
+    if (sampleNormalizedRecords.length < 10) {
+      sampleNormalizedRecords.push(normalized);
+    }
+
+    const mappedColumns = new Set(Object.values(effectiveMapping).filter(Boolean));
+    const droppedFields = Object.keys(row).filter((key) => !mappedColumns.has(key));
+    if (droppedFields.length > 0) {
+      diagnostics.push(withRemediation({
+        severity: "info",
+        stage: "mapping",
+        code: "unmapped_fields_present",
+        message: "Row contains unmapped source fields",
+        rowNumber: index + 1,
+        details: { droppedFields },
+      }));
+    }
+  }
+
+  const attemptedRows = rows.length;
+  const droppedRows = failedRows;
+
+  const fingerprintCounts = new Map<string, number>();
+  for (const row of rows) {
+    const fingerprint = JSON.stringify(row);
+    fingerprintCounts.set(fingerprint, (fingerprintCounts.get(fingerprint) ?? 0) + 1);
+  }
+  const duplicateRowCount = [...fingerprintCounts.values()].filter((count) => count > 1).length;
+
+  const currencyValues = sampleNormalizedRecords.map((record) => record.currency);
+  const invalidCurrencyCount = currencyValues.filter((currency) => currency.length !== 3).length;
+
+  const qualityGates: IngestionQualityGate[] = [
+    {
+      gate: "required_mapping_present",
+      severity: "blocking",
+      passed: requiredMissing.length === 0,
+      message:
+        requiredMissing.length === 0
+          ? "Required mapping fields are present"
+          : `Missing required mappings: ${requiredMissing.join(", ")}`,
+      metric: { requiredMissingCount: requiredMissing.length },
+    },
+    {
+      gate: "non_empty_import",
+      severity: "blocking",
+      passed: attemptedRows > 0,
+      message: attemptedRows > 0 ? "Import has at least one row" : "Import is empty",
+      metric: { attemptedRows },
+    },
+    {
+      gate: "normalization_success_ratio",
+      severity: "warning",
+      passed:
+        attemptedRows === 0 ? false : normalizedRows / attemptedRows >= profileGates.normalizationThreshold,
+      message:
+        attemptedRows === 0
+          ? "No rows to normalize"
+          : `Normalization success ratio ${(normalizedRows / attemptedRows).toFixed(2)} (threshold ${profileGates.normalizationThreshold.toFixed(2)})`,
+      metric: { normalizedRows, attemptedRows, threshold: profileGates.normalizationThreshold },
+    },
+    {
+      gate: "duplicate_row_ratio",
+      severity: "warning",
+      passed:
+        attemptedRows === 0
+          ? true
+          : duplicateRowCount / attemptedRows <= profileGates.duplicateRowThreshold,
+      message:
+        attemptedRows === 0
+          ? "No rows available for duplicate analysis"
+          : `Duplicate row ratio ${(duplicateRowCount / attemptedRows).toFixed(2)} (threshold ${profileGates.duplicateRowThreshold.toFixed(2)})`,
+      metric: { duplicateRowCount, attemptedRows, threshold: profileGates.duplicateRowThreshold },
+    },
+    {
+      gate: "currency_format_distribution",
+      severity: profileGates.currencySeverity,
+      passed: invalidCurrencyCount === 0,
+      message:
+        invalidCurrencyCount === 0
+          ? "All sampled normalized currencies are 3-char codes"
+          : `${invalidCurrencyCount} sampled normalized rows have invalid currency format`,
+      metric: { invalidCurrencyCount, sampledRows: currencyValues.length },
+    },
+  ];
+
+  if (attemptedRows > 0 && failedRows / attemptedRows > 0.2) {
+    diagnostics.push(withRemediation({
+      severity: "warning",
+      stage: "quality_gate",
+      code: "high_dropped_row_ratio",
+      message: "Dropped-row ratio exceeds 20%",
+      details: { failedRows, attemptedRows, ratio: failedRows / attemptedRows },
+    }));
+  }
+
+  const hasBlocking =
+    diagnostics.some((d) => d.severity === "blocking") ||
+    qualityGates.some((g) => !g.passed && g.severity === "blocking");
+
+  return {
+    sourceSummary: {
+      fileName,
+      sizeBytes: fileSizeBytes,
+      totalRows: rows.length,
+      headers,
+      duplicateHeaders,
+    },
+    mapping: {
+      provided: providedMapping || null,
+      detected: detectedMapping,
+      effective: effectiveMapping,
+      requiredMissing,
+    },
+    normalization: {
+      attemptedRows,
+      normalizedRows,
+      failedRows,
+      droppedRows,
+      defaultedFieldCounts,
+      sampleNormalizedRecords,
+    },
+    diagnostics,
+    qualityGates,
+    schemaDrift,
+    sourceProfile: resolvedSourceProfile,
+    canProceed: !hasBlocking,
+    contract: IMPORT_WORKBENCH_CONTRACT,
+  };
 }
 
 /**

--- a/packages/api/src/services/ingestion/ingestion-service.ts
+++ b/packages/api/src/services/ingestion/ingestion-service.ts
@@ -331,8 +331,8 @@ export async function batchCreateNormalizedTransactions(
       // Update raw record status if provided
       if (rawRecordId) {
         await client.query(
-          `UPDATE raw_records SET status = 'normalized', updated_at = NOW() WHERE id = $1`,
-          [rawRecordId]
+          `UPDATE raw_records SET status = 'normalized', updated_at = NOW() WHERE id = $1 AND tenant_id = $2`,
+          [rawRecordId, tenantId]
         );
       }
     }

--- a/packages/api/src/services/ingestion/types.ts
+++ b/packages/api/src/services/ingestion/types.ts
@@ -29,6 +29,84 @@ export interface CSVColumnMapping {
   reference?: string; // Column name for reference
 }
 
+export type IngestionDiagnosticSeverity = "info" | "warning" | "blocking";
+
+export type IngestionDiagnosticStage = "raw" | "parse" | "mapping" | "normalize" | "quality_gate";
+
+export interface IngestionDiagnostic {
+  severity: IngestionDiagnosticSeverity;
+  stage: IngestionDiagnosticStage;
+  code: string;
+  message: string;
+  remediation?: {
+    action: string;
+    hint: string;
+  };
+  rowNumber?: number;
+  field?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface IngestionQualityGate {
+  gate: string;
+  severity: IngestionDiagnosticSeverity;
+  passed: boolean;
+  message: string;
+  metric?: Record<string, unknown>;
+}
+
+export interface ImportSchemaDrift {
+  hasDrift: boolean;
+  baselineIngestionId?: string;
+  baselineCapturedAt?: string;
+  addedHeaders: string[];
+  removedHeaders: string[];
+  severity: IngestionDiagnosticSeverity;
+  trend?: {
+    historyWindow: number;
+    driftedRuns: number;
+    churnRate: number;
+    escalationThreshold: number;
+  };
+}
+
+export type ImportSourceProfile = "csv_generic" | "bank_statement" | "processor_export";
+
+export interface ImportContractReference {
+  schemaUri: string;
+  version: string;
+}
+
+export interface ImportWorkbenchPreview {
+  sourceSummary: {
+    fileName?: string;
+    sizeBytes: number;
+    totalRows: number;
+    headers: string[];
+    duplicateHeaders: string[];
+  };
+  mapping: {
+    provided: CSVColumnMapping | null;
+    detected: CSVColumnMapping;
+    effective: CSVColumnMapping;
+    requiredMissing: string[];
+  };
+  normalization: {
+    attemptedRows: number;
+    normalizedRows: number;
+    failedRows: number;
+    droppedRows: number;
+    defaultedFieldCounts: Record<string, number>;
+    sampleNormalizedRecords: NormalizedTransactionInput[];
+  };
+  diagnostics: IngestionDiagnostic[];
+  qualityGates: IngestionQualityGate[];
+  schemaDrift?: ImportSchemaDrift;
+  sourceProfile: ImportSourceProfile;
+  canProceed: boolean;
+  contract: ImportContractReference;
+}
+
 /**
  * Normalized transaction schema (internal format)
  */

--- a/packages/workhorse/src/settler_workhorse/handlers/import_validate.py
+++ b/packages/workhorse/src/settler_workhorse/handlers/import_validate.py
@@ -31,11 +31,67 @@ except ImportError:
 
 logger = get_logger("handlers.import_validate")
 
+IMPORT_WORKBENCH_CONTRACT = {
+    "schema_uri": "contracts/ingestion/import-workbench.schema.json",
+    "version": "1.0.0",
+}
+
 
 class ImportValidationError(Exception):
     """Error during import validation."""
 
     pass
+
+
+def _diag(severity: str, stage: str, code: str, message: str, **kwargs: Any) -> dict[str, Any]:
+    diagnostic = {
+        "severity": severity,
+        "stage": stage,
+        "code": code,
+        "message": message,
+    }
+    diagnostic.update({k: v for k, v in kwargs.items() if v is not None})
+    return diagnostic
+
+
+def _build_quality_gates(
+    stats: dict[str, Any], required_columns: list[str]
+) -> list[dict[str, Any]]:
+    total_rows = int(stats.get("total_rows", 0) or 0)
+    error_rows = int(stats.get("error_rows", 0) or 0)
+    missing_required = stats.get("missing_required", []) or []
+
+    return [
+        {
+            "gate": "required_columns_present",
+            "severity": "blocking",
+            "passed": len(missing_required) == 0 and len(required_columns) > 0,
+            "message": (
+                "Required columns present"
+                if len(missing_required) == 0
+                else f"Missing required columns: {', '.join(missing_required)}"
+            ),
+            "metric": {"required_columns": required_columns, "missing_required": missing_required},
+        },
+        {
+            "gate": "non_empty_import",
+            "severity": "blocking",
+            "passed": total_rows > 0,
+            "message": "Import has data rows" if total_rows > 0 else "Import has no data rows",
+            "metric": {"total_rows": total_rows},
+        },
+        {
+            "gate": "row_validation_success_ratio",
+            "severity": "warning",
+            "passed": total_rows > 0 and (total_rows - error_rows) / total_rows >= 0.8,
+            "message": (
+                "Validation ratio acceptable"
+                if total_rows > 0 and (total_rows - error_rows) / total_rows >= 0.8
+                else "Validation ratio below 80%"
+            ),
+            "metric": {"total_rows": total_rows, "error_rows": error_rows, "threshold": 0.8},
+        },
+    ]
 
 
 def validate_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -343,6 +399,38 @@ def handle_import_validate(job: Job) -> JobResult:
                 records_failed=0,
             )
 
+        diagnostics: list[dict[str, Any]] = []
+        missing_required = stats.get("missing_required", [])
+        if missing_required:
+            diagnostics.append(
+                _diag(
+                    "blocking",
+                    "mapping",
+                    "required_columns_missing",
+                    f"Missing required columns: {', '.join(missing_required)}",
+                    details={"missing_required": missing_required},
+                )
+            )
+
+        for row in preview_rows:
+            row_errors = row.get("errors", [])
+            for row_error in row_errors:
+                diagnostics.append(
+                    _diag(
+                        "warning",
+                        "normalize",
+                        "row_validation_warning",
+                        str(row_error),
+                        row_number=row.get("row_number"),
+                    )
+                )
+
+        quality_gates = _build_quality_gates(stats, required_columns)
+        can_proceed = all(
+            gate.get("passed", False) or gate.get("severity") != "blocking"
+            for gate in quality_gates
+        ) and not any(diag.get("severity") == "blocking" for diag in diagnostics)
+
         return JobResult(
             success=True,
             data={
@@ -356,8 +444,12 @@ def handle_import_validate(job: Job) -> JobResult:
                 "statistics": stats,
                 "preview_rows": preview_rows,
                 "column_mapping": column_mapping,
+                "diagnostics": diagnostics[:50],
+                "quality_gates": quality_gates,
+                "can_proceed": can_proceed,
                 "idempotency_key": idempotency_key,
                 "validated_at": datetime.utcnow().isoformat(),
+                "contract": IMPORT_WORKBENCH_CONTRACT,
             },
             records_processed=stats.get("total_rows", 0),
             records_failed=stats.get("error_rows", 0),

--- a/packages/workhorse/src/settler_workhorse/handlers/ingest_normalize.py
+++ b/packages/workhorse/src/settler_workhorse/handlers/ingest_normalize.py
@@ -12,6 +12,11 @@ from settler_workhorse.worker import register_handler
 
 logger = get_logger("handlers.ingest_normalize")
 
+IMPORT_WORKBENCH_CONTRACT = {
+    "schema_uri": "contracts/ingestion/import-workbench.schema.json",
+    "version": "1.0.0",
+}
+
 
 class NormalizationError(Exception):
     """Error during data normalization."""
@@ -36,6 +41,8 @@ def normalize_csv_data(
     """
     canonical_records = []
     errors = []
+    diagnostics: list[dict[str, Any]] = []
+    defaulted_currency_count = 0
 
     for idx, record in enumerate(records):
         try:
@@ -52,6 +59,15 @@ def normalize_csv_data(
                     normalized["amount"] = float(amount)
                 except (ValueError, TypeError):
                     errors.append({"row": idx + 1, "field": "amount", "error": "Invalid amount"})
+                    diagnostics.append(
+                        {
+                            "severity": "blocking",
+                            "stage": "normalize",
+                            "code": "invalid_amount",
+                            "message": "Invalid amount",
+                            "row_number": idx + 1,
+                        }
+                    )
                     normalized["amount"] = None
 
             # Date normalization
@@ -71,19 +87,65 @@ def normalize_csv_data(
 
             # Currency normalization (default to USD)
             currency = record.get("currency", "USD")
-            normalized["currency"] = str(currency).upper() if currency else "USD"
+            normalized_currency = str(currency).upper() if currency else "USD"
+            if not currency:
+                defaulted_currency_count += 1
+                diagnostics.append(
+                    {
+                        "severity": "info",
+                        "stage": "normalize",
+                        "code": "currency_defaulted",
+                        "message": "Currency defaulted to USD",
+                        "row_number": idx + 1,
+                    }
+                )
+            normalized["currency"] = normalized_currency
 
             canonical_records.append(normalized)
 
         except Exception as e:
             errors.append({"row": idx + 1, "error": str(e)})
+            diagnostics.append(
+                {
+                    "severity": "warning",
+                    "stage": "normalize",
+                    "code": "row_normalization_failure",
+                    "message": str(e),
+                    "row_number": idx + 1,
+                }
+            )
             logger.warning(f"Failed to normalize row {idx + 1}", error=str(e))
 
+    input_count = len(records)
+    output_count = len(canonical_records)
+    quality_gates = [
+        {
+            "gate": "non_empty_import",
+            "severity": "blocking",
+            "passed": input_count > 0,
+            "message": "Input contains rows" if input_count > 0 else "Input is empty",
+        },
+        {
+            "gate": "normalization_success_ratio",
+            "severity": "warning",
+            "passed": input_count > 0 and output_count / input_count >= 0.8,
+            "message": (
+                "Normalization ratio acceptable"
+                if input_count > 0 and output_count / input_count >= 0.8
+                else "Normalization ratio below threshold"
+            ),
+            "metric": {"input_count": input_count, "output_count": output_count, "threshold": 0.8},
+        },
+    ]
+
     return {
-        "input_count": len(records),
-        "output_count": len(canonical_records),
+        "input_count": input_count,
+        "output_count": output_count,
         "schema_version": schema_version,
         "errors": errors[:50],  # Limit error reporting
+        "diagnostics": diagnostics[:50],
+        "quality_gates": quality_gates,
+        "defaulted_field_counts": {"currency": defaulted_currency_count},
         "sample_output": canonical_records[:5] if canonical_records else [],
     }
 
@@ -149,6 +211,7 @@ def handle_ingest_normalize(job: Job) -> JobResult:
                 "output_count": 0,
                 "schema_version": schema_version,
                 "message": "No input data - safe no-op",
+                "contract": IMPORT_WORKBENCH_CONTRACT,
             },
             records_processed=0,
             records_failed=0,
@@ -172,7 +235,15 @@ def handle_ingest_normalize(job: Job) -> JobResult:
                 "output_count": result["output_count"],
                 "schema_version": result["schema_version"],
                 "errors_count": len(result["errors"]),
+                "diagnostics": result.get("diagnostics", []),
+                "quality_gates": result.get("quality_gates", []),
+                "defaulted_field_counts": result.get("defaulted_field_counts", {}),
                 "sample_output": result["sample_output"],
+                "can_proceed": not any(
+                    gate.get("severity") == "blocking" and not gate.get("passed")
+                    for gate in result.get("quality_gates", [])
+                ),
+                "contract": IMPORT_WORKBENCH_CONTRACT,
             },
             records_processed=result["output_count"],
             records_failed=len(result["errors"]),


### PR DESCRIPTION
### Motivation

- Provide a machine-readable, runtime-neutral import workbench preview to validate CSV uploads before persistence and to surface diagnostics for operators. 
- Surface lightweight quality gates and schema-drift detection to decide go/no-go for uploads and enable safe remap-and-retry flows. 
- Expose recent workbench summaries to the platform control plane and persist bounded workbench metadata on ingestions for diagnostics/recovery. 

### Description

- Introduces a JSON Schema at `contracts/ingestion/import-workbench.schema.json` and a typed `ImportWorkbenchPreview` implementation used by workhorse and API services. 
- Adds preview generation in the CSV importer (`buildImportWorkbenchPreview`) including diagnostics, remediation hints, quality gates, schema-drift detection/trend, mapping detection/validation, normalization sampling, and a `canProceed` decision. 
- Exposes new API endpoints: `POST /api/v1/ingestion/preview`, `GET /api/v1/ingestion/workbench/recent`, and `POST /api/v1/ingestion/:ingestionId/retry` (supports `dryRun` and remap-and-retry), and augments `POST /api/v1/ingestion/upload` to return and persist a workbench preview summary in ingestion `metadata.importWorkbench`. 
- Adds control-plane linkage by returning `importWorkbench` summary from `/platform-control-plane/overview` and a helper `getRecentImportWorkbenchSummary`. 
- Extends types (`services/ingestion/types.ts`) for diagnostics, quality gates, schema drift and contract references and updates parsing/normalization logic (improved amount/date parsing, currency defaulting) with remediation hints. 
- Updates workhorse handlers (`import_validate.py`, `ingest_normalize.py`) to emit diagnostics, quality gates, `can_proceed`, defaulted field counts and the contract reference. 
- Fixes tenant scoping for raw record updates in `batchCreateNormalizedTransactions` and adds column-mapping parsing helpers and previous-baseline lookup for drift detection. 
- Adds unit tests for the preview route (`ingestion-preview.route.test.ts`) and expanded CSV importer contract tests (`csv-importer.test.ts`) and wires DB mocks for tenant-scoped queries. 

### Testing

- Ran unit tests including `packages/api/src/routes/v1/__tests__/ingestion-preview.route.test.ts` and `packages/api/src/services/ingestion/__tests__/csv-importer.test.ts` via `yarn test`; the new tests passed. 
- Exercised preview generation logic in unit tests to validate diagnostics, quality gates, schema-drift behavior, `canProceed` decisions, and sample normalized outputs; assertions succeeded. 
- Exercised route-level tests that validate tenant-scoped DB queries for preview, recent workbench listing, and retry flows; assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0804cc048832889981901259be18d)