### PR TITLE
docs: clarity pass — README, onboarding, demo bootstrap, doctor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,133 @@
 # Settler
 
-Settler is an OSS-first deterministic execution and reconciliation platform.
+Settler is a deterministic financial reconciliation platform for teams that need reliable run outcomes, replayable execution, and operator-grade investigation.
 
-## Quickstart (core local path)
+It combines a reconciliation runtime with investigation and simulation tools so operators can answer three questions quickly:
 
-```bash
-pnpm run bootstrap
-pnpm run demo
-pnpm run dev:stack
-```
+1. **What happened?**
+2. **Why did it happen?**
+3. **What changes if we adjust policy?**
 
-`bootstrap` already runs `repo-integrity` and first-run doctor.
+## Project Overview
 
-## Command matrix
+Settler runs reconciliation as a deterministic execution flow, records evidence for every run, and gives operators clear tooling to inspect outcomes, replay behavior, and evaluate policy changes before they are applied.
 
-- `pnpm run bootstrap` — install + repo-integrity + first-run doctor.
-- `pnpm run doctor -- --skip-pipeline --first-run` — first-run diagnostics.
-- `pnpm run doctor -- --skip-pipeline` — strict local diagnostics (expects fuller env/runtime readiness).
-- `pnpm run demo` — deterministic demo execution + replay verification.
-- `pnpm run dev:stack` — canonical local API + web stack entrypoint.
-- `pnpm run repo-integrity` — monorepo/workspace contract validator.
-- `pnpm run verify` — full lint/typecheck/build/test/security surface.
+This repository contains the API, web console, CLI tools, demo harnesses, and documentation for local development and operational evaluation.
 
-## Core vs optional setup
+## Key Capabilities
 
-Core local onboarding does **not** require optional connectors (Stripe/Resend/Redis/etc.).
-Optional integrations should be configured only when validating those specific surfaces.
+- **Reconciliation Engine** — deterministic matching, mismatch classification, and review queues.
+- **Truth Explorer** — evidence and lineage inspection for completed runs.
+- **Replay Lab** — deterministic re-execution checks to detect drift.
+- **Policy Lab** — simulation surfaces for policy impact before rollout.
+- **Operator Intelligence** — incident triage and investigative context.
+- **Live Event Stream** — runtime telemetry and operator-facing event visibility.
+- **Alert Integrations** — Slack/Teams/Telegram alert fan-out paths.
+- **Import Workbench** — controlled ingest path for reconciliation data.
+- **Synthetic Foundry** — seeded deterministic data generation for testing and demo flows.
 
-## Repository structure
+## Architecture Overview
 
-- `packages/api` — API/control plane.
-- `packages/web` — Next.js UI.
-- `packages/cli` — Settler CLI runtime.
-- `packages/sdk` + `packages/react-settler` + `packages/types` — SDK/runtime libraries.
-- `docs/getting-started/*` — onboarding flow docs.
-- `docs/reference/repo-integrity.md` — repo truth gate.
-- `docs/reference/workspace-contracts.md` — workspace package contract.
+Settler is organized as a monorepo with six core runtime layers:
 
-## Onboarding docs
+- **API** (`packages/api`) — route surface, orchestration, tenancy-aware contracts.
+- **Reconciliation Engine** (`scripts/moat`, CLI runtime) — deterministic run execution.
+- **Operator Services** (API + web app modules) — run investigation, alerts, and controls.
+- **Runtime Telemetry** (`scripts`, metrics routes, event pipelines) — health and event capture.
+- **Policy Engine / Policy Lab** — policy checks and simulation workflows.
+- **Replay System / Replay Lab** — evidence replay and drift verification.
 
-- [Quickstart](docs/getting-started/quickstart.md)
-- [Bootstrap](docs/getting-started/bootstrap.md)
-- [Doctor](docs/getting-started/doctor.md)
-- [First-run demo](docs/demo/first-run-demo.md)
-- [Troubleshooting](docs/troubleshooting/installation-and-setup.md)
-- [Repo integrity reference](docs/reference/repo-integrity.md)
-- [Workspace contracts](docs/reference/workspace-contracts.md)
+Textual system flow:
 
-## What makes Settler different (implemented today)
+`Import Workbench -> Reconciliation Engine -> Run Explorer + Truth Explorer -> Replay Lab + Policy Lab -> Alert Integrations + Live Event Stream`
 
-Settler is positioned as **deterministic reconciliation infrastructure**, not a generic dashboard.
+## Quick Start
 
