### PR TITLE
Pilot readiness: tenant bootstrap CLI, import workbench, sample connectors, datasets, and operator runbooks

### DIFF
--- a/docs/PILOT_DEPLOYMENT_CHECKLIST.md
+++ b/docs/PILOT_DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,27 @@
+# PILOT DEPLOYMENT CHECKLIST
+
+## Environment setup
+- [ ] Production environment variables are set for API, Web, workers, and operator tooling.
+- [ ] Tenant isolation flags and auth secrets are set and rotated.
+- [ ] `pnpm tenant:create --help` executes successfully in operator environment.
+
+## Redis availability
+- [ ] Redis endpoint reachable from API + worker nodes.
+- [ ] Redis authentication/TLS validated.
+- [ ] Queue latency and failure metrics visible in telemetry.
+
+## DB migrations
+- [ ] All required migrations applied to target database.
+- [ ] RLS and tenant-bound policies verified after migration.
+- [ ] Migration verification script exits cleanly (`pnpm verify:schema`).
+
+## Alert integration
+- [ ] Alert provider configured (email/Slack/PagerDuty).
+- [ ] Reconciliation mismatch and ingestion failure alerts tested.
+- [ ] Alert payload includes workspace ID, run ID, and correlation ID.
+
+## Telemetry validation
+- [ ] Run lifecycle events emitted for create/start/complete/fail.
+- [ ] Replay events emitted and queryable.
+- [ ] Operator dashboard shows tenant-scoped run health and failure counts.
+- [ ] Audit artifacts retained for at least one complete pilot cycle.

--- a/docs/PILOT_OPERATOR_RUNBOOK.md
+++ b/docs/PILOT_OPERATOR_RUNBOOK.md
@@ -1,0 +1,44 @@
+# PILOT OPERATOR RUNBOOK
+
+## 1) Onboarding steps
+1. Create tenant bootstrap plan:
+   - `pnpm tenant:create --name "Acme Pilot" --slug acme-pilot --owner-email ops@acme.test`
+2. Execute tenant creation against target API:
+   - `pnpm tenant:create --execute --write-env --base-url https://<api-host> --api-key <operator-admin-key> --name "Acme Pilot" --slug acme-pilot --owner-email ops@acme.test`
+3. Confirm generated env file exists: `.env.tenant.acme-pilot`.
+4. Validate tenant isolation checks before opening operator access:
+   - `pnpm verify:tenant`
+
+## 2) Reconciliation workflow
+1. Stage pilot data from `/pilot-data`.
+2. Parse + validate + preview with import workbench module (`scripts/pilot/import-workbench.ts`).
+3. Load normalized transactions to ingestion route (CSV/webhook/REST).
+4. Trigger reconciliation run for the workspace.
+5. Record run ID and reconciliation evidence bundle for audit.
+
+## 3) Alert handling
+1. Monitor alert channels (email/Slack/PagerDuty) for:
+   - reconciliation drift
+   - mismatch threshold breach
+   - ingestion failures
+2. For every alert:
+   - identify tenant/workspace ID
+   - capture run ID + correlation ID
+   - classify as data quality vs system failure
+3. Apply least-privilege remediation and re-run only affected tenant scope.
+
+## 4) Replay workflow
+1. Locate target run ID from operator UI or execution ledger.
+2. Replay with immutable input snapshot and pinned policy version.
+3. Compare output hash to original evidence hash.
+4. If hash mismatch:
+   - raise `replay_divergence`
+   - block policy promotion until resolved
+   - preserve both evidence bundles.
+
+## 5) Troubleshooting
+- **Tenant creation fails**: verify admin API key scope and workspace slug uniqueness.
+- **Connector ingest fails**: validate source signature/credentials and payload schema.
+- **Reconciliation stalls**: inspect worker queue depth and Redis health.
+- **Missing alerts**: validate alert provider credentials and route configuration.
+- **Replay mismatch**: verify policy/rules version pinning and input artifact integrity.

--- a/package.json
+++ b/package.json
@@ -264,9 +264,10 @@
     "generate:api-route-inventory": "tsx scripts/generate-api-route-inventory.ts",
     "verify:api-route-inventory": "tsx scripts/verify-api-route-inventory.ts",
     "verify:event-taxonomy": "tsx scripts/verify-event-taxonomy.ts",
