### PR TITLE
Add canonical event protocol, normalize event bus, enforce taxonomy with lint/CI guard

### DIFF
--- a/.github/workflows/event-protocol-guard.yml
+++ b/.github/workflows/event-protocol-guard.yml
@@ -1,0 +1,32 @@
+name: Event Protocol Guard
+
+on:
+  pull_request:
+    paths:
+      - "platform/**"
+      - "packages/api/src/services/events/**"
+      - "packages/api/src/services/recon-core/**"
+      - "packages/api/src/services/support/**"
+      - "packages/api/src/services/webhooks/**"
+      - "packages/api/src/services/alerts/**"
+      - "scripts/verify-event-taxonomy.ts"
+      - "tools/eslint-rules/event-taxonomy-rule.js"
+      - "eslint.config.js"
+      - "package.json"
+
+jobs:
+  verify-event-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.13.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run verify:event-taxonomy
+      - run: pnpm --filter @settler/api exec jest src/services/events/__tests__/event-bus.contract.test.ts --runInBand
+      - run: pnpm --filter @settler/api exec jest src/__tests__/reconciliation/ReconciliationService.test.ts --runInBand

--- a/docs/architecture/canonical-event-protocol.md
+++ b/docs/architecture/canonical-event-protocol.md
@@ -1,0 +1,105 @@
+# Canonical Internal Event Protocol
+
+This document defines the baseline contract for internal platform events used by execution telemetry, replay, alerting, operator views, support/triage linkage, and webhook-derived flows.
+
+## Canonical envelope
+
+Important internal events must use the `PlatformEvent` envelope in `platform/primitives.ts`.
+
+Required/common fields:
+
+- `eventId`: immutable event identifier
+- `eventType`: canonical event taxonomy value (dot-separated)
+- `eventVersion`: schema version for the event family (default `1`)
+- `occurredAt`: event occurrence timestamp (`ISO-8601`)
+- `tenantId`: tenant ownership boundary
+- `executionId`: execution linkage (or best available execution scope)
+- `correlation`: cross-system correlation block
+  - `correlationId` (required)
+  - `tenantId` (required)
+  - optional links: `traceId`, `causationId`, `runId`, `actorId`, `alertId`, `replayId`, `supportIssueId`
+- `source`: producer component (`platform.runtime`, `platform.tests`, etc.)
+- `severity`: `debug|info|warning|error|critical`
+- `payload`: event-specific fields
+- `metadata`: optional producer metadata
+
+## Naming and taxonomy
+
+Event types are dot-separated verbs/nouns with consistent tense:
+
+- lifecycle: `execution.started`, `execution.completed`, `execution.failed`
+- connectors: `connector.sync.started`, `connector.sync.completed`, `connector.sync.failed`
+- policy: `policy.evaluated`
+- replay: `replay.started`, `replay.completed`, `replay.failed`
+- alerts: `alert.created`, `alert.status.changed`
+- support: `support.issue.created`, `support.issue.linked`
+- webhooks: `webhook.received`, `webhook.rejected`
+- operator/stream/degraded state: `operator.action.executed`, `stream.event.emitted`, `system.degraded`
+
+## Compatibility and evolution rules
+
+1. **Never silently break existing payloads.**
+2. **Bump `eventVersion` for breaking schema changes.**
+3. **Prefer additive fields for non-breaking changes.**
+4. **Maintain temporary alias normalization for renamed event types.**
+5. **Unknown event types must never silently coerce to a business event. Emit `system.degraded` with machine-visible metadata.**
+6. **Consumers should parse both canonical and known legacy payload keys during migrations.**
+
+Current alias normalization is implemented in `platform/event-protocol.ts`:
+
+- `connector.sync.succeeded` → `connector.sync.completed`
+- `execution.done` → `execution.completed`
+
+## Producer and consumer alignment rules
+
+- Producers should emit canonical fields instead of relying on consumer inference.
+- Consumers should call `normalizePlatformEvent()` before routing/processing.
+- Correlation fields must be propagated end-to-end (tenant, execution, run, actor where available).
+- Tenant filtering must remain based on canonical `tenantId`.
+
+## How to add a new event type safely
+
+1. Add the new type to `PlatformEventType` in `platform/primitives.ts`.
+2. Add normalization and alias mapping (if replacing an older name) in `platform/event-protocol.ts`.
+3. Update producers to emit the canonical envelope.
+4. Update relevant consumers to avoid guessing missing semantics.
+5. Add contract tests in `platform/__tests__/event-protocol.test.ts` and targeted consumer tests.
+
+## Anti-patterns
+
+- Ad hoc event names per module for the same domain concept.
+- Missing correlation fields on operationally significant events.
+- Consumer-only fixes without producer contract updates.
+- Breaking payload changes without `eventVersion` handling.
+
+## CI taxonomy guard
+
+Two layers now enforce taxonomy hygiene:
+
+1. **AST lint rule** (`local/event-taxonomy`) in `eslint.config.js` blocks unknown or dynamic event types at authoring time.
+2. **CI verifier** `pnpm run verify:event-taxonomy` parses TypeScript AST and fails on unknown event taxonomy usage.
+
+The guard fails when:
+
+- `eventBus.emitEvent("...")` uses an unknown event type.
+- `eventBus.emitEvent(...)` uses dynamic event-type expressions.
+- `platform/*` event literals use unknown types outside canonical or alias sets.
+
+## Producer migration status
+
+- `packages/api/src/services/recon-core/recon-core-engine.ts` emits canonical reconciliation families directly.
+- `packages/api/src/services/support/support-intake-service.ts` emits `support.issue.created` with actor/run correlation context.
+- `packages/api/src/services/webhooks/webhook-service.ts` emits `webhook.received` and `webhook.rejected` on delivery flows.
+- `packages/api/src/services/alerts/manager.ts` emits `alert.created` and `alert.status.changed` for lifecycle observability.
+- `packages/api/src/services/events/event-bus.ts` canonicalizes legacy names, handles v1→v2 adapters, and persists degraded events into operator runtime stream audits.
+- Legacy producer names are accepted only through explicit alias mapping; unknown names are converted to `system.degraded` and marked in metadata/payload.
+
+## Merge gate policy
+
+Workflow `.github/workflows/event-protocol-guard.yml` enforces protocol checks on PRs touching event surfaces.
+
+Required checks for those PRs:
+
+- `pnpm run verify:event-taxonomy`
+- `@settler/api` event contract tests (`event-bus.contract.test.ts`)
+- reconciliation contract regression tests (`ReconciliationService.test.ts`)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@
 
 const tseslint = require("@typescript-eslint/eslint-plugin");
 const tsparser = require("@typescript-eslint/parser");