-- **Replay Lab** (`/app/replay` + `/api/v1/runs/:id/replay`) for deterministic reruns and drift checks.
-- **Run Explorer** (`/app/runs`) for operator-grade run metadata and policy context.
-- **Truth Explorer** (`/app/proofs` + trust-explorer APIs) for lineage, proof verification, and policy impact analysis.
-- **Synthetic Reconciliation Foundry** (`pnpm run test:reconciliation*`) for seeded scenario validation.
-- **Live operator surfaces** (`/app/alerts`, `/app/system-health`, `/app/metrics`) for triage and runtime telemetry.
-- **Evidence query surface** (`/app/evidence` + `/api/v1/runs/:id/evidence`) for trust artifact retrieval by run, fingerprint, or policy hash.
-- **Tenant isolation controls** (`/app/settings`) for role boundaries and runtime freeze controls.
-
-See `docs/PRODUCT_CAPABILITIES_MATRIX.md` for maturity and evidence map.
-
-## Reconciliation synthetic verification
-
-Use the deterministic reconciliation foundry commands below during local debugging and CI parity checks:
-
-- `pnpm run test:reconciliation` — runs CLI reconciliation harness + reconciliation foundry tests.
-- `pnpm run test:reconciliation:e2e` — executes strict reconciliation verification (`smoke` profile, seed 42).
-- `pnpm run verify:reconciliation-runtime` — executes strict reconciliation verification (`integration` profile, seed 42).
-- `pnpm run generate:test-data:smoke` — generates deterministic smoke export fixtures under `test-data/exports`.
-
-For additional seeds, run:
+Fastest local path:
 
 ```bash
-pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-verify --seed 7 --profile smoke --strict
-pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-verify --seed 99 --profile smoke --strict
+git clone <your-fork-or-upstream-url>
+cd Settler
+pnpm install
+cp .env.local.example .env.local
+pnpm demo:settler
 ```
 
-## Integrity guarantee
+`pnpm demo:settler` runs environment validation, attempts migrations, loads demo data, starts local services, executes a reconciliation simulation, and prints guided next steps.
 
-`pnpm run repo-integrity` is expected to pass on a healthy checkout and fails hard when workspace manifests, script references, or package contracts drift.
+## Demo Walkthrough
 
-## Launch Readiness Snapshot
+After `pnpm demo:settler` completes:
 
-Settler launch claims in this repository are constrained to commands and artifacts that are currently reproducible:
+1. Open **Run Explorer** at `/app/runs`.
+2. Open **Truth Explorer** at `/app/proofs`.
+3. Review **Alerts** at `/app/alerts`.
+4. Open **Replay Lab** at `/app/replay` and replay the generated run.
+5. Run policy simulation with `pnpm simulate:settler` for Policy Lab verification.
 
-- `pnpm run typecheck`
-- `pnpm run build`
-- `pnpm run test`
-- `pnpm run repo-integrity`
-- `pnpm run verify`
+For CLI artifacts, inspect `examples/demo-output/` and replay with `pnpm replay:run`.
 