-    "demo:settler": "tsx scripts/settler-demo-pipeline.ts"
-    "replay:run": "pnpm --filter @settler/cli exec tsx src/tools/replay-runner.ts"
-    "simulate:settler": "tsx scripts/simulate-settler.ts"
+    "demo:settler": "tsx scripts/settler-demo-pipeline.ts",
+    "replay:run": "pnpm --filter @settler/cli exec tsx src/tools/replay-runner.ts",
+    "simulate:settler": "tsx scripts/simulate-settler.ts",
+    "tenant:create": "tsx scripts/tenant-create.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/pilot-data/README.md
+++ b/pilot-data/README.md
@@ -1,0 +1,10 @@
+# Pilot Data Pack
+
+Curated starter datasets for first-tenant validation:
+
+- `payments.csv`: baseline payment events
+- `refunds.csv`: refund flows
+- `settlements.csv`: settlement events
+- `discrepancy-scenarios.csv`: controlled mismatch scenarios
+
+These files are shaped to feed `scripts/pilot/import-workbench.ts` and can be used to validate reconciliation behavior, alerting, and replay.

--- a/pilot-data/discrepancy-scenarios.csv
+++ b/pilot-data/discrepancy-scenarios.csv
@@ -1,0 +1,4 @@
+scenario_id,external_id,scenario,expected_outcome
+disc_1,pay_1002,missing_settlement,raise_alert_unsettled_payment
+disc_2,ref_2003,currency_mismatch,raise_alert_currency_divergence
+disc_3,pay_1004,duplicate_ingestion,mark_idempotent_replay

--- a/pilot-data/payments.csv
+++ b/pilot-data/payments.csv
@@ -1,0 +1,5 @@
+external_id,amount,currency,occurred_at,type
+pay_1001,120.25,USD,2026-02-01T10:00:00Z,payment
+pay_1002,85.40,USD,2026-02-01T10:05:00Z,payment
+pay_1003,210.00,EUR,2026-02-01T10:10:00Z,payment
+pay_1004,59.99,USD,2026-02-01T10:20:00Z,payment

--- a/pilot-data/refunds.csv
+++ b/pilot-data/refunds.csv
@@ -1,0 +1,4 @@
+external_id,amount,currency,occurred_at,type
+ref_2001,20.25,USD,2026-02-02T08:00:00Z,refund
+ref_2002,9.99,USD,2026-02-02T09:15:00Z,refund
+ref_2003,15.00,EUR,2026-02-02T11:00:00Z,refund

--- a/pilot-data/settlements.csv
+++ b/pilot-data/settlements.csv
@@ -1,0 +1,3 @@
+external_id,amount,currency,occurred_at,type
+set_3001,176.15,USD,2026-02-03T00:00:00Z,settlement
+set_3002,195.00,EUR,2026-02-03T00:00:00Z,settlement