+const eventTaxonomyRule = require("./tools/eslint-rules/event-taxonomy-rule");
 
 module.exports = [
   {
@@ -70,6 +71,25 @@ module.exports = [
     },
   },
 
+  {
+    files: [
+      "platform/**/*.ts",
+      "packages/api/src/services/**/*.ts",
+      "packages/web/src/app/api/**/*.ts",
+      "scripts/**/*.ts",
+    ],
+    ignores: ["**/__tests__/**"],
+    plugins: {
+      local: {
+        rules: {
+          "event-taxonomy": eventTaxonomyRule,
+        },
+      },
+    },
+    rules: {
+      "local/event-taxonomy": "error",
+    },
+  },
   {
     files: ["packages/web/src/app/(marketing)/**/*.{ts,tsx,js,jsx}"],
     rules: {

--- a/package.json
+++ b/package.json
@@ -262,7 +262,8 @@
     "verify:release:artifacts": "node scripts/release/verify-artifacts.mjs",
     "release:dry-run": "pnpm run verify:release && pnpm run release:artifacts && pnpm run verify:release:artifacts",
     "generate:api-route-inventory": "tsx scripts/generate-api-route-inventory.ts",
-    "verify:api-route-inventory": "tsx scripts/verify-api-route-inventory.ts"
+    "verify:api-route-inventory": "tsx scripts/verify-api-route-inventory.ts",
+    "verify:event-taxonomy": "tsx scripts/verify-event-taxonomy.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/api/src/services/alerts/manager.ts
+++ b/packages/api/src/services/alerts/manager.ts
@@ -5,6 +5,7 @@
 
 import { logError, logWarn, logInfo } from "../../utils/logger";
 import { query } from "../../db";
+import { eventBus } from "../events/event-bus";
 
 export enum AlertSeverity {
   LOW = "low",
@@ -69,6 +70,33 @@ export async function createAlert(
     //   await sendPagerDutyAlert(alertId, type, message, details);
     // }
 
+    const tenantId =
+      typeof details?.tenantId === "string" && details.tenantId.length > 0
+        ? details.tenantId
+        : "system";
+    await eventBus.emitEvent(
+      "alert.created",
+      tenantId,
+      {
+        alertId,
+        type,
+        severity,
+        message,
+        details: details ?? {},
+      },
+      {
+        correlationId: `alert:${tenantId}:${alertId}:created`,
+        executionId: alertId,
+        source: "api.alert-manager",
+        severity:
+          severity === AlertSeverity.CRITICAL
+            ? "critical"
+            : severity === AlertSeverity.HIGH
+              ? "error"
+              : "warning",
+      }
+    );
+
     return alertId;
   } catch (error) {
     logError("Failed to create alert", error, { type, severity, message });
@@ -86,6 +114,21 @@ export async function resolveAlert(alertId: string): Promise<void> {
        SET resolved = TRUE, resolved_at = NOW()
        WHERE id = $1`,
       [alertId]
+    );
+
+    await eventBus.emitEvent(
+      "alert.status.changed",
+      "system",
+      {
+        alertId,
+        status: "resolved",
+      },
+      {
+        correlationId: `alert:system:${alertId}:resolved`,
+        executionId: alertId,
+        source: "api.alert-manager",
+        severity: "info",
+      }
     );
 
     logInfo("Alert resolved", { alertId });
@@ -130,32 +173,34 @@ export async function getUnresolvedAlerts(severity?: AlertSeverity): Promise<Ale
       resolved_at: Date | null;
     }>(queryStr, params as (string | number | boolean | Date | null)[]);
 
-    return results.map((r: {
-      id: string;
-      type: string;
-      severity: string;
-      message: string;
-      details: string | null;
-      resolved: boolean;
-      created_at: Date;
-      resolved_at: Date | null;
-    }) => {
-      const alert: Alert = {
-        id: r.id,
-        type: r.type,
-        severity: r.severity as AlertSeverity,
-        message: r.message,
-        resolved: r.resolved,
-        createdAt: r.created_at,
-      };
-      if (r.details) {
-        alert.details = JSON.parse(r.details) as Record<string, unknown>;
+    return results.map(
+      (r: {
+        id: string;
+        type: string;
+        severity: string;
+        message: string;
+        details: string | null;
+        resolved: boolean;
+        created_at: Date;
+        resolved_at: Date | null;
+      }) => {
+        const alert: Alert = {
+          id: r.id,
+          type: r.type,
+          severity: r.severity as AlertSeverity,
+          message: r.message,
+          resolved: r.resolved,
+          createdAt: r.created_at,
+        };
+        if (r.details) {
+          alert.details = JSON.parse(r.details) as Record<string, unknown>;
+        }
+        if (r.resolved_at) {
+          alert.resolvedAt = r.resolved_at;
+        }
+        return alert;
       }
-      if (r.resolved_at) {
-        alert.resolvedAt = r.resolved_at;
-      }
-      return alert;
-    });
+    );
   } catch (error) {
     logError("Failed to get unresolved alerts", error);
     return [];

--- a/packages/api/src/services/events/__tests__/event-bus.contract.test.ts
+++ b/packages/api/src/services/events/__tests__/event-bus.contract.test.ts
@@ -1,0 +1,109 @@
+import { adaptEventToVersion2, EventBus } from "../event-bus";
+
+describe("EventBus canonical contract", () => {
+  it("canonicalizes legacy event names and propagates correlation", async () => {
+    const bus = new EventBus();
+    const received: any[] = [];
+
+    bus.subscribe("reconciliation.completed", async (event) => {
+      received.push(event);
+    });
+
+    await bus.emitEvent(
+      "recon.completed",
+      "tenant-1",
+      {
+        reconJobId: "job-1",
+        reconResultId: "run-1",
+      },
+      {
+        correlationId: "corr-1",
+        runId: "run-1",
+        executionId: "run-1",
+        actorId: "operator-1",
+      }
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0].eventType).toBe("reconciliation.completed");
+    expect(received[0].eventVersion).toBe(1);
+    expect(received[0].correlation.correlationId).toBe("corr-1");
+    expect(received[0].correlation.tenantId).toBe("tenant-1");
+  });
+
+  it("emits machine-visible degraded event for unknown type", async () => {
+    const bus = new EventBus();
+    const received: any[] = [];
+
+    bus.subscribe("system.degraded", async (event) => {
+      received.push(event);
+    });
+
+    await bus.emitEvent("totally.unknown" as any, "tenant-1", { foo: "bar" });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].eventType).toBe("system.degraded");
+    expect(received[0].severity).toBe("warning");
+    expect(received[0].metadata.protocol_degraded).toBe(true);
+    expect(received[0].payload.unknown_event_type).toBe("totally.unknown");
+  });
+
+  it("preserves tenant-scoped correlation across replay/alert/support/webhook families", async () => {
+    const bus = new EventBus();
+    const t1: string[] = [];
+    const t2: string[] = [];
+
+    bus.subscribe("*", async (event) => {
+      if (event.tenantId === "tenant-1") t1.push(event.eventType);
+      if (event.tenantId === "tenant-2") t2.push(event.eventType);
+    });
+
+    await bus.emitEvent(
+      "replay.started",
+      "tenant-1",
+      { replayId: "rep-1" },
+      { correlationId: "c-r1" }
+    );
+    await bus.emitEvent("alert.created", "tenant-2", { alertId: "a-2" }, { correlationId: "c-a2" });
+    await bus.emitEvent(
+      "support.issue.created",
+      "tenant-1",
+      { ticketId: "s-1" },
+      { correlationId: "c-s1" }
+    );
+    await bus.emitEvent(
+      "webhook.received",
+      "tenant-2",
+      { deliveryId: "w-2" },
+      { correlationId: "c-w2" }
+    );
+
+    expect(t1).toEqual(["replay.started", "support.issue.created"]);
+    expect(t2).toEqual(["alert.created", "webhook.received"]);
+  });
+
+  it("adapts v1 payload to v2 format", () => {
+    const v1 = {
+      eventId: "ev-1",
+      idempotencyKey: "ik-1",
+      tenantId: "tenant-1",
+      executionId: "exec-1",
+      eventType: "execution.completed",
+      eventVersion: 1,
+      sequence: 1,
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      source: "api.tests",
+      severity: "info",
+      metadata: {},
+      correlation: { correlationId: "corr-1", tenantId: "tenant-1" },
+      payload: { run_fingerprint: "fp-1", connector_id: "stripe" },
+    } as any;
+
+    const v2 = adaptEventToVersion2(v1);
+    expect(v2.eventVersion).toBe(2);
+    expect(v2.payload.runFingerprint).toBe("fp-1");
+    expect(v2.payload.connectorId).toBe("stripe");
+    expect(v2.metadata.payload_adapter).toBe("v1_to_v2");
+  });
+});

--- a/packages/api/src/services/events/event-bus.ts
+++ b/packages/api/src/services/events/event-bus.ts
@@ -1,117 +1,326 @@
 /**
  * Event Bus
- * 
- * Internal event bus for platform coordination
- * Part of Phase VIII: Future-Proof Architecture
+ *
+ * Internal event bus for platform coordination.
+ * Uses a canonical event envelope with explicit versioning,
+ * correlation and degraded-state signaling.
  */
 
-import { EventEmitter } from 'events';
-import { logInfo, logError } from '../../utils/logger';
+import { EventEmitter } from "events";
+import { logInfo, logError, logWarn } from "../../utils/logger";
+import { emitOperatorRuntimeEvent } from "../ops-intelligence/runtime-events";
 
-export type EventType =
-  | 'recon.completed'
-  | 'recon.failed'
-  | 'validation.failed'
-  | 'mapping.suggested'
-  | 'drift.detected'
-  | 'workflow.failed'
-  | 'audit.ready'
-  | 'contract.breaking_change'
-  | 'usage.limit_exceeded'
-  | 'agent.fallback'
-  | 'value.reconciliation_completed'
-  | 'value.errors_prevented';
+export type CanonicalEventType =
+  | "reconciliation.completed"
+  | "reconciliation.failed"
+  | "reconciliation.value.realized"
+  | "reconciliation.errors.prevented"
+  | "validation.failed"
+  | "mapping.suggested"
+  | "drift.detected"
+  | "workflow.failed"
+  | "audit.ready"
+  | "contract.breaking_change"
+  | "usage.limit_exceeded"
+  | "agent.fallback"
+  | "system.degraded"
+  | "alert.created"
+  | "alert.status.changed"
+  | "webhook.received"
+  | "webhook.rejected"
+  | "support.issue.created"
+  | "support.issue.linked"
+  | "replay.started"
+  | "replay.completed"
+  | "replay.failed"
+  | "stream.event.emitted"
+  | "operator.action.executed";
+
+export type LegacyEventType =
+  | "recon.completed"
+  | "recon.failed"
+  | "value.reconciliation_completed"
+  | "value.errors_prevented";
+
+export type EventType = CanonicalEventType | LegacyEventType;
+
+const EVENT_TYPE_ALIASES: Record<LegacyEventType, CanonicalEventType> = {
+  "recon.completed": "reconciliation.completed",
+  "recon.failed": "reconciliation.failed",
+  "value.reconciliation_completed": "reconciliation.value.realized",
+  "value.errors_prevented": "reconciliation.errors.prevented",
+};
+
+const EVENT_TYPES: ReadonlySet<string> = new Set<string>([
+  "reconciliation.completed",
+  "reconciliation.failed",
+  "reconciliation.value.realized",
+  "reconciliation.errors.prevented",
+  "validation.failed",
+  "mapping.suggested",
+  "drift.detected",
+  "workflow.failed",
+  "audit.ready",
+  "contract.breaking_change",
+  "usage.limit_exceeded",
+  "agent.fallback",
+  "system.degraded",
+  "alert.created",
+  "alert.status.changed",
+  "webhook.received",
+  "webhook.rejected",
+  "support.issue.created",
+  "support.issue.linked",
+  "replay.started",
+  "replay.completed",
+  "replay.failed",
+  "stream.event.emitted",
+  "operator.action.executed",
+]);
 
 export interface PlatformEvent {
-  id: string;
-  type: EventType;
+  eventId: string;
+  idempotencyKey: string;
   tenantId: string;
-  timestamp: Date;
-  data: Record<string, unknown>;
+  executionId: string;
+  eventType: CanonicalEventType;
+  eventVersion: number;
+  sequence: number;
+  occurredAt: string;
+  createdAt: string;
+  source: string;
+  severity: "debug" | "info" | "warning" | "error" | "critical";
+  metadata: Record<string, unknown>;
+  correlation: {
+    correlationId: string;
+    tenantId: string;
+    traceId?: string;
+    causationId?: string;
+    runId?: string;
+    executionId?: string;
+    actorId?: string;
+  };
+  payload: Record<string, unknown>;
+}
+
+export interface EmitEventOptions {
+  correlationId?: string;
+  traceId?: string;
+  causationId?: string;
+  runId?: string;
+  executionId?: string;
+  actorId?: string;
+  source?: string;
+  severity?: PlatformEvent["severity"];
   metadata?: Record<string, unknown>;
 }
 
 export type EventHandler = (event: PlatformEvent) => Promise<void> | void;
 
-export class EventBus extends EventEmitter {
-  private handlers: Map<EventType, Set<EventHandler>> = new Map();
+export function adaptEventToVersion2(event: PlatformEvent): PlatformEvent {
+  if ((event.eventVersion ?? 1) >= 2) {
+    return event;
+  }
 
-  /**
-   * Subscribe to event type
-   */
-  subscribe(eventType: EventType, handler: EventHandler): () => void {
-    if (!this.handlers.has(eventType)) {
-      this.handlers.set(eventType, new Set());
+  const payload = { ...event.payload };
+  if (typeof payload.run_fingerprint === "string" && typeof payload.runFingerprint !== "string") {
+    payload.runFingerprint = payload.run_fingerprint;
+  }
+  if (typeof payload.connector_id === "string" && typeof payload.connectorId !== "string") {
+    payload.connectorId = payload.connector_id;
+  }
+
+  return {
+    ...event,
+    eventVersion: 2,
+    metadata: {
+      ...event.metadata,
+      adapted_from_version: event.eventVersion ?? 1,
+      payload_adapter: "v1_to_v2",
+    },
+    payload,
+  };
+}
+
+export class EventBus extends EventEmitter {
+  private handlers: Map<string, Set<EventHandler>> = new Map();
+  private sequence = 0;
+
+  private nextSequence(): number {
+    this.sequence += 1;
+    return this.sequence;
+  }
+
+  private canonicalizeEventType(eventType: EventType): CanonicalEventType {
+    const canonical = (EVENT_TYPE_ALIASES[eventType as LegacyEventType] ??
+      eventType) as CanonicalEventType;
+    if (EVENT_TYPES.has(canonical)) {
+      return canonical;
+    }
+    return "system.degraded";
+  }
+
+  private createEvent(
+    eventType: EventType,
+    tenantId: string,
+    payload: Record<string, unknown>,
+    options: EmitEventOptions = {}
+  ): PlatformEvent {
+    const occurredAt = new Date().toISOString();
+    const correlationId = options.correlationId ?? crypto.randomUUID();
+    const canonicalType = this.canonicalizeEventType(eventType);
+    const executionId =
+      options.executionId ?? String(payload.executionId ?? payload.reconResultId ?? "unknown");
+
+    const metadata: Record<string, unknown> = {
+      ...(options.metadata ?? {}),
+      producer_event_type: eventType,
+    };
+
+    const normalizedPayload = { ...payload };
+
+    if (canonicalType === "system.degraded") {
+      logWarn("Unknown event type received; emitting system.degraded event", {
+        eventType,
+        tenantId,
+        correlationId,
+      });
+      metadata.protocol_degraded = true;
+      metadata.unknown_event_type = eventType;
+      normalizedPayload.degraded_reason = "unknown_event_type";
+      normalizedPayload.unknown_event_type = eventType;
     }
 
-    this.handlers.get(eventType)!.add(handler);
-
-    // Return unsubscribe function
-    return () => {
-      this.handlers.get(eventType)?.delete(handler);
+    return {
+      eventId: crypto.randomUUID(),
+      idempotencyKey: correlationId,
+      tenantId,
+      executionId,
+      eventType: canonicalType,
+      eventVersion: 1,
+      sequence: this.nextSequence(),
+      occurredAt,
+      createdAt: occurredAt,
+      source: options.source ?? "api.recon-core",
+      severity: options.severity ?? (canonicalType === "system.degraded" ? "warning" : "info"),
+      metadata,
+      correlation: {
+        correlationId,
+        tenantId,
+        traceId: options.traceId,
+        causationId: options.causationId,
+        runId: options.runId,
+        executionId,
+        actorId: options.actorId,
+      },
+      payload: normalizedPayload,
     };
   }
 
-  /**
-   * Publish event
-   */
+  private async publishDegradedAudit(event: PlatformEvent): Promise<void> {
+    if (event.eventType !== "system.degraded") {
+      return;
+    }
+
+    if (process.env.NODE_ENV === "test") {
+      return;
+    }
+
+    try {
+      await emitOperatorRuntimeEvent({
+        eventType: "error_thrown",
+        tenantId: event.tenantId,
+        runId: event.correlation.runId ?? event.executionId,
+        metadata: {
+          source: event.source,
+          correlation_id: event.correlation.correlationId,
+          degraded_reason: event.payload.degraded_reason,
+          unknown_event_type: event.payload.unknown_event_type,
+          producer_event_type: event.metadata.producer_event_type,
+        },
+      });
+    } catch (error) {
+      logError("Failed to publish degraded event audit", error, {
+        eventId: event.eventId,
+        tenantId: event.tenantId,
+      });
+    }
+  }
+
+  subscribe(eventType: EventType | CanonicalEventType | "*", handler: EventHandler): () => void {
+    const key = eventType === "*" ? "*" : this.canonicalizeEventType(eventType);
+    if (!this.handlers.has(key)) {
+      this.handlers.set(key, new Set());
+    }
+
+    this.handlers.get(key)!.add(handler);
+
+    return () => {
+      this.handlers.get(key)?.delete(handler);
+    };
+  }
+
   async publish(event: PlatformEvent): Promise<void> {
     try {
-      logInfo('Event published', { eventType: event.type, eventId: event.id });
+      logInfo("Event published", {
+        eventType: event.eventType,
+        eventId: event.eventId,
+        tenantId: event.tenantId,
+        correlationId: event.correlation.correlationId,
+      });
 
-      // Emit to EventEmitter for backward compatibility
-      this.emit(event.type, event);
+      this.emit(event.eventType, event);
 
-      // Call registered handlers
-      const handlers = this.handlers.get(event.type);
+      const handlers = this.handlers.get(event.eventType);
       if (handlers) {
         for (const handler of handlers) {
           try {
             await handler(event);
           } catch (error) {
-            logError('Event handler failed', { error, eventType: event.type, eventId: event.id });
+            logError("Event handler failed", {
+              error,
+              eventType: event.eventType,
+              eventId: event.eventId,
+            });
           }
         }
       }
 
-      // Also call wildcard handlers
-      const wildcardHandlers = this.handlers.get('*' as EventType);
+      const wildcardHandlers = this.handlers.get("*");
       if (wildcardHandlers) {
         for (const handler of wildcardHandlers) {
           try {
             await handler(event);
           } catch (error) {
-            logError('Wildcard event handler failed', { error, eventType: event.type });
+            logError("Wildcard event handler failed", {
+              error,
+              eventType: event.eventType,
+              eventId: event.eventId,
+            });
           }
         }
       }
+
+      await this.publishDegradedAudit(event);
     } catch (error) {
-      logError('Failed to publish event', { error, event });
+      logError("Failed to publish event", {
+        error,
+        eventType: event.eventType,
+        eventId: event.eventId,
+      });
       throw error;
     }
   }
 
-  /**
-   * Create and publish event
-   */
   async emitEvent(
     type: EventType,
     tenantId: string,
-    data: Record<string, unknown>,
-    metadata?: Record<string, unknown>
+    payload: Record<string, unknown>,
+    options?: EmitEventOptions
   ): Promise<void> {
-    const event: PlatformEvent = {
-      id: `evt_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-      type,
-      tenantId,
-      timestamp: new Date(),
-      data,
-      ...(metadata !== undefined && { metadata }),
-    };
-
+    const event = this.createEvent(type, tenantId, payload, options);
     await this.publish(event);
   }
 }
 
-// Singleton instance
 export const eventBus = new EventBus();

--- a/packages/api/src/services/recon-core/recon-core-engine.ts
+++ b/packages/api/src/services/recon-core/recon-core-engine.ts
@@ -244,34 +244,58 @@ export class ReconCoreEngine {
       // Step 9.5: Record value events (reconciliation completed, anomalies detected)
       if (billingAccount) {
         try {
-          await eventBus.emitEvent("value.reconciliation_completed", tenantId, {
-            billingAccountId: billingAccount.id,
+          await eventBus.emitEvent(
+            "reconciliation.value.realized",
             tenantId,
-            userId: reconJob.userId,
-            matchedCount: results.matchedCount,
-            unmatchedCount: results.unmatchedSourceCount + results.unmatchedTargetCount,
-            totalAmount: results.totalAmountMatched
-              ? Number(results.totalAmountMatched)
-              : undefined,
-            jobId: reconJobId,
-            runId: updatedResult.id,
-          });
-
-          const totalUnmatched = results.unmatchedSourceCount + results.unmatchedTargetCount;
-          if (totalUnmatched > 0) {
-            await eventBus.emitEvent("value.errors_prevented", tenantId, {
+            {
               billingAccountId: billingAccount.id,
               tenantId,
               userId: reconJob.userId,
-              quantity: totalUnmatched,
-              unit: "anomaly",
-              metadata: {
-                source: "reconciliation_completed",
-                runId: updatedResult.id,
-                jobId: reconJobId,
-                matchedCount: results.matchedCount,
+              matchedCount: results.matchedCount,
+              unmatchedCount: results.unmatchedSourceCount + results.unmatchedTargetCount,
+              totalAmount: results.totalAmountMatched
+                ? Number(results.totalAmountMatched)
+                : undefined,
+              jobId: reconJobId,
+              runId: updatedResult.id,
+            },
+            {
+              correlationId: `recon:${tenantId}:${reconJobId}:${updatedResult.id}:value-realized`,
+              runId: updatedResult.id,
+              executionId: updatedResult.id,
+              actorId: reconJob.userId ?? undefined,
+              source: "api.recon-core",
+              severity: "info",
+            }
+          );
+
+          const totalUnmatched = results.unmatchedSourceCount + results.unmatchedTargetCount;
+          if (totalUnmatched > 0) {
+            await eventBus.emitEvent(
+              "reconciliation.errors.prevented",
+              tenantId,
+              {
+                billingAccountId: billingAccount.id,
+                tenantId,
+                userId: reconJob.userId,
+                quantity: totalUnmatched,
+                unit: "anomaly",
+                metadata: {
+                  source: "reconciliation_completed",
+                  runId: updatedResult.id,
+                  jobId: reconJobId,
+                  matchedCount: results.matchedCount,
+                },
               },
-            });
+              {
+                correlationId: `recon:${tenantId}:${reconJobId}:${updatedResult.id}:errors-prevented`,
+                runId: updatedResult.id,
+                executionId: updatedResult.id,
+                actorId: reconJob.userId ?? undefined,
+                source: "api.recon-core",
+                severity: "warning",
+              }
+            );
           }
         } catch (valueError) {
           logError("[ReconCoreEngine] Failed to emit value events", valueError);
@@ -287,11 +311,23 @@ export class ReconCoreEngine {
       });
 
       // Step 11: Emit event
-      await eventBus.emitEvent("recon.completed", tenantId, {
-        reconJobId,
-        reconResultId: updatedResult.id,
-        summary: results.summary,
-      });
+      await eventBus.emitEvent(
+        "reconciliation.completed",
+        tenantId,
+        {
+          reconJobId,
+          reconResultId: updatedResult.id,
+          summary: results.summary,
+        },
+        {
+          correlationId: `recon:${tenantId}:${reconJobId}:${updatedResult.id}:completed`,
+          runId: updatedResult.id,
+          executionId: updatedResult.id,
+          actorId: reconJob.userId ?? undefined,
+          source: "api.recon-core",
+          severity: "info",
+        }
+      );
 
       // Step 12: Send completion notification if there are exceptions
       if (results.unmatchedSourceCount > 0 || results.unmatchedTargetCount > 0) {
@@ -370,11 +406,24 @@ export class ReconCoreEngine {
       });
 
       // Emit event
-      await eventBus.emitEvent("recon.failed", tenantId, {
-        reconJobId,
-        reconResultId: failedResult.id,
-        error: errorMessage,
-      });
+      await eventBus.emitEvent(
+        "reconciliation.failed",
+        tenantId,
+        {
+          reconJobId,
+          reconResultId: failedResult.id,
+          error: errorMessage,
+        },
+        {
+          correlationId: `recon:${tenantId}:${reconJobId}:${failedResult.id}:failed`,
+          runId: failedResult.id,
+          executionId: failedResult.id,
+          actorId: reconJob.userId ?? undefined,
+          source: "api.recon-core",
+          severity: "error",
+          metadata: { failure_stage: "execute" },
+        }
+      );
 
       logError("Recon job execution failed", { error, reconJobId, tenantId });
       throw error;

--- a/packages/api/src/services/support/support-intake-service.ts
+++ b/packages/api/src/services/support/support-intake-service.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import { query } from "../../db";
 import { logError } from "../../utils/logger";
 import { supportIntakeSubmissionSchema, SupportIntakeSubmission } from "./support-intake-contract";
+import { eventBus } from "../events/event-bus";
 
 export interface StoredSupportIntake {
   submissionId: string;
@@ -30,6 +31,26 @@ export async function submitSupportIntake(params: {
       submissionId,
       payload: parsed,
     });
+
+    await eventBus.emitEvent(
+      "support.issue.created",
+      params.tenantId,
+      {
+        submissionId,
+        category: parsed.category,
+        runId: parsed.run_id ?? null,
+        route: parsed.route ?? null,
+        module: parsed.module ?? null,
+      },
+      {
+        correlationId: `support:${params.tenantId}:${submissionId}`,
+        runId: parsed.run_id ?? undefined,
+        executionId: parsed.run_id ?? submissionId,
+        actorId: params.userId,
+        source: "api.support-intake",
+        severity: "info",
+      }
+    );
   } catch (error) {
     logError("Failed to persist support intake submission", error, {
       tenantId: params.tenantId,

--- a/packages/api/src/services/webhooks/webhook-service.ts
+++ b/packages/api/src/services/webhooks/webhook-service.ts
@@ -8,6 +8,7 @@
 import { PrismaClient, Prisma } from "@prisma/client";
 import crypto from "crypto";
 import { logError, logInfo, logWarn } from "../../utils/logger";
+import { eventBus } from "../events/event-bus";
 
 /**
  * Standard webhook event payload structure
@@ -277,6 +278,24 @@ export class WebhookService {
       }
 
       if (!isSuccess) {
+        await eventBus.emitEvent(
+          "webhook.rejected",
+          event.tenantId,
+          {
+            webhookId,
+            eventType: event.type,
+            statusCode: response.status,
+            deliveryId: deliveryRecord.id,
+            reason: "delivery_failed",
+          },
+          {
+            correlationId: idempotencyKey ?? `webhook:${event.tenantId}:${event.id}:rejected`,
+            runId: String(event.data.runId ?? event.data.reconResultId ?? "unknown"),
+            executionId: String(event.data.reconResultId ?? event.id),
+            source: "api.webhook-service",
+            severity: "warning",
+          }
+        );
         logError("Webhook delivery failed", {
           webhookId,
           status: response.status,
@@ -324,6 +343,25 @@ export class WebhookService {
           error: errorMessage,
         });
       }
+
+      await eventBus.emitEvent(
+        "webhook.rejected",
+        event.tenantId,
+        {
+          webhookId,
+          eventType: event.type,
+          reason: "delivery_exception",
+          error: errorMessage,
+          deliveryId: failedDelivery.id,
+        },
+        {
+          correlationId: idempotencyKey ?? `webhook:${event.tenantId}:${event.id}:exception`,
+          runId: String(event.data.runId ?? event.data.reconResultId ?? "unknown"),
+          executionId: String(event.data.reconResultId ?? event.id),
+          source: "api.webhook-service",
+          severity: "error",
+        }
+      );
 
       logError("Webhook delivery failed", {
         webhookId,
@@ -388,6 +426,23 @@ export class WebhookService {
         replayCount: 0,
       },
     };
+
+    await eventBus.emitEvent(
+      "webhook.received",
+      tenantId,
+      {
+        webhookCount: subscribedWebhooks.length,
+        eventType,
+        eventId: event.id,
+      },
+      {
+        correlationId: idempotencyKey,
+        runId: String(eventData.runId ?? eventData.reconResultId ?? "unknown"),
+        executionId: String(eventData.reconResultId ?? event.id),
+        source: "api.webhook-service",
+        severity: "info",
+      }
+    );
 
     // Queue delivery for each webhook
     for (const webhook of subscribedWebhooks) {

--- a/platform/__tests__/event-family-contracts.test.ts
+++ b/platform/__tests__/event-family-contracts.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { createPlatformEvent, validatePlatformEventContract } from "../event-protocol";
+
+function expectValid(event: ReturnType<typeof createPlatformEvent>): void {
+  const errors = validatePlatformEventContract(event);
+  expect(errors).toEqual([]);
+}
+
+describe("event family contracts", () => {
+  it("validates replay event contract", () => {
+    const event = createPlatformEvent({
+      eventId: "replay-1",
+      tenantId: "tenant-a",
+      executionId: "run-a",
+      eventType: "replay.started",
+      sequence: 1,
+      source: "platform.tests",
+      correlation: {
+        correlationId: "corr-replay",
+        tenantId: "tenant-a",
+        runId: "run-a",
+      },
+      payload: { replayId: "rep-1", originalExecutionId: "run-o" },
+    });
+    expectValid(event);
+    expect(event.payload.replayId).toBe("rep-1");
+  });
+
+  it("validates alert event contract", () => {
+    const event = createPlatformEvent({
+      eventId: "alert-1",
+      tenantId: "tenant-a",
+      executionId: "alert-1",
+      eventType: "alert.created",
+      sequence: 2,
+      source: "platform.tests",
+      severity: "warning",
+      correlation: {
+        correlationId: "corr-alert",
+        tenantId: "tenant-a",
+        alertId: "alert-1",
+      },
+      payload: { alertId: "alert-1", status: "open" },
+    });
+    expectValid(event);
+    expect(event.correlation.alertId).toBe("alert-1");
+  });
+
+  it("validates webhook event contract", () => {
+    const event = createPlatformEvent({
+      eventId: "webhook-1",
+      tenantId: "tenant-a",
+      executionId: "run-a",
+      eventType: "webhook.received",
+      sequence: 3,
+      source: "platform.tests",
+      correlation: {
+        correlationId: "corr-webhook",
+        tenantId: "tenant-a",
+        runId: "run-a",
+      },
+      payload: { provider: "stripe", deliveryId: "d1" },
+    });
+    expectValid(event);
+    expect(event.payload.provider).toBe("stripe");
+  });
+
+  it("validates support event contract", () => {
+    const event = createPlatformEvent({
+      eventId: "support-1",
+      tenantId: "tenant-a",
+      executionId: "ticket-1",
+      eventType: "support.issue.created",
+      sequence: 4,
+      source: "platform.tests",
+      correlation: {
+        correlationId: "corr-support",
+        tenantId: "tenant-a",
+        supportIssueId: "ticket-1",
+        actorId: "user-1",
+      },
+      payload: { ticketId: "ticket-1", category: "integration" },
+    });
+    expectValid(event);
+    expect(event.correlation.supportIssueId).toBe("ticket-1");
+  });
+});

--- a/platform/__tests__/event-protocol.test.ts
+++ b/platform/__tests__/event-protocol.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  createPlatformEvent,
+  normalizePlatformEvent,
+  validatePlatformEventContract,
+} from "../event-protocol";
+import type { PlatformEvent } from "../primitives";
+
+describe("event protocol", () => {
+  it("normalizes legacy event aliases and missing envelope fields", () => {
+    const legacy: PlatformEvent = {
+      eventId: "ev-legacy",
+      tenantId: "tenant-1",
+      executionId: "exec-1",
+      eventType: "connector.sync.succeeded" as any,
+      sequence: 7,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      correlation: {
+        correlationId: "corr-legacy",
+        tenantId: "tenant-1",
+      },
+      payload: { connector_id: "stripe" },
+    };
+
+    const normalized = normalizePlatformEvent(legacy);
+    expect(normalized.eventType).toBe("connector.sync.completed");
+    expect(normalized.eventVersion).toBe(1);
+    expect(normalized.idempotencyKey).toBe("corr-legacy");
+    expect(normalized.severity).toBe("info");
+    expect(normalized.source).toBe("platform.runtime");
+    expect(normalized.occurredAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("creates canonical event envelope with first-class correlation", () => {
+    const event = createPlatformEvent({
+      eventId: "ev-1",
+      tenantId: "tenant-1",
+      executionId: "exec-1",
+      eventType: "execution.completed",
+      sequence: 1,
+      source: "platform.tests",
+      severity: "info",
+      correlation: {
+        correlationId: "corr-1",
+        traceId: "trace-1",
+        tenantId: "tenant-1",
+        executionId: "exec-1",
+        runId: "run-1",
+        actorId: "operator-1",
+      },
+      payload: { runFingerprint: "fp-1" },
+    });
+
+    expect(event.eventVersion).toBe(1);
+    expect(event.idempotencyKey).toBe("corr-1");
+    expect(event.correlation.actorId).toBe("operator-1");
+    expect(event.eventType).toBe("execution.completed");
+  });
+
+  it("emits machine-visible degraded event for unknown types", () => {
+    const unknown = normalizePlatformEvent({
+      eventId: "ev-unknown",
+      tenantId: "tenant-1",
+      executionId: "exec-1",
+      eventType: "totally.unknown" as any,
+      sequence: 11,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      source: "platform.tests",
+      correlation: {
+        correlationId: "corr-unknown",
+        tenantId: "tenant-1",
+      },
+      payload: {},
+    });
+
+    expect(unknown.eventType).toBe("system.degraded");
+    expect(unknown.severity).toBe("warning");
+    expect(unknown.metadata?.protocol_degraded).toBe(true);
+    expect(unknown.payload.unknown_event_type).toBe("totally.unknown");
+  });
+
+  it("validates required contract fields", () => {
+    const invalid = {
+      eventId: "",
+      eventType: "",
+      eventVersion: 0,
+      tenantId: "",
+      executionId: "exec-1",
+      sequence: 1,
+      source: "",
+      correlation: { correlationId: "", tenantId: "" },
+      payload: undefined,
+    } as unknown as PlatformEvent;
+
+    const errors = validatePlatformEventContract(invalid);
+    expect(errors).toContain("eventId is required");
+    expect(errors).toContain("eventType is required");
+    expect(errors).toContain("eventVersion must be >= 1");
+    expect(errors).toContain("tenantId is required");
+    expect(errors).toContain("correlation.correlationId is required");
+  });
+});

--- a/platform/__tests__/event-versioning.test.ts
+++ b/platform/__tests__/event-versioning.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { adaptPlatformEventToVersion } from "../event-protocol";
+import type { PlatformEvent } from "../primitives";
+
+describe("platform event versioning adapters", () => {
+  it("adapts v1 execution payload to v2 canonical fields", () => {
+    const v1: PlatformEvent = {
+      eventId: "ev-v1",
+      tenantId: "tenant-1",
+      executionId: "exec-1",
+      eventType: "execution.completed",
+      eventVersion: 1,
+      sequence: 1,
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      source: "platform.tests",
+      correlation: {
+        correlationId: "corr-v1",
+        tenantId: "tenant-1",
+      },
+      payload: {
+        run_fingerprint: "fp-1",
+      },
+    };
+
+    const v2 = adaptPlatformEventToVersion(v1, 2);
+    expect(v2.eventVersion).toBe(2);
+    expect(v2.payload.runFingerprint).toBe("fp-1");
+    expect(v2.metadata?.adapter).toBe("platform_v1_to_v2");
+  });
+});

--- a/platform/__tests__/platform-benchmark.test.ts
+++ b/platform/__tests__/platform-benchmark.test.ts
@@ -11,10 +11,7 @@ import { PolicySimulator } from "../policy-simulator";
 import { AICopilot } from "../ai-copilot";
 import { DeterminismAuditor } from "../determinism";
 import { ChaosHarness } from "../chaos-harness";
-import {
-  ObservabilityConsumer,
-  EventConsumerRegistry,
-} from "../event-consumers";
+import { ObservabilityConsumer, EventConsumerRegistry } from "../event-consumers";
 import type { Execution, Policy, PlatformEvent } from "../primitives";
 
 function makeExecution(i: number, tenantId: string): Execution {
@@ -40,9 +37,18 @@ function makeEvent(i: number, tenantId: string): PlatformEvent {
     tenantId,
     executionId: `exec-${i}`,
     eventType: "execution.completed",
+    eventVersion: 1,
     sequence: i,
-    createdAt: new Date().toISOString(),
-    payload: { run_fingerprint: `fp-${i}` },
+    occurredAt: new Date().toISOString(),
+    source: "platform.benchmark",
+    severity: "info",
+    correlation: {
+      correlationId: `corr-${i}`,
+      tenantId,
+      executionId: `exec-${i}`,
+      runId: `run-${i}`,
+    },
+    payload: { runFingerprint: `fp-${i}` },
   };
 }
 
@@ -84,7 +90,12 @@ describe("Performance Benchmarks", () => {
       tenantId: "t-bench",
       evidenceLevel: "full",
       replayRequired: true,
-      budgets: { maxComputeUnits: 1500, maxMemoryUnits: 5000, maxCasIoUnits: 200, maxReplayCalls: 3 },
+      budgets: {
+        maxComputeUnits: 1500,
+        maxMemoryUnits: 5000,
+        maxCasIoUnits: 200,
+        maxReplayCalls: 3,
+      },
       identity: { requiredRole: "operator", requiredScopes: [] },
       metadata: { allowDeterministicOverride: false },
     };
@@ -149,19 +160,31 @@ describe("Performance Benchmarks", () => {
     const harness = new ChaosHarness();
     harness.registerFaultHandler("worker_crash", async () => {});
     harness.registerInvariantChecker("replay_correctness", async () => ({
-      invariantId: "rc", name: "RC", description: "ok",
-      check: "replay_correctness", passed: true,
-      checkedAt: new Date().toISOString(), details: {},
+      invariantId: "rc",
+      name: "RC",
+      description: "ok",
+      check: "replay_correctness",
+      passed: true,
+      checkedAt: new Date().toISOString(),
+      details: {},
     }));
     harness.registerInvariantChecker("proof_integrity", async () => ({
-      invariantId: "pi", name: "PI", description: "ok",
-      check: "proof_integrity", passed: true,
-      checkedAt: new Date().toISOString(), details: {},
+      invariantId: "pi",
+      name: "PI",
+      description: "ok",
+      check: "proof_integrity",
+      passed: true,
+      checkedAt: new Date().toISOString(),
+      details: {},
     }));
     harness.registerInvariantChecker("execution_idempotency", async () => ({
-      invariantId: "ei", name: "EI", description: "ok",
-      check: "execution_idempotency", passed: true,
-      checkedAt: new Date().toISOString(), details: {},
+      invariantId: "ei",
+      name: "EI",
+      description: "ok",
+      check: "execution_idempotency",
+      passed: true,
+      checkedAt: new Date().toISOString(),
+      details: {},
     }));
 
     const start = Date.now();

--- a/platform/__tests__/platform-integration.test.ts
+++ b/platform/__tests__/platform-integration.test.ts
@@ -25,13 +25,7 @@ import {
   ConnectorMetricsConsumer,
   EventConsumerRegistry,
 } from "../event-consumers";
-import type {
-  Execution,
-  Artifact,
-  Proof,
-  Policy,
-  PlatformEvent,
-} from "../primitives";
+import type { Execution, Artifact, Proof, Policy, PlatformEvent } from "../primitives";
 
 // ────────────────────────────────────────────────────────────
 // Trust Graph
@@ -111,9 +105,9 @@ describe("TrustGraph", () => {
       createdAt: "2025-01-01T00:00:00Z",
       metadata: {},
     });
-    expect(() =>
-      graph.addEdge(nodeA.nodeId, nodeB.nodeId, "produced", "tenant-A")
-    ).toThrow("cross-tenant");
+    expect(() => graph.addEdge(nodeA.nodeId, nodeB.nodeId, "produced", "tenant-A")).toThrow(
+      "cross-tenant"
+    );
   });
 
   it("should produce a deterministic snapshot hash", () => {
@@ -305,10 +299,31 @@ describe("AICopilot", () => {
   it("should enforce max suggestions per execution", () => {
     const config = { maxSuggestionsPerExecution: 2 };
     const limited = new AICopilot(config);
-    limited.suggest({ tenantId: "t", executionId: "e", category: "anomaly_detection", title: "1", description: "1", confidence: 0.5 });
-    limited.suggest({ tenantId: "t", executionId: "e", category: "anomaly_detection", title: "2", description: "2", confidence: 0.5 });
+    limited.suggest({
+      tenantId: "t",
+      executionId: "e",
+      category: "anomaly_detection",
+      title: "1",
+      description: "1",
+      confidence: 0.5,
+    });
+    limited.suggest({
+      tenantId: "t",
+      executionId: "e",
+      category: "anomaly_detection",
+      title: "2",
+      description: "2",
+      confidence: 0.5,
+    });
     expect(() =>
-      limited.suggest({ tenantId: "t", executionId: "e", category: "anomaly_detection", title: "3", description: "3", confidence: 0.5 })
+      limited.suggest({
+        tenantId: "t",
+        executionId: "e",
+        category: "anomaly_detection",
+        title: "3",
+        description: "3",
+        confidence: 0.5,
+      })
     ).toThrow("Max suggestions");
   });
 });
@@ -491,9 +506,18 @@ describe("EventConsumerRegistry", () => {
       tenantId: "t-1",
       executionId: "exec-1",
       eventType: "execution.completed",
+      eventVersion: 1,
       sequence: 1,
-      createdAt: new Date().toISOString(),
-      payload: { run_fingerprint: "fp-1" },
+      occurredAt: new Date().toISOString(),
+      source: "platform.tests",
+      severity: "info",
+      correlation: {
+        correlationId: "corr-1",
+        tenantId: "t-1",
+        executionId: "exec-1",
+        runId: "run-1",
+      },
+      payload: { runFingerprint: "fp-1" },
     };
 
     await registry.dispatch(event);
@@ -519,9 +543,18 @@ describe("EventConsumerRegistry", () => {
       tenantId: "t-1",
       executionId: "exec-1",
       eventType: "connector.sync.completed",
+      eventVersion: 1,
       sequence: 2,
-      createdAt: new Date().toISOString(),
-      payload: { connector_id: "stripe", duration_ms: 1500, record_count: 42 },
+      occurredAt: new Date().toISOString(),
+      source: "platform.tests",
+      severity: "info",
+      correlation: {
+        correlationId: "corr-2",
+        tenantId: "t-1",
+        executionId: "exec-1",
+        runId: "run-1",
+      },
+      payload: { connectorId: "stripe", durationMs: 1500, recordCount: 42 },
     };
 
     await registry.dispatch(event);
@@ -542,9 +575,18 @@ describe("EventConsumerRegistry", () => {
       tenantId: "t-1",
       executionId: "exec-1",
       eventType: "policy.evaluated",
+      eventVersion: 1,
       sequence: 3,
-      createdAt: new Date().toISOString(),
-      payload: { policy_id: "p-1", decision: "allowed" },
+      occurredAt: new Date().toISOString(),
+      source: "platform.tests",
+      severity: "info",
+      correlation: {
+        correlationId: "corr-3",
+        tenantId: "t-1",
+        executionId: "exec-1",
+        runId: "run-1",
+      },
+      payload: { policyId: "p-1", decision: "allowed" },
     };
 
     await registry.dispatch(event);
@@ -628,9 +670,18 @@ describe("Platform Integration (E2E)", () => {
       tenantId,
       executionId: "exec-int-1",
       eventType: "execution.completed",
+      eventVersion: 1,
       sequence: 1,
-      createdAt: new Date().toISOString(),
-      payload: { run_fingerprint: "fp-integration" },
+      occurredAt: new Date().toISOString(),
+      source: "platform.tests",
+      severity: "info",
+      correlation: {
+        correlationId: "corr-int-1",
+        tenantId,
+        executionId: "exec-int-1",
+        runId: "run-int-1",
+      },
+      payload: { runFingerprint: "fp-integration" },
     });
 
     await registry.dispatch({
@@ -639,9 +690,18 @@ describe("Platform Integration (E2E)", () => {
       tenantId,
       executionId: "exec-int-1",
       eventType: "policy.evaluated",
+      eventVersion: 1,
       sequence: 2,
-      createdAt: new Date().toISOString(),
-      payload: { policy_id: "policy-strict", decision: "allowed" },
+      occurredAt: new Date().toISOString(),
+      source: "platform.tests",
+      severity: "info",
+      correlation: {
+        correlationId: "corr-int-2",
+        tenantId,
+        executionId: "exec-int-1",
+        runId: "run-int-1",
+      },
+      payload: { policyId: "policy-strict", decision: "allowed" },
     });
 
     // 5. Verify trust graph state
@@ -681,7 +741,12 @@ describe("Platform Integration (E2E)", () => {
       tenantId,
       evidenceLevel: "full",
       replayRequired: true,
-      budgets: { maxComputeUnits: 1500, maxMemoryUnits: 5000, maxCasIoUnits: 200, maxReplayCalls: 3 },
+      budgets: {
+        maxComputeUnits: 1500,
+        maxMemoryUnits: 5000,
+        maxCasIoUnits: 200,
+        maxReplayCalls: 3,
+      },
       identity: { requiredRole: "operator", requiredScopes: [] },
       metadata: { allowDeterministicOverride: false },
     };

--- a/platform/event-consumers.ts
+++ b/platform/event-consumers.ts
@@ -12,6 +12,7 @@
 
 import type { PlatformEvent, PlatformEventType } from "./primitives";
 import type { TrustGraph } from "./trust-graph";
+import { normalizePlatformEvent } from "./event-protocol";
 
 export interface EventConsumer {
   readonly name: string;
@@ -37,40 +38,44 @@ export class TrustGraphConsumer implements EventConsumer {
       "trust.node.added",
       "trust.edge.added",
     ];
-    return tracked.includes(event.eventType);
+    return tracked.includes(normalizePlatformEvent(event).eventType);
   }
 
-  async process(event: PlatformEvent): Promise<void> {
+  async process(rawEvent: PlatformEvent): Promise<void> {
+    const event = normalizePlatformEvent(rawEvent);
+
     switch (event.eventType) {
       case "execution.completed": {
         const payload = event.payload as {
+          runFingerprint?: string;
           run_fingerprint?: string;
+          inputHash?: string;
           input_hash?: string;
+          configHash?: string;
           config_hash?: string;
+          outputHash?: string;
           output_hash?: string;
+          policyId?: string;
           policy_id?: string;
+          engineVersion?: string;
           engine_version?: string;
         };
         this.graph.recordExecution({
           executionId: event.executionId,
-          runId: event.executionId,
+          runId: event.correlation.runId ?? event.executionId,
           tenantId: event.tenantId,
-          policyId: payload.policy_id ?? "unknown",
-          engineVersion: payload.engine_version ?? "unknown",
+          policyId: payload.policyId ?? payload.policy_id ?? "unknown",
+          engineVersion: payload.engineVersion ?? payload.engine_version ?? "unknown",
           status: "completed",
-          startedAt: event.createdAt,
-          inputHash: payload.input_hash ?? "",
-          configHash: payload.config_hash ?? "",
-          outputHash: payload.output_hash,
-          runFingerprint: payload.run_fingerprint,
+          startedAt: event.occurredAt ?? event.createdAt ?? new Date().toISOString(),
+          inputHash: payload.inputHash ?? payload.input_hash ?? "",
+          configHash: payload.configHash ?? payload.config_hash ?? "",
+          outputHash: payload.outputHash ?? payload.output_hash,
+          runFingerprint: payload.runFingerprint ?? payload.run_fingerprint,
         });
         break;
       }
-      case "proof.artifact.generated": {
-        // Proof artifacts create nodes + edges in the trust graph
-        // The actual linking is handled when the execution record is created
-        break;
-      }
+      case "proof.artifact.generated":
       default:
         break;
     }
@@ -82,9 +87,13 @@ export class TrustGraphConsumer implements EventConsumer {
 // ────────────────────────────────────────────────────────────
 export interface ObservabilityRecord {
   traceId: string;
+  correlationId: string;
   executionId: string;
   tenantId: string;
   eventType: string;
+  eventVersion: number;
+  source: string;
+  severity: string;
   timestamp: string;
   durationMs?: number;
   metadata: Record<string, unknown>;
@@ -95,17 +104,25 @@ export class ObservabilityConsumer implements EventConsumer {
   private records: ObservabilityRecord[] = [];
 
   accept(): boolean {
-    return true; // Accept all events
+    return true;
   }
 
-  async process(event: PlatformEvent): Promise<void> {
+  async process(rawEvent: PlatformEvent): Promise<void> {
+    const event = normalizePlatformEvent(rawEvent);
     this.records.push({
-      traceId: event.idempotencyKey,
+      traceId: event.correlation.traceId ?? event.idempotencyKey ?? event.correlation.correlationId,
+      correlationId: event.correlation.correlationId,
       executionId: event.executionId,
       tenantId: event.tenantId,
       eventType: event.eventType,
-      timestamp: event.createdAt,
-      metadata: event.payload,
+      eventVersion: event.eventVersion ?? 1,
+      source: event.source ?? "platform.runtime",
+      severity: event.severity ?? "info",
+      timestamp: event.occurredAt ?? event.createdAt ?? new Date().toISOString(),
+      metadata: {
+        ...event.metadata,
+        ...event.payload,
+      },
     });
   }
 
@@ -142,6 +159,7 @@ export interface PolicyDecisionLog {
   policyId: string;
   decision: "allowed" | "denied";
   reason?: string;
+  correlationId: string;
   timestamp: string;
 }
 
@@ -150,11 +168,13 @@ export class PolicyAuditConsumer implements EventConsumer {
   private decisions: PolicyDecisionLog[] = [];
 
   accept(event: PlatformEvent): boolean {
-    return event.eventType === "policy.evaluated";
+    return normalizePlatformEvent(event).eventType === "policy.evaluated";
   }
 
-  async process(event: PlatformEvent): Promise<void> {
+  async process(rawEvent: PlatformEvent): Promise<void> {
+    const event = normalizePlatformEvent(rawEvent);
     const payload = event.payload as {
+      policyId?: string;
       policy_id?: string;
       decision?: string;
       reason?: string;
@@ -162,10 +182,11 @@ export class PolicyAuditConsumer implements EventConsumer {
     this.decisions.push({
       executionId: event.executionId,
       tenantId: event.tenantId,
-      policyId: payload.policy_id ?? "unknown",
+      policyId: payload.policyId ?? payload.policy_id ?? "unknown",
       decision: payload.decision === "denied" ? "denied" : "allowed",
       reason: payload.reason,
-      timestamp: event.createdAt,
+      correlationId: event.correlation.correlationId,
+      timestamp: event.occurredAt ?? event.createdAt ?? new Date().toISOString(),
     });
   }
 
@@ -182,6 +203,7 @@ export interface ConnectorMetric {
   connectorId: string;
   tenantId: string;
   eventType: string;
+  correlationId: string;
   timestamp: string;
   durationMs?: number;
   recordCount?: number;
@@ -193,23 +215,28 @@ export class ConnectorMetricsConsumer implements EventConsumer {
   private metrics: ConnectorMetric[] = [];
 
   accept(event: PlatformEvent): boolean {
-    return event.eventType.startsWith("connector.");
+    return normalizePlatformEvent(event).eventType.startsWith("connector.");
   }
 
-  async process(event: PlatformEvent): Promise<void> {
+  async process(rawEvent: PlatformEvent): Promise<void> {
+    const event = normalizePlatformEvent(rawEvent);
     const payload = event.payload as {
+      connectorId?: string;
       connector_id?: string;
+      durationMs?: number;
       duration_ms?: number;
+      recordCount?: number;
       record_count?: number;
       error?: string;
     };
     this.metrics.push({
-      connectorId: payload.connector_id ?? "unknown",
+      connectorId: payload.connectorId ?? payload.connector_id ?? "unknown",
       tenantId: event.tenantId,
       eventType: event.eventType,
-      timestamp: event.createdAt,
-      durationMs: payload.duration_ms,
-      recordCount: payload.record_count,
+      correlationId: event.correlation.correlationId,
+      timestamp: event.occurredAt ?? event.createdAt ?? new Date().toISOString(),
+      durationMs: payload.durationMs ?? payload.duration_ms,
+      recordCount: payload.recordCount ?? payload.record_count,
       error: payload.error,
     });
   }
@@ -230,10 +257,9 @@ export class EventConsumerRegistry {
     this.consumers.push(consumer);
   }
 
-  async dispatch(event: PlatformEvent): Promise<void> {
-    const promises = this.consumers
-      .filter((c) => c.accept(event))
-      .map((c) => c.process(event));
+  async dispatch(rawEvent: PlatformEvent): Promise<void> {
+    const event = normalizePlatformEvent(rawEvent);
+    const promises = this.consumers.filter((c) => c.accept(event)).map((c) => c.process(event));
     await Promise.allSettled(promises);
   }
 

--- a/platform/event-protocol.ts
+++ b/platform/event-protocol.ts
@@ -1,0 +1,219 @@
+import type { PlatformEvent, PlatformEventType } from "./primitives";
+
+export type PlatformEventSeverity = "debug" | "info" | "warning" | "error" | "critical";
+
+export interface PlatformEventCorrelation {
+  correlationId: string;
+  traceId?: string;
+  causationId?: string;
+  tenantId: string;
+  runId?: string;
+  executionId?: string;
+  actorId?: string;
+  alertId?: string;
+  replayId?: string;
+  supportIssueId?: string;
+}
+
+export class UnknownPlatformEventTypeError extends Error {
+  constructor(public readonly eventType: string) {
+    super(`Unknown platform event type: ${eventType}`);
+    this.name = "UnknownPlatformEventTypeError";
+  }
+}
+
+export const EVENT_TYPE_ALIASES: Record<string, PlatformEventType> = {
+  "connector.sync.succeeded": "connector.sync.completed",
+  "execution.done": "execution.completed",
+  "recon.completed": "reconciliation.completed",
+  "recon.failed": "reconciliation.failed",
+  "value.reconciliation_completed": "reconciliation.value.realized",
+  "value.errors_prevented": "reconciliation.errors.prevented",
+};
+
+export const CANONICAL_EVENT_TYPES: ReadonlySet<string> = new Set<string>([
+  "workflow.triggered",
+  "worker.lease.acquired",
+  "execution.started",
+  "state.persisted",
+  "proof.artifact.generated",
+  "execution.completed",
+  "execution.failed",
+  "connector.sync.started",
+  "connector.sync.completed",
+  "connector.sync.failed",
+  "policy.evaluated",
+  "trust.node.added",
+  "trust.edge.added",
+  "ai.suggestion.created",
+  "ai.suggestion.accepted",
+  "ai.suggestion.rejected",
+  "chaos.fault.injected",
+  "chaos.invariant.checked",
+  "alert.created",
+  "alert.status.changed",
+  "replay.started",
+  "replay.completed",
+  "replay.failed",
+  "support.issue.created",
+  "support.issue.linked",
+  "webhook.received",
+  "webhook.rejected",
+  "operator.action.executed",
+  "stream.event.emitted",
+  "system.degraded",
+  "reconciliation.started",
+  "reconciliation.completed",
+  "reconciliation.failed",
+  "reconciliation.value.realized",
+  "reconciliation.errors.prevented",
+]);
+
+export function normalizeEventType(eventType: string): PlatformEventType {
+  const canonical = EVENT_TYPE_ALIASES[eventType] ?? eventType;
+  if (CANONICAL_EVENT_TYPES.has(canonical)) {
+    return canonical as PlatformEventType;
+  }
+  throw new UnknownPlatformEventTypeError(eventType);
+}
+
+function machineVisibleDegradedEvent(
+  event: PlatformEvent,
+  unknownEventType: string,
+  occurredAt: string,
+  tenantId: string,
+  executionId: string
+): PlatformEvent {
+  return {
+    ...event,
+    eventType: "system.degraded",
+    eventVersion: 1,
+    occurredAt,
+    createdAt: occurredAt,
+    source: event.source ?? "platform.runtime",
+    severity: "warning",
+    idempotencyKey: event.idempotencyKey ?? event.correlation.correlationId,
+    tenantId,
+    executionId,
+    correlation: {
+      ...event.correlation,
+      tenantId,
+      executionId,
+      correlationId: event.correlation.correlationId,
+    },
+    metadata: {
+      ...(event.metadata ?? {}),
+      protocol_degraded: true,
+      unknown_event_type: unknownEventType,
+      original_event_type: event.eventType,
+    },
+    payload: {
+      ...(event.payload ?? {}),
+      degraded_reason: "unknown_event_type",
+      unknown_event_type: unknownEventType,
+    },
+  };
+}
+
+export function normalizePlatformEvent(event: PlatformEvent): PlatformEvent {
+  const occurredAt = event.occurredAt ?? event.createdAt ?? new Date().toISOString();
+  const executionId = event.executionId ?? event.correlation.executionId ?? "unknown";
+  const tenantId = event.tenantId ?? event.correlation.tenantId;
+
+  let eventType: PlatformEventType;
+  try {
+    eventType = normalizeEventType(event.eventType);
+  } catch (error) {
+    if (error instanceof UnknownPlatformEventTypeError) {
+      return machineVisibleDegradedEvent(event, error.eventType, occurredAt, tenantId, executionId);
+    }
+    throw error;
+  }
+
+  return {
+    ...event,
+    tenantId,
+    executionId,
+    eventType,
+    eventVersion: event.eventVersion ?? 1,
+    occurredAt,
+    createdAt: occurredAt,
+    source: event.source ?? "platform.runtime",
+    severity: event.severity ?? "info",
+    payload: event.payload ?? {},
+    metadata: event.metadata ?? {},
+    correlation: {
+      ...event.correlation,
+      tenantId,
+      executionId,
+      correlationId: event.correlation.correlationId,
+    },
+    idempotencyKey: event.idempotencyKey ?? event.correlation.correlationId,
+  };
+}
+
+export function createPlatformEvent(
+  event: Omit<PlatformEvent, "eventVersion" | "occurredAt" | "createdAt" | "idempotencyKey"> &
+    Partial<Pick<PlatformEvent, "eventVersion" | "occurredAt" | "createdAt" | "idempotencyKey">>
+): PlatformEvent {
+  return normalizePlatformEvent({
+    ...event,
+    eventVersion: event.eventVersion ?? 1,
+    occurredAt: event.occurredAt ?? event.createdAt ?? new Date().toISOString(),
+    createdAt: event.createdAt ?? event.occurredAt,
+    idempotencyKey: event.idempotencyKey ?? event.correlation.correlationId,
+  });
+}
+
+export function validatePlatformEventContract(event: PlatformEvent): string[] {
+  const errors: string[] = [];
+  if (!event.eventId) errors.push("eventId is required");
+  if (!event.eventType) errors.push("eventType is required");
+  if (!event.eventVersion || event.eventVersion < 1) errors.push("eventVersion must be >= 1");
+  if (!event.occurredAt && !event.createdAt) errors.push("occurredAt is required");
+  if (!event.tenantId) errors.push("tenantId is required");
+  if (!event.correlation?.correlationId) errors.push("correlation.correlationId is required");
+  if (!event.correlation?.tenantId) errors.push("correlation.tenantId is required");
+  if (!event.source) errors.push("source is required");
+  if (!event.payload) errors.push("payload is required");
+  return errors;
+}
+
+export function adaptPlatformEventToVersion(
+  event: PlatformEvent,
+  targetVersion: number
+): PlatformEvent {
+  if (targetVersion <= (event.eventVersion ?? 1)) {
+    return event;
+  }
+
+  if ((event.eventVersion ?? 1) === 1 && targetVersion === 2) {
+    const payload = { ...event.payload };
+    if (typeof payload.run_fingerprint === "string" && typeof payload.runFingerprint !== "string") {
+      payload.runFingerprint = payload.run_fingerprint;
+    }
+    if (typeof payload.connector_id === "string" && typeof payload.connectorId !== "string") {
+      payload.connectorId = payload.connector_id;
+    }
+    return {
+      ...event,
+      eventVersion: 2,
+      payload,
+      metadata: {
+        ...event.metadata,
+        adapted_from_version: event.eventVersion ?? 1,
+        adapter: "platform_v1_to_v2",
+      },
+    };
+  }
+
+  return {
+    ...event,
+    eventVersion: targetVersion,
+    metadata: {
+      ...event.metadata,
+      adapted_from_version: event.eventVersion ?? 1,
+      adapter: "platform_passthrough",
+    },
+  };
+}

--- a/platform/index.ts
+++ b/platform/index.ts
@@ -38,3 +38,15 @@ export type {
 } from "./event-consumers";
 export { ConnectorCapabilityRegistry } from "./connector-registry";
 export type { ConnectorCapability, RetryPolicy } from "./connector-registry";
+
+export {
+  createPlatformEvent,
+  normalizePlatformEvent,
+  normalizeEventType,
+  adaptPlatformEventToVersion,
+  validatePlatformEventContract,
+  EVENT_TYPE_ALIASES,
+  CANONICAL_EVENT_TYPES,
+  UnknownPlatformEventTypeError,
+} from "./event-protocol";
+export type { PlatformEventSeverity, PlatformEventCorrelation } from "./event-protocol";

--- a/platform/primitives.ts
+++ b/platform/primitives.ts
@@ -120,12 +120,29 @@ export interface Connector {
 // ────────────────────────────────────────────────────────────
 export interface PlatformEvent {
   eventId: string;
-  idempotencyKey: string;
+  idempotencyKey?: string;
   tenantId: string;
   executionId: string;
   eventType: PlatformEventType;
+  eventVersion?: number;
   sequence: number;
-  createdAt: string;
+  occurredAt?: string;
+  createdAt?: string;
+  source?: string;
+  severity?: "debug" | "info" | "warning" | "error" | "critical";
+  metadata?: Record<string, unknown>;
+  correlation: {
+    correlationId: string;
+    traceId?: string;
+    causationId?: string;
+    tenantId: string;
+    runId?: string;
+    executionId?: string;
+    actorId?: string;
+    alertId?: string;
+    replayId?: string;
+    supportIssueId?: string;
+  };
   payload: Record<string, unknown>;
 }
 
@@ -147,7 +164,24 @@ export type PlatformEventType =
   | "ai.suggestion.accepted"
   | "ai.suggestion.rejected"
   | "chaos.fault.injected"
-  | "chaos.invariant.checked";
+  | "chaos.invariant.checked"
+  | "alert.created"
+  | "alert.status.changed"
+  | "replay.started"
+  | "replay.completed"
+  | "replay.failed"
+  | "support.issue.created"
+  | "support.issue.linked"
+  | "webhook.received"
+  | "webhook.rejected"
+  | "operator.action.executed"
+  | "stream.event.emitted"
+  | "system.degraded"
+  | "reconciliation.started"
+  | "reconciliation.completed"
+  | "reconciliation.failed"
+  | "reconciliation.value.realized"
+  | "reconciliation.errors.prevented";
 
 // ────────────────────────────────────────────────────────────
 // Proof

--- a/scripts/verify-event-taxonomy.ts
+++ b/scripts/verify-event-taxonomy.ts
@@ -1,0 +1,102 @@
+import ts from "typescript";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { CANONICAL_EVENT_TYPES, EVENT_TYPE_ALIASES } from "../platform/event-protocol";
+
+const ROOT = resolve(process.cwd());
+
+function gatherFiles(command: string): string[] {
+  try {
+    const out = execSync(command, { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] })
+      .toString()
+      .trim();
+    return out ? out.split("\n").filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+function isAllowedEventType(eventType: string): boolean {
+  return CANONICAL_EVENT_TYPES.has(eventType) || eventType in EVENT_TYPE_ALIASES;
+}
+
+function checkFile(filePath: string): string[] {
+  const content = readFileSync(resolve(ROOT, filePath), "utf8");
+  const source = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TS
+  );
+  const violations: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      if (node.expression.name.text === "emitEvent" && node.arguments.length > 0) {
+        const eventTypeArg = node.arguments[0];
+        if (ts.isStringLiteral(eventTypeArg)) {
+          if (!isAllowedEventType(eventTypeArg.text)) {
+            const { line, character } = source.getLineAndCharacterOfPosition(
+              eventTypeArg.getStart()
+            );
+            violations.push(
+              `${filePath}:${line + 1}:${character + 1} unknown eventBus.emitEvent type '${eventTypeArg.text}'`
+            );
+          }
+        } else if (!filePath.includes("__tests__/")) {
+          const { line, character } = source.getLineAndCharacterOfPosition(eventTypeArg.getStart());
+          violations.push(
+            `${filePath}:${line + 1}:${character + 1} dynamic event type expression in eventBus.emitEvent is not allowed`
+          );
+        }
+      }
+    }
+
+    if (ts.isPropertyAssignment(node)) {
+      const keyName = ts.isIdentifier(node.name)
+        ? node.name.text
+        : ts.isStringLiteral(node.name)
+          ? node.name.text
+          : null;
+
+      if (keyName === "eventType" && ts.isStringLiteral(node.initializer)) {
+        const eventType = node.initializer.text;
+        if (
+          filePath.includes("platform/") &&
+          !filePath.includes("platform/__tests__/event-protocol.test.ts") &&
+          !isAllowedEventType(eventType)
+        ) {
+          const { line, character } = source.getLineAndCharacterOfPosition(
+            node.initializer.getStart()
+          );
+          violations.push(
+            `${filePath}:${line + 1}:${character + 1} unknown PlatformEvent.eventType '${eventType}'`
+          );
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+  return violations;
+}
+
+const files = gatherFiles(
+  "rg --files platform packages/api/src/services packages/web/src/app/api scripts --glob '*.ts' --glob '!**/dist/**'"
+);
+
+const violations = files.flatMap(checkFile);
+
+if (violations.length > 0) {
+  console.error("❌ Event taxonomy verification failed:");
+  for (const violation of violations) {
+    console.error(`  - ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.warn(`✅ Event taxonomy verification passed for ${files.length} files.`);

--- a/tools/eslint-rules/event-taxonomy-rule.js
+++ b/tools/eslint-rules/event-taxonomy-rule.js
@@ -1,0 +1,118 @@
+const CANONICAL_EVENT_TYPES = new Set([
+  "workflow.triggered",
+  "worker.lease.acquired",
+  "execution.started",
+  "state.persisted",
+  "proof.artifact.generated",
+  "execution.completed",
+  "execution.failed",
+  "connector.sync.started",
+  "connector.sync.completed",
+  "connector.sync.failed",
+  "policy.evaluated",
+  "trust.node.added",
+  "trust.edge.added",
+  "ai.suggestion.created",
+  "ai.suggestion.accepted",
+  "ai.suggestion.rejected",
+  "chaos.fault.injected",
+  "chaos.invariant.checked",
+  "alert.created",
+  "alert.status.changed",
+  "replay.started",
+  "replay.completed",
+  "replay.failed",
+  "support.issue.created",
+  "support.issue.linked",
+  "webhook.received",
+  "webhook.rejected",
+  "operator.action.executed",
+  "stream.event.emitted",
+  "system.degraded",
+  "reconciliation.started",
+  "reconciliation.completed",
+  "reconciliation.failed",
+  "reconciliation.value.realized",
+  "reconciliation.errors.prevented",
+  "validation.failed",
+  "mapping.suggested",
+  "drift.detected",
+  "workflow.failed",
+  "audit.ready",
+  "contract.breaking_change",
+  "usage.limit_exceeded",
+  "agent.fallback",
+]);
+
+const ALIAS_EVENT_TYPES = new Set([
+  "connector.sync.succeeded",
+  "execution.done",
+  "recon.completed",
+  "recon.failed",
+  "value.reconciliation_completed",
+  "value.errors_prevented",
+]);
+
+function isAllowedEventType(value) {
+  return CANONICAL_EVENT_TYPES.has(value) || ALIAS_EVENT_TYPES.has(value);
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "enforce canonical internal event taxonomy",
+    },
+    schema: [],
+    messages: {
+      unknownType:
+        "Unknown event type '{{eventType}}'. Use canonical taxonomy or registered alias.",
+      dynamicType:
+        "Dynamic event type construction is not allowed for internal events. Use a string literal from canonical taxonomy.",
+    },
+  },
+  create(context) {
+    function reportUnknown(node, eventType) {
+      if (!isAllowedEventType(eventType)) {
+        context.report({ node, messageId: "unknownType", data: { eventType } });
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee &&
+          node.callee.type === "MemberExpression" &&
+          !node.callee.computed &&
+          node.callee.property &&
+          node.callee.property.type === "Identifier" &&
+          node.callee.property.name === "emitEvent" &&
+          node.arguments.length > 0
+        ) {
+          const eventTypeArg = node.arguments[0];
+          if (eventTypeArg.type === "Literal" && typeof eventTypeArg.value === "string") {
+            reportUnknown(eventTypeArg, eventTypeArg.value);
+          } else {
+            context.report({ node: eventTypeArg, messageId: "dynamicType" });
+          }
+        }
+      },
+      Property(node) {
+        if (!context.filename.includes("platform/")) {
+          return;
+        }
+
+        if (
+          node.key &&
+          ((node.key.type === "Identifier" && node.key.name === "eventType") ||
+            (node.key.type === "Literal" && node.key.value === "eventType"))
+        ) {
+          const value = node.value;
+          if (value.type === "Literal" && typeof value.value === "string") {
+            reportUnknown(value, value.value);
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
### Motivation

- Define a canonical internal event envelope and taxonomy so producers and consumers share a stable contract for observability, replay, alerts, support and webhooks.
- Prevent accidental or dynamic use of unknown event types and provide a machine-visible degraded signal when taxonomy mismatches occur.
- Propagate first-class correlation and versioning fields end-to-end for operational observability and safe schema evolution.
- Enforce event taxonomy at authoring time and in CI to catch regressions early.

### Description

- Implemented a canonical event protocol with normalization, adapters and validators in `platform/event-protocol.ts` and exported helpers from `platform/index.ts` as well as updated `platform/primitives.ts` types accordingly.
- Reworked the internal `EventBus` (`packages/api/src/services/events/event-bus.ts`) to emit canonical envelopes, support legacy aliases, sequence numbers, correlation propagation, degraded-event emission and degraded auditing, and added `adaptEventToVersion2` adapter and singleton `eventBus` usage.
- Updated consumers and platform subsystems to normalize events before processing by adding `normalizePlatformEvent` usage in `platform/event-consumers.ts` and wired canonical event emissions in `packages/api` services (`alerts/manager.ts`, `recon-core/recon-core-engine.ts`, `webhooks/webhook-service.ts`, `support/support-intake-service.ts`).
- Added tooling and policy: an ESLint local rule at `tools/eslint-rules/event-taxonomy-rule.js`, a verification script `scripts/verify-event-taxonomy.ts`, a CI workflow `/.github/workflows/event-protocol-guard.yml` to run taxonomy checks and contract tests, and documentation `docs/architecture/canonical-event-protocol.md` describing the protocol and merge gate policy.
- Added and updated tests and benchmarks under `platform/__tests__` and `packages/api/src/services/events/__tests__` to validate normalization, version adapters and contract behavior.

### Testing

- Ran the event taxonomy verifier with `pnpm run verify:event-taxonomy` which checks TypeScript AST usages and returned no violations.
- Executed `jest` contract tests under `@settler/api` including `src/services/events/__tests__/event-bus.contract.test.ts` and the reconciliation contract test referenced by the CI job, which passed.
- Ran the new `platform` unit tests (`platform/__tests__/*`) (Vitest) that cover protocol normalization, family contracts and version adapters and they passed.
- The new CI workflow (`event-protocol-guard.yml`) is configured to run the above checks on PRs touching event surfaces.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07ea1e29c8328a5833baeab2bd96b)