-See `docs/demo/demo-walkthrough.md` for a deterministic walkthrough and `docs/launch/launch-checklist.md` for pre-launch gates.
+## Project Structure
+
+- `packages/api` — API and reconciliation control-plane services.
+- `packages/web` — operator UI (Run Explorer, Truth Explorer, Replay Lab, Policy Lab).
+- `packages/cli` — CLI runtime and deterministic foundry tooling.
+- `scripts` — bootstrap, diagnostics, simulation, verification, and demo orchestration.
+- `prisma` — schema and migrations.
+- `docs` — architecture, operations, demo, deployment, and contribution docs.
+
+## Development Commands
+
+### Core
+
+- `pnpm install`
+- `pnpm build`
+- `pnpm dev`
+- `pnpm test`
+- `pnpm doctor`
+
+### Demo and Simulation
+
+- `pnpm demo:settler`
+- `pnpm simulate:settler`
+- `pnpm replay:run`
+
+### Command Discovery Index
+
+- `pnpm demo:settler` — full local demo bootstrap flow.
+- `pnpm simulate:settler` — deterministic policy/reconciliation simulation harness.
+- `pnpm replay:run` — run replay utility.
+- `pnpm chaos:test` — deterministic chaos test harness.
+- `pnpm tenant:create` — tenant bootstrap utility.
+- `pnpm doctor` — environment and dependency diagnostics.
+
+## Environment Configuration
+
+Settler reads `.env.local` first, then `.env`.
+
+Common required variables:
+
+- `DATABASE_URL` (or `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`)
+- `REDIS_URL`
+- `NEXT_PUBLIC_API_URL` (for local web/API connectivity)
+
+Optional integration variables are validated by feature-specific checks and should only be set when those integrations are enabled.
+
+Run `pnpm doctor` to validate runtime prerequisites (Node version, env shape, database connectivity, Redis connectivity).
+
+## Contributing
+
+- Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) for repository-wide standards.
+- Read [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md) for contributor workflow, CI expectations, and PR readiness checks.
+- Keep claims in docs constrained to commands that pass in this repository.
+
+## License and Project Philosophy
+
+Licensed under the repository license terms.
+
+Project philosophy:
+
+- deterministic behavior over opaque automation
+- tenant-safe defaults over convenience shortcuts
+- explicit evidence over implied guarantees
+- operator clarity over marketing language

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing (Docs + Repo Workflow)
+
+This guide focuses on contributor workflow for the Settler repository.
+
+## Branching model
+
+- Branch from the default branch using a focused name (`feat/*`, `fix/*`, `docs/*`).
+- Keep each branch scoped to a single concern (for example: docs clarity pass, replay reliability fix).
+- Rebase before opening a PR to minimize merge noise.
+
+## Coding and documentation standards
+
+- Prefer deterministic behavior and explicit failure modes.
+- Do not introduce tenant-unsafe shortcuts.
+- Keep terminology aligned with canonical product names:
+  - Reconciliation Engine
+  - Truth Explorer
+  - Replay Lab
+  - Policy Lab
+  - Operator Intelligence
+  - Run Explorer
+  - Import Workbench
+  - Synthetic Foundry
+  - Live Event Stream
+- If implementation and documentation disagree, update docs or code in the same PR.
+
+## Test and verification expectations
+
+Before opening a PR, run:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+Recommended additional checks for runtime confidence:
+
+```bash
+pnpm doctor
+pnpm demo:settler
+pnpm repo-integrity
+```
+
+## Pull request workflow
+
+1. Explain the user or operator outcome first.
+2. List exact commands used for verification.
+3. Include risk notes for behavior that could not be verified locally.
+4. Keep claims constrained to commands and artifacts that actually passed.
+
+## CI checks
+
+At minimum, PRs are expected to remain green on lint, typecheck, test, and build surfaces.
+
+For security and tenant-boundary sensitive changes, include explicit evidence commands (for example `pnpm verify:security:fast`) in the PR description.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,18 +2,36 @@
 
 This directory is the canonical documentation surface for Settler.
 
-## Primary entry points
+## Documentation Structure
 
-- **Role-based map**: [`docs/INDEX.md`](./INDEX.md)
-- **Terminology standard**: [`docs/reference/glossary.md`](./reference/glossary.md)
-- **Developer fast path**: [`docs/getting-started/README.md`](./getting-started/README.md)
-- **Product/architecture truth**: [`docs/architecture/README.md`](./architecture/README.md)
-- **API route contract**: [`docs/api/README.md`](./api/README.md)
-- **Operations and runbooks**: [`docs/operations/README.md`](./operations/README.md)
-- **Support and troubleshooting**: [`docs/support/README.md`](./support/README.md), [`docs/troubleshooting/README.md`](./troubleshooting/README.md)
+- [`architecture/`](./architecture/) — system and control-plane architecture.
+- [`reconciliation/`](./reconciliation/) — Reconciliation Engine behavior and operator workflows.
+- [`replay/`](./replay/) — Replay Lab and deterministic replay guidance.
+- [`operations/`](./operations/) — Operator Intelligence, runbooks, and operational procedures.
+- [`integrations/`](./integrations/) — alert integrations and connector guidance.
+- [`demo/`](./demo/) — demo bootstrap and walkthrough.
+- [`deployment/`](./deployment/) — deployment and runtime rollout docs.
+- [`security/`](./security/) — security model, controls, and verification.
+- [`troubleshooting/`](./troubleshooting/) — recovery and debugging references.
+- [`reference/`](./reference/) — terminology and command reference.
 
-## Scope rules
+## Canonical topic map
 
-- If implementation and docs disagree, narrow docs or fix code immediately.
-- Experimental/internal features must be explicitly marked.
-- Public website copy, README, and docs must use the same terms.
+To keep naming consistent with product surfaces, treat these terms as canonical in docs:
+
+- Reconciliation Engine
+- Truth Explorer
+- Replay Lab
+- Policy Lab
+- Operator Intelligence
+- Run Explorer
+- Import Workbench
+- Synthetic Foundry
+- Live Event Stream
+
+## High-signal entry points
+
+- [`docs/getting-started/README.md`](./getting-started/README.md)
+- [`docs/demo/demo-walkthrough.md`](./demo/demo-walkthrough.md)
+- [`docs/reference/operator-terminology.md`](./reference/operator-terminology.md)
+- [`docs/CONTRIBUTING.md`](./CONTRIBUTING.md)

--- a/docs/demo/demo-walkthrough.md
+++ b/docs/demo/demo-walkthrough.md
@@ -1,25 +1,44 @@
-# Demo Walkthrough (Deterministic Operator Flow)
+# Demo Walkthrough (Settler Operator Flow)
 
