### PR TITLE
Operationalize Rust kernel: CI binary packaging, promotion guardrails, and replay identity hashing

### DIFF
--- a/.github/workflows/kernel-binary-ci.yml
+++ b/.github/workflows/kernel-binary-ci.yml
@@ -1,0 +1,77 @@
+name: Kernel Binary CI
+
+on:
+  pull_request:
+    paths:
+      - "crates/settler-kernel/**"
+      - "crates/settler-kernel-cli/**"
+      - "packages/cli/src/lib/kernel-client.ts"
+      - "packages/cli/src/lib/replay-verification.ts"
+      - "packages/cli/src/lib/reconciliation-foundry.ts"
+      - "packages/cli/src/commands/foundry.ts"
+      - "packages/cli/src/__tests__/kernel-client.test.ts"
+      - "packages/cli/src/__tests__/replay-verification.test.ts"
+      - "scripts/kernel/**"
+      - "docs/architecture/rust-kernel-boundary.md"
+      - "packages/cli/KERNEL_RUNNER.md"
+      - ".github/workflows/kernel-binary-ci.yml"
+  push:
+    branches: [main, develop]
+    paths:
+      - "crates/settler-kernel/**"
+      - "crates/settler-kernel-cli/**"
+      - "packages/cli/src/lib/kernel-client.ts"
+      - "scripts/kernel/**"
+      - ".github/workflows/kernel-binary-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  kernel-binary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo fmt check
+        run: cargo fmt --all -- --check
+
+      - name: Cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Cargo test
+        run: cargo test --all
+
+      - name: Build kernel binary (release)
+        run: cargo build --locked --release -p settler-kernel-cli
+
+      - name: Capture binary metadata
+        id: metadata
+        run: |
+          BIN=target/release/settler-kernel-cli
+          echo "binary_path=${BIN}" >> "$GITHUB_OUTPUT"
+          echo "binary_sha256=$(sha256sum $BIN | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          echo "kernel_version=$($BIN <<<'{"operation":"handshake","payload":{}}' | jq -r '.kernel_version')" >> "$GITHUB_OUTPUT"
+
+      - name: Kernel handshake smoke
+        run: |
+          BIN="${{ steps.metadata.outputs.binary_path }}"
+          HANDSHAKE=$($BIN <<<'{"operation":"handshake","payload":{}}')
+          echo "$HANDSHAKE"
+          echo "$HANDSHAKE" | jq -e '.ok == true and .operation == "handshake" and .protocol_version == "v1" and (.supported_operations | index("canonicalize_hash")) != null and (.supported_operations | index("proof_bundle_hash")) != null and (.supported_operations | index("artifact_identity_hash")) != null'
+
+      - name: Upload kernel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: settler-kernel-cli-linux-amd64-${{ steps.metadata.outputs.kernel_version }}
+          path: ${{ steps.metadata.outputs.binary_path }}
+          if-no-files-found: error
+
+      - name: Publish metadata summary
+        run: |
+          echo "### Kernel Binary Artifact" >> "$GITHUB_STEP_SUMMARY"
+          echo "- binary: \\`${{ steps.metadata.outputs.binary_path }}\\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- version: \\`${{ steps.metadata.outputs.kernel_version }}\\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- sha256: \\`${{ steps.metadata.outputs.binary_sha256 }}\\`" >> "$GITHUB_STEP_SUMMARY"

--- a/crates/settler-kernel-cli/src/main.rs
+++ b/crates/settler-kernel-cli/src/main.rs
@@ -113,7 +113,12 @@ fn run(req: KernelRequest) -> KernelResponse {
                 operation: "handshake",
                 protocol_version: KERNEL_PROTOCOL_VERSION,
                 kernel_version: env!("CARGO_PKG_VERSION"),
-                supported_operations: vec!["handshake", "canonicalize_hash", "proof_bundle_hash"],
+                supported_operations: vec![
+                    "handshake",
+                    "canonicalize_hash",
+                    "proof_bundle_hash",
+                    "artifact_identity_hash",
+                ],
             };
             match serde_json::to_value(result) {
                 Ok(value) => success("handshake", value),
@@ -142,6 +147,19 @@ fn run(req: KernelRequest) -> KernelResponse {
             },
             Err(e) => failure("proof_bundle_hash", "KERNEL_SERIALIZATION_FAILED", e),
         },