--- a/scripts/pilot/import-workbench.ts
+++ b/scripts/pilot/import-workbench.ts
@@ -1,0 +1,83 @@
+export type RawImportRow = Record<string, string>;
+
+export type ValidationIssue = {
+  row: number;
+  field: string;
+  reason: string;
+};
+
+export type NormalizedTransaction = {
+  externalId: string;
+  amountMinor: number;
+  currency: string;
+  occurredAt: string;
+  type: "payment" | "refund" | "settlement";
+};
+
+export function parseCsv(input: string): RawImportRow[] {
+  const lines = input.trim().split(/\r?\n/);
+  if (lines.length < 2) return [];
+  const headers = lines[0].split(",").map((h) => h.trim());
+  return lines.slice(1).map((line) => {
+    const values = line.split(",").map((v) => v.trim());
+    const row: RawImportRow = {};
+    headers.forEach((h, i) => {
+      row[h] = values[i] ?? "";
+    });
+    return row;
+  });
+}
+
+export function validateImportRows(rows: RawImportRow[]): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  rows.forEach((row, index) => {
+    const rowNumber = index + 2;
+    if (!row.external_id) issues.push({ row: rowNumber, field: "external_id", reason: "missing" });
+    if (!row.amount || Number.isNaN(Number(row.amount))) {
+      issues.push({ row: rowNumber, field: "amount", reason: "must be numeric" });
+    }
+    if (!row.currency || row.currency.length !== 3) {
+      issues.push({ row: rowNumber, field: "currency", reason: "must be ISO-4217" });
+    }
+    if (!row.occurred_at || Number.isNaN(Date.parse(row.occurred_at))) {
+      issues.push({ row: rowNumber, field: "occurred_at", reason: "must be ISO timestamp" });
+    }
+    if (!["payment", "refund", "settlement"].includes(row.type ?? "")) {
+      issues.push({ row: rowNumber, field: "type", reason: "unsupported transaction type" });
+    }
+  });
+
+  return issues;
+}
+
+export function previewImport(rows: RawImportRow[]): {
+  totalRows: number;
+  byType: Record<string, number>;
+  currencies: string[];
+} {
+  const byType: Record<string, number> = {};
+  const currencies = new Set<string>();
+
+  rows.forEach((row) => {
+    const type = row.type ?? "unknown";
+    byType[type] = (byType[type] ?? 0) + 1;
+    if (row.currency) currencies.add(row.currency.toUpperCase());
+  });
+
+  return {
+    totalRows: rows.length,
+    byType,
+    currencies: [...currencies].sort(),
+  };
+}
+
+export function normalizeImport(rows: RawImportRow[]): NormalizedTransaction[] {
+  return rows.map((row) => ({
+    externalId: row.external_id,
+    amountMinor: Math.round(Number(row.amount) * 100),
+    currency: row.currency.toUpperCase(),
+    occurredAt: new Date(row.occurred_at).toISOString(),
+    type: row.type as NormalizedTransaction["type"],
+  }));
+}

--- a/scripts/pilot/sample-connectors.md
+++ b/scripts/pilot/sample-connectors.md
@@ -1,0 +1,47 @@
+# Pilot Sample Connectors (Reference)
+
+## CSV import
+Use `scripts/pilot/import-workbench.ts` to parse, validate, preview, and normalize staged CSV files before creating reconciliation inputs.
+
+## Webhook ingestion
+Reference payload:
+
+```json
+{
+  "eventType": "transaction.created",
+  "workspaceId": "ws_pilot",
+  "externalId": "evt_1001",
+  "amount": 120.25,
+  "currency": "USD",
+  "occurredAt": "2026-02-01T10:00:00Z"
+}
+```
+
+Required controls:
+- Verify signature before parsing body.
+- Enforce timestamp skew window and idempotency key replay protections.
+- Persist tenant/workspace identifiers with each event.
+
+## REST ingestion endpoint
+`POST /api/v1/ingestion/transactions`
+
+```json
+{
+  "workspaceId": "ws_pilot",
+  "source": "rest",
+  "transactions": [
+    {
+      "externalId": "txn_1001",
+      "type": "payment",
+      "amountMinor": 12025,
+      "currency": "USD",
+      "occurredAt": "2026-02-01T10:00:00Z"
+    }
+  ]
+}
+```
+
+Required controls:
+- Reject cross-tenant workspace IDs.
+- Validate payload schema and normalization contract.
+- Emit ingestion evidence with run correlation ID.

