### PR TITLE
chore: harden npm registry resolution for public @types packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -26,6 +26,10 @@ engine-strict=true
 
 # Use the public npm registry for all packages
 registry=https://registry.npmjs.org/
+# Avoid scoped registry leakage for DefinitelyTyped packages
+@types:registry=https://registry.npmjs.org/
+# Default to public unauthenticated fetch unless a scoped registry overrides this
+always-auth=false
 
 # Skip Sentry CLI auto-installation during npm ci (prevents timeout issues)
 # This is set via environment variable in preinstall script


### PR DESCRIPTION
### Motivation
- Address intermittent `pnpm install` 403s when fetching `@types/*` (e.g. `@types/bcrypt`) caused by scoped registry/auth leakage or environment-level npm config drift by making scope resolution explicit and reducing unintended auth requirements.

### Description
- Update root `.npmrc` to pin the `@types` scope to the public registry with `@types:registry=https://registry.npmjs.org/` and set `always-auth=false` to avoid requiring authentication for public fetches, keeping the change minimal and scoped to install/bootstrap reliability (`.npmrc` was modified).

### Testing
- Ran `pnpm install` (succeeds), `pnpm exec turbo --version` (succeeds), `pnpm -r exec node -v` (succeeds), `pnpm lint` (succeeds with warnings), `pnpm typecheck` (succeeds), `pnpm build` (succeeds), and `pnpm test` (package-level tests ran and passed; monorepo `pnpm test` observed pre-existing Jest open-handle behavior that prevents a clean process exit, which is a non-install/bootstrap issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d9c8be688328aace5dce1ee19742)