+        "artifact_identity_hash" => {
+            match build_hash_result(&req.payload, "artifact_identity_hash@v1") {
+                Ok(result) => match serde_json::to_value(result) {
+                    Ok(value) => success("artifact_identity_hash", value),
+                    Err(e) => failure(
+                        "artifact_identity_hash",
+                        "KERNEL_SERIALIZATION_FAILED",
+                        e.to_string(),
+                    ),
+                },
+                Err(e) => failure("artifact_identity_hash", "KERNEL_SERIALIZATION_FAILED", e),
+            }
+        }
         other => failure(
             other,
             "KERNEL_UNKNOWN_OPERATION",
@@ -220,6 +238,20 @@ mod tests {
         assert_ne!(
             response.result.as_ref().unwrap()["rule_hash"],
             Value::String(hash_str("canonicalize_hash@v1"))
+        );
+    }
+
+    #[test]
+    fn artifact_identity_hash_uses_distinct_rule_hash() {
+        let payload = serde_json::json!({"artifact":"bundle"});
+        let response = run(KernelRequest {
+            operation: "artifact_identity_hash".to_string(),
+            payload,
+        });
+        assert!(response.ok);
+        assert_eq!(
+            response.result.as_ref().unwrap()["rule_hash"],
+            Value::String(hash_str("artifact_identity_hash@v1"))
         );
     }
 

--- a/docs/architecture/rust-kernel-boundary.md
+++ b/docs/architecture/rust-kernel-boundary.md
@@ -1,47 +1,116 @@
-# Rust Kernel Boundary (Phase 1: Canonicalization + Fingerprints)
+# Rust Kernel Boundary (Operationalization Baseline)
 
-Settler now supports an optional Rust subprocess kernel for deterministic canonicalization and fingerprint generation in reconciliation foundry exports.
+Settler supports an optional Rust subprocess kernel for deterministic canonicalization and fingerprint generation in reconciliation foundry exports and replay verification.
 
 ## Boundary
 
-Kept in TypeScript:
-- CLI command orchestration and file IO
-- feature-flag policy selection
-- fallback behavior and user-visible responses
+Kept in TypeScript (control plane and safety boundary):
 
-Moved to Rust kernel (subprocess):
+- CLI command orchestration and file IO
+- feature/config policy selection
+- fallback behavior and user-visible responses
+- route safety, tenancy/auth/persistence boundaries
+
+Moved to Rust kernel (deterministic compute boundary):
+
 - canonical JSON normalization (sorted object keys)
 - deterministic input hash and normalized hash generation
+- deterministic proof bundle hash primitive
+- deterministic artifact identity hash primitive
 - typed error envelopes for kernel failures
 
-## Feature flags
+## Kernel-backed operation map
 
-- `SETTLER_KERNEL_ENABLED=1` enables kernel integration.
-- `SETTLER_KERNEL_CANONICALIZE=1` enables canonicalization operation routing.
-- `SETTLER_KERNEL_SHADOW_MODE=1` keeps TS result primary and runs Rust for divergence checks.
+- `canonicalize_hash`
+  - eligible for controlled primary (`SETTLER_KERNEL_PRIMARY_ALLOWLIST`)
+  - supports shadow / compare-only modes
+- `proof_bundle_hash`
+  - eligible for controlled primary
+  - TS fallback retained
+- `artifact_identity_hash`
+  - eligible for controlled primary
+  - used to strengthen replay/proof artifact identity determinism
 
-Default behavior remains TS-only when flags are unset.
+Not extracted in this phase:
+
+- runtime reconciliation matching
+- orchestration, storage, tenancy, billing, auth
+
+## Execution and promotion flags
+
+- `SETTLER_KERNEL_ENABLED=1`
+- `SETTLER_KERNEL_CANONICALIZE=1`
+- `SETTLER_KERNEL_EXECUTION_MODE=disabled|compare_only|shadow|primary`
+- `SETTLER_KERNEL_PRIMARY_ALLOWLIST=canonicalize_hash,proof_bundle_hash,artifact_identity_hash`
+
+Back-compat:
+
+- `SETTLER_KERNEL_SHADOW_MODE=1` maps to shadow when `SETTLER_KERNEL_EXECUTION_MODE` is unset.
+
+## Guardrails and rollback
+
+Primary execution for an operation is allowed only when:
+
+1. kernel enabled + operation flag enabled
+2. handshake valid and protocol compatible (`v1`)
+3. operation listed in kernel `supported_operations`
+4. operation explicitly allowlisted for primary mode
+5. TS fallback path remains available
+
+Fast rollback options:
+
+- global TS-only: `SETTLER_KERNEL_EXECUTION_MODE=disabled`
+- global TS primary + compare: `SETTLER_KERNEL_EXECUTION_MODE=shadow`
+- operation rollback: remove op from `SETTLER_KERNEL_PRIMARY_ALLOWLIST`
+- environment rollback: remove/fix `SETTLER_KERNEL_BIN`
+
+## CI binary packaging and delivery discipline
+
+`Kernel Binary CI` workflow now:
+
+- runs rust fmt/clippy/tests
+- builds `settler-kernel-cli` release binary
+- handshake-smoke validates protocol + operation support matrix
+- uploads versioned binary artifact (`settler-kernel-cli-linux-amd64-<kernel_version>`)
+- emits SHA256 + version metadata in workflow summary
+
+Runtime binary resolution helper:
+
+```bash
+node scripts/kernel/resolve-kernel-bin.mjs
+```
 
 ## Failure / fallback guarantees
 
-- Kernel timeout, malformed output, or non-zero exit degrades to TS canonicalization.
-- CLI command still returns structured output without route-level hard failures.
-- Shadow mode records divergence metadata without changing primary result.
+- binary missing/non-executable, spawn issues, timeout, malformed output, protocol mismatch, unsupported operation => TS fallback
+- CLI output remains structured and route-safe
+- no hard-500 behavior introduced from kernel failures
+- fallback reason is machine-visible in execution metadata + telemetry counters
+
+## Observability
+
+Kernel telemetry includes:
+
+- attempt/success/primary/shadow-compare/compare-only counts
+- fallback counts + fallback-by-reason
+- divergence counts + divergence-by-operation
+- timeout, malformed output, version mismatch, binary unavailable
+
+Foundry output includes per-execution metadata:
+
+- operation
+- execution mode
+- primary vs TS decision
+- shadow compare status
+- fallback reason (if any)
 
 ## Local run
 
 ```bash
-SETTLER_KERNEL_ENABLED=1 SETTLER_KERNEL_CANONICALIZE=1 pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-generate --seed 42 --profile smoke
+SETTLER_KERNEL_ENABLED=1 \
+SETTLER_KERNEL_CANONICALIZE=1 \
+SETTLER_KERNEL_EXECUTION_MODE=shadow \
+SETTLER_KERNEL_PRIMARY_ALLOWLIST=canonicalize_hash \
+SETTLER_KERNEL_BIN=$PWD/target/debug/settler-kernel-cli \
+pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-generate --seed 42 --profile smoke
 ```
-
-For explicit kernel binary path (optional):
-
-```bash
-SETTLER_KERNEL_BIN=/path/to/settler-kernel-cli SETTLER_KERNEL_ENABLED=1 SETTLER_KERNEL_CANONICALIZE=1 ...
-```
-
-## Deferred to later extraction
-
-- runtime reconciliation matching in Rust
-- proof artifact bundling in Rust
-- API-server call-site integration outside CLI foundry path

--- a/packages/cli/KERNEL_RUNNER.md
+++ b/packages/cli/KERNEL_RUNNER.md
@@ -8,11 +8,14 @@ The CLI kernel bridge resolves execution in this order:
 2. Optional cargo fallback when explicitly allowed (`runnerMode: "cargo-run"`)
 3. Safe TS fallback (`runnerMode: "fallback-ts"`)
 
-Kernel feature flags remain:
+Kernel feature flags:
 
 - `SETTLER_KERNEL_ENABLED=1`
 - `SETTLER_KERNEL_CANONICALIZE=1`
-- `SETTLER_KERNEL_SHADOW_MODE=1` (shadow compare mode)
+- `SETTLER_KERNEL_EXECUTION_MODE=disabled|compare_only|shadow|primary`
+- `SETTLER_KERNEL_PRIMARY_ALLOWLIST=canonicalize_hash,proof_bundle_hash,artifact_identity_hash`
+
+`SETTLER_KERNEL_SHADOW_MODE=1` is still honored for backward compatibility and maps to `shadow` when explicit execution mode is absent.
 
 ## Binary-first policy
 
@@ -22,39 +25,66 @@ Production-like environments should set:
 - `NODE_ENV=production`
 - `CI=true`
 
-If the binary is missing, non-executable, times out, returns malformed output, or fails compatibility checks, the CLI degrades to TS hashing and remains route-safe.
+Use the helper to resolve binary location predictably:
 
-## Cargo fallback (local/dev only)
+```bash
+node scripts/kernel/resolve-kernel-bin.mjs
+```
 
-Cargo fallback is intentionally explicit:
+If the binary is missing, non-executable, times out, returns malformed output, fails compatibility checks, or does not support an operation, the CLI degrades to TS hashing and remains route-safe.
 
-- `SETTLER_KERNEL_ALLOW_CARGO=1` **or**
-- `SETTLER_KERNEL_DEV_FALLBACK=1`
+## Promotion/readiness guardrails
 
-Without one of these flags, production-like envs (`NODE_ENV=production` + `CI=true`) do not use `cargo run` automatically.
+Primary mode is never broad by default:
+
+- operation must be in `SETTLER_KERNEL_PRIMARY_ALLOWLIST`
+- handshake must succeed (`operation: "handshake"`)
+- operation must be listed in `supported_operations`
+- wrapper always retains TS fallback path
+
+This allows targeted promotion (one operation at a time) with immediate rollback by:
+
+- `SETTLER_KERNEL_EXECUTION_MODE=disabled` (global TS-only)
+- `SETTLER_KERNEL_EXECUTION_MODE=shadow` (TS primary + compare)
+- removing operation from `SETTLER_KERNEL_PRIMARY_ALLOWLIST`
 
 ## Handshake and compatibility
 
-Before kernel work, the TS wrapper performs a handshake (`operation: "handshake"`) and validates:
+Before kernel work, the TS wrapper performs handshake validation:
 
 - `kernel_version` present
 - `protocol_version` compatible (`v1`)
-- operation envelope integrity
+- operation support list includes requested operation
+- operation envelope/schema integrity
 
-On mismatch, TS fallback is selected and telemetry counters are incremented.
+On mismatch, TS fallback is selected and telemetry counters are incremented with machine-visible fallback reason.
 
 ## Telemetry signal
 
-Foundry export logs now include:
+Foundry export logs include:
 
 - `kernel_mode` (`ts`, `rust_primary`, `ts_with_shadow`)
 - `kernel_runner_mode` (`binary`, `cargo-run`, `disabled`, `fallback-ts`)
+- `kernel_execution` metadata (`operation`, `executionMode`, `usedPrimary`, `shadowCompared`, `fallbackReason`)
 - per-path durations (`kernel_duration_ms`, `ts_duration_ms`)
-- `kernel_telemetry` counters (attempted/success/fallback/timeout/malformed/version-mismatch/divergence/hash-mismatch)
+- `kernel_telemetry` counters:
+  - attempts/success/primary/shadow-compare/compare-only
+  - fallback totals and fallback-by-reason
+  - timeout, malformed output, version mismatch, binary unavailable
+  - divergence totals and divergence-by-operation
+
+## CI binary packaging
+
+`Kernel Binary CI` workflow builds `settler-kernel-cli` (release), validates handshake support matrix, and uploads binary artifact with auditable metadata (version + sha256).
 
 ## Local smoke
 
 ```bash
 cargo build -p settler-kernel-cli
-SETTLER_KERNEL_ENABLED=1 SETTLER_KERNEL_CANONICALIZE=1 SETTLER_KERNEL_BIN=$PWD/target/debug/settler-kernel-cli pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-generate --profile smoke --seed 42 --output test-data/exports/latest
+SETTLER_KERNEL_ENABLED=1 \
+SETTLER_KERNEL_CANONICALIZE=1 \
+SETTLER_KERNEL_EXECUTION_MODE=shadow \
+SETTLER_KERNEL_PRIMARY_ALLOWLIST=canonicalize_hash \
+SETTLER_KERNEL_BIN=$PWD/target/debug/settler-kernel-cli \
+pnpm --filter @settler/cli exec tsx src/index.ts foundry reconciliation-generate --profile smoke --seed 42 --output test-data/exports/latest
 ```

--- a/packages/cli/src/__tests__/kernel-client.test.ts
+++ b/packages/cli/src/__tests__/kernel-client.test.ts
@@ -7,7 +7,9 @@ import os from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import {
+  artifactIdentityHashWithFallback,
   canonicalizeHashWithFallback,
+  getKernelTelemetrySnapshot,
   proofBundleHashWithFallback,
   readKernelFlags,
   resetKernelTelemetry,
@@ -21,11 +23,15 @@ describe("kernel client", () => {
       SETTLER_KERNEL_ENABLED: "1",
       SETTLER_KERNEL_CANONICALIZE: "0",
       SETTLER_KERNEL_SHADOW_MODE: "1",
+      SETTLER_KERNEL_EXECUTION_MODE: "shadow",
+      SETTLER_KERNEL_PRIMARY_ALLOWLIST: "canonicalize_hash",
     } as NodeJS.ProcessEnv);
 
     expect(flags.enabled).toBe(true);
     expect(flags.canonicalize).toBe(false);
     expect(flags.shadowMode).toBe(true);
+    expect(flags.executionMode).toBe("shadow");
+    expect(flags.primaryAllowlist.has("canonicalize_hash")).toBe(true);
   });
 
   test("resolves binary runner when executable path is provided", () => {
@@ -74,27 +80,52 @@ describe("kernel client", () => {
     process.env.SETTLER_KERNEL_ENABLED = "0";
     process.env.SETTLER_KERNEL_CANONICALIZE = "0";
     process.env.SETTLER_KERNEL_SHADOW_MODE = "0";
+    process.env.SETTLER_KERNEL_EXECUTION_MODE = "disabled";
     resetKernelTelemetry();
 
     const result = await canonicalizeHashWithFallback({ b: 1, a: 2 });
     expect(result.mode).toBe("ts");
     expect(result.runnerMode).toBe("disabled");
+    expect(result.metadata.fallbackReason).toBe("kernel_disabled");
     expect(result.result.normalizedHash).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  test("proof bundle fallback uses ts rule hash when runner unavailable", async () => {
+  test("proof bundle fallback uses ts rule hash when primary not allowlisted", async () => {
     process.env.SETTLER_KERNEL_ENABLED = "1";
     process.env.SETTLER_KERNEL_CANONICALIZE = "1";
-    process.env.SETTLER_KERNEL_BIN = "/definitely/missing/settler-kernel";
+    process.env.SETTLER_KERNEL_EXECUTION_MODE = "primary";
+    process.env.SETTLER_KERNEL_PRIMARY_ALLOWLIST = "canonicalize_hash";
+    process.env.SETTLER_KERNEL_BIN = process.execPath;
     process.env.SETTLER_KERNEL_ALLOW_CARGO = "0";
     process.env.NODE_ENV = "production";
     process.env.CI = "true";
+    resetKernelTelemetry();
 
     const result = await proofBundleHashWithFallback({ evidence: { b: 2, a: 1 } });
     expect(result.mode).toBe("ts");
     expect(result.runnerMode).toBe("fallback-ts");
+    expect(result.metadata.fallbackReason).toBe("primary_not_allowed");
     const expected = createHash("sha256").update("proof_bundle_hash@v1").digest("hex");
     expect(result.result.ruleHash).toBe(expected);
     expect(result.result.ruleHash).not.toBe(tsCanonicalizeHash({ a: 1 }).ruleHash);
+
+    const telemetry = getKernelTelemetrySnapshot();
+    expect(telemetry.fallbackByReason.primary_not_allowed).toBe(1);
+  });
+
+  test("artifact identity hash is deterministic with ts fallback", async () => {
+    process.env.SETTLER_KERNEL_ENABLED = "1";
+    process.env.SETTLER_KERNEL_CANONICALIZE = "1";
+    process.env.SETTLER_KERNEL_EXECUTION_MODE = "primary";
+    process.env.SETTLER_KERNEL_PRIMARY_ALLOWLIST = "artifact_identity_hash";
+    process.env.SETTLER_KERNEL_BIN = "/missing/bin";
+    process.env.SETTLER_KERNEL_ALLOW_CARGO = "0";
+    process.env.NODE_ENV = "production";
+    process.env.CI = "true";
+
+    const a = await artifactIdentityHashWithFallback({ b: 2, a: 1 });
+    const b = await artifactIdentityHashWithFallback({ a: 1, b: 2 });
+    expect(a.result.normalizedHash).toBe(b.result.normalizedHash);
+    expect(a.metadata.fallbackReason).toBe("binary_unavailable");
   });
 });

--- a/packages/cli/src/__tests__/replay-verification.test.ts
+++ b/packages/cli/src/__tests__/replay-verification.test.ts
@@ -20,6 +20,12 @@ describe("replay verification", () => {
 
     expect(reports.every((report) => report.hash_match)).toBe(true);
     expect(reports.every((report) => report.replay_status === "matched")).toBe(true);
+    expect(
+      reports.every(
+        (report) =>
+          report.hashes.artifact_identity_original === report.hashes.artifact_identity_replay
+      )
+    ).toBe(true);
   });
 
   test("replays 50 random simulation runs with identical outputs", async () => {
@@ -39,6 +45,12 @@ describe("replay verification", () => {
 
     expect(reports.every((report) => report.hash_match)).toBe(true);
     expect(reports.every((report) => report.replay_status === "matched")).toBe(true);
+    expect(
+      reports.every(
+        (report) =>
+          report.hashes.artifact_identity_original === report.hashes.artifact_identity_replay
+      )
+    ).toBe(true);
   });
 
   test("detects divergence and emits detailed report", async () => {
@@ -57,6 +69,9 @@ describe("replay verification", () => {
     const report = await runReplayVerification(tampered);
     expect(report.hash_match).toBe(false);
     expect(report.replay_status).toBe("diverged");
+    expect(report.hashes.artifact_identity_original).not.toBe(
+      report.hashes.artifact_identity_replay
+    );
     expect(report.divergence?.field_differences.length).toBeGreaterThan(0);
     expect(report.divergence?.policy_path_differences.length).toBeGreaterThan(0);
     expect(report.divergence?.timing_differences.length).toBeGreaterThan(0);

--- a/packages/cli/src/commands/foundry.ts
+++ b/packages/cli/src/commands/foundry.ts
@@ -279,6 +279,7 @@ foundryCommand
           kernel_duration_ms: result.durations.kernel ?? null,
           ts_duration_ms: result.durations.ts,
           kernel_telemetry: result.telemetry,
+          kernel_execution: result.execution,
           profile: suite.manifest.profile,
           records: Object.fromEntries(Object.entries(suite.sources).map(([k, v]) => [k, v.length])),
         });

--- a/packages/cli/src/lib/kernel-client.ts
+++ b/packages/cli/src/lib/kernel-client.ts
@@ -6,7 +6,9 @@ const KERNEL_STDIO_CAPTURE_LIMIT = 4096;
 const KERNEL_PROTOCOL_VERSION = "v1";
 const KERNEL_MIN_VERSION_PREFIX = "0.";
 
-type KernelOperation = "canonicalize_hash" | "proof_bundle_hash";
+type KernelOperation = "canonicalize_hash" | "proof_bundle_hash" | "artifact_identity_hash";
+
+export type KernelExecutionMode = "disabled" | "compare_only" | "shadow" | "primary";
 
 export interface CanonicalizeHashResult {
   schemaVersion: string;
@@ -20,6 +22,8 @@ export interface KernelFlags {
   enabled: boolean;
   canonicalize: boolean;
   shadowMode: boolean;
+  executionMode: KernelExecutionMode;
+  primaryAllowlist: Set<KernelOperation>;
 }
 
 export type KernelRunnerMode = "binary" | "cargo-run" | "disabled" | "fallback-ts";
@@ -70,12 +74,26 @@ interface ResolvedKernelRunner {
 interface KernelTelemetrySnapshot {
   attempted: number;
   success: number;
+  primaryMode: number;
+  shadowCompare: number;
+  compareOnly: number;
   fallbackTs: number;
+  fallbackByReason: Record<string, number>;
   timeout: number;
   malformedOutput: number;
   versionMismatch: number;
+  binaryUnavailable: number;
   divergence: number;
+  divergenceByOperation: Record<string, number>;
   hashMismatch: number;
+}
+
+export interface KernelExecutionMetadata {
+  operation: KernelOperation;
+  executionMode: KernelExecutionMode;
+  usedPrimary: boolean;
+  shadowCompared: boolean;
+  fallbackReason?: string;
 }
 
 class KernelInvocationError extends Error {
@@ -90,11 +108,17 @@ class KernelInvocationError extends Error {
 const telemetry: KernelTelemetrySnapshot = {
   attempted: 0,
   success: 0,
+  primaryMode: 0,
+  shadowCompare: 0,
+  compareOnly: 0,
   fallbackTs: 0,
+  fallbackByReason: {},
   timeout: 0,
   malformedOutput: 0,
   versionMismatch: 0,
+  binaryUnavailable: 0,
   divergence: 0,
+  divergenceByOperation: {},
   hashMismatch: 0,
 };
 
@@ -123,11 +147,79 @@ function shouldAllowCargoFallback(env: NodeJS.ProcessEnv): boolean {
   return env.NODE_ENV !== "production" && env.CI !== "true";
 }
 
+function parseExecutionMode(env: NodeJS.ProcessEnv): KernelExecutionMode {
+  const explicit = env.SETTLER_KERNEL_EXECUTION_MODE?.trim().toLowerCase();
+  if (
+    explicit === "disabled" ||
+    explicit === "compare_only" ||
+    explicit === "shadow" ||
+    explicit === "primary"
+  ) {
+    return explicit;
+  }
+  if (env.SETTLER_KERNEL_SHADOW_MODE === "1") return "shadow";
+  return "primary";
+}
+
+function parsePrimaryAllowlist(env: NodeJS.ProcessEnv): Set<KernelOperation> {
+  const configured =
+    env.SETTLER_KERNEL_PRIMARY_ALLOWLIST?.split(",")
+      .map((item) => item.trim())
+      .filter(Boolean) ?? [];
+  const out = new Set<KernelOperation>();
+  for (const candidate of configured) {
+    if (
+      candidate === "canonicalize_hash" ||
+      candidate === "proof_bundle_hash" ||
+      candidate === "artifact_identity_hash"
+    ) {
+      out.add(candidate);
+    }
+  }
+  return out;
+}
+
+function recordFallback(reason: string): void {
+  telemetry.fallbackTs += 1;
+  telemetry.fallbackByReason[reason] = (telemetry.fallbackByReason[reason] ?? 0) + 1;
+}
+
+function classifyErrorReason(error: unknown, defaultReason: string): string {
+  if (error instanceof KernelInvocationError) {
+    switch (error.kind) {
+      case "BINARY_MISSING":
+      case "BINARY_NOT_EXECUTABLE":
+        return "binary_unavailable";
+      case "VERSION_MISMATCH":
+        return "protocol_mismatch";
+      case "UNKNOWN_OPERATION":
+        return "unsupported_operation";
+      case "TIMEOUT":
+        return "timeout";
+      default:
+        return defaultReason;
+    }
+  }
+  return defaultReason;
+}
+
+function recordDivergence(operation: KernelOperation): void {
+  telemetry.divergence += 1;
+  telemetry.divergenceByOperation[operation] =
+    (telemetry.divergenceByOperation[operation] ?? 0) + 1;
+}
+
+function shouldUsePrimary(flags: KernelFlags, operation: KernelOperation): boolean {
+  return flags.executionMode === "primary" && flags.primaryAllowlist.has(operation);
+}
+
 export function readKernelFlags(env: NodeJS.ProcessEnv = process.env): KernelFlags {
   return {
     enabled: env.SETTLER_KERNEL_ENABLED === "1",
     canonicalize: env.SETTLER_KERNEL_CANONICALIZE === "1",
     shadowMode: env.SETTLER_KERNEL_SHADOW_MODE === "1",
+    executionMode: parseExecutionMode(env),
+    primaryAllowlist: parsePrimaryAllowlist(env),
   };
 }
 
@@ -195,6 +287,14 @@ function tsProofBundleHash(value: unknown): CanonicalizeHashResult {
   return {
     ...base,
     ruleHash: createHash("sha256").update("proof_bundle_hash@v1").digest("hex"),
+  };
+}
+
+function tsArtifactIdentityHash(value: unknown): CanonicalizeHashResult {
+  const base = tsCanonicalizeHash(value);
+  return {
+    ...base,
+    ruleHash: createHash("sha256").update("artifact_identity_hash@v1").digest("hex"),
   };
 }
 
@@ -319,6 +419,16 @@ async function ensureHandshake(runner: ResolvedKernelRunner, timeoutMs: number):
   handshakeCache.set(cacheKey, result);
 }
 
+function ensureOperationSupport(runner: ResolvedKernelRunner, operation: KernelOperation): void {
+  const handshake = handshakeCache.get(runnerCacheKey(runner));
+  if (!handshake) {
+    throw new KernelInvocationError("VERSION_MISMATCH");
+  }
+  if (!handshake.supported_operations.includes(operation)) {
+    throw new KernelInvocationError("UNKNOWN_OPERATION", { code: "KERNEL_UNKNOWN_OPERATION" });
+  }
+}
+
 async function invokeKernelOperation(
   operation: KernelOperation,
   value: unknown,
@@ -330,6 +440,7 @@ async function invokeKernelOperation(
 }> {
   const resolved = resolveKernelRunner();
   if (!resolved.runner) {
+    telemetry.binaryUnavailable += 1;
     if (resolved.reason === "binary_missing") {
       throw new KernelInvocationError("BINARY_MISSING");
     }
@@ -340,6 +451,7 @@ async function invokeKernelOperation(
   }
 
   await ensureHandshake(resolved.runner, Math.min(1500, timeoutMs));
+  ensureOperationSupport(resolved.runner, operation);
 
   const req = JSON.stringify({ operation, payload: value });
   const { envelope, durationMs } = await spawnKernelRequest(resolved.runner, req, timeoutMs);
@@ -380,30 +492,60 @@ export async function invokeKernelProofBundleHash(
   return invokeKernelOperation("proof_bundle_hash", value, timeoutMs);
 }
 
+export async function invokeKernelArtifactIdentityHash(
+  value: unknown,
+  timeoutMs = 5000
+): Promise<{
+  result: CanonicalizeHashResult;
+  runnerMode: Extract<KernelRunnerMode, "binary" | "cargo-run">;
+  durationMs: number;
+}> {
+  return invokeKernelOperation("artifact_identity_hash", value, timeoutMs);
+}
+
 export async function canonicalizeHashWithFallback(value: unknown): Promise<{
   result: CanonicalizeHashResult;
   mode: "ts" | "rust_primary" | "ts_with_shadow";
   runnerMode: KernelRunnerMode;
   divergence?: { normalizedHashMatch: boolean };
   durationMs: { kernel?: number; ts: number };
+  metadata: KernelExecutionMetadata;
 }> {
   const flags = readKernelFlags();
   const tsStartedAt = Date.now();
   const ts = tsCanonicalizeHash(value);
   const tsDuration = Date.now() - tsStartedAt;
 
-  if (!flags.enabled || !flags.canonicalize) {
-    return { result: ts, mode: "ts", runnerMode: "disabled", durationMs: { ts: tsDuration } };
+  if (!flags.enabled || !flags.canonicalize || flags.executionMode === "disabled") {
+    return {
+      result: ts,
+      mode: "ts",
+      runnerMode: "disabled",
+      durationMs: { ts: tsDuration },
+      metadata: {
+        operation: "canonicalize_hash",
+        executionMode: "disabled",
+        usedPrimary: false,
+        shadowCompared: false,
+        fallbackReason: "kernel_disabled",
+      },
+    };
   }
 
   telemetry.attempted += 1;
 
-  if (flags.shadowMode) {
+  const compare = flags.executionMode === "shadow" || flags.executionMode === "compare_only";
+  if (compare) {
+    if (flags.executionMode === "compare_only") {
+      telemetry.compareOnly += 1;
+    } else {
+      telemetry.shadowCompare += 1;
+    }
     try {
       const rust = await invokeKernelCanonicalizeHash(value);
       const match = rust.result.normalizedHash === ts.normalizedHash;
       if (!match) {
-        telemetry.divergence += 1;
+        recordDivergence("canonicalize_hash");
         telemetry.hashMismatch += 1;
       }
       telemetry.success += 1;
@@ -413,36 +555,82 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
         runnerMode: rust.runnerMode,
         divergence: { normalizedHashMatch: match },
         durationMs: { kernel: rust.durationMs, ts: tsDuration },
+        metadata: {
+          operation: "canonicalize_hash",
+          executionMode: flags.executionMode,
+          usedPrimary: false,
+          shadowCompared: true,
+        },
       };
-    } catch {
-      telemetry.fallbackTs += 1;
-      telemetry.divergence += 1;
+    } catch (error) {
+      const reason = classifyErrorReason(error, "shadow_kernel_failed");
+      recordFallback(reason);
+      recordDivergence("canonicalize_hash");
       return {
         result: ts,
         mode: "ts_with_shadow",
         runnerMode: "fallback-ts",
         divergence: { normalizedHashMatch: false },
         durationMs: { ts: tsDuration },
+        metadata: {
+          operation: "canonicalize_hash",
+          executionMode: flags.executionMode,
+          usedPrimary: false,
+          shadowCompared: true,
+          fallbackReason: reason,
+        },
       };
     }
   }
 
-  try {
-    const rust = await invokeKernelCanonicalizeHash(value);
-    telemetry.success += 1;
-    return {
-      result: rust.result,
-      mode: "rust_primary",
-      runnerMode: rust.runnerMode,
-      durationMs: { kernel: rust.durationMs, ts: tsDuration },
-    };
-  } catch {
-    telemetry.fallbackTs += 1;
+  if (!shouldUsePrimary(flags, "canonicalize_hash")) {
+    recordFallback("primary_not_allowed");
     return {
       result: ts,
       mode: "ts",
       runnerMode: "fallback-ts",
       durationMs: { ts: tsDuration },
+      metadata: {
+        operation: "canonicalize_hash",
+        executionMode: flags.executionMode,
+        usedPrimary: false,
+        shadowCompared: false,
+        fallbackReason: "primary_not_allowed",
+      },
+    };
+  }
+
+  try {
+    const rust = await invokeKernelCanonicalizeHash(value);
+    telemetry.success += 1;
+    telemetry.primaryMode += 1;
+    return {
+      result: rust.result,
+      mode: "rust_primary",
+      runnerMode: rust.runnerMode,
+      durationMs: { kernel: rust.durationMs, ts: tsDuration },
+      metadata: {
+        operation: "canonicalize_hash",
+        executionMode: flags.executionMode,
+        usedPrimary: true,
+        shadowCompared: false,
+      },
+    };
+  } catch (error) {
+    const reason = classifyErrorReason(error, "primary_kernel_failed");
+    recordFallback(reason);
+    return {
+      result: ts,
+      mode: "ts",
+      runnerMode: "fallback-ts",
+      durationMs: { ts: tsDuration },
+      metadata: {
+        operation: "canonicalize_hash",
+        executionMode: flags.executionMode,
+        usedPrimary: false,
+        shadowCompared: false,
+        fallbackReason: reason,
+      },
     };
   }
 }
@@ -452,33 +640,159 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
   mode: "ts" | "rust_primary";
   runnerMode: KernelRunnerMode;
   durationMs: { kernel?: number; ts: number };
+  metadata: KernelExecutionMetadata;
 }> {
   const flags = readKernelFlags();
   const tsStartedAt = Date.now();
   const ts = tsProofBundleHash(value);
   const tsDuration = Date.now() - tsStartedAt;
 
-  if (!flags.enabled || !flags.canonicalize) {
-    return { result: ts, mode: "ts", runnerMode: "disabled", durationMs: { ts: tsDuration } };
+  if (!flags.enabled || !flags.canonicalize || flags.executionMode === "disabled") {
+    return {
+      result: ts,
+      mode: "ts",
+      runnerMode: "disabled",
+      durationMs: { ts: tsDuration },
+      metadata: {
+        operation: "proof_bundle_hash",
+        executionMode: "disabled",
+        usedPrimary: false,
+        shadowCompared: false,
+        fallbackReason: "kernel_disabled",
+      },
+    };
+  }
+
+  if (!shouldUsePrimary(flags, "proof_bundle_hash")) {
+    recordFallback("primary_not_allowed");
+    return {
+      result: ts,
+      mode: "ts",
+      runnerMode: "fallback-ts",
+      durationMs: { ts: tsDuration },
+      metadata: {
+        operation: "proof_bundle_hash",
+        executionMode: flags.executionMode,
+        usedPrimary: false,
+        shadowCompared: false,
+        fallbackReason: "primary_not_allowed",
+      },
+    };
   }
 
   telemetry.attempted += 1;
   try {
     const rust = await invokeKernelProofBundleHash(value);
     telemetry.success += 1;
+    telemetry.primaryMode += 1;
     return {
       result: rust.result,
       mode: "rust_primary",
       runnerMode: rust.runnerMode,
       durationMs: { kernel: rust.durationMs, ts: tsDuration },
+      metadata: {
+        operation: "proof_bundle_hash",
+        executionMode: flags.executionMode,
+        usedPrimary: true,
+        shadowCompared: false,
+      },
     };
-  } catch {
-    telemetry.fallbackTs += 1;
+  } catch (error) {
+    const reason = classifyErrorReason(error, "primary_kernel_failed");
+    recordFallback(reason);
     return {
       result: ts,
       mode: "ts",
       runnerMode: "fallback-ts",
       durationMs: { ts: tsDuration },
+      metadata: {
+        operation: "proof_bundle_hash",
+        executionMode: flags.executionMode,
+        usedPrimary: false,
+        shadowCompared: false,
+        fallbackReason: reason,
+      },
+    };
+  }
+}
+
+export async function artifactIdentityHashWithFallback(value: unknown): Promise<{
+  result: CanonicalizeHashResult;
+  mode: "ts" | "rust_primary";
+  runnerMode: KernelRunnerMode;
+  durationMs: { kernel?: number; ts: number };
+  metadata: KernelExecutionMetadata;
+}> {
+  const flags = readKernelFlags();
+  const tsStartedAt = Date.now();
+  const ts = tsArtifactIdentityHash(value);
+  const tsDuration = Date.now() - tsStartedAt;
+
+  if (!flags.enabled || !flags.canonicalize || flags.executionMode === "disabled") {
+    return {
+      result: ts,
+      mode: "ts",
+      runnerMode: "disabled",
+      durationMs: { ts: tsDuration },
+      metadata: {
+        operation: "artifact_identity_hash",
+        executionMode: "disabled",
+        usedPrimary: false,
+        shadowCompared: false,
+        fallbackReason: "kernel_disabled",
+      },
+    };
+  }
+
+  if (!shouldUsePrimary(flags, "artifact_identity_hash")) {
+    recordFallback("primary_not_allowed");
+    return {
+      result: ts,
+      mode: "ts",
+      runnerMode: "fallback-ts",
+      durationMs: { ts: tsDuration },
+      metadata: {
+        operation: "artifact_identity_hash",
+        executionMode: flags.executionMode,
+        usedPrimary: false,
+        shadowCompared: false,
+        fallbackReason: "primary_not_allowed",
+      },
+    };
+  }
+
+  telemetry.attempted += 1;
+  try {
+    const rust = await invokeKernelArtifactIdentityHash(value);
+    telemetry.success += 1;
+    telemetry.primaryMode += 1;
+    return {
+      result: rust.result,
+      mode: "rust_primary",
+      runnerMode: rust.runnerMode,
+      durationMs: { kernel: rust.durationMs, ts: tsDuration },
+      metadata: {
+        operation: "artifact_identity_hash",
+        executionMode: flags.executionMode,
+        usedPrimary: true,
+        shadowCompared: false,
+      },
+    };
+  } catch (error) {
+    const reason = classifyErrorReason(error, "primary_kernel_failed");
+    recordFallback(reason);
+    return {
+      result: ts,
+      mode: "ts",
+      runnerMode: "fallback-ts",
+      durationMs: { ts: tsDuration },
+      metadata: {
+        operation: "artifact_identity_hash",
+        executionMode: flags.executionMode,
+        usedPrimary: false,
+        shadowCompared: false,
+        fallbackReason: reason,
+      },
     };
   }
 }
@@ -490,11 +804,17 @@ export function getKernelTelemetrySnapshot(): KernelTelemetrySnapshot {
 export function resetKernelTelemetry(): void {
   telemetry.attempted = 0;
   telemetry.success = 0;
+  telemetry.primaryMode = 0;
+  telemetry.shadowCompare = 0;
+  telemetry.compareOnly = 0;
   telemetry.fallbackTs = 0;
+  telemetry.fallbackByReason = {};
   telemetry.timeout = 0;
   telemetry.malformedOutput = 0;
   telemetry.versionMismatch = 0;
+  telemetry.binaryUnavailable = 0;
   telemetry.divergence = 0;
+  telemetry.divergenceByOperation = {};
   telemetry.hashMismatch = 0;
   handshakeCache.clear();
 }

--- a/packages/cli/src/lib/reconciliation-foundry.ts
+++ b/packages/cli/src/lib/reconciliation-foundry.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
-import { canonicalizeHashWithFallback, getKernelTelemetrySnapshot } from "./kernel-client";
+import {
+  canonicalizeHashWithFallback,
+  getKernelTelemetrySnapshot,
+  type KernelExecutionMetadata,
+} from "./kernel-client";
 
 export type SourceSystem =
   | "BANK_STATEMENT"
@@ -669,6 +673,7 @@ export async function exportReconciliationSuiteWithKernel(
   divergence?: { normalizedHashMatch: boolean };
   durations: { kernel?: number; ts: number };
   telemetry: ReturnType<typeof getKernelTelemetrySnapshot>;
+  execution: KernelExecutionMetadata;
 }> {
   const exported = exportReconciliationSuite(suite, outputRoot);
   const kernel = await canonicalizeHashWithFallback({
@@ -684,6 +689,7 @@ export async function exportReconciliationSuiteWithKernel(
     divergence: kernel.divergence,
     durations: kernel.durationMs,
     telemetry: getKernelTelemetrySnapshot(),
+    execution: kernel.metadata,
   };
 }
 

--- a/packages/cli/src/lib/replay-verification.ts
+++ b/packages/cli/src/lib/replay-verification.ts
@@ -6,7 +6,7 @@ import {
   type GeneratedSuite,
   type RuntimeReconMatch,
 } from "./reconciliation-foundry";
-import { proofBundleHashWithFallback } from "./kernel-client";
+import { artifactIdentityHashWithFallback, proofBundleHashWithFallback } from "./kernel-client";
 
 export interface ReplayBundle {
   run_id: string;
@@ -41,6 +41,8 @@ export interface ReplayVerificationReport {
   hashes: {
     original: string;
     replay: string;
+    artifact_identity_original: string;
+    artifact_identity_replay: string;
   };
 }
 
@@ -59,6 +61,11 @@ function stableStringify(value: unknown): string {
 
 async function hashProofBundle(value: unknown): Promise<string> {
   const hashed = await proofBundleHashWithFallback(value);
+  return hashed.result.normalizedHash;
+}
+
+async function hashArtifactIdentity(value: unknown): Promise<string> {
+  const hashed = await artifactIdentityHashWithFallback(value);
   return hashed.result.normalizedHash;
 }
 
@@ -164,7 +171,10 @@ export async function runReplayVerification(
   const replayOutput = await outputFromSuite(suite);
   const originalHash = await hashProofBundle(bundle.original_output);
   const replayHash = await hashProofBundle(replayOutput);
-  const hashMatch = originalHash === replayHash;
+  const originalArtifactIdentityHash = await hashArtifactIdentity(bundle.original_output);
+  const replayArtifactIdentityHash = await hashArtifactIdentity(replayOutput);
+  const hashMatch =
+    originalHash === replayHash && originalArtifactIdentityHash === replayArtifactIdentityHash;
 
   const executionTimeMs = Date.now() - startedAt;
   const fieldDiffs = diffPaths(bundle.original_output, replayOutput);
@@ -190,6 +200,8 @@ export async function runReplayVerification(
     hashes: {
       original: originalHash,
       replay: replayHash,
+      artifact_identity_original: originalArtifactIdentityHash,
+      artifact_identity_replay: replayArtifactIdentityHash,
     },
   };
 

--- a/scripts/kernel/resolve-kernel-bin.mjs
+++ b/scripts/kernel/resolve-kernel-bin.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const cwd = process.cwd();
+const candidates = [
+  process.env.SETTLER_KERNEL_BIN,
+  path.join(cwd, "target", "release", "settler-kernel-cli"),
+  path.join(cwd, "target", "debug", "settler-kernel-cli"),
+].filter(Boolean);
+
+const found = candidates.find((candidate) => fs.existsSync(candidate));
+
+if (!found) {
+  console.error(
+    JSON.stringify(
+      {
+        ok: false,
+        code: "KERNEL_BINARY_NOT_FOUND",
+        checked: candidates,
+      },
+      null,
+      2
+    )
+  );
+  process.exit(1);
+}
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      path: found,
+      source: process.env.SETTLER_KERNEL_BIN ? "SETTLER_KERNEL_BIN" : "default_target_path",
+    },
+    null,
+    2
+  )
+);


### PR DESCRIPTION
### Motivation
- Make the Rust kernel operationally credible by adding a CI packaging path, explicit promotion controls, and stronger replay/proof identity checks without turning the kernel into a control-plane dependency.
- Ensure any promotion to primary-mode is explicit, auditable, and immediately reversible, while preserving the TypeScript fallback and tenancy/auth boundaries.
- Reduce replay divergence risk by adding a narrow deterministic primitive for artifact identity and asserting it during replay verification.

### Description
- CI binary packaging and handshake smoke: add a `Kernel Binary CI` workflow that runs `cargo fmt`, `clippy`, `cargo test`, produces a release binary, validates a handshake that includes supported operations, uploads the artifact, and publishes SHA256/version metadata for auditability.
- Promotion/readiness guardrails in TS wrapper: introduce explicit execution modes (`disabled|compare_only|shadow|primary`), a per-operation `SETTLER_KERNEL_PRIMARY_ALLOWLIST`, handshake-based operation support gating, structured per-execution metadata (`operation`, `executionMode`, `usedPrimary`, `shadowCompared`, `fallbackReason`), and richer fallback classification and telemetry.
- Replay / proof improvements: add a new kernel operation `artifact_identity_hash` (Rust + tests) and wire replay verification to assert both proof-bundle and artifact-identity hash parity to strengthen artifact identity determinism.
- Observability and ergonomics: expand kernel telemetry counters (primary/shadow/compare-only counts, fallback-by-reason, divergence-by-operation, binary-unavailable) and add `scripts/kernel/resolve-kernel-bin.mjs` plus documentation updates (`KERNEL_RUNNER.md`, kernel boundary docs) and foundry output to surface execution metadata.

### Testing
- Rust quality and unit tests: ran `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all`, all succeeded.
- Kernel release build and handshake smoke: built `settler-kernel-cli` (`cargo build --locked --release -p settler-kernel-cli`) and verified the handshake output (protocol and supported operation matrix) successfully.
- JS/monorepo verification: ran `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `pnpm test`; package-level tests completed and the targeted CLI test suite `pnpm --filter @settler/cli test` passed.
- Notes: the run surfaced existing repository lint warnings unrelated to these changes and some long-running Jest handle warnings in unrelated packages; all added/modified tests and CI steps introduced by this PR passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b2984f008328bcc3e62d0384023d)