### PR TITLE
Add visual-proof UI, evidence registry, and RealityEvidencePanel across site

### DIFF
--- a/packages/web/src/__tests__/content/visual-proof-registry.test.ts
+++ b/packages/web/src/__tests__/content/visual-proof-registry.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { visualProofRegistry } from "@/lib/public/visual-proof-registry";
+
+function collectRoutes(appDir: string): Set<string> {
+  const routes = new Set<string>();
+
+  function walk(dir: string) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name === "page.tsx") {
+        const relative = path.relative(appDir, full).replace(/\\/g, "/");
+        const route =
+          "/" +
+          relative
+            .replace(/\/page\.tsx$/, "")
+            .split("/")
+            .filter((segment) => segment && !segment.startsWith("(") && segment !== "page.tsx")
+            .join("/");
+        routes.add(route === "/" ? "/" : route);
+      }
+    }
+  }
+
+  walk(appDir);
+  return routes;
+}
+
+describe("visual proof registry", () => {
+  const appDir = path.join(process.cwd(), "src/app");
+  const routes = collectRoutes(appDir);
+
+  it("only references resolvable route patterns", () => {
+    const missing: string[] = [];
+
+    Object.values(visualProofRegistry)
+      .flat()
+      .forEach((entry) => {
+        entry.refs
+          .filter((ref) => ref.type === "route")
+          .forEach((ref) => {
+            const normalized = ref.href.replace(/\/\[[^/]+\]/g, "");
+            const hasMatch = [...routes].some(
+              (route) => route === normalized || route.startsWith(normalized)
+            );
+            if (!hasMatch) {
+              missing.push(ref.href);
+            }
+          });
+      });
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/web/src/app/(marketing)/home/page.tsx
+++ b/packages/web/src/app/(marketing)/home/page.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/accordion";
 import Image from "next/image";
 import { AnimatedCodeBlock } from "@/components/AnimatedCodeBlock";
+import { PlatformOverviewDiagram } from "@/components/public-visual-proof";
 
 export default function HomePage() {
   const repoUrl = process.env.NEXT_PUBLIC_REPO_URL || "https://github.com/Hardonian/Settler";
@@ -530,6 +531,27 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                 );
               })}
             </div>
+          </div>
+        </section>
+
+        <section
+          className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900"
+          aria-label="Platform architecture preview"
+        >
+          <div className="max-w-6xl mx-auto space-y-4">
+            <div className="max-w-3xl">
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
+                Visual proof
+              </p>
+              <h2 className="text-2xl sm:text-3xl font-bold text-slate-900 dark:text-white tracking-tight">
+                See the actual system shape, not just feature claims
+              </h2>
+              <p className="mt-3 text-slate-600 dark:text-slate-400">
+                This architecture preview maps shipped surfaces, control-plane modules, and runtime
+                boundaries. Continue to the dedicated architecture page for deeper detail.
+              </p>
+            </div>
+            <PlatformOverviewDiagram />
           </div>
         </section>
 

--- a/packages/web/src/app/architecture/page.tsx
+++ b/packages/web/src/app/architecture/page.tsx
@@ -1,12 +1,47 @@
 import { Metadata } from "next";
-import ArchitectureOverview from "@/components/stitch-import/ArchitectureOverview";
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
+import {
+  CapabilityMap,
+  IntegrationAndPackagingMap,
+  PlatformOverviewDiagram,
+  WorkflowJourneyDiagram,
+} from "@/components/public-visual-proof";
 
 export const metadata: Metadata = {
   title: "Architecture - Settler",
   description:
-    "Settler's open source architecture: deterministic reconciliation engine, evidence hash chain, tenant isolation model, and replay infrastructure.",
+    "Platform architecture diagrams for Settler covering product surfaces, control plane boundaries, workflows, capability clusters, and packaging boundaries.",
 };
 
 export default function ArchitecturePage() {
-  return <ArchitectureOverview />;
+  return (
+    <>
+      <Navigation />
+      <main className="min-h-screen bg-slate-50 px-4 pb-16 pt-24 dark:bg-slate-950 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl space-y-8">
+          <section>
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400">
+              Architecture proof layer
+            </p>
+            <h1 className="mt-3 text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
+              How Settler is assembled in production
+            </h1>
+            <p className="mt-4 max-w-3xl text-slate-600 dark:text-slate-400">
+              These visuals are grounded in repository modules, route structure, and shipped product
+              surfaces. They describe current-state architecture and current-state workflows.
+            </p>
+          </section>
+
+          <PlatformOverviewDiagram />
+          <WorkflowJourneyDiagram />
+          <CapabilityMap />
+          <IntegrationAndPackagingMap />
+          <RealityEvidencePanel scope="architecture" />
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
 }

--- a/packages/web/src/app/console/page.tsx
+++ b/packages/web/src/app/console/page.tsx
@@ -22,6 +22,8 @@ import { RBACGate } from "@/lib/rbac-gate";
 import { appLogger } from "@/lib/utils/logger";
 import { ErrorBoundary } from "@/components/shared/error-boundary";
 import { PageLoadingSkeleton, CardLoadingSkeleton } from "@/components/shared/loading-state";
+import { ConsoleSurfaceMap } from "@/components/feature-visual-proof";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
 
 // OPTIMIZATION: Code-split heavy dashboard components
 // These are not needed for initial paint and add ~15KB to the bundle
@@ -335,6 +337,9 @@ async function ConsoleOverviewContent() {
               </div>
             </CardContent>
           </Card>
+
+          <ConsoleSurfaceMap />
+          <RealityEvidencePanel scope="console" title="Console evidence references" />
         </div>
       );
     }

--- a/packages/web/src/app/how-it-works/page.tsx
+++ b/packages/web/src/app/how-it-works/page.tsx
@@ -1,216 +1,99 @@
-"use client";
-
 import Link from "next/link";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
-import { Button } from "@/components/ui/button";
-import { SpotlightCard } from "@/components/ui/SpotlightCard";
-import { TextRevealHeading } from "@/components/ui/TextReveal";
-import { ParallaxBackground, ParallaxBlobs } from "@/components/ui/ParallaxBackground";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
-import ArchitectureOverview from "@/components/stitch-import/ArchitectureOverview";
-import { Plug, Code2, Play, BarChart3 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { WorkflowJourneyDiagram } from "@/components/public-visual-proof";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
 
-const steps = [
+const implementationProof = [
   {
-    number: 1,
     title: "Connect",
-    description: "Attach a data source — Stripe, Shopify, QuickBooks, a CSV export, or your own adapter.",
-    icon: Plug,
+    detail:
+      "Use adapter-backed source and target definitions for Stripe, databases, and file feeds.",
+    route: "/app/connections",
   },
   {
-    number: 2,
-    title: "Define Rules",
-    description: "Write matching rules in code: field mappings, numeric tolerances, and date windows. Rules are version-controlled and testable.",
-    icon: Code2,
+    title: "Define",
+    detail: "Write deterministic matching rules and policies before each run.",
+    route: "/app/rules",
   },
   {
-    number: 3,
-    title: "Run",
-    description: "Execute the reconciliation. The engine applies your rules deterministically — same inputs always produce the same output.",
-    icon: Play,
+    title: "Execute",
+    detail: "Launch runs and track pipeline execution, traces, and system health.",
+    route: "/app/runs",
   },
   {
-    number: 4,
-    title: "Review Evidence",
-    description: "Inspect every mismatch with full context: which rule matched, what the variance was, and a SHA-256 hash-linked audit trail.",
-    icon: BarChart3,
+    title: "Verify",
+    detail: "Inspect proofs, audit logs, and mismatch classifications with replay support.",
+    route: "/app/proofs",
   },
 ];
 
 export default function HowItWorksPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 dark:from-slate-900 dark:via-slate-800 dark:to-black">
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
       <Navigation />
 
-      {/* Breadcrumbs */}
-      <section className="px-4 sm:px-6 lg:px-8 pt-24">
-        <div className="max-w-7xl mx-auto">
+      <section className="px-4 pb-8 pt-24 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl">
           <Breadcrumbs items={[{ label: "How It Works" }]} />
-        </div>
-      </section>
-
-      {/* Hero Section */}
-      <section
-        className="relative pt-8 pb-16 md:pb-20 px-4 sm:px-6 lg:px-8 overflow-hidden min-h-[50vh] md:min-h-[60vh] flex items-center"
-        aria-labelledby="hero-heading"
-      >
-        <ParallaxBackground>
-          <ParallaxBlobs count={3} />
-        </ParallaxBackground>
-
-        <div className="max-w-7xl mx-auto relative z-10">
-          <div className="text-center">
-            <TextRevealHeading
-              as="h1"
-              id="hero-heading"
-              text="How Settler Works"
-              className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold mb-4 md:mb-6 bg-gradient-to-r from-slate-900 to-slate-700 dark:from-white dark:to-slate-300 bg-clip-text text-transparent leading-tight"
-              delay={0}
-              staggerDelay={0.02}
-            />
-            <p className="text-lg md:text-xl text-slate-600 dark:text-slate-300 mb-6 md:mb-8 max-w-2xl mx-auto leading-relaxed">
-              Connect a data source, define matching rules, run the engine, review evidence. Four explicit steps with no hidden logic.
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">
-              <Button
-                size="lg"
-                asChild
-                className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-8 py-5 sm:py-6 text-base sm:text-lg font-semibold"
-              >
-                <Link href="/docs/quickstart">Read the Quickstart</Link>
-              </Button>
-              <Button
-                size="lg"
-                variant="outline"
-                asChild
-                className="w-full sm:w-auto px-8 py-5 sm:py-6 text-base sm:text-lg"
-              >
-                <Link href="/docs">View Documentation</Link>
-              </Button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Steps Section */}
-      <section className="py-16 md:py-20 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-6xl mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5 md:gap-6">
-            {steps.map((step, index) => {
-              const Icon = step.icon;
-              return (
-                <SpotlightCard key={index} className="p-5 md:p-6 text-center">
-                  <div className="w-14 h-14 md:w-16 md:h-16 mx-auto mb-4 rounded-xl bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center text-white text-xl md:text-2xl font-bold">
-                    {step.number}
-                  </div>
-                  <div className="w-10 h-10 md:w-12 md:h-12 mx-auto mb-4 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-500 flex items-center justify-center">
-                    <Icon className="w-5 h-5 md:w-6 md:h-6 text-white" />
-                  </div>
-                  <h3 className="text-lg md:text-xl font-bold mb-2 text-slate-900 dark:text-white">
-                    {step.title}
-                  </h3>
-                  <p className="text-sm md:text-base text-slate-600 dark:text-slate-300 leading-relaxed">
-                    {step.description}
-                  </p>
-                </SpotlightCard>
-              );
-            })}
-          </div>
-        </div>
-      </section>
-
-      {/* Code Example */}
-      <section className="py-16 md:py-20 px-4 sm:px-6 lg:px-8 bg-slate-50 dark:bg-slate-900/50">
-        <div className="max-w-4xl mx-auto">
-          <SpotlightCard className="p-6 md:p-8">
-            <div className="text-center mb-5 md:mb-6">
-              <h2 className="text-xl md:text-2xl lg:text-3xl font-bold mb-3 md:mb-4 text-slate-900 dark:text-white">
-                Run a Demo Reconciliation in 5 Minutes
-              </h2>
-              <p className="text-slate-600 dark:text-slate-400 text-sm md:text-base max-w-lg mx-auto">
-                No database or API keys required for the demo. The example runs a Stripe↔QuickBooks reconciliation and writes <code className="font-mono text-xs bg-slate-800 text-green-400 px-1 rounded">evidence.json</code> and <code className="font-mono text-xs bg-slate-800 text-green-400 px-1 rounded">report.html</code> to <code className="font-mono text-xs bg-slate-800 text-green-400 px-1 rounded">examples/demo-output/</code>.
-              </p>
-            </div>
-
-            <div className="bg-slate-900 dark:bg-slate-800 rounded-lg p-4 md:p-6 overflow-x-auto mb-5 md:mb-6">
-              <pre className="text-green-400 text-xs md:text-sm leading-relaxed">
-                <code>{`# Clone and install
-git clone https://github.com/Hardonian/Settler.git
-cd Settler && pnpm install
-
-# Run the built-in demo (no API key required)
-pnpm demo
-
-# Inspect outputs
-cat examples/demo-output/results.json
-cat examples/demo-output/evidence.json
-
-# Replay verification — re-runs deterministically from stored artifacts
-pnpm settler:replay examples/demo-output/evidence.json`}</code>
-              </pre>
-            </div>
-
-            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
-              <Button
-                size="lg"
-                asChild
-                className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-8 py-5 sm:py-6 text-base sm:text-lg font-semibold"
-              >
-                <Link href="/docs/quickstart">Read the Quickstart</Link>
-              </Button>
-              <Button
-                size="lg"
-                variant="outline"
-                asChild
-                className="w-full sm:w-auto px-8 py-5 sm:py-6 text-base sm:text-lg"
-              >
-                <Link href="/docs">View Documentation</Link>
-              </Button>
-            </div>
-          </SpotlightCard>
-        </div>
-      </section>
-
-      {/* CTA Section */}
-      <section className="py-16 md:py-20 px-4 sm:px-6 lg:px-8 relative overflow-hidden">
-        <ParallaxBackground speed={0.2}>
-          <ParallaxBlobs count={2} />
-        </ParallaxBackground>
-        <div className="max-w-4xl mx-auto relative z-10 text-center">
-          <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-3 md:mb-4 text-slate-900 dark:text-white">
-            Start with the Demo or Read the Docs
-          </h2>
-          <p className="text-base md:text-lg text-slate-600 dark:text-slate-300 mb-6 md:mb-8 leading-relaxed">
-            Run <code className="font-mono text-sm">pnpm demo</code> locally for a zero-credential first run, or read the quickstart to connect your own data sources.
+          <h1 className="mt-6 text-4xl font-bold text-slate-900 dark:text-slate-100">
+            Workflow proof from integration to audit evidence
+          </h1>
+          <p className="mt-4 max-w-3xl text-slate-600 dark:text-slate-400">
+            Settler runs are designed to be deterministic, inspectable, and tenant-safe. This page
+            maps the shipped workflow across user, operator, and developer personas.
           </p>
-          <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
-            <Button
-              size="lg"
-              asChild
-              className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-8 py-5 sm:py-6 text-base sm:text-lg font-semibold"
-            >
-              <Link href="/docs/quickstart">Read the Quickstart</Link>
-            </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              asChild
-              className="w-full sm:w-auto px-8 py-5 sm:py-6 text-base sm:text-lg"
-            >
-              <Link href="/docs">Full Documentation</Link>
-            </Button>
-          </div>
         </div>
       </section>
 
-      <section className="py-12 px-4 sm:px-6 lg:px-8 border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
-        <div className="max-w-6xl mx-auto">
-          <h2 className="text-2xl font-bold mb-4 text-slate-900 dark:text-white">
-            Architecture Overview
-          </h2>
-          <ArchitectureOverview />
+      <section className="px-4 py-4 sm:px-6 lg:px-8">
+        <div className="mx-auto grid max-w-6xl gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {implementationProof.map((item) => (
+            <article
+              key={item.title}
+              className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+            >
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600">
+                {item.title}
+              </p>
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{item.detail}</p>
+              <p className="mt-3 text-xs text-slate-500">Primary route: {item.route}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl space-y-8">
+          <WorkflowJourneyDiagram />
+
+          <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+              CLI and API execution proof
+            </h2>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+              Teams can execute the same workflow in CI or local environments through the CLI and
+              SDK layers.
+            </p>
+            <pre className="mt-4 overflow-x-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-100">
+              <code>{`pnpm --filter @settler/cli start reconcile \\
+  --config ./reconciliation.config.ts \\
+  --output ./recon_output/latest.json`}</code>
+            </pre>
+          </article>
+
+          <RealityEvidencePanel scope="architecture" title="Workflow evidence references" />
+
+          <div className="flex flex-wrap gap-3">
+            <Button asChild>
+              <Link href="/architecture">View architecture</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/docs/quickstart">Read quickstart</Link>
+            </Button>
+          </div>
         </div>
       </section>
 

--- a/packages/web/src/app/integrations/page.tsx
+++ b/packages/web/src/app/integrations/page.tsx
@@ -1,15 +1,17 @@
-import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
-import { MdxPlainRenderer } from '@/components/content/MdxPlainRenderer';
-import { PageLayout } from '@/components/content/PageLayout';
-import { getContentPage } from '@/lib/content/pages';
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { MdxPlainRenderer } from "@/components/content/MdxPlainRenderer";
+import { PageLayout } from "@/components/content/PageLayout";
+import { getContentPage } from "@/lib/content/pages";
+import { IntegrationFlowDiagram } from "@/components/feature-visual-proof";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 export function generateMetadata(): Metadata {
-  const page = getContentPage('integrations');
+  const page = getContentPage("integrations");
   if (!page) {
-    return { title: 'Integrations' };
+    return { title: "Integrations" };
   }
   return {
     title: page.title,
@@ -18,7 +20,7 @@ export function generateMetadata(): Metadata {
 }
 
 export default function IntegrationsPage() {
-  const page = getContentPage('integrations');
+  const page = getContentPage("integrations");
   if (!page) {
     notFound();
   }
@@ -26,6 +28,10 @@ export default function IntegrationsPage() {
   return (
     <PageLayout title={page.title} description={page.description}>
       <MdxPlainRenderer source={page.content} />
+      <div className="mt-10 space-y-8">
+        <IntegrationFlowDiagram />
+        <RealityEvidencePanel scope="integrations" />
+      </div>
     </PageLayout>
   );
 }

--- a/packages/web/src/app/operator/incidents/page.tsx
+++ b/packages/web/src/app/operator/incidents/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
 
 interface IncidentRecord {
   id: string;
@@ -28,6 +29,7 @@ export default function OperatorIncidentsPage() {
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [linkRunByIncident, setLinkRunByIncident] = useState<Record<string, string>>({});
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     void loadIncidents();
@@ -37,10 +39,22 @@ export default function OperatorIncidentsPage() {
     setLoading(true);
     const params = new URLSearchParams({ page: String(page), pageSize: "20" });
     if (statusFilter) params.set("status", statusFilter);
-    const res = await fetch(`/api/operator/incidents?${params.toString()}`);
-    const payload = (await res.json()) as IncidentResponse;
-    setItems(payload.data ?? []);
-    setLoading(false);
+    try {
+      const res = await fetch(`/api/operator/incidents?${params.toString()}`);
+      if (!res.ok) {
+        setLoadError(`Unable to load incidents (${res.status}).`);
+        setItems([]);
+        return;
+      }
+      const payload = (await res.json()) as IncidentResponse;
+      setLoadError(null);
+      setItems(payload.data ?? []);
+    } catch {
+      setLoadError("Unable to load incidents due to network/runtime error.");
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
   }
 
   async function acknowledge(incidentId: string) {
@@ -88,6 +102,12 @@ export default function OperatorIncidentsPage() {
         </select>
       </div>
 
+      {loadError ? (
+        <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+          {loadError}
+        </div>
+      ) : null}
+
       {loading ? (
         <div className="text-sm">Loading incidents…</div>
       ) : (
@@ -112,7 +132,9 @@ export default function OperatorIncidentsPage() {
                   <td className="p-2">{item.severity}</td>
                   <td className="p-2">{item.status}</td>
                   <td className="p-2 font-mono">{item.tenant_id?.slice(0, 8) ?? "—"}</td>
-                  <td className="p-2 font-mono">{(item.linked_run_id ?? item.run_id)?.slice(0, 8) ?? "—"}</td>
+                  <td className="p-2 font-mono">
+                    {(item.linked_run_id ?? item.run_id)?.slice(0, 8) ?? "—"}
+                  </td>
                   <td className="p-2 max-w-[360px]">{item.summary}</td>
                   <td className="p-2">{new Date(item.created_at).toLocaleString()}</td>
                   <td className="p-2 space-y-2">
@@ -155,6 +177,8 @@ export default function OperatorIncidentsPage() {
           </table>
         </div>
       )}
+
+      <RealityEvidencePanel scope="console" title="Operator incident evidence references" />
     </div>
   );
 }

--- a/packages/web/src/app/platform/page.tsx
+++ b/packages/web/src/app/platform/page.tsx
@@ -6,6 +6,7 @@ import { Section } from "@/components/marketing/Section";
 import { Button } from "@/components/ui/button";
 import { UiLink } from "@/components/ui/link";
 import { Badge } from "@/components/ui/badge";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
 import {
   ArrowRight,
   Code2,
@@ -94,14 +95,21 @@ export default function PlatformPage() {
       <Navigation />
 
       {/* Hero */}
-      <Section className="pt-24 pb-16" containerClassName="max-w-6xl" aria-labelledby="platform-heading">
+      <Section
+        className="pt-24 pb-16"
+        containerClassName="max-w-6xl"
+        aria-labelledby="platform-heading"
+      >
         <div className="flex items-center gap-3 mb-5">
           <Badge variant="outline">
             <Cpu className="w-3 h-3 mr-1.5" />
             Platform
           </Badge>
         </div>
-        <h1 id="platform-heading" className="text-fluid-4xl font-bold text-foreground max-w-4xl mb-6">
+        <h1
+          id="platform-heading"
+          className="text-fluid-4xl font-bold text-foreground max-w-4xl mb-6"
+        >
           Deterministic Reconciliation. AI-Assisted Review.
         </h1>
         <p className="mt-4 max-w-3xl text-xl text-muted-foreground leading-relaxed">
@@ -146,10 +154,7 @@ export default function PlatformPage() {
           {platformLayers.map((layer) => {
             const Icon = layer.icon;
             return (
-              <div
-                key={layer.title}
-                className="rounded-2xl border border-border bg-card p-6"
-              >
+              <div key={layer.title} className="rounded-2xl border border-border bg-card p-6">
                 <div className="w-10 h-10 rounded-lg bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center mb-4">
                   <Icon className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                 </div>
@@ -171,13 +176,15 @@ export default function PlatformPage() {
         </div>
       </Section>
 
+      <Section className="py-12" containerClassName="max-w-6xl">
+        <RealityEvidencePanel scope="architecture" title="Platform implementation references" />
+      </Section>
+
       {/* Integrations */}
       <Section className="py-12 border-t border-border" containerClassName="max-w-6xl">
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
           <div>
-            <h2 className="text-2xl font-bold text-foreground mb-1">
-              Integrations &amp; Adapters
-            </h2>
+            <h2 className="text-2xl font-bold text-foreground mb-1">Integrations &amp; Adapters</h2>
             <p className="text-muted-foreground">
               Connect the systems you already use. Adapters handle schema normalization so your
               rules stay clean.
@@ -209,9 +216,7 @@ export default function PlatformPage() {
             <Badge variant="outline" className="border-slate-600 text-slate-400 mb-4">
               Apache 2.0
             </Badge>
-            <h2 className="text-2xl font-bold text-white mb-3">
-              Self-Host or Managed
-            </h2>
+            <h2 className="text-2xl font-bold text-white mb-3">Self-Host or Managed</h2>
             <p className="text-slate-400 leading-relaxed">
               Deploy Settler inside your own infrastructure. Your financial data never transits a
               Settler-managed network unless you choose the managed cloud deployment.

--- a/packages/web/src/app/product/page.tsx
+++ b/packages/web/src/app/product/page.tsx
@@ -1,19 +1,37 @@
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
-import ArchitectureOverview from "@/components/stitch-import/ArchitectureOverview";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
+import {
+  CapabilityMap,
+  IntegrationAndPackagingMap,
+  PlatformOverviewDiagram,
+  VisualProofCTA,
+} from "@/components/public-visual-proof";
 
 export default function ProductPage() {
   return (
     <>
       <Navigation />
-      <main id="main-content" className="min-h-screen bg-slate-50 pt-24">
-        <section className="mx-auto max-w-6xl px-4 pb-8">
-          <h1 className="text-4xl font-bold text-slate-900">Product Architecture</h1>
-          <p className="mt-3 text-slate-600">
-            The stitched control-plane architecture is now the primary product surface.
-          </p>
-        </section>
-        <ArchitectureOverview />
+      <main
+        id="main-content"
+        className="min-h-screen bg-slate-50 px-4 pb-16 pt-24 dark:bg-slate-950 sm:px-6 lg:px-8"
+      >
+        <div className="mx-auto max-w-6xl space-y-8">
+          <section>
+            <h1 className="text-4xl font-bold text-slate-900 dark:text-slate-100">
+              Product architecture and capability proof
+            </h1>
+            <p className="mt-3 max-w-3xl text-slate-600 dark:text-slate-400">
+              A visual view of what is currently shipped: module boundaries, capability clusters,
+              integration points, and packaging boundaries.
+            </p>
+          </section>
+          <PlatformOverviewDiagram />
+          <CapabilityMap />
+          <IntegrationAndPackagingMap />
+          <VisualProofCTA />
+          <RealityEvidencePanel scope="architecture" title="Product proof references" />
+        </div>
       </main>
       <Footer />
     </>

--- a/packages/web/src/app/proof-explorer/page.tsx
+++ b/packages/web/src/app/proof-explorer/page.tsx
@@ -2,6 +2,8 @@ import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
 import { ProofExplorer } from "@/components/proof/ProofExplorer";
 import { ResultsPanel } from "@/components/stitch-import/ResultsPanel";
+import { ProofLifecycleDiagram } from "@/components/feature-visual-proof";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
 
 export const metadata = {
   title: "Proof Explorer | Settler",
@@ -13,35 +15,33 @@ export default function ProofExplorerPage() {
   return (
     <>
       <Navigation />
-      <main id="main-content" className="min-h-screen bg-slate-50 dark:bg-slate-950 antialiased">
-        {/* Page header */}
-        <section className="pt-24 sm:pt-28 pb-8 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
-          <div className="max-w-6xl mx-auto">
-            <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
+      <main id="main-content" className="min-h-screen bg-slate-50 antialiased dark:bg-slate-950">
+        <section className="border-b border-slate-200 bg-white px-4 pb-8 pt-24 dark:border-slate-800 dark:bg-slate-900 sm:px-6 sm:pt-28 lg:px-8">
+          <div className="mx-auto max-w-6xl">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500">
               Evidence &amp; Trust
             </p>
-            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-slate-900 dark:text-white tracking-tight mb-3">
+            <h1 className="mb-3 text-2xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-3xl lg:text-4xl">
               Proof Explorer
             </h1>
-            <p className="text-base text-slate-600 dark:text-slate-400 max-w-2xl leading-relaxed">
+            <p className="max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-400">
               Navigate trust graphs for execution proofs and artifact lineage. Inspect SHA-256 hash
               chains, verify reconciliation runs, and explore the full evidence DAG.
             </p>
           </div>
         </section>
 
-        {/* Explorer panel */}
-        <section className="py-8 sm:py-10 px-4 sm:px-6 lg:px-8">
-          <div className="max-w-6xl mx-auto">
+        <section className="px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+          <div className="mx-auto max-w-6xl space-y-8">
+            <ProofLifecycleDiagram />
+            <RealityEvidencePanel scope="proof" />
             <ProofExplorer />
           </div>
         </section>
 
-        <section className="py-10 sm:py-12 px-4 sm:px-6 lg:px-8 border-t border-slate-200 dark:border-slate-800">
-          <div className="max-w-6xl mx-auto">
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
-              Run Results
-            </h2>
+        <section className="border-t border-slate-200 px-4 py-10 dark:border-slate-800 sm:px-6 sm:py-12 lg:px-8">
+          <div className="mx-auto max-w-6xl">
+            <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">Run Results</h2>
             <ResultsPanel />
           </div>
         </section>

--- a/packages/web/src/app/roadmap/page.tsx
+++ b/packages/web/src/app/roadmap/page.tsx
@@ -1,120 +1,103 @@
-import { Navigation } from '@/components/Navigation';
-import { Footer } from '@/components/Footer';
-import { AnimatedPageWrapper } from '@/components/AnimatedPageWrapper';
-import { Breadcrumbs } from '@/components/Breadcrumbs';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+import { AnimatedPageWrapper } from "@/components/AnimatedPageWrapper";
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
+
+const roadmap = {
+  shipped: [
+    "Node.js SDK package",
+    "Trust and transparency routes",
+    "Receipts and reconciliation product routes",
+    "Proof explorer and architecture surfaces",
+  ],
+  inProgress: [
+    "Expanded operator workflows in /app/*",
+    "SDK parity improvements across Java and C# packages",
+    "Enterprise control-plane polish",
+  ],
+  directional: [
+    "Managed cloud deployment hardening",
+    "Additional adapter packs and workflow templates",
+    "Deeper anomaly and remediation guidance",
+  ],
+};
 
 export default function RoadmapPage() {
-  const roadmap = {
-    now: [
-      "Node.js SDK v1.0",
-      "Trust & Compliance Portal",
-      "Receipts API with AI OCR",
-      "Reconciliation Playground"
-    ],
-    next: [
-      "Python & Go SDKs",
-      "Webhooks v2 with Retries",
-      "Self-Hosted Enterprise Edition",
-      "Advanced Conflict Resolution UI"
-    ],
-    later: [
-      "Mobile SDKs (iOS/Android)",
-      "Global Tax Calculation Engine",
-      "Anomaly Detection Alerts",
-      "QuickBooks Desktop Adapter"
-    ],
-    considering: [
-      "Blockchain Transaction Recon",
-      "Predictive Cash Flow Analysis",
-      "Natural Language Querying",
-      "Managed PCI Vault"
-    ]
-  };
-
   return (
     <AnimatedPageWrapper aria-label="Roadmap page">
       <Navigation />
-      <section className="px-4 sm:px-6 lg:px-8 pt-24">
-        <div className="max-w-7xl mx-auto">
-          <Breadcrumbs items={[{ label: 'Roadmap' }]} />
+      <section className="px-4 pt-24 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-7xl">
+          <Breadcrumbs items={[{ label: "Roadmap" }]} />
+        </div>
+
+        <div className="mx-auto max-w-7xl">
+          <RealityEvidencePanel scope="roadmap" title="Roadmap provenance references" />
         </div>
       </section>
 
-      <section className="px-4 sm:px-6 lg:px-8 py-12">
-        <div className="max-w-4xl mx-auto text-center mb-16">
-          <h1 className="text-4xl font-bold mb-6 text-slate-900 dark:text-white">
-            Public Roadmap
+      <section className="px-4 py-12 sm:px-6 lg:px-8">
+        <div className="mx-auto mb-12 max-w-4xl text-center">
+          <h1 className="text-4xl font-bold text-slate-900 dark:text-white">
+            Roadmap and direction (explicitly labeled)
           </h1>
-          <p className="text-xl text-slate-600 dark:text-slate-300">
-            We build in the open. Here's what we're working on to help you build better financial software.
+          <p className="mt-4 text-lg text-slate-600 dark:text-slate-300">
+            This view separates shipped capabilities from in-progress work and directional themes.
+            Directional items are not represented as currently shipped functionality.
           </p>
         </div>
 
-        <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          <Card className="border-green-200 dark:border-green-900/30 bg-green-50/50 dark:bg-green-900/10">
+        <div className="mx-auto mb-8 grid max-w-7xl gap-6 md:grid-cols-3">
+          <Card className="border-emerald-200 bg-emerald-50/50 dark:border-emerald-900/30 dark:bg-emerald-900/10">
             <CardHeader>
-              <Badge className="w-fit bg-green-500 hover:bg-green-600 mb-2">Now</Badge>
-              <CardTitle>Q1 2026</CardTitle>
+              <Badge className="w-fit bg-emerald-600 hover:bg-emerald-700">Shipped</Badge>
+              <CardTitle>Current-state proof</CardTitle>
             </CardHeader>
             <CardContent>
               <ul className="space-y-3">
-                {roadmap.now.map(item => (
-                  <li key={item} className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full bg-green-500" />
-                    <span className="text-sm font-medium">{item}</span>
+                {roadmap.shipped.map((item) => (
+                  <li key={item} className="flex gap-2 text-sm">
+                    <span className="mt-2 h-2 w-2 rounded-full bg-emerald-600" />
+                    <span>{item}</span>
                   </li>
                 ))}
               </ul>
             </CardContent>
           </Card>
 
-          <Card className="border-blue-200 dark:border-blue-900/30 bg-blue-50/50 dark:bg-blue-900/10">
+          <Card className="border-blue-200 bg-blue-50/50 dark:border-blue-900/30 dark:bg-blue-900/10">
             <CardHeader>
-              <Badge className="w-fit bg-blue-500 hover:bg-blue-600 mb-2">Next</Badge>
-              <CardTitle>Q2 2026</CardTitle>
+              <Badge className="w-fit bg-blue-600 hover:bg-blue-700">In progress</Badge>
+              <CardTitle>Execution underway</CardTitle>
             </CardHeader>
             <CardContent>
               <ul className="space-y-3">
-                {roadmap.next.map(item => (
-                  <li key={item} className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full bg-blue-500" />
-                    <span className="text-sm font-medium">{item}</span>
+                {roadmap.inProgress.map((item) => (
+                  <li key={item} className="flex gap-2 text-sm">
+                    <span className="mt-2 h-2 w-2 rounded-full bg-blue-600" />
+                    <span>{item}</span>
                   </li>
                 ))}
               </ul>
             </CardContent>
           </Card>
 
-          <Card className="border-purple-200 dark:border-purple-900/30 bg-purple-50/50 dark:bg-purple-900/10">
+          <Card className="border-slate-200 bg-slate-50/50 dark:border-slate-800 dark:bg-slate-900/10">
             <CardHeader>
-              <Badge className="w-fit bg-purple-500 hover:bg-purple-600 mb-2">Later</Badge>
-              <CardTitle>H2 2026</CardTitle>
+              <Badge variant="outline" className="w-fit">
+                Directional
+              </Badge>
+              <CardTitle>Planned / future direction</CardTitle>
             </CardHeader>
             <CardContent>
               <ul className="space-y-3">
-                {roadmap.later.map(item => (
-                  <li key={item} className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full bg-purple-500" />
-                    <span className="text-sm font-medium">{item}</span>
-                  </li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
-
-          <Card className="border-slate-200 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/10">
-            <CardHeader>
-              <Badge variant="outline" className="w-fit mb-2">Considering</Badge>
-              <CardTitle>Future</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-3">
-                {roadmap.considering.map(item => (
-                  <li key={item} className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full bg-slate-400" />
-                    <span className="text-sm text-slate-600 dark:text-slate-400">{item}</span>
+                {roadmap.directional.map((item) => (
+                  <li key={item} className="flex gap-2 text-sm text-slate-600 dark:text-slate-400">
+                    <span className="mt-2 h-2 w-2 rounded-full bg-slate-400" />
+                    <span>{item}</span>
                   </li>
                 ))}
               </ul>

--- a/packages/web/src/app/security-and-audit/page.tsx
+++ b/packages/web/src/app/security-and-audit/page.tsx
@@ -5,6 +5,7 @@ import { Section } from "@/components/marketing/Section";
 import { FeatureList } from "@/components/marketing/FeatureList";
 import { Button } from "@/components/ui/button";
 import { UiLink } from "@/components/ui/link";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
 import {
   ShieldCheck,
   Lock,
@@ -221,6 +222,10 @@ export default function SecurityAndAuditPage() {
             </UiLink>
           </Button>
         </div>
+      </Section>
+
+      <Section className="py-8" containerClassName="max-w-6xl">
+        <RealityEvidencePanel scope="security" title="Security evidence references" />
       </Section>
 
       <Footer />

--- a/packages/web/src/app/trust/page.tsx
+++ b/packages/web/src/app/trust/page.tsx
@@ -1,15 +1,16 @@
-import { Navigation } from '@/components/Navigation';
-import { Footer } from '@/components/Footer';
-import { AnimatedPageWrapper } from '@/components/AnimatedPageWrapper';
-import { Breadcrumbs } from '@/components/Breadcrumbs';
-import { Shield, Clock, Database, GitBranch, CheckCircle, AlertCircle } from 'lucide-react';
-import { Metadata } from 'next';
-import { Badge } from '@/components/ui/badge';
-import { getPublicRealityData } from '@/lib/public/reality-data';
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+import { AnimatedPageWrapper } from "@/components/AnimatedPageWrapper";
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { Shield, Clock, Database, GitBranch, CheckCircle, AlertCircle } from "lucide-react";
+import { Metadata } from "next";
+import { Badge } from "@/components/ui/badge";
+import { getPublicRealityData } from "@/lib/public/reality-data";
+import { RealityEvidencePanel } from "@/components/RealityEvidencePanel";
 
 export const metadata: Metadata = {
-  title: 'Trust & Reliability',
-  description: 'Settler Trust - Uptime, backups, change management, and operational reliability.',
+  title: "Trust & Reliability",
+  description: "Settler Trust - Uptime, backups, change management, and operational reliability.",
   robots: {
     index: true,
     follow: true,
@@ -21,11 +22,11 @@ export default async function TrustPage() {
   return (
     <AnimatedPageWrapper aria-label="Trust page">
       <Navigation />
-      
+
       {/* Breadcrumbs */}
       <section className="px-4 sm:px-6 lg:px-8 pt-24">
         <div className="max-w-7xl mx-auto">
-          <Breadcrumbs items={[{ label: 'Trust' }]} />
+          <Breadcrumbs items={[{ label: "Trust" }]} />
         </div>
       </section>
 
@@ -50,30 +51,38 @@ export default async function TrustPage() {
             </div>
             <h2 className="text-3xl font-bold text-slate-900 dark:text-white">Uptime Policy</h2>
           </div>
-          
+
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12">
             <div className="bg-white dark:bg-slate-800 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">Service Level Objectives</h3>
+              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">
+                Service Level Objectives
+              </h3>
               <div className="space-y-4">
                 <div>
                   <div className="flex justify-between items-center mb-2">
                     <span className="text-slate-600 dark:text-slate-300">API Availability</span>
                     <div className="flex items-center gap-2">
                       <span className="font-semibold text-slate-900 dark:text-white">
-                        {realityData?.uptime_proxy ? `${realityData.uptime_proxy.toFixed(1)}%` : '99.9%'}
+                        {realityData?.uptime_proxy
+                          ? `${realityData.uptime_proxy.toFixed(1)}%`
+                          : "99.9%"}
                       </span>
-                      {realityData?.status === 'assumed' && (
-                        <Badge variant="outline" className="text-xs">ASSUMED</Badge>
+                      {realityData?.status === "assumed" && (
+                        <Badge variant="outline" className="text-xs">
+                          ASSUMED
+                        </Badge>
                       )}
-                      {realityData?.status === 'proven' && (
+                      {realityData?.status === "proven" && (
                         <Badge className="bg-green-500 text-xs">PROVEN</Badge>
                       )}
                     </div>
                   </div>
                   <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2">
-                    <div 
-                      className="bg-green-600 h-2 rounded-full" 
-                      style={{ width: realityData?.uptime_proxy ? `${realityData.uptime_proxy}%` : '99.9%' }}
+                    <div
+                      className="bg-green-600 h-2 rounded-full"
+                      style={{
+                        width: realityData?.uptime_proxy ? `${realityData.uptime_proxy}%` : "99.9%",
+                      }}
                     ></div>
                   </div>
                 </div>
@@ -83,7 +92,7 @@ export default async function TrustPage() {
                     <span className="font-semibold text-slate-900 dark:text-white">99.5%</span>
                   </div>
                   <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2">
-                    <div className="bg-green-600 h-2 rounded-full" style={{ width: '99.5%' }}></div>
+                    <div className="bg-green-600 h-2 rounded-full" style={{ width: "99.5%" }}></div>
                   </div>
                 </div>
                 <div>
@@ -92,7 +101,10 @@ export default async function TrustPage() {
                     <span className="font-semibold text-slate-900 dark:text-white">99.95%</span>
                   </div>
                   <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2">
-                    <div className="bg-green-600 h-2 rounded-full" style={{ width: '99.95%' }}></div>
+                    <div
+                      className="bg-green-600 h-2 rounded-full"
+                      style={{ width: "99.95%" }}
+                    ></div>
                   </div>
                 </div>
                 {realityData?.hard_500_count !== undefined && (
@@ -106,7 +118,9 @@ export default async function TrustPage() {
                         {realityData.hard_500_count === 0 ? (
                           <Badge className="bg-green-500 text-xs">ZERO</Badge>
                         ) : (
-                          <Badge variant="destructive" className="text-xs">VIOLATION</Badge>
+                          <Badge variant="destructive" className="text-xs">
+                            VIOLATION
+                          </Badge>
                         )}
                       </div>
                     </div>
@@ -114,9 +128,11 @@ export default async function TrustPage() {
                 )}
               </div>
             </div>
-            
+
             <div className="bg-white dark:bg-slate-800 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">Monitoring & Status</h3>
+              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">
+                Monitoring & Status
+              </h3>
               <ul className="space-y-3 text-slate-600 dark:text-slate-300">
                 <li className="flex items-start gap-2">
                   <CheckCircle className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" />
@@ -124,7 +140,12 @@ export default async function TrustPage() {
                 </li>
                 <li className="flex items-start gap-2">
                   <CheckCircle className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" />
-                  <span>Real-time status page: <a href="/status" className="text-blue-600 dark:text-blue-400 hover:underline">settler.dev/status</a></span>
+                  <span>
+                    Real-time status page:{" "}
+                    <a href="/status" className="text-blue-600 dark:text-blue-400 hover:underline">
+                      settler.dev/status
+                    </a>
+                  </span>
                 </li>
                 <li className="flex items-start gap-2">
                   <CheckCircle className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" />
@@ -146,19 +167,25 @@ export default async function TrustPage() {
             <div className="flex items-start gap-3">
               <AlertCircle className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" />
               <div>
-                <h4 className="font-semibold mb-2 text-blue-900 dark:text-blue-100">Uptime Calculation</h4>
+                <h4 className="font-semibold mb-2 text-blue-900 dark:text-blue-100">
+                  Uptime Calculation
+                </h4>
                 <p className="text-sm text-blue-800 dark:text-blue-200">
-                  Uptime is calculated monthly, excluding scheduled maintenance windows (announced 48 hours in advance) 
-                  and force majeure events. Planned maintenance typically occurs during low-traffic hours and is kept under 4 hours per month.
+                  Uptime is calculated monthly, excluding scheduled maintenance windows (announced
+                  48 hours in advance) and force majeure events. Planned maintenance typically
+                  occurs during low-traffic hours and is kept under 4 hours per month.
                 </p>
                 {realityData?.last_incident && (
                   <p className="text-sm text-blue-800 dark:text-blue-200 mt-2">
-                    <strong>Last Incident:</strong> {new Date(realityData.last_incident.timestamp).toLocaleDateString()} - {realityData.last_incident.event}
+                    <strong>Last Incident:</strong>{" "}
+                    {new Date(realityData.last_incident.timestamp).toLocaleDateString()} -{" "}
+                    {realityData.last_incident.event}
                   </p>
                 )}
-                {realityData?.status === 'assumed' && (
+                {realityData?.status === "assumed" && (
                   <p className="text-sm text-yellow-800 dark:text-yellow-200 mt-2">
-                    <strong>Note:</strong> Some metrics are currently ASSUMED and will be updated as we collect more data.
+                    <strong>Note:</strong> Some metrics are currently ASSUMED and will be updated as
+                    we collect more data.
                   </p>
                 )}
               </div>
@@ -174,12 +201,16 @@ export default async function TrustPage() {
             <div className="w-12 h-12 rounded-lg bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
               <Database className="w-6 h-6 text-blue-600" />
             </div>
-            <h2 className="text-3xl font-bold text-slate-900 dark:text-white">Backups & Recovery</h2>
+            <h2 className="text-3xl font-bold text-slate-900 dark:text-white">
+              Backups & Recovery
+            </h2>
           </div>
-          
+
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div className="bg-white dark:bg-slate-800 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">Backup Strategy</h3>
+              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">
+                Backup Strategy
+              </h3>
               <ul className="space-y-3 text-slate-600 dark:text-slate-300">
                 <li>• Automated daily full backups</li>
                 <li>• Continuous point-in-time recovery (PITR)</li>
@@ -188,20 +219,28 @@ export default async function TrustPage() {
                 <li>• 30-day retention (extendable for enterprise)</li>
               </ul>
             </div>
-            
+
             <div className="bg-white dark:bg-slate-800 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">Recovery Objectives</h3>
+              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">
+                Recovery Objectives
+              </h3>
               <ul className="space-y-3 text-slate-600 dark:text-slate-300">
-                <li><strong>RPO:</strong> 5 minutes (Recovery Point Objective)</li>
-                <li><strong>RTO:</strong> 1 hour (Recovery Time Objective)</li>
+                <li>
+                  <strong>RPO:</strong> 5 minutes (Recovery Point Objective)
+                </li>
+                <li>
+                  <strong>RTO:</strong> 1 hour (Recovery Time Objective)
+                </li>
                 <li>• Tested quarterly with documented results</li>
                 <li>• Automated backup verification</li>
                 <li>• Cross-region disaster recovery plan</li>
               </ul>
             </div>
-            
+
             <div className="bg-white dark:bg-slate-800 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">Data Durability</h3>
+              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">
+                Data Durability
+              </h3>
               <ul className="space-y-3 text-slate-600 dark:text-slate-300">
                 <li>• 99.999999999% (11 nines) durability</li>
                 <li>• Immutable backup storage</li>
@@ -223,10 +262,12 @@ export default async function TrustPage() {
             </div>
             <h2 className="text-3xl font-bold text-slate-900 dark:text-white">Change Management</h2>
           </div>
-          
+
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             <div className="bg-white dark:bg-slate-800 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">Deployment Process</h3>
+              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">
+                Deployment Process
+              </h3>
               <ol className="space-y-3 text-slate-600 dark:text-slate-300 list-decimal list-inside">
                 <li>All changes go through code review and automated testing</li>
                 <li>Staged deployments: dev → staging → production</li>
@@ -236,11 +277,18 @@ export default async function TrustPage() {
                 <li>Post-deployment monitoring and validation</li>
               </ol>
             </div>
-            
+
             <div className="bg-white dark:bg-slate-800 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">Change Communication</h3>
+              <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">
+                Change Communication
+              </h3>
               <ul className="space-y-3 text-slate-600 dark:text-slate-300">
-                <li>• Changelog published at <a href="/changelog" className="text-blue-600 dark:text-blue-400 hover:underline">settler.dev/changelog</a></li>
+                <li>
+                  • Changelog published at{" "}
+                  <a href="/changelog" className="text-blue-600 dark:text-blue-400 hover:underline">
+                    settler.dev/changelog
+                  </a>
+                </li>
                 <li>• Breaking changes announced 30 days in advance</li>
                 <li>• Email notifications for critical changes</li>
                 <li>• API versioning maintains backward compatibility</li>
@@ -251,24 +299,35 @@ export default async function TrustPage() {
           </div>
 
           <div className="mt-8 bg-white dark:bg-slate-800 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-            <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">Change Types & Windows</h3>
+            <h3 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">
+              Change Types & Windows
+            </h3>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               <div>
-                <h4 className="font-semibold mb-2 text-slate-900 dark:text-white">Routine Updates</h4>
+                <h4 className="font-semibold mb-2 text-slate-900 dark:text-white">
+                  Routine Updates
+                </h4>
                 <p className="text-sm text-slate-600 dark:text-slate-300">
-                  Non-breaking changes deployed during business hours with automated testing. No customer notification required.
+                  Non-breaking changes deployed during business hours with automated testing. No
+                  customer notification required.
                 </p>
               </div>
               <div>
-                <h4 className="font-semibold mb-2 text-slate-900 dark:text-white">Scheduled Maintenance</h4>
+                <h4 className="font-semibold mb-2 text-slate-900 dark:text-white">
+                  Scheduled Maintenance
+                </h4>
                 <p className="text-sm text-slate-600 dark:text-slate-300">
-                  Infrastructure updates announced 48 hours in advance. Typically scheduled during low-traffic windows.
+                  Infrastructure updates announced 48 hours in advance. Typically scheduled during
+                  low-traffic windows.
                 </p>
               </div>
               <div>
-                <h4 className="font-semibold mb-2 text-slate-900 dark:text-white">Emergency Changes</h4>
+                <h4 className="font-semibold mb-2 text-slate-900 dark:text-white">
+                  Emergency Changes
+                </h4>
                 <p className="text-sm text-slate-600 dark:text-slate-300">
-                  Security patches and critical fixes deployed immediately with post-deployment notification and documentation.
+                  Security patches and critical fixes deployed immediately with post-deployment
+                  notification and documentation.
                 </p>
               </div>
             </div>
@@ -283,12 +342,15 @@ export default async function TrustPage() {
             <div className="w-12 h-12 rounded-lg bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center">
               <Shield className="w-6 h-6 text-indigo-600" />
             </div>
-            <h2 className="text-3xl font-bold text-slate-900 dark:text-white">Operational Transparency</h2>
+            <h2 className="text-3xl font-bold text-slate-900 dark:text-white">
+              Operational Transparency
+            </h2>
           </div>
-          
+
           <div className="bg-white dark:bg-slate-800 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-300 mb-6">
-              We believe in transparency about how we operate Settler. Enterprise customers can request:
+              We believe in transparency about how we operate Settler. Enterprise customers can
+              request:
             </p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <ul className="space-y-2 text-slate-600 dark:text-slate-300">
@@ -322,13 +384,22 @@ export default async function TrustPage() {
             </div>
             <div className="mt-6 pt-6 border-t border-slate-200 dark:border-slate-700">
               <p className="text-sm text-slate-500">
-                To request operational reports or discuss custom SLA requirements, contact{' '}
-                <a href="mailto:enterprise@settler.dev" className="text-blue-600 dark:text-blue-400 hover:underline">
+                To request operational reports or discuss custom SLA requirements, contact{" "}
+                <a
+                  href="mailto:enterprise@settler.dev"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
                   enterprise@settler.dev
                 </a>
               </p>
             </div>
           </div>
+        </div>
+      </section>
+
+      <section className="px-4 sm:px-6 lg:px-8 py-8">
+        <div className="max-w-7xl mx-auto">
+          <RealityEvidencePanel scope="trust" title="Trust evidence references" />
         </div>
       </section>
 

--- a/packages/web/src/components/RealityEvidencePanel.tsx
+++ b/packages/web/src/components/RealityEvidencePanel.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { visualProofRegistry } from "@/lib/public/visual-proof-registry";
+
+type RegistryKey = keyof typeof visualProofRegistry;
+
+export function RealityEvidencePanel({ scope, title }: { scope: RegistryKey; title?: string }) {
+  const entries = visualProofRegistry[scope] ?? [];
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+        {title ?? "Implementation evidence references"}
+      </h2>
+      <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+        This section ties visuals to concrete routes/modules so claims remain testable and
+        auditable.
+      </p>
+      <div className="mt-4 space-y-3">
+        {entries.map((entry) => (
+          <article
+            key={entry.title}
+            className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+          >
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+              {entry.title}
+            </h3>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{entry.detail}</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {entry.refs.map((ref) => (
+                <Link
+                  key={`${entry.title}-${ref.href}`}
+                  href={ref.href.startsWith("/") ? ref.href : "/open-source"}
+                  className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-950/50 dark:text-slate-300"
+                >
+                  {ref.type}: {ref.label}
+                </Link>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/feature-visual-proof.tsx
+++ b/packages/web/src/components/feature-visual-proof.tsx
@@ -1,0 +1,153 @@
+import Link from "next/link";
+import { ArrowRight, GitBranch, Link2, ShieldCheck, TerminalSquare } from "lucide-react";
+
+const integrationFlow = [
+  {
+    title: "Connector handshake",
+    detail: "Authenticate provider accounts and validate webhook signatures before ingest.",
+    route: "/integrations/request",
+  },
+  {
+    title: "Canonical normalization",
+    detail: "Map provider payloads into deterministic reconciliation primitives.",
+    route: "/app/connections",
+  },
+  {
+    title: "Run + divergence detection",
+    detail: "Execute reconciliations and classify mismatches for operator review.",
+    route: "/app/runs",
+  },
+  {
+    title: "Evidence + replay",
+    detail: "Persist proof artifacts and replay trace context for audit verification.",
+    route: "/proof-explorer",
+  },
+];
+
+const proofLifecycle = [
+  {
+    label: "Input attestation",
+    detail: "Source and target payload hashes are captured at ingestion time.",
+  },
+  {
+    label: "Deterministic evaluation",
+    detail: "Rule engine evaluates canonical records with explicit tolerances.",
+  },
+  {
+    label: "Artifact generation",
+    detail: "Mismatch sets, trace metadata, and outcome envelope are emitted.",
+  },
+  {
+    label: "Verification + replay",
+    detail: "Operators verify lineage and reproduce outcomes from stored evidence.",
+  },
+];
+
+const consoleSurfaces = [
+  {
+    title: "Execution control",
+    detail: "Runs, traces, and pipeline status surfaces under /app and /console routes.",
+    icon: TerminalSquare,
+  },
+  {
+    title: "Governance + policy",
+    detail: "Policy and audit workflows enforce explicit approvals and reviewer accountability.",
+    icon: ShieldCheck,
+  },
+  {
+    title: "Evidence graph",
+    detail: "Proof explorer and replay routes expose lineage across transaction artifacts.",
+    icon: GitBranch,
+  },
+];
+
+export function IntegrationFlowDiagram() {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="mb-4 flex items-center gap-2">
+        <Link2 className="h-4 w-4 text-blue-600" />
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+          Integration runtime flow
+        </h2>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+        {integrationFlow.map((step, index) => (
+          <article
+            key={step.title}
+            className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600">
+              Step {index + 1}
+            </p>
+            <h3 className="mt-2 text-sm font-semibold text-slate-900 dark:text-slate-100">
+              {step.title}
+            </h3>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{step.detail}</p>
+            <p className="mt-2 text-xs text-slate-500">Route: {step.route}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ProofLifecycleDiagram() {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+        Proof lifecycle map
+      </h2>
+      <div className="mt-4 space-y-3">
+        {proofLifecycle.map((step, index) => (
+          <div
+            key={step.label}
+            className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+          >
+            <div className="flex items-center gap-2">
+              <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white dark:bg-white dark:text-slate-900">
+                {index + 1}
+              </span>
+              <p className="font-semibold text-slate-900 dark:text-slate-100">{step.label}</p>
+            </div>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{step.detail}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ConsoleSurfaceMap() {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+          Console surface map
+        </h2>
+        <Link
+          href="/architecture"
+          className="inline-flex items-center gap-1 text-sm font-semibold text-blue-600"
+        >
+          Full architecture <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        {consoleSurfaces.map((item) => {
+          const Icon = item.icon;
+          return (
+            <article
+              key={item.title}
+              className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+            >
+              <Icon className="h-4 w-4 text-blue-600" />
+              <h3 className="mt-2 text-sm font-semibold text-slate-900 dark:text-slate-100">
+                {item.title}
+              </h3>
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{item.detail}</p>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/public-visual-proof.tsx
+++ b/packages/web/src/components/public-visual-proof.tsx
@@ -1,0 +1,378 @@
+import Link from "next/link";
+import {
+  ArrowRight,
+  Cloud,
+  Code2,
+  GitBranch,
+  Lock,
+  MonitorSmartphone,
+  Server,
+  Shield,
+  TerminalSquare,
+  Workflow,
+} from "lucide-react";
+
+type Node = {
+  title: string;
+  detail: string;
+  badge?: string;
+};
+
+const platformLayers: { heading: string; nodes: Node[] }[] = [
+  {
+    heading: "Product surfaces",
+    nodes: [
+      {
+        title: "Public site",
+        detail: "Routes under src/app for product, architecture, docs, roadmap.",
+      },
+      {
+        title: "Operator console",
+        detail: "Authenticated routes under src/app/app for runs, policies, proofs, and audit.",
+      },
+      { title: "APIs + docs", detail: "Route handlers under src/app/api and OpenAPI surface." },
+    ],
+  },
+  {
+    heading: "Control plane + deterministic engine",
+    nodes: [
+      {
+        title: "Reconciliation + proof services",
+        detail: "Domain + lib modules for run execution, evidence, replay, and validation.",
+      },
+      {
+        title: "Policy + governance",
+        detail: "Policies, rule evaluation, approvals, and entitlement boundaries.",
+      },
+      {
+        title: "Observability + diagnostics",
+        detail: "Audit logs, trust graph checks, and system health surfaces.",
+        badge: "Tenant-safe",
+      },
+    ],
+  },
+  {
+    heading: "Execution + data boundary",
+    nodes: [
+      {
+        title: "Workers + adapters",
+        detail: "packages/adapters, jobforge adapter packages, and CLI-triggered jobs.",
+      },
+      {
+        title: "Storage + cache",
+        detail: "Database access, Redis/cache modules, and immutable evidence artifacts.",
+      },
+      {
+        title: "External systems",
+        detail:
+          "Stripe/ERP/bank sources through adapter interfaces and signed ingestion endpoints.",
+      },
+    ],
+  },
+];
+
+const integrationSurface = [
+  {
+    label: "CLI",
+    detail: "packages/cli for local runs, automation, and CI orchestration.",
+    icon: TerminalSquare,
+  },
+  {
+    label: "SDKs",
+    detail: "packages/sdk, sdk-java, sdk-csharp, and react-settler integration points.",
+    icon: Code2,
+  },
+  {
+    label: "API",
+    detail: "REST/route handlers in src/app/api with OpenAPI schema route support.",
+    icon: Workflow,
+  },
+  {
+    label: "Events + hooks",
+    detail: "Webhook and async flow support through queue/worker modules and replay traces.",
+    icon: GitBranch,
+  },
+];
+
+const capabilityClusters = [
+  {
+    title: "Deterministic reconciliation",
+    bullets: [
+      "Rule-based matching with explicit tolerances",
+      "Replayable run semantics",
+      "Mismatch classification and explainability",
+    ],
+  },
+  {
+    title: "Evidence + auditability",
+    bullets: [
+      "Proof explorer and evidence routes",
+      "Hash-linked output artifacts",
+      "Traceability across run lifecycle",
+    ],
+  },
+  {
+    title: "Tenant safety + governance",
+    bullets: [
+      "Shared tenant middleware + context boundaries",
+      "Policy enforcement surfaces",
+      "Role-aware operator workflows",
+    ],
+  },
+  {
+    title: "Developer ergonomics",
+    bullets: [
+      "CLI + SDK onboarding",
+      "Docs, cookbook, and quickstart routes",
+      "Adapter extension model",
+    ],
+  },
+];
+
+const journey = [
+  {
+    lane: "User",
+    steps: ["Connect sources", "Define matching rules", "Launch run", "Review mismatches + proof"],
+  },
+  {
+    lane: "Operator",
+    steps: [
+      "Monitor run health",
+      "Investigate exceptions",
+      "Approve governed changes",
+      "Export audit evidence",
+    ],
+  },
+  {
+    lane: "Developer",
+    steps: ["Install CLI/SDK", "Configure adapters", "Integrate API/webhooks", "Automate in CI"],
+  },
+];
+
+const packaging = [
+  {
+    title: "Open source core",
+    icon: Server,
+    detail: "Core engine, CLI, and SDK packages available in this repository.",
+    routes: ["/open-source", "/oss", "packages/*"],
+  },
+  {
+    title: "Cloud / managed workflows",
+    icon: Cloud,
+    detail: "Hosted control-plane and dashboard experiences surfaced through web routes.",
+    routes: ["/dashboard", "/app/*", "/status"],
+  },
+  {
+    title: "Enterprise controls",
+    icon: Shield,
+    detail: "Policy, audit, and trust-oriented features highlighted in enterprise and trust pages.",
+    routes: ["/enterprise", "/trust", "/security-and-audit"],
+  },
+];
+
+export function PlatformOverviewDiagram() {
+  return (
+    <section
+      className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+      aria-label="Platform overview diagram"
+    >
+      <div className="mb-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400">
+          System map
+        </p>
+        <h2 className="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-100">
+          Platform overview: surfaces, control plane, and runtime boundary
+        </h2>
+      </div>
+      <div className="space-y-4">
+        {platformLayers.map((layer) => (
+          <div key={layer.heading}>
+            <h3 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-300">
+              {layer.heading}
+            </h3>
+            <div className="grid gap-3 md:grid-cols-3">
+              {layer.nodes.map((node) => (
+                <article
+                  key={node.title}
+                  className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-950/50"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                      {node.title}
+                    </p>
+                    {node.badge ? (
+                      <span className="rounded-full bg-emerald-100 px-2 py-1 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+                        {node.badge}
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{node.detail}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function WorkflowJourneyDiagram() {
+  return (
+    <section
+      className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+      aria-label="Workflow journey diagram"
+    >
+      <div className="mb-6 flex items-center gap-3">
+        <MonitorSmartphone className="h-5 w-5 text-blue-600" />
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+          User, operator, and developer journey lanes
+        </h2>
+      </div>
+      <div className="space-y-4">
+        {journey.map((row) => (
+          <div
+            key={row.lane}
+            className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+          >
+            <p className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+              {row.lane}
+            </p>
+            <div className="grid gap-3 md:grid-cols-4">
+              {row.steps.map((step, index) => (
+                <div
+                  key={step}
+                  className="flex items-center gap-2 rounded-lg bg-slate-50 p-3 text-sm dark:bg-slate-950/40"
+                >
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white dark:bg-white dark:text-slate-900">
+                    {index + 1}
+                  </span>
+                  <span className="text-slate-700 dark:text-slate-300">{step}</span>
+                  {index < row.steps.length - 1 ? (
+                    <ArrowRight className="ml-auto h-4 w-4 text-slate-400" />
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function CapabilityMap() {
+  return (
+    <section
+      className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+      aria-label="Capability map"
+    >
+      <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+        Capability map grounded in shipped surfaces
+      </h2>
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        {capabilityClusters.map((cluster) => (
+          <article
+            key={cluster.title}
+            className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+          >
+            <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+              {cluster.title}
+            </h3>
+            <ul className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-400">
+              {cluster.bullets.map((bullet) => (
+                <li key={bullet} className="flex gap-2">
+                  <span aria-hidden>•</span>
+                  <span>{bullet}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function IntegrationAndPackagingMap() {
+  return (
+    <section className="grid gap-6 lg:grid-cols-2" aria-label="Integration and packaging maps">
+      <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+          Integration surface map
+        </h2>
+        <div className="mt-5 space-y-3">
+          {integrationSurface.map((item) => {
+            const Icon = item.icon;
+            return (
+              <div
+                key={item.label}
+                className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+              >
+                <div className="flex items-center gap-3">
+                  <Icon className="h-4 w-4 text-blue-600" />
+                  <p className="font-semibold text-slate-900 dark:text-slate-100">{item.label}</p>
+                </div>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{item.detail}</p>
+              </div>
+            );
+          })}
+        </div>
+      </article>
+
+      <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="flex items-center gap-2">
+          <Lock className="h-4 w-4 text-emerald-600" />
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            Packaging boundary map
+          </h2>
+        </div>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+          Boundaries are based on repository packages and current public route structure.
+        </p>
+        <div className="mt-5 space-y-3">
+          {packaging.map((item) => {
+            const Icon = item.icon;
+            return (
+              <div
+                key={item.title}
+                className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+              >
+                <div className="flex items-center gap-3">
+                  <Icon className="h-4 w-4 text-slate-700 dark:text-slate-300" />
+                  <p className="font-semibold text-slate-900 dark:text-slate-100">{item.title}</p>
+                </div>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{item.detail}</p>
+                <p className="mt-2 text-xs text-slate-500 dark:text-slate-500">
+                  {item.routes.join(" · ")}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </article>
+    </section>
+  );
+}
+
+export function VisualProofCTA() {
+  return (
+    <div className="rounded-2xl border border-blue-200 bg-blue-50 p-5 dark:border-blue-900/40 dark:bg-blue-950/30">
+      <p className="text-sm text-slate-700 dark:text-slate-300">
+        Want deeper implementation proof? See{" "}
+        <Link href="/architecture" className="font-semibold text-blue-700 dark:text-blue-300">
+          architecture
+        </Link>
+        ,{" "}
+        <Link href="/how-it-works" className="font-semibold text-blue-700 dark:text-blue-300">
+          workflow lanes
+        </Link>
+        , and{" "}
+        <Link href="/roadmap" className="font-semibold text-blue-700 dark:text-blue-300">
+          roadmap labeling
+        </Link>{" "}
+        with shipped versus directional separation.
+      </p>
+    </div>
+  );
+}

--- a/packages/web/src/lib/public/visual-proof-registry.ts
+++ b/packages/web/src/lib/public/visual-proof-registry.ts
@@ -1,0 +1,118 @@
+export type EvidenceRef = {
+  label: string;
+  href: string;
+  type: "route" | "package" | "doc";
+};
+
+export type VisualProofEntry = {
+  title: string;
+  detail: string;
+  refs: EvidenceRef[];
+};
+
+export const visualProofRegistry: Record<string, VisualProofEntry[]> = {
+  architecture: [
+    {
+      title: "Control-plane and reconciliation surfaces",
+      detail:
+        "Public and authenticated route layers expose deterministic run, policy, and evidence paths.",
+      refs: [
+        { label: "Architecture", href: "/architecture", type: "route" },
+        { label: "App runs", href: "/app/runs", type: "route" },
+        { label: "App policies", href: "/app/policies", type: "route" },
+      ],
+    },
+    {
+      title: "Execution runtime modules",
+      detail:
+        "Adapter, SDK, and protocol packages back deterministic execution and integration boundaries.",
+      refs: [
+        { label: "packages/adapters", href: "packages/adapters", type: "package" },
+        { label: "packages/sdk", href: "packages/sdk", type: "package" },
+        { label: "packages/protocol", href: "packages/protocol", type: "package" },
+      ],
+    },
+  ],
+  integrations: [
+    {
+      title: "Provider connection handshake",
+      detail:
+        "Connector runtime path includes auth/callback/sync lifecycle routes and request flows.",
+      refs: [
+        { label: "Integrations request", href: "/integrations/request", type: "route" },
+        { label: "Dashboard integrations", href: "/dashboard/integrations", type: "route" },
+        { label: "API connectors", href: "/docs/integrations", type: "route" },
+      ],
+    },
+    {
+      title: "Canonical mapping + reconciliation",
+      detail:
+        "Connected providers flow through deterministic matching and proof generation routes.",
+      refs: [
+        { label: "App connections", href: "/app/connections", type: "route" },
+        { label: "App runs", href: "/app/runs", type: "route" },
+        { label: "Proof explorer", href: "/proof-explorer", type: "route" },
+      ],
+    },
+  ],
+  proof: [
+    {
+      title: "Evidence lifecycle",
+      detail:
+        "Proof generation, lineage inspection, and replay verification are available as first-class flows.",
+      refs: [
+        { label: "Proof explorer", href: "/proof-explorer", type: "route" },
+        { label: "Replay lab", href: "/replay-lab", type: "route" },
+        { label: "App proofs", href: "/app/proofs", type: "route" },
+      ],
+    },
+  ],
+  console: [
+    {
+      title: "Developer/operator console surfaces",
+      detail:
+        "Console routes provide runtime observability, policy controls, usage, and integration management.",
+      refs: [
+        { label: "Console", href: "/console", type: "route" },
+        { label: "Console operator", href: "/console/operator", type: "route" },
+        { label: "Console usage", href: "/console/usage", type: "route" },
+      ],
+    },
+  ],
+  trust: [
+    {
+      title: "Trust posture and degraded-state transparency",
+      detail:
+        "Trust and status pages expose uptime proxy, reliability signals, and operational disclosures.",
+      refs: [
+        { label: "Trust", href: "/trust", type: "route" },
+        { label: "Status", href: "/status", type: "route" },
+        { label: "Transparency", href: "/transparency", type: "route" },
+      ],
+    },
+  ],
+  security: [
+    {
+      title: "Isolation + audit verification surfaces",
+      detail:
+        "Security and audit pages map tenant safety, immutable logging, and evidence export boundaries.",
+      refs: [
+        { label: "Security and audit", href: "/security-and-audit", type: "route" },
+        { label: "Trust", href: "/trust", type: "route" },
+        { label: "App audit", href: "/app/audit", type: "route" },
+      ],
+    },
+  ],
+  roadmap: [
+    {
+      title: "Roadmap honesty guardrails",
+      detail:
+        "Roadmap statuses are explicitly separated into shipped, in-progress, and directional lanes.",
+      refs: [
+        { label: "Roadmap", href: "/roadmap", type: "route" },
+        { label: "Changelog", href: "/changelog", type: "route" },
+        { label: "Open source", href: "/open-source", type: "route" },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
### Motivation
- Surface concrete implementation proof tied to routes, packages, and docs so public architecture and feature claims remain testable and auditable. 
- Provide reusable visual diagrams and a single registry to centralize references between UI visuals and code artifacts. 
- Improve operator UX and robustness by surfacing evidence links and adding simple error handling for incidents loading. 

### Description
- Introduces a `visualProofRegistry` data file at `src/lib/public/visual-proof-registry.ts` that maps visual proof entries to `route`/`package`/`doc` refs. 
- Adds a reusable `RealityEvidencePanel` component at `src/components/RealityEvidencePanel.tsx` that renders registry entries and link chips. 
- Adds public visual components in `src/components/public-visual-proof.tsx` and feature-focused pieces in `src/components/feature-visual-proof.tsx` (platform overview, workflow diagram, capability map, integration and packaging map, console maps, lifecycle diagrams, CTA, etc.). 
- Integrates the new visuals and `RealityEvidencePanel` into many pages including `home`, `architecture`, `console`, `how-it-works`, `integrations`, `operator/incidents`, `platform`, `product`, `proof-explorer`, `roadmap`, `security-and-audit`, and `trust`, and adjusts copy/layout where needed. 
- Adds a unit test `packages/web/src/__tests__/content/visual-proof-registry.test.ts` that walks `src/app` routes and asserts all `route` refs in the registry resolve to an actual route. 
- Small behavioral and UX improvements such as network/error handling for `operator/incidents` loading and various text/CSS cleanups. 

### Testing
- Added `packages/web/src/__tests__/content/visual-proof-registry.test.ts` and ran the test suite with `pnpm test`; the new registry test and the test suite passed. 
- Performed a local type-check/build and validated the affected pages render with the new components (dev build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e7053c508328ba52b01cad61c18d)