### PR TITLE
Harden kernel runner with binary-first policy, handshake validation, and proof hash expansion

### DIFF
--- a/crates/settler-kernel-cli/src/main.rs
+++ b/crates/settler-kernel-cli/src/main.rs
@@ -3,6 +3,8 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use std::io::{self, Read};
 
+const KERNEL_PROTOCOL_VERSION: &str = "v1";
+
 #[derive(Debug, Deserialize)]
 struct KernelRequest {
     operation: String,
@@ -18,17 +20,28 @@ struct KernelError {
 #[derive(Debug, Serialize)]
 struct KernelResponse {
     ok: bool,
-    result: Option<KernelResult>,
+    operation: String,
+    protocol_version: &'static str,
+    kernel_version: &'static str,
+    result: Option<Value>,
     error: Option<KernelError>,
 }
 
 #[derive(Debug, Serialize)]
-struct KernelResult {
+struct HashResult {
     schema_version: &'static str,
     canonical_json: String,
     input_hash: String,
     normalized_hash: String,
     rule_hash: String,
+}
+
+#[derive(Debug, Serialize)]
+struct HandshakeResult {
+    operation: &'static str,
+    protocol_version: &'static str,
+    kernel_version: &'static str,
+    supported_operations: Vec<&'static str>,
 }
 
 fn hash_str(value: &str) -> String {
@@ -55,17 +68,23 @@ fn canonicalize(value: &Value) -> Value {
     }
 }
 
-fn success(result: KernelResult) -> KernelResponse {
+fn success(operation: &str, result: Value) -> KernelResponse {
     KernelResponse {
         ok: true,
+        operation: operation.to_string(),
+        protocol_version: KERNEL_PROTOCOL_VERSION,
+        kernel_version: env!("CARGO_PKG_VERSION"),
         result: Some(result),
         error: None,
     }
 }
 
-fn failure(code: &'static str, message: impl Into<String>) -> KernelResponse {
+fn failure(operation: &str, code: &'static str, message: impl Into<String>) -> KernelResponse {
     KernelResponse {
         ok: false,
+        operation: operation.to_string(),
+        protocol_version: KERNEL_PROTOCOL_VERSION,
+        kernel_version: env!("CARGO_PKG_VERSION"),
         result: None,
         error: Some(KernelError {
             code,
@@ -74,28 +93,57 @@ fn failure(code: &'static str, message: impl Into<String>) -> KernelResponse {
     }
 }
 
+fn build_hash_result(payload: &Value, rule: &'static str) -> Result<HashResult, String> {
+    let input_json = serde_json::to_string(payload).map_err(|e| e.to_string())?;
+    let canonical = canonicalize(payload);
+    let canonical_json = serde_json::to_string(&canonical).map_err(|e| e.to_string())?;
+    Ok(HashResult {
+        schema_version: "v1",
+        canonical_json: canonical_json.clone(),
+        input_hash: hash_str(&input_json),
+        normalized_hash: hash_str(&canonical_json),
+        rule_hash: hash_str(rule),
+    })
+}
+
 fn run(req: KernelRequest) -> KernelResponse {
     match req.operation.as_str() {
-        "canonicalize_hash" => {
-            let input_json = match serde_json::to_string(&req.payload) {
-                Ok(v) => v,
-                Err(e) => return failure("KERNEL_SERIALIZATION_FAILED", e.to_string()),
+        "handshake" => {
+            let result = HandshakeResult {
+                operation: "handshake",
+                protocol_version: KERNEL_PROTOCOL_VERSION,
+                kernel_version: env!("CARGO_PKG_VERSION"),
+                supported_operations: vec!["handshake", "canonicalize_hash", "proof_bundle_hash"],
             };
-            let canonical = canonicalize(&req.payload);
-            let canonical_json = match serde_json::to_string(&canonical) {
-                Ok(v) => v,
-                Err(e) => return failure("KERNEL_SERIALIZATION_FAILED", e.to_string()),
-            };
-
-            success(KernelResult {
-                schema_version: "v1",
-                canonical_json: canonical_json.clone(),
-                input_hash: hash_str(&input_json),
-                normalized_hash: hash_str(&canonical_json),
-                rule_hash: hash_str("canonicalize_hash@v1"),
-            })
+            match serde_json::to_value(result) {
+                Ok(value) => success("handshake", value),
+                Err(e) => failure("handshake", "KERNEL_SERIALIZATION_FAILED", e.to_string()),
+            }
         }
+        "canonicalize_hash" => match build_hash_result(&req.payload, "canonicalize_hash@v1") {
+            Ok(result) => match serde_json::to_value(result) {
+                Ok(value) => success("canonicalize_hash", value),
+                Err(e) => failure(
+                    "canonicalize_hash",
+                    "KERNEL_SERIALIZATION_FAILED",
+                    e.to_string(),
+                ),
+            },
+            Err(e) => failure("canonicalize_hash", "KERNEL_SERIALIZATION_FAILED", e),
+        },
+        "proof_bundle_hash" => match build_hash_result(&req.payload, "proof_bundle_hash@v1") {
+            Ok(result) => match serde_json::to_value(result) {
+                Ok(value) => success("proof_bundle_hash", value),
+                Err(e) => failure(
+                    "proof_bundle_hash",
+                    "KERNEL_SERIALIZATION_FAILED",
+                    e.to_string(),
+                ),
+            },
+            Err(e) => failure("proof_bundle_hash", "KERNEL_SERIALIZATION_FAILED", e),
+        },
         other => failure(
+            other,
             "KERNEL_UNKNOWN_OPERATION",
             format!("Unsupported operation: {other}"),
         ),
@@ -108,6 +156,7 @@ fn main() {
         println!(
             "{}",
             serde_json::to_string(&failure(
+                "stdin",
                 "KERNEL_IO_READ_FAILED",
                 "failed to read stdin payload"
             ))
@@ -121,7 +170,7 @@ fn main() {
         Err(err) => {
             println!(
                 "{}",
-                serde_json::to_string(&failure("KERNEL_INVALID_REQUEST", err.to_string()))
+                serde_json::to_string(&failure("parse", "KERNEL_INVALID_REQUEST", err.to_string()))
                     .unwrap_or_else(|_| "{\"ok\":false}".to_string())
             );
             std::process::exit(1);
@@ -155,9 +204,34 @@ mod tests {
         });
         assert!(left.ok);
         assert_eq!(
-            left.result.as_ref().unwrap().normalized_hash,
-            right.result.as_ref().unwrap().normalized_hash
+            left.result.as_ref().unwrap()["normalized_hash"],
+            right.result.as_ref().unwrap()["normalized_hash"]
         );
+    }
+
+    #[test]
+    fn proof_bundle_hash_uses_distinct_rule_hash() {
+        let payload = serde_json::json!({"proof":"bundle"});
+        let response = run(KernelRequest {
+            operation: "proof_bundle_hash".to_string(),
+            payload,
+        });
+        assert!(response.ok);
+        assert_ne!(
+            response.result.as_ref().unwrap()["rule_hash"],
+            Value::String(hash_str("canonicalize_hash@v1"))
+        );
+    }
+
+    #[test]
+    fn handshake_returns_protocol_and_version() {
+        let response = run(KernelRequest {
+            operation: "handshake".to_string(),
+            payload: serde_json::json!({}),
+        });
+        assert!(response.ok);
+        assert_eq!(response.protocol_version, "v1");
+        assert!(!response.kernel_version.is_empty());
     }
 
     #[test]

--- a/crates/settler-kernel/src/lib.rs
+++ b/crates/settler-kernel/src/lib.rs
@@ -146,7 +146,7 @@ fn canonicalize_records(mut records: Vec<NormalizedRecord>) -> Vec<NormalizedRec
             record.schema_version = SCHEMA_VERSION.to_string();
         }
     }
-    records.sort_by(|a, b| stable_record_sort_key(a).cmp(&stable_record_sort_key(b)));
+    records.sort_by_key(stable_record_sort_key);
     records
 }
 
@@ -222,8 +222,8 @@ pub fn compute_variances(
         let mut left_records = left_map.remove(&key).unwrap_or_default();
         let mut right_records = right_map.remove(&key).unwrap_or_default();
 
-        left_records.sort_by(|a, b| stable_record_sort_key(a).cmp(&stable_record_sort_key(b)));
-        right_records.sort_by(|a, b| stable_record_sort_key(a).cmp(&stable_record_sort_key(b)));
+        left_records.sort_by_key(stable_record_sort_key);
+        right_records.sort_by_key(stable_record_sort_key);
 
         let max_len = left_records.len().max(right_records.len());
         for idx in 0..max_len {

--- a/packages/cli/KERNEL_RUNNER.md
+++ b/packages/cli/KERNEL_RUNNER.md
@@ -1,0 +1,60 @@
+# Settler CLI Kernel Runner (Binary-First)
+
+## Runner modes
+
+The CLI kernel bridge resolves execution in this order:
+
+1. `SETTLER_KERNEL_BIN` executable (`runnerMode: "binary"`)
+2. Optional cargo fallback when explicitly allowed (`runnerMode: "cargo-run"`)
+3. Safe TS fallback (`runnerMode: "fallback-ts"`)
+
+Kernel feature flags remain:
+
+- `SETTLER_KERNEL_ENABLED=1`
+- `SETTLER_KERNEL_CANONICALIZE=1`
+- `SETTLER_KERNEL_SHADOW_MODE=1` (shadow compare mode)
+
+## Binary-first policy
+
+Production-like environments should set:
+
+- `SETTLER_KERNEL_BIN=/absolute/path/to/settler-kernel-cli`
+- `NODE_ENV=production`
+- `CI=true`
+
+If the binary is missing, non-executable, times out, returns malformed output, or fails compatibility checks, the CLI degrades to TS hashing and remains route-safe.
+
+## Cargo fallback (local/dev only)
+
+Cargo fallback is intentionally explicit:
+
+- `SETTLER_KERNEL_ALLOW_CARGO=1` **or**
+- `SETTLER_KERNEL_DEV_FALLBACK=1`
+
+Without one of these flags, production-like envs (`NODE_ENV=production` + `CI=true`) do not use `cargo run` automatically.
+
+## Handshake and compatibility
+
+Before kernel work, the TS wrapper performs a handshake (`operation: "handshake"`) and validates:
+
+- `kernel_version` present
+- `protocol_version` compatible (`v1`)
+- operation envelope integrity
+
+On mismatch, TS fallback is selected and telemetry counters are incremented.
+
+## Telemetry signal
+
+Foundry export logs now include:
+
+- `kernel_mode` (`ts`, `rust_primary`, `ts_with_shadow`)
+- `kernel_runner_mode` (`binary`, `cargo-run`, `disabled`, `fallback-ts`)
+- per-path durations (`kernel_duration_ms`, `ts_duration_ms`)
+- `kernel_telemetry` counters (attempted/success/fallback/timeout/malformed/version-mismatch/divergence/hash-mismatch)
+
+## Local smoke
+
+```bash
+cargo build -p settler-kernel-cli
+SETTLER_KERNEL_ENABLED=1 SETTLER_KERNEL_CANONICALIZE=1 SETTLER_KERNEL_BIN=$PWD/target/debug/settler-kernel-cli pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-generate --profile smoke --seed 42 --output test-data/exports/latest
+```

--- a/packages/cli/src/__tests__/kernel-client.test.ts
+++ b/packages/cli/src/__tests__/kernel-client.test.ts
@@ -2,9 +2,16 @@ declare const describe: (name: string, fn: () => void) => void;
 declare const test: (name: string, fn: () => Promise<void> | void) => void;
 declare const expect: any;
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createHash } from "node:crypto";
 import {
   canonicalizeHashWithFallback,
+  proofBundleHashWithFallback,
   readKernelFlags,
+  resetKernelTelemetry,
+  resolveKernelRunner,
   tsCanonicalizeHash,
 } from "../lib/kernel-client";
 
@@ -21,6 +28,41 @@ describe("kernel client", () => {
     expect(flags.shadowMode).toBe(true);
   });
 
+  test("resolves binary runner when executable path is provided", () => {
+    const resolved = resolveKernelRunner({
+      SETTLER_KERNEL_BIN: process.execPath,
+      NODE_ENV: "production",
+      CI: "true",
+    });
+    expect(resolved.mode).toBe("binary");
+    expect(resolved.runner?.cmd).toBe(process.execPath);
+  });
+
+  test("degrades to fallback-ts when configured binary is missing", () => {
+    const resolved = resolveKernelRunner({
+      SETTLER_KERNEL_BIN: "/definitely/missing/settler-kernel",
+      NODE_ENV: "production",
+      CI: "true",
+    });
+    expect(resolved.mode).toBe("fallback-ts");
+    expect(resolved.reason).toBe("binary_missing");
+  });
+
+  test("degrades to fallback-ts when configured binary is not executable", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kernel-test-"));
+    const bin = path.join(dir, "kernel.bin");
+    fs.writeFileSync(bin, "#!/bin/sh\necho nope\n", { mode: 0o644 });
+
+    const resolved = resolveKernelRunner({
+      SETTLER_KERNEL_BIN: bin,
+      NODE_ENV: "production",
+      CI: "true",
+    });
+
+    expect(resolved.mode).toBe("fallback-ts");
+    expect(resolved.reason).toBe("binary_not_executable");
+  });
+
   test("ts canonicalization is stable across key order", () => {
     const a = tsCanonicalizeHash({ z: 1, a: { m: 2, b: 3 } });
     const b = tsCanonicalizeHash({ a: { b: 3, m: 2 }, z: 1 });
@@ -32,9 +74,27 @@ describe("kernel client", () => {
     process.env.SETTLER_KERNEL_ENABLED = "0";
     process.env.SETTLER_KERNEL_CANONICALIZE = "0";
     process.env.SETTLER_KERNEL_SHADOW_MODE = "0";
+    resetKernelTelemetry();
 
     const result = await canonicalizeHashWithFallback({ b: 1, a: 2 });
     expect(result.mode).toBe("ts");
+    expect(result.runnerMode).toBe("disabled");
     expect(result.result.normalizedHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("proof bundle fallback uses ts rule hash when runner unavailable", async () => {
+    process.env.SETTLER_KERNEL_ENABLED = "1";
+    process.env.SETTLER_KERNEL_CANONICALIZE = "1";
+    process.env.SETTLER_KERNEL_BIN = "/definitely/missing/settler-kernel";
+    process.env.SETTLER_KERNEL_ALLOW_CARGO = "0";
+    process.env.NODE_ENV = "production";
+    process.env.CI = "true";
+
+    const result = await proofBundleHashWithFallback({ evidence: { b: 2, a: 1 } });
+    expect(result.mode).toBe("ts");
+    expect(result.runnerMode).toBe("fallback-ts");
+    const expected = createHash("sha256").update("proof_bundle_hash@v1").digest("hex");
+    expect(result.result.ruleHash).toBe(expected);
+    expect(result.result.ruleHash).not.toBe(tsCanonicalizeHash({ a: 1 }).ruleHash);
   });
 });

--- a/packages/cli/src/commands/foundry.ts
+++ b/packages/cli/src/commands/foundry.ts
@@ -274,7 +274,11 @@ foundryCommand
           output: result.path,
           hash: result.hash,
           kernel_mode: result.kernelMode,
+          kernel_runner_mode: result.runnerMode,
           kernel_divergence: result.divergence ?? null,
+          kernel_duration_ms: result.durations.kernel ?? null,
+          ts_duration_ms: result.durations.ts,
+          kernel_telemetry: result.telemetry,
           profile: suite.manifest.profile,
           records: Object.fromEntries(Object.entries(suite.sources).map(([k, v]) => [k, v.length])),
         });

--- a/packages/cli/src/lib/kernel-client.ts
+++ b/packages/cli/src/lib/kernel-client.ts
@@ -1,5 +1,12 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { accessSync, constants, existsSync } from "node:fs";
+
+const KERNEL_STDIO_CAPTURE_LIMIT = 4096;
+const KERNEL_PROTOCOL_VERSION = "v1";
+const KERNEL_MIN_VERSION_PREFIX = "0.";
+
+type KernelOperation = "canonicalize_hash" | "proof_bundle_hash";
 
 export interface CanonicalizeHashResult {
   schemaVersion: string;
@@ -15,8 +22,25 @@ export interface KernelFlags {
   shadowMode: boolean;
 }
 
+export type KernelRunnerMode = "binary" | "cargo-run" | "disabled" | "fallback-ts";
+
+export type KernelErrorKind =
+  | "BINARY_MISSING"
+  | "BINARY_NOT_EXECUTABLE"
+  | "SPAWN_FAILED"
+  | "TIMEOUT"
+  | "MALFORMED_JSON"
+  | "NON_ZERO_EXIT"
+  | "VERSION_MISMATCH"
+  | "UNKNOWN_OPERATION"
+  | "UNEXPECTED_SCHEMA"
+  | "INVALID_ENVELOPE";
+
 interface KernelEnvelope {
   ok: boolean;
+  operation?: string;
+  protocol_version?: string;
+  kernel_version?: string;
   result?: {
     schema_version: string;
     canonical_json: string;
@@ -30,12 +54,113 @@ interface KernelEnvelope {
   };
 }
 
+interface KernelHandshakeResult {
+  operation: "handshake";
+  protocol_version: string;
+  kernel_version: string;
+  supported_operations: string[];
+}
+
+interface ResolvedKernelRunner {
+  mode: Extract<KernelRunnerMode, "binary" | "cargo-run">;
+  cmd: string;
+  args: string[];
+}
+
+interface KernelTelemetrySnapshot {
+  attempted: number;
+  success: number;
+  fallbackTs: number;
+  timeout: number;
+  malformedOutput: number;
+  versionMismatch: number;
+  divergence: number;
+  hashMismatch: number;
+}
+
+class KernelInvocationError extends Error {
+  constructor(
+    readonly kind: KernelErrorKind,
+    readonly details?: { code?: string; stderr?: string; exitCode?: number | null }
+  ) {
+    super(`KERNEL_${kind}`);
+  }
+}
+
+const telemetry: KernelTelemetrySnapshot = {
+  attempted: 0,
+  success: 0,
+  fallbackTs: 0,
+  timeout: 0,
+  malformedOutput: 0,
+  versionMismatch: 0,
+  divergence: 0,
+  hashMismatch: 0,
+};
+
+const handshakeCache = new Map<string, KernelHandshakeResult>();
+
+function runnerCacheKey(runner: ResolvedKernelRunner): string {
+  return `${runner.mode}:${runner.cmd}:${runner.args.join("\u{1f}")}`;
+}
+
+function boundedAppend(current: string, chunk: Buffer | string): string {
+  const next = `${current}${chunk.toString()}`;
+  if (next.length <= KERNEL_STDIO_CAPTURE_LIMIT) return next;
+  return next.slice(next.length - KERNEL_STDIO_CAPTURE_LIMIT);
+}
+
+function redactStderr(stderr: string): string {
+  return stderr
+    .replace(/(token|secret|password|apikey|api_key)=([^\s]+)/gi, "$1=[REDACTED]")
+    .replace(/[A-Za-z0-9_\-]{28,}/g, "[REDACTED]")
+    .slice(0, KERNEL_STDIO_CAPTURE_LIMIT);
+}
+
+function shouldAllowCargoFallback(env: NodeJS.ProcessEnv): boolean {
+  if (env.SETTLER_KERNEL_ALLOW_CARGO === "1") return true;
+  if (env.SETTLER_KERNEL_DEV_FALLBACK === "1") return true;
+  return env.NODE_ENV !== "production" && env.CI !== "true";
+}
+
 export function readKernelFlags(env: NodeJS.ProcessEnv = process.env): KernelFlags {
   return {
     enabled: env.SETTLER_KERNEL_ENABLED === "1",
     canonicalize: env.SETTLER_KERNEL_CANONICALIZE === "1",
     shadowMode: env.SETTLER_KERNEL_SHADOW_MODE === "1",
   };
+}
+
+export function resolveKernelRunner(env: NodeJS.ProcessEnv = process.env): {
+  runner: ResolvedKernelRunner | null;
+  mode: KernelRunnerMode;
+  reason?: string;
+} {
+  const configuredBin = env.SETTLER_KERNEL_BIN?.trim();
+  if (configuredBin) {
+    if (!existsSync(configuredBin)) {
+      return { runner: null, mode: "fallback-ts", reason: "binary_missing" };
+    }
+    try {
+      accessSync(configuredBin, constants.X_OK);
+      return { runner: { mode: "binary", cmd: configuredBin, args: [] }, mode: "binary" };
+    } catch {
+      return { runner: null, mode: "fallback-ts", reason: "binary_not_executable" };
+    }
+  }
+
+  if (shouldAllowCargoFallback(env)) {
+    return {
+      runner: {
+        mode: "cargo-run",
+        cmd: "cargo",
+        args: ["run", "--quiet", "-p", "settler-kernel-cli"],
+      },
+      mode: "cargo-run",
+    };
+  }
+
+  return { runner: null, mode: "fallback-ts", reason: "no_runner_available" };
 }
 
 function tsCanonicalize(value: unknown): unknown {
@@ -65,103 +190,311 @@ export function tsCanonicalizeHash(value: unknown): CanonicalizeHashResult {
   };
 }
 
-function kernelCommand(): { cmd: string; args: string[] } {
-  if (process.env.SETTLER_KERNEL_BIN) {
-    return { cmd: process.env.SETTLER_KERNEL_BIN, args: [] };
-  }
+function tsProofBundleHash(value: unknown): CanonicalizeHashResult {
+  const base = tsCanonicalizeHash(value);
   return {
-    cmd: "cargo",
-    args: ["run", "--quiet", "-p", "settler-kernel-cli"],
+    ...base,
+    ruleHash: createHash("sha256").update("proof_bundle_hash@v1").digest("hex"),
   };
 }
 
-export async function invokeKernelCanonicalizeHash(
-  value: unknown,
-  timeoutMs = 5000
-): Promise<CanonicalizeHashResult> {
-  const req = JSON.stringify({ operation: "canonicalize_hash", payload: value });
-  const { cmd, args } = kernelCommand();
-
+async function spawnKernelRequest(
+  runner: ResolvedKernelRunner,
+  body: string,
+  timeoutMs: number
+): Promise<{ envelope: KernelEnvelope; durationMs: number }> {
   return await new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"] });
+    const startedAt = Date.now();
+    const child = spawn(runner.cmd, runner.args, { stdio: ["pipe", "pipe", "pipe"] });
     const timer = setTimeout(() => {
+      telemetry.timeout += 1;
       child.kill("SIGKILL");
-      reject(new Error("KERNEL_TIMEOUT"));
+      reject(new KernelInvocationError("TIMEOUT"));
     }, timeoutMs);
 
     let stdout = "";
     let stderr = "";
 
     child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
+      stdout = boundedAppend(stdout, chunk);
     });
     child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
+      stderr = boundedAppend(stderr, chunk);
     });
 
-    child.on("error", (error) => {
+    child.on("error", () => {
       clearTimeout(timer);
-      reject(error);
+      reject(new KernelInvocationError("SPAWN_FAILED"));
     });
 
     child.on("close", (code) => {
       clearTimeout(timer);
+      const safeStderr = redactStderr(stderr);
       let parsed: KernelEnvelope;
       try {
         parsed = JSON.parse(stdout.trim());
       } catch {
-        reject(new Error(`KERNEL_MALFORMED_OUTPUT:${code ?? "unknown"}:${stderr.slice(0, 120)}`));
+        telemetry.malformedOutput += 1;
+        reject(new KernelInvocationError("MALFORMED_JSON", { stderr: safeStderr, exitCode: code }));
         return;
       }
 
-      if (!parsed.ok || !parsed.result) {
-        reject(new Error(parsed.error?.code ?? "KERNEL_FAILED"));
+      if (code !== 0 && !parsed.ok) {
+        reject(
+          new KernelInvocationError("NON_ZERO_EXIT", {
+            code: parsed.error?.code,
+            stderr: safeStderr,
+            exitCode: code,
+          })
+        );
         return;
       }
 
-      resolve({
-        schemaVersion: parsed.result.schema_version,
-        canonicalJson: parsed.result.canonical_json,
-        inputHash: parsed.result.input_hash,
-        normalizedHash: parsed.result.normalized_hash,
-        ruleHash: parsed.result.rule_hash,
-      });
+      resolve({ envelope: parsed, durationMs: Date.now() - startedAt });
     });
 
-    child.stdin.write(req);
+    child.stdin.write(body);
     child.stdin.end();
   });
+}
+
+function validateKernelEnvelope(
+  envelope: KernelEnvelope,
+  expectedOperation: string
+): NonNullable<KernelEnvelope["result"]> {
+  if (!envelope.ok || !envelope.result) {
+    if (envelope.error?.code === "KERNEL_UNKNOWN_OPERATION") {
+      throw new KernelInvocationError("UNKNOWN_OPERATION", { code: envelope.error.code });
+    }
+    throw new KernelInvocationError("INVALID_ENVELOPE", { code: envelope.error?.code });
+  }
+
+  if (envelope.operation !== expectedOperation) {
+    throw new KernelInvocationError("UNEXPECTED_SCHEMA");
+  }
+
+  if (!envelope.kernel_version || !envelope.protocol_version) {
+    telemetry.versionMismatch += 1;
+    throw new KernelInvocationError("VERSION_MISMATCH");
+  }
+
+  if (!envelope.protocol_version.startsWith(KERNEL_PROTOCOL_VERSION)) {
+    telemetry.versionMismatch += 1;
+    throw new KernelInvocationError("VERSION_MISMATCH");
+  }
+
+  if (!envelope.kernel_version.startsWith(KERNEL_MIN_VERSION_PREFIX)) {
+    telemetry.versionMismatch += 1;
+    throw new KernelInvocationError("VERSION_MISMATCH");
+  }
+
+  if (envelope.result.schema_version !== "v1") {
+    throw new KernelInvocationError("UNEXPECTED_SCHEMA");
+  }
+
+  return envelope.result;
+}
+
+async function ensureHandshake(runner: ResolvedKernelRunner, timeoutMs: number): Promise<void> {
+  const cacheKey = runnerCacheKey(runner);
+  if (handshakeCache.has(cacheKey)) return;
+
+  const req = JSON.stringify({ operation: "handshake", payload: {} });
+  const { envelope } = await spawnKernelRequest(runner, req, timeoutMs);
+  if (!envelope.ok || !envelope.kernel_version || !envelope.protocol_version) {
+    throw new KernelInvocationError("VERSION_MISMATCH");
+  }
+  if (envelope.operation !== "handshake" || !envelope.result) {
+    throw new KernelInvocationError("UNEXPECTED_SCHEMA");
+  }
+
+  const result = envelope.result as unknown as KernelHandshakeResult;
+  if (!result.kernel_version || !result.protocol_version || result.operation !== "handshake") {
+    throw new KernelInvocationError("UNEXPECTED_SCHEMA");
+  }
+  if (result.protocol_version !== KERNEL_PROTOCOL_VERSION) {
+    throw new KernelInvocationError("VERSION_MISMATCH");
+  }
+
+  handshakeCache.set(cacheKey, result);
+}
+
+async function invokeKernelOperation(
+  operation: KernelOperation,
+  value: unknown,
+  timeoutMs = 5000
+): Promise<{
+  result: CanonicalizeHashResult;
+  runnerMode: Extract<KernelRunnerMode, "binary" | "cargo-run">;
+  durationMs: number;
+}> {
+  const resolved = resolveKernelRunner();
+  if (!resolved.runner) {
+    if (resolved.reason === "binary_missing") {
+      throw new KernelInvocationError("BINARY_MISSING");
+    }
+    if (resolved.reason === "binary_not_executable") {
+      throw new KernelInvocationError("BINARY_NOT_EXECUTABLE");
+    }
+    throw new KernelInvocationError("SPAWN_FAILED");
+  }
+
+  await ensureHandshake(resolved.runner, Math.min(1500, timeoutMs));
+
+  const req = JSON.stringify({ operation, payload: value });
+  const { envelope, durationMs } = await spawnKernelRequest(resolved.runner, req, timeoutMs);
+  const validated = validateKernelEnvelope(envelope, operation);
+
+  return {
+    result: {
+      schemaVersion: validated.schema_version,
+      canonicalJson: validated.canonical_json,
+      inputHash: validated.input_hash,
+      normalizedHash: validated.normalized_hash,
+      ruleHash: validated.rule_hash,
+    },
+    runnerMode: resolved.runner.mode,
+    durationMs,
+  };
+}
+
+export async function invokeKernelCanonicalizeHash(
+  value: unknown,
+  timeoutMs = 5000
+): Promise<{
+  result: CanonicalizeHashResult;
+  runnerMode: Extract<KernelRunnerMode, "binary" | "cargo-run">;
+  durationMs: number;
+}> {
+  return invokeKernelOperation("canonicalize_hash", value, timeoutMs);
+}
+
+export async function invokeKernelProofBundleHash(
+  value: unknown,
+  timeoutMs = 5000
+): Promise<{
+  result: CanonicalizeHashResult;
+  runnerMode: Extract<KernelRunnerMode, "binary" | "cargo-run">;
+  durationMs: number;
+}> {
+  return invokeKernelOperation("proof_bundle_hash", value, timeoutMs);
 }
 
 export async function canonicalizeHashWithFallback(value: unknown): Promise<{
   result: CanonicalizeHashResult;
   mode: "ts" | "rust_primary" | "ts_with_shadow";
+  runnerMode: KernelRunnerMode;
   divergence?: { normalizedHashMatch: boolean };
+  durationMs: { kernel?: number; ts: number };
 }> {
   const flags = readKernelFlags();
+  const tsStartedAt = Date.now();
   const ts = tsCanonicalizeHash(value);
+  const tsDuration = Date.now() - tsStartedAt;
 
   if (!flags.enabled || !flags.canonicalize) {
-    return { result: ts, mode: "ts" };
+    return { result: ts, mode: "ts", runnerMode: "disabled", durationMs: { ts: tsDuration } };
   }
+
+  telemetry.attempted += 1;
 
   if (flags.shadowMode) {
     try {
       const rust = await invokeKernelCanonicalizeHash(value);
+      const match = rust.result.normalizedHash === ts.normalizedHash;
+      if (!match) {
+        telemetry.divergence += 1;
+        telemetry.hashMismatch += 1;
+      }
+      telemetry.success += 1;
       return {
         result: ts,
         mode: "ts_with_shadow",
-        divergence: { normalizedHashMatch: rust.normalizedHash === ts.normalizedHash },
+        runnerMode: rust.runnerMode,
+        divergence: { normalizedHashMatch: match },
+        durationMs: { kernel: rust.durationMs, ts: tsDuration },
       };
     } catch {
-      return { result: ts, mode: "ts_with_shadow", divergence: { normalizedHashMatch: false } };
+      telemetry.fallbackTs += 1;
+      telemetry.divergence += 1;
+      return {
+        result: ts,
+        mode: "ts_with_shadow",
+        runnerMode: "fallback-ts",
+        divergence: { normalizedHashMatch: false },
+        durationMs: { ts: tsDuration },
+      };
     }
   }
 
   try {
     const rust = await invokeKernelCanonicalizeHash(value);
-    return { result: rust, mode: "rust_primary" };
+    telemetry.success += 1;
+    return {
+      result: rust.result,
+      mode: "rust_primary",
+      runnerMode: rust.runnerMode,
+      durationMs: { kernel: rust.durationMs, ts: tsDuration },
+    };
   } catch {
-    return { result: ts, mode: "ts" };
+    telemetry.fallbackTs += 1;
+    return {
+      result: ts,
+      mode: "ts",
+      runnerMode: "fallback-ts",
+      durationMs: { ts: tsDuration },
+    };
   }
+}
+
+export async function proofBundleHashWithFallback(value: unknown): Promise<{
+  result: CanonicalizeHashResult;
+  mode: "ts" | "rust_primary";
+  runnerMode: KernelRunnerMode;
+  durationMs: { kernel?: number; ts: number };
+}> {
+  const flags = readKernelFlags();
+  const tsStartedAt = Date.now();
+  const ts = tsProofBundleHash(value);
+  const tsDuration = Date.now() - tsStartedAt;
+
+  if (!flags.enabled || !flags.canonicalize) {
+    return { result: ts, mode: "ts", runnerMode: "disabled", durationMs: { ts: tsDuration } };
+  }
+
+  telemetry.attempted += 1;
+  try {
+    const rust = await invokeKernelProofBundleHash(value);
+    telemetry.success += 1;
+    return {
+      result: rust.result,
+      mode: "rust_primary",
+      runnerMode: rust.runnerMode,
+      durationMs: { kernel: rust.durationMs, ts: tsDuration },
+    };
+  } catch {
+    telemetry.fallbackTs += 1;
+    return {
+      result: ts,
+      mode: "ts",
+      runnerMode: "fallback-ts",
+      durationMs: { ts: tsDuration },
+    };
+  }
+}
+
+export function getKernelTelemetrySnapshot(): KernelTelemetrySnapshot {
+  return { ...telemetry };
+}
+
+export function resetKernelTelemetry(): void {
+  telemetry.attempted = 0;
+  telemetry.success = 0;
+  telemetry.fallbackTs = 0;
+  telemetry.timeout = 0;
+  telemetry.malformedOutput = 0;
+  telemetry.versionMismatch = 0;
+  telemetry.divergence = 0;
+  telemetry.hashMismatch = 0;
+  handshakeCache.clear();
 }

--- a/packages/cli/src/lib/reconciliation-foundry.ts
+++ b/packages/cli/src/lib/reconciliation-foundry.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
-import { canonicalizeHashWithFallback } from "./kernel-client";
+import { canonicalizeHashWithFallback, getKernelTelemetrySnapshot } from "./kernel-client";
 
 export type SourceSystem =
   | "BANK_STATEMENT"
@@ -661,15 +661,29 @@ export function exportReconciliationSuite(
 export async function exportReconciliationSuiteWithKernel(
   suite: GeneratedSuite,
   outputRoot: string
-): Promise<{ path: string; hash: string; kernelMode: string; divergence?: { normalizedHashMatch: boolean } }> {
+): Promise<{
+  path: string;
+  hash: string;
+  kernelMode: string;
+  runnerMode: string;
+  divergence?: { normalizedHashMatch: boolean };
+  durations: { kernel?: number; ts: number };
+  telemetry: ReturnType<typeof getKernelTelemetrySnapshot>;
+}> {
   const exported = exportReconciliationSuite(suite, outputRoot);
-  const kernel = await canonicalizeHashWithFallback({ manifest: suite.manifest, golden: suite.golden });
+  const kernel = await canonicalizeHashWithFallback({
+    manifest: suite.manifest,
+    golden: suite.golden,
+  });
   fs.writeFileSync(path.join(outputRoot, "integrity.sha256"), `${kernel.result.normalizedHash}\n`);
   return {
     path: exported.path,
     hash: kernel.result.normalizedHash,
     kernelMode: kernel.mode,
+    runnerMode: kernel.runnerMode,
     divergence: kernel.divergence,
+    durations: kernel.durationMs,
+    telemetry: getKernelTelemetrySnapshot(),
   };
 }
 

--- a/packages/cli/src/lib/replay-verification.ts
+++ b/packages/cli/src/lib/replay-verification.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
-import { createHash } from "node:crypto";
 import {
   generateReconciliationSuite,
   runSyntheticEngineValidationRuntime,
   type GeneratedSuite,
   type RuntimeReconMatch,
 } from "./reconciliation-foundry";
+import { proofBundleHashWithFallback } from "./kernel-client";
 
 export interface ReplayBundle {
   run_id: string;
@@ -57,13 +57,9 @@ function stableStringify(value: unknown): string {
   return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;
 }
 
-function hashBLAKE3(value: unknown): string {
-  const payload = stableStringify(value);
-  try {
-    return createHash("blake3").update(payload).digest("hex");
-  } catch {
-    return createHash("blake2s256").update(`blake3-unavailable:${payload}`).digest("hex");
-  }
+async function hashProofBundle(value: unknown): Promise<string> {
+  const hashed = await proofBundleHashWithFallback(value);
+  return hashed.result.normalizedHash;
 }
 
 function normalizeManualReview(
@@ -166,8 +162,8 @@ export async function runReplayVerification(
     });
 
   const replayOutput = await outputFromSuite(suite);
-  const originalHash = hashBLAKE3(bundle.original_output);
-  const replayHash = hashBLAKE3(replayOutput);
+  const originalHash = await hashProofBundle(bundle.original_output);
+  const replayHash = await hashProofBundle(replayOutput);
   const hashMatch = originalHash === replayHash;
 
   const executionTimeMs = Date.now() - startedAt;


### PR DESCRIPTION
### Motivation
- Reduce runtime drift and make kernel execution safe for production by preferring a prebuilt binary over `cargo run` while preserving a conservative local/dev `cargo` fallback and always retaining a TS fallback path. 
- Make the TS↔Rust boundary observable and auditable with a lightweight version/protocol handshake and clear error taxonomy so degraded behavior is deterministic and measurable. 
- Expand the Rust kernel boundary one minimal step to include an adjacent proof/contract hashing operation useful for replay/verification without changing control-plane responsibilities. 

### Description
- Implemented a binary-first runner resolver and policy in `packages/cli/src/lib/kernel-client.ts` with `resolveKernelRunner`, executable checks, explicit runner modes (`binary`, `cargo-run`, `disabled`, `fallback-ts`), bounded stdio handling, stderr redaction, typed `KernelInvocationError` kinds, handshake caching, and telemetry counters. 
- Added a small kernel protocol handshake and a `proof_bundle_hash` operation to the Rust CLI in `crates/settler-kernel-cli/src/main.rs` so the kernel now returns `operation`, `protocol_version`, and `kernel_version` and supports `handshake`, `canonicalize_hash`, and `proof_bundle_hash`. 
- Wired the new proof hashing call into TS: `proofBundleHashWithFallback` and `invokeKernelProofBundleHash`, updated replay verification to use the kernel proof hash (`packages/cli/src/lib/replay-verification.ts`), and surfaced runner/duration/telemetry in foundry exports (`packages/cli/src/lib/reconciliation-foundry.ts` and `packages/cli/src/commands/foundry.ts`). 
- Added tests and docs: new/updated JS tests for runner resolution, fallback, and proof hash rule in `packages/cli/src/__tests__/kernel-client.test.ts`, Rust tests for handshake and proof operation in `crates/settler-kernel-cli/src/main.rs`, and operation guidance in `packages/cli/KERNEL_RUNNER.md`; made a small clippy fix (`sort_by_key`) in `crates/settler-kernel/src/lib.rs`. 

### Testing
- Rust: ran `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all`, and `cargo test -p settler-kernel-cli`, all succeeded. 
- CLI package: ran `pnpm --filter @settler/cli lint`, `pnpm --filter @settler/cli typecheck`, `pnpm --filter @settler/cli test`, and local `pnpm --filter @settler/cli build`, and all CLI checks and tests passed. 
- Repo-level verification: ran `pnpm install --frozen-lockfile`, `pnpm lint`, and `pnpm typecheck` successfully; `pnpm test` hit an unrelated `@settler/web` Next.js build lock contention during the repo build step (concurrent `.next/lock`) and failed there, which is operational noise and not caused by the kernel changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1973519d48328a0e806df832b1c7e)