-## CLI + artifact validation
+This walkthrough assumes `pnpm demo:settler` has completed successfully.
 
-1. `pnpm run bootstrap`
-2. `pnpm run demo`
-3. Inspect `examples/demo-output/evidence.json` for proof envelope and evidence metadata.
-4. Inspect `examples/demo-output/run.json` for execution metadata.
-5. Replay evidence: `pnpm exec tsx scripts/settler-replay.ts examples/demo-output/evidence.json`
+## 1) Bootstrap the demo
 
-## In-product operator story
+```bash
+pnpm demo:settler
+```
 
-1. Open `/app` (**Control Plane**) for workflow entrypoints.
-2. Open `/app/runs` and select a run from **Run Explorer**.
-3. From run detail, inspect deterministic replay status and evidence summary.
-4. Open `/app/proofs` (**Truth Explorer**) for proof-chain and lineage investigation.
-5. Open `/app/evidence` (**Evidence Query Surface**) and verify retrieval modes (run id, fingerprint, policy hash).
-6. Open `/app/alerts` (**Live Alerts**) for incident context.
-7. Open `/app/replay` (**Replay Lab**) to re-run deterministic checks.
-8. Open `/app/settings` (**Tenant Isolation Controls**) to inspect boundary and governance controls.
-9. Open `/app/metrics` (**Runtime Event Signals**) for event-derived telemetry.
+The command verifies the environment, attempts migrations, loads demo data, starts local services, runs a deterministic reconciliation simulation, and verifies replay.
 
-## Route integrity
+## 2) Explore operator surfaces
 
-- Optional UI verification: `pnpm run verify:routes`
+- **Run Explorer**: `http://localhost:3000/app/runs`
+- **Truth Explorer**: `http://localhost:3000/app/proofs`
+- **Live Event Stream**: `http://localhost:3000/app/metrics`
+- **Alerts**: `http://localhost:3000/app/alerts`
+- **Replay Lab**: `http://localhost:3000/app/replay`
+
+## 3) Validate replay determinism
+
+```bash
+pnpm replay:run
+```
+
+For direct replay file verification:
+
+```bash
+pnpm exec tsx scripts/settler-replay.ts examples/demo-output/evidence.json
+```
+
+## 4) Validate policy simulation
+
+```bash
+pnpm simulate:settler
+```
+
+## 5) Inspect generated artifacts
+
+- `examples/demo-output/run.json`
+- `examples/demo-output/results.json`
+- `examples/demo-output/evidence.json`
+- `examples/demo-output/operator-demo-artifacts.json`

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,28 +1,23 @@
 # Getting Started
 
-## One quickstart path (canonical)
-
-1. Install dependencies and configure environment.
-2. Run migrations.
-3. Run web app.
-4. Execute demo and replay evidence.
+## Canonical onboarding path
 
 ```bash
 pnpm install
-cp .env.example .env
-pnpm exec tsx scripts/run-migrations-remote.ts
-pnpm --filter @settler/web dev
-pnpm demo
-pnpm settler:replay examples/demo-output/evidence.json
+cp .env.local.example .env.local
+pnpm demo:settler
 ```
+
+This path is optimized for first-time contributors and operators.
 
 ## Inputs and outputs
 
-- **Inputs:** transaction feeds, documents, connector payloads, reconciliation rules, policy configuration.
-- **Outputs:** run results (matched and mismatched records), exception queue items, evidence packs (`run.json`, `results.json`, `evidence.json`, `report.html`).
+- **Inputs:** reconciliation feeds, connector payloads, rules, and policy configuration.
+- **Outputs:** run results, mismatch queues, and evidence artifacts (`run.json`, `results.json`, `evidence.json`).
 
-## Where to go next
+## Next docs
 
 - Developer API + SDK: [`docs/api/README.md`](../api/README.md)
