### PR TITLE
Add operator incident detection, system_incidents table, and operator incidents UI

### DIFF
--- a/docs/INCIDENT_RESPONSE_PLAYBOOK.md
+++ b/docs/INCIDENT_RESPONSE_PLAYBOOK.md
@@ -1,0 +1,60 @@
+# Incident Response Playbook
+
+## Scope
+This playbook defines operator actions for runtime incidents surfaced in `/operator/incidents`.
+
+## Detection Sources
+- Runtime metrics from operator control plane (`run throughput`, `API latency`, `reconciliation duration`, `manual review rate`, `error rate`).
+- Automated anomaly detection for:
+  - `match_rate_drop`
+  - `run_failure`
+  - `latency_spike`
+  - `error_spike`
+- Incident records in `system_incidents`.
+
+## Severity Model
+- **warning**: investigate within business hours.
+- **critical**: investigate immediately, open incident channel, and assign owner.
+
+## Triage Steps
+1. Open `/operator/incidents` and filter `status=open`.
+2. Sort by severity then recency.
+3. For each incident:
+   - Validate evidence values vs baseline.
+   - Link affected `run_id` (or most representative run) using **Link**.
+   - Click **Acknowledge** once owner is assigned.
+4. If customer impact exists, open support ticket with tenant and run linkage.
+
+## Response by Incident Type
+### match_rate_drop
+- Validate upstream schema changes and adapter mapping drift.
+- Inspect unmatched categories and manual review growth.
+- Mitigate via mapping fix or rollback recent matching rules.
+
+### run_failure
+- Inspect failed runs and top error signatures.
+- Verify queue health, dependency outages, and tenant-specific regressions.
+- Retry failed runs once root cause mitigation is applied.
+
+### latency_spike
+- Check API p95 and DB saturation indicators.
+- Correlate to deploy window and high-traffic tenants.
+- Apply throttling/caching or rollback high-latency release.
+
+### error_spike
+- Inspect dominant 5xx signatures and impacted routes.
+- Confirm blast radius by tenant.
+- Ship hotfix and monitor regression for 24h.
+
+## Closure Criteria
+Close incident only when:
+- metric returns near baseline,
+- no new critical alerts for the same type in observation window,
+- linked run or validation evidence is documented.
+
+## Auditability
+All incident lifecycle actions must be machine-visible:
+- incident creation timestamp,
+- acknowledgement metadata,
+- run linkage metadata,
+- evidence payload and summary.

--- a/packages/web/src/app/api/console/operator/control-plane/route.ts
+++ b/packages/web/src/app/api/console/operator/control-plane/route.ts
@@ -33,6 +33,16 @@ interface AlertCandidate {
   message: string;
 }
 
