### PR TITLE
Introduce operator-focused UI (Evidence, Run/Replay, Metrics, Settings) and product capabilities docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Optional integrations should be configured only when validating those specific s
 - [Repo integrity reference](docs/reference/repo-integrity.md)
 - [Workspace contracts](docs/reference/workspace-contracts.md)
 
+## What makes Settler different (implemented today)
+
+Settler is positioned as **deterministic reconciliation infrastructure**, not a generic dashboard.
+
+- **Replay Lab** (`/app/replay` + `/api/v1/runs/:id/replay`) for deterministic reruns and drift checks.
+- **Run Explorer** (`/app/runs`) for operator-grade run metadata and policy context.
+- **Truth Explorer** (`/app/proofs` + trust-explorer APIs) for lineage, proof verification, and policy impact analysis.
+- **Synthetic Reconciliation Foundry** (`pnpm run test:reconciliation*`) for seeded scenario validation.
+- **Live operator surfaces** (`/app/alerts`, `/app/system-health`, `/app/metrics`) for triage and runtime telemetry.
+- **Evidence query surface** (`/app/evidence` + `/api/v1/runs/:id/evidence`) for trust artifact retrieval by run, fingerprint, or policy hash.
+- **Tenant isolation controls** (`/app/settings`) for role boundaries and runtime freeze controls.
+
+See `docs/PRODUCT_CAPABILITIES_MATRIX.md` for maturity and evidence map.
+
 ## Reconciliation synthetic verification
 
 Use the deterministic reconciliation foundry commands below during local debugging and CI parity checks:

--- a/docs/PRODUCT_CAPABILITIES_MATRIX.md
+++ b/docs/PRODUCT_CAPABILITIES_MATRIX.md
@@ -1,0 +1,28 @@
+# Settler Product Capabilities Matrix (Evidence-Backed)
+
+This matrix tracks what is currently implemented in-repo and how each capability maps to operator-facing value.
+
+| Capability                       | Product/API Surface                                                                                            | Problem Solved                                                                                | Differentiation Signal                                                             | Maturity                                                                   |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Deterministic replay             | UI: `/app/replay`, API: `/api/v1/runs/:id/replay`                                                              | Re-run historical reconciliations and detect drift with explicit match status.                | Replayability + deterministic verification for financial runs.                     | Mature                                                                     |
+| Run explorer                     | UI: `/app/runs`, `/app/runs/:id`, API: `/api/v1/runs`, `/api/v1/runs/:id`                                      | Gives operators execution metadata, policy context, and run-level troubleshooting entrypoint. | Operator-grade execution introspection instead of opaque batch jobs.               | Mature                                                                     |
+| Truth / lineage explorer         | UI: `/app/proofs` and `ProofExplorer`, API: trust-explorer endpoints under `/api/v1/runs/:id/trust-explorer/*` | Trace artifacts and execution graph for audit/debug workflows.                                | Explicit lineage + proof-chain navigation.                                         | Mature                                                                     |
+| Evidence query surface           | UI: `/app/evidence`, API: `/api/v1/runs/:id/evidence`                                                          | Retrieve trust artifacts using run id, fingerprint, and policy hash selectors.                | Structured evidence retrieval for audits and replay validation.                    | Mature                                                                     |
+| Tenant isolation controls        | UI: `/app/settings`, supporting artifacts in `security/evidence/*`                                             | Preserve multi-tenant boundaries via governance controls and explicit verification artifacts. | Isolation controls are visible to operators, not hidden behind internal-only docs. | Mature                                                                     |
+| Policy impact simulation         | UI: Truth Explorer policy impact panel, API: `/trust-explorer/findPolicyImpact`                                | Evaluate which artifacts/execution nodes are impacted by policy decisions.                    | Policy-aware investigation, not just static policy docs.                           | Partial (embedded in Truth Explorer, not yet standalone simulator)         |
+| Live operations + alerts         | UI: `/app/alerts`, `/app/system-health`                                                                        | Fast incident triage and operator context during runtime events.                              | Control-plane visibility for financial operations.                                 | Partial (surface is visible; deep alert-to-run automation remains limited) |
+| Runtime event model visibility   | UI: `/app/metrics`, API: `/api/v1/metrics/*`, docs: `docs/packages/api/EVENT_DRIVEN_ARCHITECTURE.md`           | Make event-derived execution behavior machine-visible for operators and developers.           | Infrastructure-style event semantics with live telemetry hooks.                    | Partial (currently focused on route latency/top signals)                   |
+| Synthetic reconciliation foundry | CLI: `foundry reconciliation-verify`, docs: `docs/demos/FOUNDRY_DEMO.md`                                       | Generate deterministic test scenarios for reconciliation verification.                        | Scenario-driven validation with reproducible seeds.                                | Mature                                                                     |
+
+## Operator Demo Flow (Reality-Backed)
+
+1. Open **Control Plane** at `/app`.
+2. Inspect a recent run in **Run Explorer** (`/app/runs/:id`).
+3. Open **Truth Explorer** (`/app/proofs`) for lineage + proof chain checks.
+4. Pull trust artifacts from **Evidence Query Surface** (`/app/evidence`).
+5. Inspect **Live Alerts** (`/app/alerts`) for incident context.
+6. Replay the run in **Replay Lab** (`/app/replay`) and compare hash outcomes.
+7. Review tenant boundary controls in **Tenant Isolation Controls** (`/app/settings`).
+8. Inspect **Runtime Event Signals** (`/app/metrics`) for event-derived telemetry.
+
+This sequence is intentionally constrained to implemented routes/endpoints in this repository.