-- Product and operator workflow: [`docs/product/README.md`](../product/README.md)
-- Security/reliability trust path: [`docs/security/README.md`](../security/README.md)
+- Architecture overview: [`docs/architecture/README.md`](../architecture/README.md)
+- Demo walkthrough: [`docs/demo/demo-walkthrough.md`](../demo/demo-walkthrough.md)
+- Security and tenant boundaries: [`docs/security/README.md`](../security/README.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,24 +1,25 @@
 # Quickstart
 
-## Fast path (core local)
+## Fast path
 
 ```bash
-pnpm run bootstrap
-pnpm run demo
-pnpm run dev:stack
+pnpm install
+cp .env.local.example .env.local
+pnpm demo:settler
 ```
 
-## Full path
+## What `pnpm demo:settler` does
 
-1. Install Node 24.x and pnpm 10.13.1.
-2. Run `pnpm run bootstrap`.
-3. Re-run `pnpm run repo-integrity` to validate monorepo contract manually.
-4. Run `pnpm run doctor -- --skip-pipeline` for strict diagnostics once env/runtime services are available.
-5. Run `pnpm run demo` to validate deterministic execution + replay proof.
+1. Verifies environment with `pnpm doctor -- --skip-pipeline --first-run`.
+2. Attempts migrations when `DATABASE_URL` is set.
+3. Loads demo dataset into `examples/demo-data/dataset.json`.
+4. Starts local services (`pnpm dev:stack`) if not already running.
+5. Runs deterministic reconciliation simulation (`pnpm demo`).
+6. Runs replay verification and prints guided operator URLs.
 
 ## Success criteria
 
-- `repo-integrity` passes.
-- `doctor --first-run` passes.
-- `demo` prints run fingerprint + replay verified.
-- `dev:stack` starts API and web processes (with required local runtime dependencies available).
+- `demo:settler` exits successfully.
+- Demo artifacts are generated in `examples/demo-output/`.
+- Web console is reachable at `http://localhost:3000`.
+- API is reachable at `http://localhost:4000`.

--- a/docs/reference/operator-terminology.md
+++ b/docs/reference/operator-terminology.md
@@ -1,13 +1,33 @@
 # Operator Terminology (Canonical)
 
-Use these terms consistently across issues, docs, support, and telemetry contracts.
+Use these terms consistently across README, docs, UI labels, scripts, and API references.
 
-- **run**: a single reconciliation execution instance.
-- **job**: scheduled or user-triggered unit that may create one or more runs.
-- **replay run**: deterministic re-execution of a prior run.
-- **support issue**: user/operator help request requiring investigation.
-- **incident**: runtime degradation or failure requiring operational triage.
-- **error signature**: stable grouping key (`ErrorName|Route|Module`).
-- **usage event**: contract-level meter event for analytics/billing.
-- **telemetry event**: operational health signal (logs/metrics/traces), not inherently billable.
-- **tenant**: canonical isolation boundary (workspace/org synonyms should map to tenant in technical surfaces).
+## Platform components
+
+- **Reconciliation Engine**: deterministic run execution and matching logic.
+- **Truth Explorer**: proof, lineage, and evidence investigation surface.
+- **Replay Lab**: deterministic re-execution and drift checks.
+- **Policy Lab**: simulation surface for policy outcome analysis.
+- **Operator Intelligence**: incident and investigation context for operators.
+- **Run Explorer**: run-level investigation and status surface.
+- **Import Workbench**: controlled ingest and normalization entrypoint.
+- **Synthetic Foundry**: deterministic synthetic data generation and verification tooling.
+- **Live Event Stream**: runtime event visibility for operational awareness.
+
+## Core entities
+
+- **Run**: a single reconciliation execution instance.
+- **Replay run**: deterministic re-execution of a prior run.
+- **Tenant**: canonical isolation boundary.
+- **Incident**: runtime degradation requiring operational triage.
+- **Telemetry event**: operational signal (logs/metrics/traces).
+- **Usage event**: meter event for analytics and/or billing contracts.
+
+## Avoided synonyms
+
+To reduce confusion, avoid mixing these synonyms in technical docs:
+
+- Use **Policy Lab** instead of "policy sandbox".
+- Use **Run Explorer** instead of "execution ledger" UI label.
+- Use **Live Event Stream** instead of "runtime event signals" when describing the operator surface.
+- Use **Synthetic Foundry** instead of "synthetic reconciliation foundry" in headings.

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "demo:settler": "tsx scripts/settler-demo-pipeline.ts",
     "replay:run": "pnpm --filter @settler/cli exec tsx src/tools/replay-runner.ts",
     "simulate:settler": "tsx scripts/simulate-settler.ts",
-    "tenant:create": "tsx scripts/tenant-create.ts"
+    "tenant:create": "tsx scripts/tenant-create.ts",
     "chaos:test": "tsx scripts/chaos-test.ts"
   },
   "lint-staged": {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -3,7 +3,6 @@
 import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
 
 const rootDir = process.cwd();
 const flags = new Set(process.argv.slice(2));
@@ -35,7 +34,16 @@ function loadEnvFiles() {
   [".env.local", ".env"].forEach((filename) => {
     const fullPath = path.join(rootDir, filename);
     if (fs.existsSync(fullPath)) {
-      dotenv.config({ path: fullPath, override: false });
+      const rows = fs.readFileSync(fullPath, "utf-8").split("\n");
+      for (const row of rows) {
+        const line = row.trim();
+        if (!line || line.startsWith("#") || !line.includes("=")) continue;
+        const idx = line.indexOf("=");
+        const key = line.slice(0, idx).trim();
+        const raw = line.slice(idx + 1).trim();
+        const value = raw.replace(/^"|"$/g, "").replace(/^'|'$/g, "");
+        if (!(key in process.env)) process.env[key] = value;
+      }
     }
   });
 }
@@ -75,6 +83,19 @@ function checkToolchain() {
 function checkEnv() {
   loadEnvFiles();
 
+  const requiredVars = ["DATABASE_URL", "REDIS_URL", "NEXT_PUBLIC_API_URL"];
+  const missingRequired = requiredVars.filter((variable) => !process.env[variable]);
+
+  addResult(
+    "env",
+    "Required environment variables",
+    missingRequired.length === 0,
+    missingRequired.length === 0
+      ? "DATABASE_URL, REDIS_URL, NEXT_PUBLIC_API_URL present"
+      : `missing: ${missingRequired.join(", ")}`,
+    "Populate .env.local from .env.local.example"
+  );
+
   if (firstRunMode) {
     const hasLocal =
       fs.existsSync(path.join(rootDir, ".env.local")) || fs.existsSync(path.join(rootDir, ".env"));
@@ -108,6 +129,54 @@ function checkEnv() {
       result.ok
         ? "validated without leaking secret values"
         : result.stderr.split("\n").slice(-6).join("\n")
+    );
+  }
+}
+
+function checkRuntimeDependencies() {
+  const databaseProbe = runCommand("node", [
+    "-e",
+    `import net from 'node:net'; const raw = process.env.DATABASE_URL; if (!raw) process.exit(2); let url; try { url = new URL(raw); } catch { process.exit(1); } const socket = net.createConnection({ host: url.hostname, port: Number(url.port || '5432') }); socket.setTimeout(1500); socket.on('connect', () => { socket.end(); process.exit(0); }); socket.on('timeout', () => { socket.destroy(); process.exit(1); }); socket.on('error', () => process.exit(1));`,
+  ]);
+
+  if (databaseProbe.status === 2) {
+    addResult(
+      "runtime",
+      "Database connection",
+      false,
+      "DATABASE_URL missing",
+      "Set DATABASE_URL to a reachable PostgreSQL endpoint"
+    );
+  } else {
+    addResult(
+      "runtime",
+      "Database connection",
+      databaseProbe.ok,
+      databaseProbe.ok ? "Connected to PostgreSQL" : databaseProbe.stderr || databaseProbe.stdout,
+      "Check DATABASE_URL and network path to PostgreSQL"
+    );
+  }
+
+  const redisProbe = runCommand("node", [
+    "-e",
+    `import net from 'node:net'; const raw = process.env.REDIS_URL; if (!raw) { process.exit(2); } const url = new URL(raw); const socket = net.createConnection({ host: url.hostname, port: Number(url.port || '6379') }); socket.setTimeout(1500); socket.on('connect', () => { socket.end(); process.exit(0); }); socket.on('timeout', () => { socket.destroy(); process.exit(1); }); socket.on('error', () => process.exit(1));`,
+  ]);
+
+  if (redisProbe.status === 2) {
+    addResult(
+      "runtime",
+      "Redis connection",
+      false,
+      "REDIS_URL missing",
+      "Set REDIS_URL to a reachable Redis endpoint"
+    );
+  } else {
+    addResult(
+      "runtime",
+      "Redis connection",
+      redisProbe.ok,
+      redisProbe.ok ? "Connected to Redis socket" : "Unable to open Redis socket",
+      "Check REDIS_URL and network path to Redis"
     );
   }
 }
@@ -252,6 +321,7 @@ function printSummary() {
 
 checkToolchain();
 checkEnv();
+checkRuntimeDependencies();
 checkNextVercel();
 checkAssetsAndSafety();
 if (!flags.has("--skip-pipeline")) {

--- a/scripts/settler-demo-pipeline.ts
+++ b/scripts/settler-demo-pipeline.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env tsx
 import fs from "node:fs/promises";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import net from "node:net";
+import { spawn, spawnSync } from "node:child_process";
 
 interface DemoAlert {
   id: string;
@@ -14,21 +15,90 @@ interface DemoAlert {
 const outDir = path.resolve("examples/demo-output");
 const demoArtifactsPath = path.join(outDir, "operator-demo-artifacts.json");
 const seededDatasetPath = path.resolve("examples/demo-data/dataset.json");
+const serviceLogPath = path.resolve("examples/demo-output/dev-stack.log");
 
-function runCommand(command: string, args: string[]) {
+function runCommand(command: string, args: string[], step: string) {
+  console.log(`\n▶ ${step}`);
   const result = spawnSync(command, args, { stdio: "inherit", env: process.env });
   if (result.status !== 0) {
-    throw new Error(`Command failed: ${command} ${args.join(" ")}`);
+    throw new Error(`Step failed (${step}): ${command} ${args.join(" ")}`);
   }
+}
+
+function runCommandAllowFailure(command: string, args: string[], step: string): boolean {
+  console.log(`\n▶ ${step}`);
+  const result = spawnSync(command, args, { stdio: "inherit", env: process.env });
+  if (result.status !== 0) {
+    console.warn(`⚠️ ${step} failed; continuing with non-blocking demo path.`);
+    return false;
+  }
+  return true;
 }
 
 async function readJson<T>(filePath: string): Promise<T> {
   return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
 }
 
+async function isPortOpen(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    socket.setTimeout(700);
+    socket.on("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.on("error", () => {
+      resolve(false);
+    });
+    socket.connect(port, "127.0.0.1");
+  });
+}
+
+async function startServices(): Promise<{ started: boolean; note: string }> {
+  const webOpen = await isPortOpen(3000);
+  const apiOpen = await isPortOpen(4000);
+
+  if (webOpen && apiOpen) {
+    return { started: true, note: "Detected existing services on :3000 and :4000." };
+  }
+
+  const child = spawn("pnpm", ["run", "dev:stack"], {
+    env: process.env,
+    stdio: "ignore",
+    detached: true,
+  });
+
+  child.unref();
+  await fs.mkdir(path.dirname(serviceLogPath), { recursive: true });
+  await fs.writeFile(
+    serviceLogPath,
+    `Started detached dev stack PID=${child.pid ?? "unknown"} at ${new Date().toISOString()}\n`
+  );
+
+  return {
+    started: true,
+    note: `Started detached dev stack (PID ${child.pid ?? "unknown"}).`,
+  };
+}
+
 async function main() {
-  console.log("\n▶ Settler operator demo pipeline\n");
-  console.log("1) Load dataset");
+  console.log("\n▶ Settler demo bootstrap pipeline\n");
+
+  console.log("1) Verify environment");
+  runCommand("pnpm", ["run", "doctor", "--", "--skip-pipeline", "--first-run"], "Doctor checks");
+
+  console.log("2) Run migrations");
+  if (!process.env.DATABASE_URL) {
+    console.warn("⚠️ DATABASE_URL not set; migration step skipped.");
+  } else {
+    runCommandAllowFailure("pnpm", ["exec", "prisma", "migrate", "deploy"], "Prisma migrations");
+  }
+
+  console.log("3) Load demo dataset");
   const seededData = {
     stripe: [
       { id: "st_1", invoice_number: "INV-100", amount: 101.0 },
@@ -44,10 +114,14 @@ async function main() {
   await fs.mkdir(path.dirname(seededDatasetPath), { recursive: true });
   await fs.writeFile(seededDatasetPath, JSON.stringify(seededData, null, 2));
 
-  console.log("2) Execute reconciliation run");
-  runCommand("pnpm", ["run", "demo"]);
+  console.log("4) Start services");
+  const serviceState = await startServices();
+  console.log(`   ${serviceState.note}`);
 
-  console.log("3) Trigger anomaly + generate alert stream artifacts");
+  console.log("5) Run reconciliation simulation");
+  runCommand("pnpm", ["run", "demo"], "Deterministic reconciliation demo");
+
+  console.log("6) Generate alert stream artifacts + replay");
   const results = await readJson<Record<string, unknown>>(path.join(outDir, "results.json"));
   const runEnvelope = await readJson<Record<string, unknown>>(path.join(outDir, "run.json"));
 
@@ -58,41 +132,24 @@ async function main() {
   const totalRecords = matched + mismatches + reviewQueue;
   const matchRate = totalRecords > 0 ? (matched / totalRecords) * 100 : 0;
 
-  const alerts: DemoAlert[] = [];
-  const simulatedMatchRate = Math.min(matchRate, 94.5);
-  alerts.push({
-    id: "match-rate-drop",
-    severity: "warning",
-    type: "match_rate_drop",
-    message: `Synthetic anomaly: match rate dropped to ${simulatedMatchRate.toFixed(2)}%.`,
-    triggeredAt: new Date().toISOString(),
-  });
+  const alerts: DemoAlert[] = [
+    {
+      id: "match-rate-drop",
+      severity: "warning",
+      type: "match_rate_drop",
+      message: `Synthetic anomaly: match rate dropped to ${Math.min(matchRate, 94.5).toFixed(2)}%.`,
+      triggeredAt: new Date().toISOString(),
+    },
+    {
+      id: "api-error-spike",
+      severity: "critical",
+      type: "api_error_spike",
+      message: "Synthetic API error spike triggered for operator demo.",
+      triggeredAt: new Date().toISOString(),
+    },
+  ];
 
-  alerts.push({
-    id: "api-error-spike",
-    severity: "critical",
-    type: "api_error_spike",
-    message: "Synthetic API error spike triggered for operator demo.",
-    triggeredAt: new Date().toISOString(),
-  });
-
-  console.log("4) Show alert feed");
-  for (const alert of alerts) {
-    console.log(`   [${alert.severity.toUpperCase()}] ${alert.type} :: ${alert.message}`);
-  }
-
-  console.log("5) Inspect run");
-  console.log(`   runId: ${String(runEnvelope.runId ?? "demo-run-1")}`);
-  console.log(`   recordsProcessed: ${totalRecords}`);
-  console.log(`   matchRate: ${matchRate.toFixed(2)}%`);
-
-  console.log("6) Replay run");
-  runCommand("pnpm", [
-    "exec",
-    "tsx",
-    "scripts/settler-replay.ts",
-    "examples/demo-output/evidence.json",
-  ]);
+  runCommand("pnpm", ["exec", "tsx", "scripts/settler-replay.ts", "examples/demo-output/evidence.json"], "Replay verification");
 
   await fs.writeFile(
     demoArtifactsPath,
@@ -100,11 +157,11 @@ async function main() {
       {
         generatedAt: new Date().toISOString(),
         steps: [
+          "verify environment",
+          "run migrations",
           "load dataset",
-          "execute reconciliation",
-          "trigger anomaly",
-          "show alert",
-          "inspect run",
+          "start services",
+          "run reconciliation simulation",
           "replay run",
         ],
         run: {
@@ -119,7 +176,14 @@ async function main() {
     )
   );
 
-  console.log(`\n✅ Demo artifacts saved: ${demoArtifactsPath}`);
+  console.log("\n✅ Demo bootstrap complete.");
+  console.log("\nNext steps:");
+  console.log("- Run Explorer:      http://localhost:3000/app/runs");
+  console.log("- Truth Explorer:    http://localhost:3000/app/proofs");
+  console.log("- Alerts:            http://localhost:3000/app/alerts");
+  console.log("- Replay Lab:        http://localhost:3000/app/replay");
+  console.log("- Policy Lab check:  pnpm simulate:settler");
+  console.log(`\nArtifacts: ${demoArtifactsPath}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
### Motivation

- Make the repository approachable for first-time contributors and operators by replacing scattered onboarding steps with a single, reliable fast-path.
- Normalize terminology across docs, scripts, and operator-facing surfaces to reduce ambiguity (Reconciliation Engine, Truth Explorer, Replay Lab, Policy Lab, Operator Intelligence, Run Explorer, Import Workbench, Synthetic Foundry, Live Event Stream).
- Improve demo bootstrap and diagnostics so a demo run is discoverable, deterministic, and fails visibly when runtime prerequisites are missing.

### Description

- Rewrote the root `README.md` to provide a clear Project Overview, Key Capabilities, Architecture Overview, Quick Start, Demo Walkthrough, Project Structure, Command Discovery, Environment Configuration, and Contributing links. 
- Added and edited documentation under `docs/` (`docs/README.md`, `docs/getting-started/*`, `docs/demo/demo-walkthrough.md`, `docs/reference/operator-terminology.md`, and `docs/CONTRIBUTING.md`) to centralize onboarding, canonical terminology, and contributor expectations.
- Implemented a unified demo bootstrap script `scripts/settler-demo-pipeline.ts` and wire-up `package.json` script `demo:settler` so `pnpm demo:settler` performs: environment verification, optional migrations, demo dataset load, service startup (detects existing services or starts `pnpm run dev:stack` detached), reconciliation simulation, replay verification, and artifact output.
- Improved `scripts/doctor.mjs` to inline `.env`/`.env.local` loading (avoid optional `dotenv` runtime), add required env var checks (`DATABASE_URL`, `REDIS_URL`, `NEXT_PUBLIC_API_URL`), and add runtime connectivity probes for PostgreSQL and Redis sockets to provide machine-visible, actionable diagnostics while preserving `--first-run` behavior.
- Fixed `package.json` script map syntax (restored missing comma between `tenant:create` and `chaos:test`) and refreshed the command discovery index referenced from the README.

### Testing

- Ran `node --check scripts/doctor.mjs` which succeeded and validated JavaScript syntax for the modified doctor script. 
- Ran `node --check scripts/settler-demo-pipeline.ts` which succeeded and validated the demo pipeline script syntax. 
- Validated `package.json` parse with `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` which returned successfully. 
- Executed `node scripts/doctor.mjs --skip-pipeline --first-run` which reported explicit failures for missing required environment variables (expected in this environment and considered a correct, explicit diagnostic). 
- Attempted `pnpm install` but it failed in this environment due to a registry 403 for a dependency (`ERR_PNPM_FETCH_403` for `@shopify/shopify-api`), and as a result `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` could not be completed here and should be re-run in an environment where `pnpm install` succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a0d81a4c83289f36adad6ba20d3a)