--- a/scripts/tenant-create.ts
+++ b/scripts/tenant-create.ts
@@ -1,0 +1,251 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+type Args = {
+  name: string;
+  slug: string;
+  ownerEmail: string;
+  baseUrl: string;
+  apiKey?: string;
+  execute: boolean;
+  writeEnv: boolean;
+};
+
+type StepResult = {
+  step: string;
+  status: "completed" | "degraded";
+  detail: string;
+};
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = {
+    name: "Pilot Workspace",
+    slug: "pilot-workspace",
+    ownerEmail: "operator@example.com",
+    baseUrl: process.env.SETTLER_API_BASE_URL ?? "http://localhost:4000",
+    apiKey: process.env.SETTLER_OPERATOR_API_KEY,
+    execute: false,
+    writeEnv: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    if (token === "--execute") out.execute = true;
+    else if (token === "--write-env") out.writeEnv = true;
+    else if (token === "--name" && next) {
+      out.name = next;
+      i += 1;
+    } else if (token === "--slug" && next) {
+      out.slug = next;
+      i += 1;
+    } else if (token === "--owner-email" && next) {
+      out.ownerEmail = next;
+      i += 1;
+    } else if (token === "--base-url" && next) {
+      out.baseUrl = next;
+      i += 1;
+    } else if (token === "--api-key" && next) {
+      out.apiKey = next;
+      i += 1;
+    } else if (token === "--help" || token === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  return out;
+}
+
+function printHelp(): void {
+  console.log(`\nUsage: pnpm tenant:create [options]\n\nOptions:\n  --name <name>             Workspace display name\n  --slug <slug>             Workspace slug\n  --owner-email <email>     Owner operator email\n  --base-url <url>          API base URL (default: $SETTLER_API_BASE_URL or http://localhost:4000)\n  --api-key <key>           Operator API key (default: $SETTLER_OPERATOR_API_KEY)\n  --execute                 Execute API calls (default is dry-run plan only)\n  --write-env               Persist .env.tenant.<slug> file\n  -h, --help                Show help\n`);
+}
+
+async function postJson(
+  baseUrl: string,
+  path: string,
+  body: Record<string, unknown>,
+  apiKey?: string
+): Promise<{ ok: boolean; body: unknown; status: number }> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  let payload: unknown = text;
+  try {
+    payload = text ? (JSON.parse(text) as unknown) : null;
+  } catch {
+    payload = text;
+  }
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    body: payload,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const results: StepResult[] = [];
+
+  const plan = {
+    tenant: {
+      name: args.name,
+      slug: args.slug,
+      ownerEmail: args.ownerEmail,
+    },
+    steps: [
+      "tenant_registration",
+      "environment_configuration",
+      "api_key_generation",
+      "source_connection_setup",
+      "first_reconciliation_run",
+    ],
+    executionMode: args.execute ? "execute" : "dry-run",
+  };
+
+  if (!args.execute) {
+    results.push({
+      step: "tenant_registration",
+      status: "degraded",
+      detail: "Dry-run mode: no API calls made.",
+    });
+  }
+
+  let workspaceId = `ws_${args.slug}`;
+  let generatedKey = args.apiKey ?? "<generated-operator-key>";
+
+  if (args.execute) {
+    const workspaceResponse = await postJson(
+      args.baseUrl,
+      "/api/v1/workspaces",
+      {
+        name: args.name,
+        slug: args.slug,
+        ownerEmail: args.ownerEmail,
+      },
+      args.apiKey
+    );
+
+    if (workspaceResponse.ok) {
+      const payload = workspaceResponse.body as { id?: string };
+      workspaceId = payload?.id ?? workspaceId;
+      results.push({
+        step: "tenant_registration",
+        status: "completed",
+        detail: `Workspace created (${workspaceId}).`,
+      });
+    } else {
+      results.push({
+        step: "tenant_registration",
+        status: "degraded",
+        detail: `Workspace creation failed with status ${workspaceResponse.status}.`,
+      });
+    }
+
+    const keyResponse = await postJson(
+      args.baseUrl,
+      `/api/v1/workspaces/${workspaceId}/api-keys`,
+      {
+        label: "pilot-operator",
+        scopes: ["workspace:read", "workspace:write", "reconciliation:run", "alerts:read"],
+      },
+      args.apiKey
+    );
+
+    if (keyResponse.ok) {
+      const payload = keyResponse.body as { token?: string };
+      generatedKey = payload?.token ?? generatedKey;
+      results.push({
+        step: "api_key_generation",
+        status: "completed",
+        detail: "Operator API key issued.",
+      });
+    } else {
+      results.push({
+        step: "api_key_generation",
+        status: "degraded",
+        detail: `API key creation failed with status ${keyResponse.status}.`,
+      });
+    }
+
+    for (const source of ["csv", "webhook", "rest"]) {
+      const connectorResponse = await postJson(
+        args.baseUrl,
+        "/api/v1/connectors",
+        {
+          workspaceId,
+          type: source,
+          name: `pilot-${source}`,
+          config: { mode: "sample", source },
+        },
+        generatedKey
+      );
+
+      results.push({
+        step: "source_connection_setup",
+        status: connectorResponse.ok ? "completed" : "degraded",
+        detail: connectorResponse.ok
+          ? `Connector provisioned (${source}).`
+          : `Connector (${source}) failed with status ${connectorResponse.status}.`,
+      });
+    }
+
+    const runResponse = await postJson(
+      args.baseUrl,
+      "/api/v1/reconciliations/runs",
+      {
+        workspaceId,
+        mode: "pilot_bootstrap",
+        sourceRefs: ["pilot-csv", "pilot-webhook", "pilot-rest"],
+      },
+      generatedKey
+    );
+
+    results.push({
+      step: "first_reconciliation_run",
+      status: runResponse.ok ? "completed" : "degraded",
+      detail: runResponse.ok
+        ? "Initial reconciliation run created."
+        : `Initial reconciliation run failed with status ${runResponse.status}.`,
+    });
+  }
+
+  results.push({
+    step: "environment_configuration",
+    status: "completed",
+    detail: "Generated tenant-scoped environment payload.",
+  });
+
+  const envPayload = [
+    `SETTLER_WORKSPACE_ID=${workspaceId}`,
+    `SETTLER_WORKSPACE_SLUG=${args.slug}`,
+    `SETTLER_OPERATOR_EMAIL=${args.ownerEmail}`,
+    `SETTLER_OPERATOR_API_KEY=${generatedKey}`,
+    `SETTLER_API_BASE_URL=${args.baseUrl}`,
+  ].join("\n");
+
+  if (args.writeEnv) {
+    const envPath = resolve(process.cwd(), `.env.tenant.${args.slug}`);
+    writeFileSync(envPath, `${envPayload}\n`, "utf8");
+  }
+
+  const summary = {
+    generatedAt: new Date().toISOString(),
+    plan,
+    workspaceId,
+    env: envPayload,
+    results,
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+void main();


### PR DESCRIPTION
### Motivation
- Prepare the platform for first-tenant pilot operations by providing deterministic onboarding tooling and operator guidance to create workspaces, connect sources, run reconciliation, inspect/replay runs, and handle alerts.
- Provide small, well-scoped reference connectors and a validation/normalization workbench so pilot data can be safely staged and ingested.
- Ship operator-facing runbooks and a deployment checklist to reduce friction and surface operational checks for a safe pilot launch.

### Description
- Added a `tenant:create` entry to the root scripts in `package.json` and fixed the malformed script comma so root scripts parse and `pnpm tenant:create` is available as a repo command. (`package.json`)
- Implemented `scripts/tenant-create.ts`, an operator helper that supports dry-run and execute modes for tenant registration, environment payload generation, operator API key issuance, connector provisioning (`csv`, `webhook`, `rest`), first reconciliation run trigger, and machine-readable per-step `completed|degraded` status output. (`scripts/tenant-create.ts`)
- Added an import workbench library with `parseCsv`, `validateImportRows`, `previewImport`, and `normalizeImport` to enable validation, preview, and normalization of CSV pilot data prior to ingestion. (`scripts/pilot/import-workbench.ts`)
- Added connector reference guidance for CSV, webhook, and REST ingestion including tenant-safety controls (signature verification, replay protection, cross-tenant rejection, evidence emissions). (`scripts/pilot/sample-connectors.md`)
- Added curated pilot datasets for payments, refunds, settlements, and discrepancy scenarios to `/pilot-data` plus a README to explain intended usage. (`pilot-data/*`)
- Added operator documentation: `docs/PILOT_OPERATOR_RUNBOOK.md` describing onboarding, reconciliation, alerts, replay, and troubleshooting, and `docs/PILOT_DEPLOYMENT_CHECKLIST.md` covering environment, Redis, DB migrations, alert integration, and telemetry validation. (`docs/*`)

### Testing
- Validated that the root `package.json` is syntactically correct by running `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`, which succeeded. (pass)
- Attempted to exercise the CLI help via `pnpm -s tenant:create --help` in the current container and it failed because `tsx` is not present in the PATH in this environment, which prevents local execution of the TypeScript script here (environment limitation). (failed — environment)
- No other automated lint/typecheck/build tests were executed in this pass; runtime verification of `tenant:create` requires a host with `tsx`/Node tooling and reachable API routes and will report explicit degraded step statuses if API contracts differ. (manual follow-up required)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09e5f8dc083289a411d4741f3b088)