### PR TITLE
Expand public product site IA with unified marketing primitives and depth pages

### DIFF
--- a/packages/web/src/app/architecture/page.tsx
+++ b/packages/web/src/app/architecture/page.tsx
@@ -1,12 +1,86 @@
 import { Metadata } from "next";
-import ArchitectureOverview from "@/components/stitch-import/ArchitectureOverview";
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+import {
+  CTASection,
+  FeatureCard,
+  FeatureGrid,
+  PageHero,
+  Section,
+  SectionHeader,
+} from "@/components/site/primitives";
 
 export const metadata: Metadata = {
   title: "Architecture - Settler",
   description:
-    "Settler's open source architecture: deterministic reconciliation engine, evidence hash chain, tenant isolation model, and replay infrastructure.",
+    "Architecture overview of Settler covering ingestion, deterministic matching, evidence generation, and operator control surfaces.",
 };
 
+const layers = [
+  {
+    title: "Ingestion and adapters",
+    description: "Connect external systems and normalize records into reconciliation inputs.",
+    bullets: ["Provider adapters", "Schema normalization", "Tenant-scoped ingestion"],
+  },
+  {
+    title: "Deterministic reconciliation kernel",
+    description: "Apply rules in a stable execution path to produce matched and unmatched sets.",
+    bullets: ["Rules engine", "Tolerance logic", "Deterministic output contract"],
+  },
+  {
+    title: "Evidence and replay",
+    description:
+      "Generate artifacts that can be replayed and compared for determinism verification.",
+    bullets: ["Evidence manifests", "Replay outputs", "Hash-based provenance"],
+  },
+  {
+    title: "Operator control plane",
+    description: "Surface run state, exception queues, diagnostics, and governance controls.",
+    bullets: ["Run observability", "Exception remediation", "Audit and policy views"],
+  },
+  {
+    title: "APIs, SDK, and CLI",
+    description: "Provide programmable interfaces for integration and automation.",
+    bullets: ["REST APIs", "TypeScript SDK", "CLI workflows"],
+  },
+  {
+    title: "Deployment boundaries",
+    description: "Support OSS self-hosted operation and enterprise packaging options.",
+    bullets: ["Repository deployment", "Environment isolation", "Packaging separation"],
+  },
+];
+
 export default function ArchitecturePage() {
-  return <ArchitectureOverview />;
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main id="main-content" className="pt-16">
+        <PageHero
+          eyebrow="Architecture"
+          title="System layers built for deterministic execution and operational trust"
+          description="This architecture view maps implemented concerns across adapter ingestion, deterministic run logic, replay evidence, and operational governance."
+        />
+        <Section>
+          <SectionHeader
+            title="Layered model"
+            description="Each layer has explicit responsibilities to keep reconciliation outcomes reproducible and reviewable."
+          />
+          <FeatureGrid>
+            {layers.map((layer) => (
+              <FeatureCard key={layer.title} {...layer} />
+            ))}
+          </FeatureGrid>
+        </Section>
+        <CTASection
+          title="Cross-check architecture with operations"
+          description="Use the security and use-case pages to map architecture boundaries to governance workflows."
+          primaryHref="/security-and-audit"
+          primaryLabel="View security model"
+          secondaryHref="/use-cases"
+          secondaryLabel="View use cases"
+        />
+      </main>
+      <Footer />
+    </div>
+  );
 }