--- a/docs/demo/demo-walkthrough.md
+++ b/docs/demo/demo-walkthrough.md
@@ -1,8 +1,25 @@
-# Demo Walkthrough
+# Demo Walkthrough (Deterministic Operator Flow)
+
+## CLI + artifact validation
 
 1. `pnpm run bootstrap`
 2. `pnpm run demo`
-3. Inspect `examples/demo-output/evidence.json` for proof envelope.
+3. Inspect `examples/demo-output/evidence.json` for proof envelope and evidence metadata.
 4. Inspect `examples/demo-output/run.json` for execution metadata.
 5. Replay evidence: `pnpm exec tsx scripts/settler-replay.ts examples/demo-output/evidence.json`
-6. Optional UI verification: `pnpm run verify:routes`
+
+## In-product operator story
+
+1. Open `/app` (**Control Plane**) for workflow entrypoints.
+2. Open `/app/runs` and select a run from **Run Explorer**.
+3. From run detail, inspect deterministic replay status and evidence summary.
+4. Open `/app/proofs` (**Truth Explorer**) for proof-chain and lineage investigation.
+5. Open `/app/evidence` (**Evidence Query Surface**) and verify retrieval modes (run id, fingerprint, policy hash).
+6. Open `/app/alerts` (**Live Alerts**) for incident context.
+7. Open `/app/replay` (**Replay Lab**) to re-run deterministic checks.
+8. Open `/app/settings` (**Tenant Isolation Controls**) to inspect boundary and governance controls.
+9. Open `/app/metrics` (**Runtime Event Signals**) for event-derived telemetry.
+
+## Route integrity
+
+- Optional UI verification: `pnpm run verify:routes`