+interface IncidentCandidate {
+  incidentType: "match_rate_drop" | "run_failure" | "latency_spike" | "error_spike";
+  severity: "warning" | "critical";
+  tenantId: string | null;
+  runId: string | null;
+  status: "open";
+  summary: string;
+  evidence: Record<string, number | string | null>;
+}
+
 const supportSchema = z.object({
   subject: z.string().min(3).max(180),
   description: z.string().min(5).max(5000),
@@ -80,6 +90,24 @@ async function ensureOperatorTables(): Promise<void> {
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
     CREATE INDEX IF NOT EXISTS idx_operator_error_issue_links_last_seen ON operator_error_issue_links(last_seen_at DESC);
+
+    CREATE TABLE IF NOT EXISTS system_incidents (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      incident_type TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      tenant_id UUID,
+      run_id UUID,
+      status TEXT NOT NULL DEFAULT 'open',
+      summary TEXT NOT NULL,
+      evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+      acknowledged_at TIMESTAMPTZ,
+      acknowledged_by TEXT,
+      linked_run_id UUID,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_system_incidents_created_at ON system_incidents(created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_system_incidents_status ON system_incidents(status);
   `);
 }
 
@@ -138,6 +166,66 @@ function computeAnomalies(row: Record<string, number | null | undefined>): Alert
   return anomalies;
 }
 
+function computeIncidentCandidates(row: Record<string, number | null | undefined>): IncidentCandidate[] {
+  const toNumber = (v: number | null | undefined) => Number(v ?? 0);
+  const recentFailure = toNumber(row.recent_failure_rate);
+  const baseFailure = toNumber(row.baseline_failure_rate);
+  const recentMatchRate = toNumber(row.recent_match_rate);
+  const baseMatchRate = toNumber(row.baseline_match_rate);
+  const recentP95 = toNumber(row.recent_api_p95_ms);
+  const baseP95 = toNumber(row.baseline_api_p95_ms);
+  const recentApiError = toNumber(row.recent_api_error_rate);
+  const baseApiError = toNumber(row.baseline_api_error_rate);
+
+  const incidents: IncidentCandidate[] = [];
+  if (recentMatchRate < Math.max(85, baseMatchRate - 6)) {
+    incidents.push({
+      incidentType: "match_rate_drop",
+      severity: recentMatchRate < Math.max(75, baseMatchRate - 12) ? "critical" : "warning",
+      tenantId: null,
+      runId: null,
+      status: "open",
+      summary: `Match rate dropped to ${recentMatchRate.toFixed(2)}% (baseline ${baseMatchRate.toFixed(2)}%).`,
+      evidence: { recentMatchRate, baselineMatchRate: baseMatchRate },
+    });
+  }
+  if (recentFailure > Math.max(6, baseFailure * 1.75)) {
+    incidents.push({
+      incidentType: "run_failure",
+      severity: recentFailure > Math.max(12, baseFailure * 2.2) ? "critical" : "warning",
+      tenantId: null,
+      runId: null,
+      status: "open",
+      summary: `Run failure rate spiked to ${recentFailure.toFixed(2)}% (baseline ${baseFailure.toFixed(2)}%).`,
+      evidence: { recentFailureRate: recentFailure, baselineFailureRate: baseFailure },
+    });
+  }
+  if (recentP95 > Math.max(1200, baseP95 * 1.8)) {
+    incidents.push({
+      incidentType: "latency_spike",
+      severity: recentP95 > Math.max(2500, baseP95 * 2.5) ? "critical" : "warning",
+      tenantId: null,
+      runId: null,
+      status: "open",
+      summary: `API latency p95 rose to ${Math.round(recentP95)}ms (baseline ${Math.round(baseP95)}ms).`,
+      evidence: { recentApiLatencyP95Ms: recentP95, baselineApiLatencyP95Ms: baseP95 },
+    });
+  }
+  if (recentApiError > Math.max(2.5, baseApiError * 2)) {
+    incidents.push({
+      incidentType: "error_spike",
+      severity: recentApiError > Math.max(7, baseApiError * 2.5) ? "critical" : "warning",
+      tenantId: null,
+      runId: null,
+      status: "open",
+      summary: `API error rate increased to ${recentApiError.toFixed(2)}% (baseline ${baseApiError.toFixed(2)}%).`,
+      evidence: { recentApiErrorRate: recentApiError, baselineApiErrorRate: baseApiError },
+    });
+  }
+
+  return incidents;
+}
+
 async function persistAlerts(anomalies: AlertCandidate[]): Promise<void> {
   for (const alert of anomalies) {
     await prisma.$executeRaw`
@@ -164,6 +252,41 @@ async function persistAlerts(anomalies: AlertCandidate[]): Promise<void> {
         message = EXCLUDED.message,
         payload = EXCLUDED.payload,
         updated_at = NOW();
+    `;
+  }
+}
+
+async function persistIncidents(candidates: IncidentCandidate[]): Promise<void> {
+  for (const incident of candidates) {
+    await prisma.$executeRaw`
+      INSERT INTO system_incidents (
+        incident_type,
+        severity,
+        tenant_id,
+        run_id,
+        status,
+        summary,
+        evidence,
+        created_at,
+        updated_at
+      )
+      SELECT
+        ${incident.incidentType},
+        ${incident.severity},
+        ${incident.tenantId}::uuid,
+        ${incident.runId}::uuid,
+        ${incident.status},
+        ${incident.summary},
+        ${JSON.stringify(incident.evidence)}::jsonb,
+        NOW(),
+        NOW()
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM system_incidents si
+        WHERE si.incident_type = ${incident.incidentType}
+          AND si.status = 'open'
+          AND si.created_at >= NOW() - interval '6 hours'
+      );
     `;
   }
 }
@@ -382,6 +505,7 @@ async function buildPayload(days: number) {
     ), recent_runs AS (
       SELECT
         COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS failure_rate,
+        COALESCE((SUM(matched_count)::numeric / NULLIF(SUM(source_count), 0)) * 100, 0)::float8 AS match_rate,
         COALESCE(AVG(CASE WHEN source_count > 0
           THEN COALESCE(mrc.manual_review_count, 0) / source_count::float8 * 100
           ELSE 0
@@ -395,6 +519,7 @@ async function buildPayload(days: number) {
     baseline_runs AS (
       SELECT
         COALESCE((COUNT(*) FILTER (WHERE status = 'failed')::numeric / NULLIF(COUNT(*), 0)) * 100, 0)::float8 AS failure_rate,
+        COALESCE((SUM(matched_count)::numeric / NULLIF(SUM(source_count), 0)) * 100, 0)::float8 AS match_rate,
         COALESCE(AVG(CASE WHEN source_count > 0
           THEN COALESCE(mrc.manual_review_count, 0) / source_count::float8 * 100
           ELSE 0
@@ -424,6 +549,8 @@ async function buildPayload(days: number) {
     SELECT
       recent_runs.failure_rate AS recent_failure_rate,
       baseline_runs.failure_rate AS baseline_failure_rate,
+      recent_runs.match_rate AS recent_match_rate,
+      baseline_runs.match_rate AS baseline_match_rate,
       recent_runs.manual_review_rate AS recent_manual_review_rate,
       baseline_runs.manual_review_rate AS baseline_manual_review_rate,
       recent_api.p95_ms AS recent_api_p95_ms,
@@ -435,6 +562,8 @@ async function buildPayload(days: number) {
 
   const anomalies = computeAnomalies(anomalyWindow ?? {});
   await persistAlerts(anomalies);
+  const incidentCandidates = computeIncidentCandidates(anomalyWindow ?? {});
+  await persistIncidents(incidentCandidates);
 
   const persistedAlerts = await prisma.$queryRaw<Array<Record<string, unknown>>>(`
     SELECT dedupe_key, metric, severity, status, triggered_count,
@@ -589,6 +718,13 @@ async function buildPayload(days: number) {
 
   return {
     systemHealth: systemHealth ?? null,
+    runtimeMetrics: {
+      runThroughputPerDay: Number(systemHealth?.runs_per_day ?? 0),
+      apiLatencyP95Ms: Number(systemHealth?.api_latency_p95 ?? 0),
+      reconciliationDurationP95Ms: Number(systemHealth?.run_duration_p95 ?? 0),
+      manualReviewRate: Number(systemHealth?.manual_review_rate ?? 0),
+      errorRate: Number(systemHealth?.api_error_rate ?? 0),
+    },
     activity: {
       recentRuns,
       failedRuns: recentRuns.filter((r) => r.status === "failed").slice(0, 10),

--- a/packages/web/src/app/api/operator/incidents/route.ts
+++ b/packages/web/src/app/api/operator/incidents/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/api/auth-gate";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const updateSchema = z.object({
+  incidentId: z.string().uuid(),
+  action: z.enum(["acknowledge", "link_run"]),
+  runId: z.string().uuid().optional(),
+});
+
+export const GET = withSecurity(
+  async function GET(request: NextRequest) {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isAdmin) return adminCheck.error!;
+
+    const { searchParams } = new URL(request.url);
+    const status = (searchParams.get("status") ?? "").trim();
+    const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+    const pageSize = Math.min(50, Math.max(1, Number(searchParams.get("pageSize") ?? "20") || 20));
+    const offset = (page - 1) * pageSize;
+
+    const [countRow] = await prisma.$queryRaw<Array<{ total: number }>>(
+      `
+      SELECT COUNT(*)::int AS total
+      FROM system_incidents si
+      WHERE ($1::text = '' OR si.status = $1::text)
+      `,
+      status
+    );
+
+    const incidents = await prisma.$queryRaw<
+      Array<{
+        id: string;
+        incident_type: string;
+        severity: string;
+        tenant_id: string | null;
+        run_id: string | null;
+        linked_run_id: string | null;
+        status: string;
+        summary: string;
+        evidence: Record<string, unknown>;
+        created_at: string;
+        acknowledged_at: string | null;
+        acknowledged_by: string | null;
+      }>
+    >(
+      `
+      SELECT
+        si.id::text,
+        si.incident_type,
+        si.severity,
+        si.tenant_id::text,
+        si.run_id::text,
+        si.linked_run_id::text,
+        si.status,
+        si.summary,
+        si.evidence,
+        si.created_at::text,
+        si.acknowledged_at::text,
+        si.acknowledged_by
+      FROM system_incidents si
+      WHERE ($1::text = '' OR si.status = $1::text)
+      ORDER BY si.created_at DESC, si.id DESC
+      LIMIT $2 OFFSET $3
+      `,
+      status,
+      pageSize,
+      offset
+    );
+
+    return NextResponse.json({
+      data: incidents,
+      pagination: {
+        page,
+        pageSize,
+        total: Number(countRow?.total ?? 0),
+        totalPages: Math.max(1, Math.ceil(Number(countRow?.total ?? 0) / pageSize)),
+      },
+    });
+  },
+  { requireAuth: true }
+);
+
+export const PATCH = withSecurity(
+  async function PATCH(request: NextRequest) {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isAdmin) return adminCheck.error!;
+
+    const payload = updateSchema.parse(await request.json());
+
+    if (payload.action === "acknowledge") {
+      const [result] = await prisma.$queryRaw<Array<{ id: string }>>(
+        `
+        UPDATE system_incidents
+        SET
+          status = 'acknowledged',
+          acknowledged_at = NOW(),
+          acknowledged_by = $2,
+          updated_at = NOW()
+        WHERE id = $1::uuid
+        RETURNING id::text
+        `,
+        payload.incidentId,
+        adminCheck.user?.email ?? "operator"
+      );
+
+      return NextResponse.json({ success: Boolean(result?.id) });
+    }
+
+    const [result] = await prisma.$queryRaw<Array<{ id: string }>>(
+      `
+      UPDATE system_incidents
+      SET
+        linked_run_id = $2::uuid,
+        updated_at = NOW()
+      WHERE id = $1::uuid
+      RETURNING id::text
+      `,
+      payload.incidentId,
+      payload.runId ?? null
+    );
+
+    return NextResponse.json({ success: Boolean(result?.id) });
+  },
+  { requireAuth: true }
+);

--- a/packages/web/src/app/console/operator/page.tsx
+++ b/packages/web/src/app/console/operator/page.tsx
@@ -148,7 +148,7 @@ export default function OperatorControlPlanePage() {
         <p className="text-sm text-amber-600">Degraded mode: partial data available.</p>
       ) : null}
 
-      <section className="grid grid-cols-2 md:grid-cols-5 gap-3">
+      <section className="grid grid-cols-2 md:grid-cols-7 gap-3">
         <Metric label="Runs/day" value={health?.runs_per_day ?? 0} />
         <Metric
           label="Failure rate"
@@ -160,6 +160,11 @@ export default function OperatorControlPlanePage() {
           value={`${Number(health?.manual_review_rate ?? 0).toFixed(2)}%`}
         />
         <Metric label="API error" value={`${Number(health?.api_error_rate ?? 0).toFixed(2)}%`} />
+        <Metric label="API p95" value={`${Math.round(Number(health?.api_latency_p95 ?? 0))}ms`} />
+        <Metric
+          label="Recon p95"
+          value={`${Math.round(Number(health?.run_duration_p95 ?? 0))}ms`}
+        />
       </section>
 
       <section className="grid md:grid-cols-2 gap-4">
@@ -182,6 +187,12 @@ export default function OperatorControlPlanePage() {
           <p className="text-sm">Error spikes in 24h: {recentErrorSpikeCount}</p>
           <p className="text-sm">Alert history entries: {payload.data.alerts.length}</p>
         </div>
+      </section>
+
+      <section>
+        <a className="text-sm underline" href="/operator/incidents">
+          Open incident queue (/operator/incidents)
+        </a>
       </section>
 
       <section className="rounded border p-4">

--- a/packages/web/src/app/operator/incidents/page.tsx
+++ b/packages/web/src/app/operator/incidents/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface IncidentRecord {
+  id: string;
+  incident_type: string;
+  severity: string;
+  tenant_id: string | null;
+  run_id: string | null;
+  linked_run_id: string | null;
+  status: string;
+  summary: string;
+  evidence: Record<string, unknown>;
+  created_at: string;
+  acknowledged_at: string | null;
+  acknowledged_by: string | null;
+}
+
+interface IncidentResponse {
+  data: IncidentRecord[];
+  pagination: { page: number; pageSize: number; total: number; totalPages: number };
+}
+
+export default function OperatorIncidentsPage() {
+  const [items, setItems] = useState<IncidentRecord[]>([]);
+  const [statusFilter, setStatusFilter] = useState("");
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [linkRunByIncident, setLinkRunByIncident] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    void loadIncidents();
+  }, [statusFilter, page]);
+
+  async function loadIncidents() {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(page), pageSize: "20" });
+    if (statusFilter) params.set("status", statusFilter);
+    const res = await fetch(`/api/operator/incidents?${params.toString()}`);
+    const payload = (await res.json()) as IncidentResponse;
+    setItems(payload.data ?? []);
+    setLoading(false);
+  }
+
+  async function acknowledge(incidentId: string) {
+    await fetch("/api/operator/incidents", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ incidentId, action: "acknowledge" }),
+    });
+    await loadIncidents();
+  }
+
+  async function linkRun(incidentId: string) {
+    const runId = (linkRunByIncident[incidentId] ?? "").trim();
+    if (!runId) return;
+
+    await fetch("/api/operator/incidents", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ incidentId, action: "link_run", runId }),
+    });
+    await loadIncidents();
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Operator Incidents</h1>
+      <p className="text-sm text-slate-600">
+        Track anomaly-driven incidents, acknowledge ownership, and link incidents to reconciliation
+        runs.
+      </p>
+
+      <div className="flex items-center gap-2">
+        <label className="text-sm">Status</label>
+        <select
+          value={statusFilter}
+          onChange={(e) => {
+            setPage(1);
+            setStatusFilter(e.target.value);
+          }}
+          className="border rounded px-2 py-1 text-sm"
+        >
+          <option value="">All</option>
+          <option value="open">Open</option>
+          <option value="acknowledged">Acknowledged</option>
+        </select>
+      </div>
+
+      {loading ? (
+        <div className="text-sm">Loading incidents…</div>
+      ) : (
+        <div className="overflow-x-auto rounded border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-slate-50 text-left">
+                <th className="p-2">Type</th>
+                <th className="p-2">Severity</th>
+                <th className="p-2">Status</th>
+                <th className="p-2">Tenant</th>
+                <th className="p-2">Run</th>
+                <th className="p-2">Summary</th>
+                <th className="p-2">Created</th>
+                <th className="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <tr key={item.id} className="border-b align-top">
+                  <td className="p-2 font-mono">{item.incident_type}</td>
+                  <td className="p-2">{item.severity}</td>
+                  <td className="p-2">{item.status}</td>
+                  <td className="p-2 font-mono">{item.tenant_id?.slice(0, 8) ?? "—"}</td>
+                  <td className="p-2 font-mono">{(item.linked_run_id ?? item.run_id)?.slice(0, 8) ?? "—"}</td>
+                  <td className="p-2 max-w-[360px]">{item.summary}</td>
+                  <td className="p-2">{new Date(item.created_at).toLocaleString()}</td>
+                  <td className="p-2 space-y-2">
+                    <button
+                      type="button"
+                      className="border rounded px-2 py-1"
+                      onClick={() => acknowledge(item.id)}
+                      disabled={item.status === "acknowledged"}
+                    >
+                      Acknowledge
+                    </button>
+                    <div className="flex gap-1">
+                      <input
+                        className="border rounded px-2 py-1 w-36"
+                        placeholder="Run UUID"
+                        value={linkRunByIncident[item.id] ?? ""}
+                        onChange={(e) =>
+                          setLinkRunByIncident((prev) => ({ ...prev, [item.id]: e.target.value }))
+                        }
+                      />
+                      <button
+                        type="button"
+                        className="border rounded px-2 py-1"
+                        onClick={() => linkRun(item.id)}
+                      >
+                        Link
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {!items.length ? (
+                <tr>
+                  <td className="p-3 text-sm text-slate-500" colSpan={8}>
+                    No incidents found.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260310000000_system_incidents.sql
+++ b/supabase/migrations/20260310000000_system_incidents.sql
@@ -1,0 +1,20 @@
+-- Incident records for operator response workflows
+CREATE TABLE IF NOT EXISTS system_incidents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  incident_type TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  tenant_id UUID,
+  run_id UUID,
+  status TEXT NOT NULL DEFAULT 'open',
+  summary TEXT NOT NULL,
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  acknowledged_at TIMESTAMPTZ,
+  acknowledged_by TEXT,
+  linked_run_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_system_incidents_created_at ON system_incidents(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_system_incidents_status ON system_incidents(status);
+CREATE INDEX IF NOT EXISTS idx_system_incidents_tenant ON system_incidents(tenant_id);


### PR DESCRIPTION
### Motivation

- Provide operators with timely, machine-visible incident records derived from runtime anomalies so they can detect, triage, and resolve problems quickly. 
- Surface explicit runtime metrics (run throughput, API latency, reconciliation duration, manual review rate, error rate) used for anomaly detection and operator dashboards.

### Description

- Add a durable `system_incidents` table and migration (`supabase/migrations/20260310000000_system_incidents.sql`) to persist incident records with acknowledgement and run-linking metadata. 
- Extend the operator control-plane payload and backend (`packages/web/src/app/api/console/operator/control-plane/route.ts`) to compute anomaly candidates (`match_rate_drop`, `run_failure`, `latency_spike`, `error_spike`), persist deduplicated incidents, and expose `runtimeMetrics` (throughput, api p95, recon p95, manual review, error rate). 
- Implement a paginated incidents API at `/api/operator/incidents` with `GET` (list/filter) and `PATCH` (acknowledge/link run) handlers (`packages/web/src/app/api/operator/incidents/route.ts`). 
- Add an operator-facing triage UI at `/operator/incidents` (`packages/web/src/app/operator/incidents/page.tsx`) and surface an entry link on the existing operator control-plane (`packages/web/src/app/console/operator/page.tsx`). 
- Ship an operator playbook documenting detection, triage, severity, and closure criteria (`docs/INCIDENT_RESPONSE_PLAYBOOK.md`).

### Testing

- Ran `git diff --check` to verify basic diffs and whitespace rules and it passed. 
- Ran TypeScript check via `pnpm --filter @settler/web exec tsc --noEmit` which failed due to an unrelated root `package.json` integrity issue and not due to the changes in this patch. 
- Attempted a Playwright screenshot of `/operator/incidents` which failed because no local web server responded at `127.0.0.1:3000`. 
- Pre-commit migration verification flagged existing repository migration filename/transaction wrapper issues unrelated to this change (verification reported warnings/errors), so migration file content was added following the repo schema conventions for a new `system_incidents` table.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09e46a42c83289dad24f27a1ba737)