--- a/packages/web/src/app/capabilities/page.tsx
+++ b/packages/web/src/app/capabilities/page.tsx
@@ -1,0 +1,85 @@
+import { Metadata } from "next";
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+import {
+  CTASection,
+  FeatureCard,
+  FeatureGrid,
+  PageHero,
+  Section,
+  SectionHeader,
+} from "@/components/site/primitives";
+
+export const metadata: Metadata = {
+  title: "Capabilities - Settler",
+  description:
+    "Capability map for deterministic reconciliation, evidence, controls, and integrations.",
+};
+
+const capabilityGroups = [
+  {
+    title: "Run orchestration",
+    description: "Create, execute, and monitor reconciliation runs via API, UI, or CLI.",
+    bullets: ["Scheduled or on-demand runs", "Replay from artifacts", "Execution metadata"],
+  },
+  {
+    title: "Matching rules",
+    description: "Configure reconciliation logic with deterministic outcomes.",
+    bullets: ["Exact and tolerance-based matching", "Rule versions", "Normalization support"],
+  },
+  {
+    title: "Exception workflows",
+    description: "Investigate mismatches with context instead of ad-hoc spreadsheets.",
+    bullets: ["Exception queues", "Reason codes", "Resolution tracking"],
+  },
+  {
+    title: "Evidence output",
+    description: "Capture proof bundles for audit and replay verification.",
+    bullets: ["Evidence manifest", "Report artifacts", "Determinism checks"],
+  },
+  {
+    title: "Control plane",
+    description: "Operate tenant-safe workflows with explicit role boundaries.",
+    bullets: ["Scoped API keys", "Audit logging", "Policy-gated actions"],
+  },
+  {
+    title: "Extensibility",
+    description: "Connect existing systems through adapters and APIs.",
+    bullets: ["Integration adapters", "Webhook events", "SDK extension points"],
+  },
+];
+
+export default function CapabilitiesPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main id="main-content" className="pt-16">
+        <PageHero
+          eyebrow="Capabilities"
+          title="A capability model grounded in real workflows"
+          description="Settler combines deterministic execution, operator workflows, and evidence-first outputs so engineering, finance, and security teams can reason about reconciliation outcomes."
+        />
+        <Section>
+          <SectionHeader
+            title="Capability clusters"
+            description="These clusters reflect implemented areas across the application, API surfaces, and operational documentation."
+          />
+          <FeatureGrid>
+            {capabilityGroups.map((group) => (
+              <FeatureCard key={group.title} {...group} />
+            ))}
+          </FeatureGrid>
+        </Section>
+        <CTASection
+          title="See how these capabilities combine"
+          description="Use the architecture and use-case pages to understand execution flow and persona-specific outcomes."
+          primaryHref="/architecture"
+          primaryLabel="Explore architecture"
+          secondaryHref="/use-cases"
+          secondaryLabel="View use cases"
+        />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/web/src/app/faq/page.tsx
+++ b/packages/web/src/app/faq/page.tsx
@@ -1,0 +1,66 @@
+import { Metadata } from "next";
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+import { CTASection, PageHero, Section } from "@/components/site/primitives";
+
+export const metadata: Metadata = {
+  title: "FAQ - Settler",
+  description: "Frequently asked questions about Settler capabilities, packaging, and deployment.",
+};
+
+const faqItems = [
+  [
+    "Is Settler open source?",
+    "Yes. Core reconciliation components in this repository are Apache 2.0 licensed, with enterprise packaging documented separately.",
+  ],
+  [
+    "What is deterministic in Settler?",
+    "Given the same inputs and rules, the run output and evidence hash should remain stable and replayable.",
+  ],
+  [
+    "Does Settler replace accounting software?",
+    "No. Settler focuses on reconciliation workflows between systems, not general ledger ownership.",
+  ],
+  [
+    "How do teams run Settler?",
+    "Teams can run local demos, self-host open-source workflows, or evaluate managed enterprise deployment paths.",
+  ],
+  [
+    "How should roadmap items be interpreted?",
+    "Roadmap items are planned work only. They are not represented as delivered capabilities until implemented.",
+  ],
+];
+
+export default function FaqPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main id="main-content" className="pt-16">
+        <PageHero
+          eyebrow="FAQ"
+          title="Common product and architecture questions"
+          description="Answers are constrained to documented product behavior and packaging boundaries."
+        />
+        <Section>
+          <div className="space-y-4">
+            {faqItems.map(([question, answer]) => (
+              <div key={question} className="rounded-xl border border-border bg-card p-5">
+                <h2 className="text-lg font-semibold text-foreground">{question}</h2>
+                <p className="mt-2 text-muted-foreground">{answer}</p>
+              </div>
+            ))}
+          </div>
+        </Section>
+        <CTASection
+          title="Still evaluating fit?"
+          description="Use platform, capabilities, architecture, and contact pages for a complete review path."
+          primaryHref="/platform"
+          primaryLabel="Review platform"
+          secondaryHref="/contact"
+          secondaryLabel="Contact team"
+        />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -1,1 +1,139 @@
-export { default } from "./(marketing)/home/page";
+import { Metadata } from "next";
+import { ArrowRight } from "lucide-react";
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+import {
+  CTASection,
+  FeatureCard,
+  FeatureGrid,
+  PageHero,
+  Section,
+  SectionHeader,
+} from "@/components/site/primitives";
+import { Button } from "@/components/ui/button";
+import { UiLink } from "@/components/ui/link";
+
+export const metadata: Metadata = {
+  title: "Settler - Deterministic Reconciliation Platform",
+  description:
+    "Settler helps teams reconcile financial data with deterministic runs, replayable evidence, and operator-grade controls.",
+};
+
+const capabilityClusters = [
+  {
+    title: "Deterministic engine",
+    description: "Rules-based matching with tolerance controls and stable outputs.",
+    bullets: ["Rules as code", "Field-level tolerance", "Replay verification"],
+  },
+  {
+    title: "Evidence and auditability",
+    description: "Evidence manifests and hash-linked artifacts for each run.",
+    bullets: ["Evidence JSON", "Replay reports", "Run provenance"],
+  },
+  {
+    title: "Operator workflows",
+    description: "Exception review, diagnostics, and control-plane style operations.",
+    bullets: ["Exception queues", "Audit trails", "Diagnostics views"],
+  },
+  {
+    title: "Integration layer",
+    description: "Adapters for payment, commerce, accounting, and custom systems.",
+    bullets: ["API and CLI execution", "Webhook support", "Custom adapters"],
+  },
+  {
+    title: "Deployment choices",
+    description: "Run open-source core yourself or evaluate managed enterprise delivery.",
+    bullets: ["Apache 2.0 OSS", "Self-host workflows", "Enterprise controls"],
+  },
+  {
+    title: "Security posture",
+    description: "Tenant-aware boundaries and explicit control surfaces for operators.",
+    bullets: ["Scoped access", "Policy controls", "Security architecture docs"],
+  },
+];
+
+export default function HomePage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main id="main-content" className="pt-16">
+        <PageHero
+          eyebrow="Settler platform"
+          title="Deterministic reconciliation for teams that need proof, not guesswork."
+          description="Settler is built for reconciliation workflows where correctness, auditability, and operational clarity matter. Run deterministic matching, triage exceptions, and export evidence that can be replayed and reviewed."
+          actions={
+            <>
+              <Button asChild>
+                <UiLink href="/platform">
+                  Explore platform <ArrowRight className="ml-1 h-4 w-4" />
+                </UiLink>
+              </Button>
+              <Button variant="outline" asChild>
+                <UiLink href="/docs">Read docs</UiLink>
+              </Button>
+            </>
+          }
+        />
+
+        <Section>
+          <SectionHeader
+            title="What you can do today"
+            description="The public site now maps core capabilities, architecture, operational workflows, and packaging without collapsing everything into a single landing section."
+          />
+          <FeatureGrid>
+            {capabilityClusters.map((capability) => (
+              <FeatureCard key={capability.title} {...capability} />
+            ))}
+          </FeatureGrid>
+        </Section>
+
+        <Section className="bg-muted/20">
+          <SectionHeader title="Navigate by intent" />
+          <div className="grid gap-4 md:grid-cols-2">
+            {[
+              {
+                role: "Developer",
+                href: "/capabilities",
+                desc: "SDK, CLI, and deterministic run model.",
+              },
+              {
+                role: "Operator",
+                href: "/use-cases",
+                desc: "Exception handling, controls, and run operations.",
+              },
+              {
+                role: "Architecture reviewer",
+                href: "/architecture",
+                desc: "System boundaries, data flow, and execution model.",
+              },
+              {
+                role: "Buyer / evaluator",
+                href: "/pricing",
+                desc: "Packaging and open-source vs enterprise posture.",
+              },
+            ].map((item) => (
+              <UiLink
+                key={item.role}
+                href={item.href}
+                className="rounded-xl border border-border bg-card p-5 hover:border-primary/50"
+              >
+                <h3 className="text-lg font-semibold text-foreground">{item.role}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{item.desc}</p>
+              </UiLink>
+            ))}
+          </div>
+        </Section>
+
+        <CTASection
+          title="Start with product truth"
+          description="Use the platform, capability, architecture, and roadmap pages to evaluate what exists now, what is packaged, and what is planned next."
+          primaryHref="/platform"
+          primaryLabel="View platform overview"
+          secondaryHref="/roadmap"
+          secondaryLabel="Read roadmap"
+        />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/web/src/app/use-cases/page.tsx
+++ b/packages/web/src/app/use-cases/page.tsx
@@ -1,0 +1,85 @@
+import { Metadata } from "next";
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+import {
+  CTASection,
+  FeatureCard,
+  FeatureGrid,
+  PageHero,
+  Section,
+  SectionHeader,
+} from "@/components/site/primitives";
+
+export const metadata: Metadata = {
+  title: "Use Cases - Settler",
+  description: "Representative workflows for developers, operators, and enterprise evaluators.",
+};
+
+const useCases = [
+  {
+    title: "Developer integration workflow",
+    description: "Implement reconciliation in product code with SDK and API endpoints.",
+    bullets: ["Create run definitions", "Version matching rules", "Trigger runs in CI"],
+  },
+  {
+    title: "Finance operations workflow",
+    description: "Detect and triage mismatches with deterministic, replayable records.",
+    bullets: ["Daily exception queues", "Variance review", "Export reconciliation evidence"],
+  },
+  {
+    title: "Platform operations workflow",
+    description: "Operate run infrastructure and diagnostics from the control plane.",
+    bullets: ["Run monitoring", "Failure taxonomy", "Remediation playbooks"],
+  },
+  {
+    title: "Security and audit workflow",
+    description: "Provide machine-verifiable evidence and action logs to reviewers.",
+    bullets: ["Tenant-scoped access", "Audit artifacts", "Replay verification"],
+  },
+  {
+    title: "Open-source adoption workflow",
+    description: "Evaluate and self-host core reconciliation workflows.",
+    bullets: ["Repository quickstart", "CLI-driven demos", "Local replay checks"],
+  },
+  {
+    title: "Enterprise evaluation workflow",
+    description: "Assess packaging, governance controls, and support requirements.",
+    bullets: [
+      "Deployment model review",
+      "Security architecture review",
+      "Commercial packaging path",
+    ],
+  },
+];
+
+export default function UseCasesPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main id="main-content" className="pt-16">
+        <PageHero
+          eyebrow="Use cases"
+          title="Workflows for builders, operators, and evaluators"
+          description="Settler supports distinct user journeys without hiding technical detail. These examples map directly to documented APIs, console surfaces, and operational artifacts in the repository."
+        />
+        <Section>
+          <SectionHeader title="Representative scenarios" />
+          <FeatureGrid>
+            {useCases.map((useCase) => (
+              <FeatureCard key={useCase.title} {...useCase} />
+            ))}
+          </FeatureGrid>
+        </Section>
+        <CTASection
+          title="Need deeper implementation detail?"
+          description="Continue into docs for API references and into roadmap for what is in-progress versus already shipped."
+          primaryHref="/docs"
+          primaryLabel="Open docs"
+          secondaryHref="/roadmap"
+          secondaryLabel="Review roadmap"
+        />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/web/src/components/Footer.tsx
+++ b/packages/web/src/components/Footer.tsx
@@ -7,20 +7,21 @@ const footerSections = [
     heading: "Product",
     links: [
       { href: "/platform", label: "Platform" },
-      { href: "/how-it-works", label: "How It Works" },
+      { href: "/capabilities", label: "Capabilities" },
+      { href: "/use-cases", label: "Use Cases" },
+      { href: "/architecture", label: "Architecture" },
       { href: "/pricing", label: "Pricing" },
       { href: "/security-and-audit", label: "Security" },
-      { href: "/login", label: "Login" },
-      { href: "/signup", label: "Get Started" },
     ],
   },
   {
-    heading: "Features",
+    heading: "Resources",
     links: [
-      { href: "/replay-lab", label: "Replay Lab" },
-      { href: "/proof-explorer", label: "Proof Explorer" },
-      { href: "/docs/quickstart", label: "Quickstart" },
       { href: "/docs", label: "Documentation" },
+      { href: "/docs/quickstart", label: "Quickstart" },
+      { href: "/roadmap", label: "Roadmap" },
+      { href: "/changelog", label: "Changelog" },
+      { href: "/faq", label: "FAQ" },
     ],
   },
   {
@@ -28,6 +29,8 @@ const footerSections = [
     links: [
       { href: "/about", label: "About" },
       { href: "/contact", label: "Contact" },
+      { href: "/open-source", label: "Open Source" },
+      { href: "/enterprise", label: "Enterprise" },
       { href: "https://github.com/Hardonian/Settler", label: "GitHub", external: true },
       { href: "/terms", label: "Terms" },
       { href: "/privacy", label: "Privacy" },

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -15,22 +15,27 @@ const siteMode = process.env.NEXT_PUBLIC_SITE_MODE || "oss";
 
 const primaryNavigationItems = [
   { href: "/platform", label: "Platform" },
+  { href: "/capabilities", label: "Capabilities" },
+  { href: "/use-cases", label: "Use Cases" },
   ...(siteMode === "enterprise" ? [{ href: "/enterprise", label: "Enterprise" }] : []),
   { href: "/pricing", label: "Pricing" },
-  { href: "/security-and-audit", label: "Security" },
   { href: "/docs", label: "Docs" },
 ];
 
 // Feature pages exposed in a dropdown
 const featureNavigationItems = [
   { href: "/how-it-works", label: "How It Works" },
-  { href: "/replay-lab", label: "Replay Lab" },
-  { href: "/proof-explorer", label: "Proof Explorer" },
+  { href: "/architecture", label: "Architecture" },
+  { href: "/security-and-audit", label: "Security & Audit" },
+  { href: "/open-source", label: "Open Source" },
+  { href: "/roadmap", label: "Roadmap" },
 ];
 
 // Secondary navigation items (in "More" dropdown on desktop, accordion on mobile)
 const secondaryNavigationItems = [
+  { href: "/faq", label: "FAQ" },
   { href: "/contact", label: "Contact" },
+  { href: "/changelog", label: "Changelog" },
   { href: "/privacy", label: "Privacy" },
   { href: "/terms", label: "Terms" },
 ];

--- a/packages/web/src/components/site/primitives.tsx
+++ b/packages/web/src/components/site/primitives.tsx
@@ -1,0 +1,115 @@
+import { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { UiLink } from "@/components/ui/link";
+import { cn } from "@/lib/utils";
+
+export function PublicPageShell({ children }: { children: ReactNode }) {
+  return <div className="min-h-screen bg-background">{children}</div>;
+}
+
+export function Section({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <section className={cn("px-4 py-16 sm:px-6 lg:px-8", className)}>
+      <div className="mx-auto max-w-6xl">{children}</div>
+    </section>
+  );
+}
+
+export function PageHero({
+  eyebrow,
+  title,
+  description,
+  actions,
+}: {
+  eyebrow?: string;
+  title: string;
+  description: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <Section className="border-b border-border/70 bg-muted/20 pt-20">
+      {eyebrow ? <Badge className="mb-5">{eyebrow}</Badge> : null}
+      <h1 className="max-w-4xl text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+        {title}
+      </h1>
+      <p className="mt-5 max-w-3xl text-lg text-muted-foreground">{description}</p>
+      {actions ? <div className="mt-8 flex flex-wrap gap-3">{actions}</div> : null}
+    </Section>
+  );
+}
+
+export function SectionHeader({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="mb-8 max-w-3xl">
+      <h2 className="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">{title}</h2>
+      {description ? <p className="mt-3 text-muted-foreground">{description}</p> : null}
+    </div>
+  );
+}
+
+export function FeatureGrid({ children }: { children: ReactNode }) {
+  return <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">{children}</div>;
+}
+
+export function FeatureCard({
+  title,
+  description,
+  bullets,
+}: {
+  title: string;
+  description: string;
+  bullets?: string[];
+}) {
+  return (
+    <Card className="h-full border-border/70">
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      {bullets?.length ? (
+        <CardContent>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            {bullets.map((item) => (
+              <li key={item}>• {item}</li>
+            ))}
+          </ul>
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}
+
+export function CTASection({
+  title,
+  description,
+  primaryHref,
+  primaryLabel,
+  secondaryHref,
+  secondaryLabel,
+}: {
+  title: string;
+  description: string;
+  primaryHref: string;
+  primaryLabel: string;
+  secondaryHref?: string;
+  secondaryLabel?: string;
+}) {
+  return (
+    <Section className="border-t border-border/70 bg-slate-900 py-14 text-white">
+      <h2 className="text-3xl font-semibold tracking-tight">{title}</h2>
+      <p className="mt-3 max-w-2xl text-slate-300">{description}</p>
+      <div className="mt-6 flex flex-wrap gap-3">
+        <Button asChild>
+          <UiLink href={primaryHref}>{primaryLabel}</UiLink>
+        </Button>
+        {secondaryHref && secondaryLabel ? (
+          <Button variant="outline" asChild>
+            <UiLink href={secondaryHref}>{secondaryLabel}</UiLink>
+          </Button>
+        ) : null}
+      </div>
+    </Section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Transform the thin landing surface into a credible multi-page product site that exposes present capabilities, workflows, architecture, and evaluation paths. 
- Reduce visual drift and duplication by introducing a small set of reusable Tailwind marketing primitives for consistent composition. 
- Improve discoverability and persona routing so visitors can quickly reach capability, architecture, and evaluation content.

### Description
- Add a reusable marketing primitives module at `packages/web/src/components/site/primitives.tsx` providing `PageHero`, `Section`, `SectionHeader`, `FeatureGrid`, `FeatureCard`, and `CTASection` to standardize page composition. 
- Rebuild the homepage at `packages/web/src/app/page.tsx` to act as a platform front door with capability clusters and role-based navigation entry points. 
- Add depth pages `Capabilities`, `Use Cases`, and `FAQ` at `packages/web/src/app/capabilities/page.tsx`, `packages/web/src/app/use-cases/page.tsx`, and `packages/web/src/app/faq/page.tsx` respectively, and replace the architecture surface with a layered architecture overview at `packages/web/src/app/architecture/page.tsx`. 
- Expand site IA by updating `Navigation` and `Footer` to surface the new pages and reorganize resource links for better discoverability.

### Testing
- Ran workspace lint with `pnpm lint`; the run completed and surfaced pre-existing warnings but introduced no new lint errors. 
- Ran package lint with `pnpm --filter @settler/web lint`; completed with pre-existing warnings only. 
- Type-check for the web package with `pnpm --filter @settler/web typecheck` passed. 
- Ran a focused Jest run `pnpm --filter @settler/web exec jest src/__tests__/content/content-pages.test.ts --runInBand` and it passed. 
- Attempted `pnpm --filter @settler/web build`; the build started but was terminated in this environment after prolonged runtime (SIGTERM) and should be re-run in CI or a full build environment. 
- Captured a development screenshot of the updated homepage (`artifacts/home-expanded.png`) to validate layout visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e56aaa7c8328906b957a30753502)