--- a/packages/web/src/app/app/evidence/page.tsx
+++ b/packages/web/src/app/app/evidence/page.tsx
@@ -1,10 +1,66 @@
+import Link from "next/link";
+
+const queryModes = [
+  {
+    key: "Run ID",
+    description: "Fetch the canonical evidence bundle for a specific reconciliation run.",
+    example: "/api/v1/runs/run_01HXYZ/evidence",
+  },
+  {
+    key: "Fingerprint",
+    description: "Confirm exact deterministic output lineage for a known fingerprint.",
+    example: "/api/v1/runs/:id/evidence?fingerprint=sha256:...",
+  },
+  {
+    key: "Policy hash",
+    description: "Audit which policy version was active when a run was executed.",
+    example: "/api/v1/runs/:id/evidence?policy_hash=...",
+  },
+];
+
 export default function EvidencePage() {
   return (
-    <div className="space-y-3">
-      <h1 className="text-2xl font-semibold">Evidence</h1>
-      <div className="rounded border border-slate-200 bg-white p-4 text-sm text-slate-600">
-        Query evidence from <code>/api/v1/runs/:id/evidence</code> using run_id, fingerprint, or
-        policy hash.
+    <div className="space-y-6">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Trust Surface
+        </p>
+        <h1 className="text-2xl font-semibold">Evidence Query Surface</h1>
+        <p className="mt-2 max-w-3xl text-sm text-slate-600">
+          Evidence retrieval is tenant-scoped and designed for deterministic audit workflows. Query
+          by run identifier, fingerprint, or policy hash from the run evidence endpoint.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-4">
+        <p className="text-sm text-slate-700">
+          Endpoint:{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5">/api/v1/runs/:id/evidence</code>
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        {queryModes.map((mode) => (
+          <article key={mode.key} className="rounded-xl border border-slate-200 bg-white p-4">
+            <h2 className="text-sm font-semibold text-slate-900">{mode.key}</h2>
+            <p className="mt-2 text-sm text-slate-600">{mode.description}</p>
+            <p className="mt-3 break-all rounded bg-slate-50 p-2 font-mono text-xs text-slate-700">
+              {mode.example}
+            </p>
+          </article>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-4 text-sm">
+        <Link href="/app/runs" className="font-medium text-blue-600">
+          Open Run Explorer →
+        </Link>
+        <Link href="/app/proofs" className="font-medium text-blue-600">
+          Open Truth Explorer →
+        </Link>
+        <Link href="/app/settings" className="font-medium text-blue-600">
+          Review Tenant Isolation Controls →
+        </Link>
       </div>
     </div>
   );

--- a/packages/web/src/app/app/layout.tsx
+++ b/packages/web/src/app/app/layout.tsx
@@ -32,17 +32,34 @@ function SignedOutScreen() {
   );
 }
 
-const navItems = [
-  { name: "Overview", href: "/app" },
-  { name: "Executions", href: "/app/executions" },
-  { name: "Reconciliation", href: "/app/reconciliation" },
-  { name: "Replay", href: "/app/replay" },
-  { name: "Proofs", href: "/app/proofs" },
-  { name: "Policies", href: "/app/policies" },
-  { name: "Audit", href: "/app/audit" },
-  { name: "Integrations", href: "/app/integrations" },
-  { name: "System Health", href: "/app/system-health" },
-  { name: "Settings", href: "/app/settings" },
+const navSections = [
+  {
+    label: "Execution Infrastructure",
+    items: [
+      { name: "Control Plane", href: "/app" },
+      { name: "Run Explorer", href: "/app/runs" },
+      { name: "Truth Explorer", href: "/app/proofs" },
+      { name: "Replay Lab", href: "/app/replay" },
+      { name: "Policy Lab", href: "/app/policies" },
+    ],
+  },
+  {
+    label: "Operator Intelligence",
+    items: [
+      { name: "Live Alerts", href: "/app/alerts" },
+      { name: "Runtime Event Signals", href: "/app/metrics" },
+      { name: "System Telemetry", href: "/app/system-health" },
+      { name: "Evidence Query Surface", href: "/app/evidence" },
+      { name: "Integrations", href: "/app/integrations" },
+    ],
+  },
+  {
+    label: "Governance",
+    items: [
+      { name: "Audit Surfaces", href: "/app/audit" },
+      { name: "Tenant Isolation Controls", href: "/app/settings" },
+    ],
+  },
 ];
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
@@ -58,7 +75,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 
   return (
     <div className="flex h-screen bg-background-light">
-      <aside className="w-64 border-r border-slate-200 bg-white">
+      <aside className="w-72 border-r border-slate-200 bg-white">
         <Link href="/" className="flex border-b border-slate-200 p-4">
           <Image
             src={SETTLER_IMAGES.logoMain.webpPath || SETTLER_IMAGES.logoMain.path}
@@ -69,15 +86,22 @@ export default async function AppLayout({ children }: { children: React.ReactNod
             priority
           />
         </Link>
-        <nav className="p-3">
-          {navItems.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="mb-1 block rounded px-3 py-2 text-sm hover:bg-slate-100"
-            >
-              {item.name}
-            </Link>
+        <nav className="space-y-4 p-3">
+          {navSections.map((section) => (
+            <div key={section.label}>
+              <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                {section.label}
+              </p>
+              {section.items.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="mb-1 block rounded px-3 py-2 text-sm hover:bg-slate-100"
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </div>
           ))}
         </nav>
       </aside>

--- a/packages/web/src/app/app/metrics/page.tsx
+++ b/packages/web/src/app/app/metrics/page.tsx
@@ -19,9 +19,19 @@ async function getTop() {
 export default async function MetricsPage() {
   const rows = await getTop();
   return (
-    <div>
-      <h1 className="text-2xl font-semibold">Metrics</h1>
-      <div className="mt-4 rounded border border-slate-200 bg-white p-4">
+    <div className="space-y-4">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Runtime Event Model
+        </p>
+        <h1 className="text-2xl font-semibold">Runtime Event Signals</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Event-derived route telemetry for operator triage. This surface currently focuses on top
+          slow routes and should be read as partial runtime event visibility.
+        </p>
+      </div>
+
+      <div className="rounded border border-slate-200 bg-white p-4">
         <div className="mb-2 text-sm text-slate-600">Top slow routes (7d)</div>
         <ul className="space-y-2 text-sm">
           {rows.length === 0 ? (

--- a/packages/web/src/app/app/page.tsx
+++ b/packages/web/src/app/app/page.tsx
@@ -1,5 +1,129 @@
-import ControlPlaneOverview from "@/components/stitch-import/ControlPlaneOverview";
+import Link from "next/link";
+
+const workflows = [
+  {
+    name: "Evidence Query Workflow",
+    description:
+      "Pull run evidence by run id, fingerprint, or policy hash and keep trust artifacts machine-readable for audits.",
+    cta: "Open Evidence Query Surface",
+    href: "/app/evidence",
+  },
+  {
+    name: "Replay Workflow",
+    description:
+      "Inspect a run, replay deterministic execution, and confirm whether output hashes remain stable.",
+    cta: "Open Replay Lab",
+    href: "/app/replay",
+  },
+  {
+    name: "Truth Investigation",
+    description:
+      "Drill into proof lineage, impacted artifacts, and verification checks for run-level evidence review.",
+    cta: "Open Truth Explorer",
+    href: "/app/proofs",
+  },
+  {
+    name: "Policy Simulation",
+    description:
+      "Review policy posture and evaluate tolerance impacts on runtime behavior before rollout.",
+    cta: "Open Policy Lab",
+    href: "/app/policies",
+  },
+  {
+    name: "Live Operations",
+    description:
+      "Track live alerts, route into affected runs, and monitor system telemetry for operator triage.",
+    cta: "Open Live Alerts",
+    href: "/app/alerts",
+  },
+];
+
+const quickLinks = [
+  {
+    label: "Tenant Isolation Controls",
+    href: "/app/settings",
+    detail: "Role boundaries and freeze controls for multi-tenant safety",
+  },
+  {
+    label: "Runtime Event Signals",
+    href: "/app/metrics",
+    detail: "Event-derived latency and route behavior signals",
+  },
+  {
+    label: "Run Explorer",
+    href: "/app/runs",
+    detail: "Recent run metadata, status, and policy context",
+  },
+  {
+    label: "System Telemetry",
+    href: "/app/system-health",
+    detail: "Control-plane health and runtime posture",
+  },
+  {
+    label: "Audit Surfaces",
+    href: "/app/audit",
+    detail: "Security and evidence-facing system surfaces",
+  },
+  {
+    label: "Integrations",
+    href: "/app/integrations",
+    detail: "Connection and adapter operating state",
+  },
+];
 
 export default function AppPage() {
-  return <ControlPlaneOverview />;
+  return (
+    <div className="space-y-8">
+      <section className="rounded-xl border border-slate-200 bg-white p-6">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Settler Control Plane
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold text-slate-900">
+          Deterministic Reconciliation Infrastructure
+        </h1>
+        <p className="mt-3 max-w-3xl text-sm text-slate-600">
+          This workspace is organized for operator-grade execution: deterministic replay, evidence
+          lineage, policy-aware simulation, and live triage surfaces. Use the workflows below to
+          move from incident detection to replayable root-cause analysis.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-slate-900">Differentiated operator workflows</h2>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          {workflows.map((workflow) => (
+            <article
+              key={workflow.name}
+              className="rounded-xl border border-slate-200 bg-white p-5"
+            >
+              <h3 className="text-lg font-semibold text-slate-900">{workflow.name}</h3>
+              <p className="mt-2 text-sm text-slate-600">{workflow.description}</p>
+              <Link
+                href={workflow.href}
+                className="mt-4 inline-flex text-sm font-medium text-blue-600"
+              >
+                {workflow.cta} →
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-slate-900">Trust and control surfaces</h2>
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {quickLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="rounded-lg border border-slate-200 bg-white p-4 transition hover:border-slate-300"
+            >
+              <p className="font-medium text-slate-900">{link.label}</p>
+              <p className="mt-1 text-sm text-slate-600">{link.detail}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/packages/web/src/app/app/runs/[id]/page.tsx
+++ b/packages/web/src/app/app/runs/[id]/page.tsx
@@ -1,10 +1,32 @@
+import Link from "next/link";
 import { headers } from "next/headers";
 
-async function getRun(id: string) {
+type RunRecord = {
+  id: string;
+  status?: string;
+  created_at?: string;
+  policy_hash?: string;
+  policy?: string;
+  tenant_id?: string;
+};
+
+type ReplaySummary = {
+  match?: boolean;
+  baseline_hash?: string;
+  replay_hash?: string;
+};
+
+type EvidenceSummary = {
+  run_id?: string;
+  fingerprint?: string;
+  policy_hash?: string;
+};
+
+async function fetchFromApi<T>(path: string): Promise<T | null> {
   const h = await headers();
   const host = h.get("host") || "localhost:3000";
   const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-  const res = await fetch(`${protocol}://${host}/api/v1/runs/${id}`, {
+  const res = await fetch(`${protocol}://${host}${path}`, {
     headers: { authorization: h.get("authorization") || "" },
     cache: "no-store",
   });
@@ -14,17 +36,74 @@ async function getRun(id: string) {
 
 export default async function RunDetail({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const run = await getRun(id);
-  if (!run)
+
+  const [run, replay, evidence] = await Promise.all([
+    fetchFromApi<RunRecord>(`/api/v1/runs/${id}`),
+    fetchFromApi<ReplaySummary>(`/api/v1/runs/${id}/replay`),
+    fetchFromApi<EvidenceSummary>(`/api/v1/runs/${id}/evidence`),
+  ]);
+
+  if (!run) {
     return <div className="rounded border border-slate-200 bg-white p-4">Run not found.</div>;
+  }
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-semibold">Run {run.id}</h1>
-      <div className="rounded border border-slate-200 bg-white p-4 text-sm">
-        <div>Status: {run.status}</div>
-        <div>Created: {run.created_at}</div>
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Run Explorer</p>
+        <h1 className="text-2xl font-semibold">Run {run.id}</h1>
       </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <section className="rounded border border-slate-200 bg-white p-4 text-sm">
+          <h2 className="font-semibold text-slate-900">Execution metadata</h2>
+          <div className="mt-2 space-y-1 text-slate-700">
+            <div>Status: {run.status ?? "unknown"}</div>
+            <div>Created: {run.created_at ?? "n/a"}</div>
+            <div>Tenant: {run.tenant_id ?? "n/a"}</div>
+            <div>Policy: {run.policy ?? run.policy_hash ?? "n/a"}</div>
+          </div>
+        </section>
+
+        <section className="rounded border border-slate-200 bg-white p-4 text-sm">
+          <h2 className="font-semibold text-slate-900">Deterministic replay status</h2>
+          {replay ? (
+            <div className="mt-2 space-y-1 text-slate-700">
+              <div>Replay verdict: {replay.match ? "hash matched" : "drift detected"}</div>
+              <div>Baseline hash: {replay.baseline_hash ?? "not returned"}</div>
+              <div>Replay hash: {replay.replay_hash ?? "not returned"}</div>
+            </div>
+          ) : (
+            <p className="mt-2 text-slate-500">
+              Replay summary unavailable from API. Run still accessible for investigation.
+            </p>
+          )}
+        </section>
+      </div>
+
+      <section className="rounded border border-slate-200 bg-white p-4 text-sm">
+        <h2 className="font-semibold text-slate-900">Evidence and lineage context</h2>
+        {evidence ? (
+          <div className="mt-2 space-y-1 text-slate-700">
+            <div>Evidence run id: {evidence.run_id ?? run.id}</div>
+            <div>Fingerprint: {evidence.fingerprint ?? "not returned"}</div>
+            <div>Policy hash: {evidence.policy_hash ?? run.policy_hash ?? "not returned"}</div>
+          </div>
+        ) : (
+          <p className="mt-2 text-slate-500">Evidence endpoint unavailable for this run.</p>
+        )}
+        <div className="mt-4 flex flex-wrap gap-4">
+          <Link href="/app/proofs" className="font-medium text-blue-600">
+            Open Truth Explorer →
+          </Link>
+          <Link href="/app/replay" className="font-medium text-blue-600">
+            Open Replay Lab →
+          </Link>
+          <Link href="/app/alerts" className="font-medium text-blue-600">
+            Open Live Alerts →
+          </Link>
+        </div>
+      </section>
     </div>
   );
 }

--- a/packages/web/src/app/app/settings/page.tsx
+++ b/packages/web/src/app/app/settings/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import RoleMatrix from "@/components/stitch-import/RoleMatrix";
 import FreezeToggle from "@/components/stitch-import/FreezeToggle";
 
@@ -5,14 +6,29 @@ export default function SettingsPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold">Settings & Governance</h1>
-        <p className="text-sm text-slate-600">Configure runtime controls and role boundaries.</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Governance</p>
+        <h1 className="text-2xl font-semibold">Tenant Isolation Controls</h1>
+        <p className="text-sm text-slate-600">
+          Configure runtime controls and role boundaries used to preserve multi-tenant safety.
+        </p>
       </div>
       <div className="rounded-xl border border-slate-200 bg-white p-4">
         <FreezeToggle />
       </div>
       <div className="rounded-xl border border-slate-200 bg-white p-4">
         <RoleMatrix />
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-700">
+        Tenant isolation verification artifacts are tracked under <code>security/evidence</code> and
+        route-level controls are visible in the audit surfaces.
+        <div className="mt-3 flex flex-wrap gap-4">
+          <Link href="/app/audit" className="font-medium text-blue-600">
+            Open Audit Surfaces →
+          </Link>
+          <Link href="/app/evidence" className="font-medium text-blue-600">
+            Open Evidence Query Surface →
+          </Link>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Surface operator-grade workflows (deterministic replay, evidence retrieval, truth/lineage exploration, runtime signals, and tenant controls) so the app reflects implemented control-plane capabilities. 
- Centralize and document implemented product capabilities and maturity to align README and onboarding materials with current repo behavior. 
- Improve run-level troubleshooting by exposing replay and evidence summaries directly in the UI for faster operator triage.

### Description
- Add `docs/PRODUCT_CAPABILITIES_MATRIX.md` and update `README.md` with a "What makes Settler different" section describing implemented control-plane surfaces. 
- Enhance demo docs in `docs/demo/demo-walkthrough.md` to include in-product operator flows and evidence verification notes. 
- Replace and extend several UI pages and layout in `packages/web/src/app/*`: reorganize sidebar into labeled `navSections`, widen sidebar, add operator-focused landing at `/app`, implement `/app/evidence` page, enrich `/app/metrics` and `/app/settings` with operator-facing copy, and overhaul run detail page at `/app/runs/[id]` to fetch and display run metadata, replay summary, and evidence summary. 
- Introduce small refactors and typed client fetch helper (`fetchFromApi`) and a few UI link additions to connect the new surfaces (e.g., links to Run Explorer, Truth Explorer, Replay Lab, Audit, and Evidence surfaces).

### Testing
- Ran static type checking with `pnpm run typecheck`, which completed successfully. 
- Performed local route verification with `pnpm run verify:routes` to ensure new pages and links resolve, and it passed. 
- Built and ran the web app locally (Next.js dev server) to validate page rendering and API fetch flows, and no runtime errors were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b096785d188328a63ed47807ca1680)