### PR TITLE
Harden kernel startup health and promotion telemetry

### DIFF
--- a/packages/cli/KERNEL_RUNNER.md
+++ b/packages/cli/KERNEL_RUNNER.md
@@ -59,6 +59,8 @@ Before kernel work, the TS wrapper performs handshake validation:
 
 On mismatch, TS fallback is selected and telemetry counters are incremented with machine-visible fallback reason.
 
+At startup, call `getKernelStartupHealth()` to preflight handshake health and runner readiness (`healthy`, `runnerMode`, `reason`, protocol/version, supported operations).
+
 ## Telemetry signal
 
 Foundry export logs include:
@@ -71,6 +73,7 @@ Foundry export logs include:
   - attempts/success/primary/shadow-compare/compare-only
   - fallback totals and fallback-by-reason
   - timeout, malformed output, version mismatch, binary unavailable
+  - startup health checks and startup health check failures
   - divergence totals and divergence-by-operation
 
 ## CI binary packaging

--- a/packages/cli/src/__tests__/kernel-client.test.ts
+++ b/packages/cli/src/__tests__/kernel-client.test.ts
@@ -11,6 +11,7 @@ import {
   canonicalizeHashWithFallback,
   getKernelTelemetrySnapshot,
   proofBundleHashWithFallback,
+  getKernelStartupHealth,
   readKernelFlags,
   resetKernelTelemetry,
   resolveKernelRunner,
@@ -34,6 +35,38 @@ describe("kernel client", () => {
     expect(flags.primaryAllowlist.has("canonicalize_hash")).toBe(true);
   });
 
+  test("execution mode falls back to shadow via legacy flag", () => {
+    const flags = readKernelFlags({
+      SETTLER_KERNEL_ENABLED: "1",
+      SETTLER_KERNEL_CANONICALIZE: "1",
+      SETTLER_KERNEL_SHADOW_MODE: "1",
+    } as NodeJS.ProcessEnv);
+
+    expect(flags.executionMode).toBe("shadow");
+  });
+
+  test("explicit execution mode takes precedence over legacy shadow flag", () => {
+    const flags = readKernelFlags({
+      SETTLER_KERNEL_ENABLED: "1",
+      SETTLER_KERNEL_CANONICALIZE: "1",
+      SETTLER_KERNEL_SHADOW_MODE: "1",
+      SETTLER_KERNEL_EXECUTION_MODE: "primary",
+    } as NodeJS.ProcessEnv);
+
+    expect(flags.executionMode).toBe("primary");
+  });
+
+  test("startup health reports degraded when binary is missing", async () => {
+    process.env.SETTLER_KERNEL_BIN = "/missing/kernel-bin";
+    process.env.SETTLER_KERNEL_ALLOW_CARGO = "0";
+    process.env.NODE_ENV = "production";
+    process.env.CI = "true";
+
+    const health = await getKernelStartupHealth();
+    expect(health.healthy).toBe(false);
+    expect(health.runnerMode).toBe("fallback-ts");
+    expect(health.reason).toBe("binary_missing");
+  });
   test("resolves binary runner when executable path is provided", () => {
     const resolved = resolveKernelRunner({
       SETTLER_KERNEL_BIN: process.execPath,
@@ -87,6 +120,7 @@ describe("kernel client", () => {
     expect(result.mode).toBe("ts");
     expect(result.runnerMode).toBe("disabled");
     expect(result.metadata.fallbackReason).toBe("kernel_disabled");
+    expect(result.metadata.health).toBe("degraded");
     expect(result.result.normalizedHash).toMatch(/^[a-f0-9]{64}$/);
   });
 
@@ -105,6 +139,7 @@ describe("kernel client", () => {
     expect(result.mode).toBe("ts");
     expect(result.runnerMode).toBe("fallback-ts");
     expect(result.metadata.fallbackReason).toBe("primary_not_allowed");
+    expect(result.metadata.health).toBe("degraded");
     const expected = createHash("sha256").update("proof_bundle_hash@v1").digest("hex");
     expect(result.result.ruleHash).toBe(expected);
     expect(result.result.ruleHash).not.toBe(tsCanonicalizeHash({ a: 1 }).ruleHash);
@@ -127,5 +162,101 @@ describe("kernel client", () => {
     const b = await artifactIdentityHashWithFallback({ a: 1, b: 2 });
     expect(a.result.normalizedHash).toBe(b.result.normalizedHash);
     expect(a.metadata.fallbackReason).toBe("binary_unavailable");
+    expect(a.metadata.health).toBe("degraded");
+  });
+
+  test("falls back with protocol_mismatch when handshake protocol is incompatible", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kernel-test-"));
+    const bin = path.join(dir, "kernel-protocol-mismatch.sh");
+    fs.writeFileSync(
+      bin,
+      `#!/bin/sh
+cat >/dev/null
+echo '{"ok":true,"operation":"handshake","protocol_version":"v9","kernel_version":"9.9.9","result":{"operation":"handshake","protocol_version":"v9","kernel_version":"9.9.9","supported_operations":["canonicalize_hash"]}}'
+`,
+      { mode: 0o755 }
+    );
+
+    process.env.SETTLER_KERNEL_ENABLED = "1";
+    process.env.SETTLER_KERNEL_CANONICALIZE = "1";
+    process.env.SETTLER_KERNEL_EXECUTION_MODE = "primary";
+    process.env.SETTLER_KERNEL_PRIMARY_ALLOWLIST = "canonicalize_hash";
+    process.env.SETTLER_KERNEL_BIN = bin;
+    process.env.SETTLER_KERNEL_ALLOW_CARGO = "0";
+    process.env.NODE_ENV = "production";
+    process.env.CI = "true";
+    resetKernelTelemetry();
+
+    const result = await canonicalizeHashWithFallback({ a: 1 });
+    expect(result.mode).toBe("ts");
+    expect(result.metadata.fallbackReason).toBe("protocol_mismatch");
+    expect(result.metadata.health).toBe("degraded");
+  });
+
+  test("falls back on malformed kernel output", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kernel-test-"));
+    const bin = path.join(dir, "kernel-malformed.sh");
+    fs.writeFileSync(
+      bin,
+      `#!/bin/sh
+REQUEST=$(cat)
+if echo "$REQUEST" | grep -q '"operation":"handshake"'; then
+  echo '{"ok":true,"operation":"handshake","protocol_version":"v1","kernel_version":"0.1.0","result":{"operation":"handshake","protocol_version":"v1","kernel_version":"0.1.0","supported_operations":["canonicalize_hash"]}}'
+else
+  echo 'not-json'
+fi
+`,
+      { mode: 0o755 }
+    );
+
+    process.env.SETTLER_KERNEL_ENABLED = "1";
+    process.env.SETTLER_KERNEL_CANONICALIZE = "1";
+    process.env.SETTLER_KERNEL_EXECUTION_MODE = "primary";
+    process.env.SETTLER_KERNEL_PRIMARY_ALLOWLIST = "canonicalize_hash";
+    process.env.SETTLER_KERNEL_BIN = bin;
+    process.env.SETTLER_KERNEL_ALLOW_CARGO = "0";
+    process.env.NODE_ENV = "production";
+    process.env.CI = "true";
+    resetKernelTelemetry();
+
+    const result = await canonicalizeHashWithFallback({ a: 1 });
+    expect(result.mode).toBe("ts");
+    expect(result.metadata.fallbackReason).toBe("primary_kernel_failed");
+    const telemetry = getKernelTelemetrySnapshot();
+    expect(telemetry.malformedOutput).toBeGreaterThan(0);
+  });
+
+  test("falls back with timeout reason when kernel invocation exceeds timeout", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kernel-test-"));
+    const bin = path.join(dir, "kernel-timeout.sh");
+    fs.writeFileSync(
+      bin,
+      `#!/bin/sh
+REQUEST=$(cat)
+if echo "$REQUEST" | grep -q '"operation":"handshake"'; then
+  echo '{"ok":true,"operation":"handshake","protocol_version":"v1","kernel_version":"0.1.0","result":{"operation":"handshake","protocol_version":"v1","kernel_version":"0.1.0","supported_operations":["canonicalize_hash"]}}'
+else
+  sleep 6
+  echo '{"ok":true,"operation":"canonicalize_hash","protocol_version":"v1","kernel_version":"0.1.0","result":{"schema_version":"v1","canonical_json":"{}","input_hash":"a","normalized_hash":"b","rule_hash":"c"}}'
+fi
+`,
+      { mode: 0o755 }
+    );
+
+    process.env.SETTLER_KERNEL_ENABLED = "1";
+    process.env.SETTLER_KERNEL_CANONICALIZE = "1";
+    process.env.SETTLER_KERNEL_EXECUTION_MODE = "primary";
+    process.env.SETTLER_KERNEL_PRIMARY_ALLOWLIST = "canonicalize_hash";
+    process.env.SETTLER_KERNEL_BIN = bin;
+    process.env.SETTLER_KERNEL_ALLOW_CARGO = "0";
+    process.env.NODE_ENV = "production";
+    process.env.CI = "true";
+    resetKernelTelemetry();
+
+    const result = await canonicalizeHashWithFallback({ a: 1 });
+    expect(result.mode).toBe("ts");
+    expect(result.metadata.fallbackReason).toBe("timeout");
+    const telemetry = getKernelTelemetrySnapshot();
+    expect(telemetry.timeout).toBeGreaterThan(0);
   });
 });

--- a/packages/cli/src/commands/foundry.ts
+++ b/packages/cli/src/commands/foundry.ts
@@ -270,6 +270,11 @@ foundryCommand
         profile: options.profile,
       });
       return exportReconciliationSuiteWithKernel(suite, options.output).then((result) => {
+        const promotionReady =
+          result.execution.executionMode === "primary" &&
+          result.execution.usedPrimary &&
+          result.execution.health === "healthy";
+
         logJson({
           output: result.path,
           hash: result.hash,
@@ -278,6 +283,14 @@ foundryCommand
           kernel_divergence: result.divergence ?? null,
           kernel_duration_ms: result.durations.kernel ?? null,
           ts_duration_ms: result.durations.ts,
+          kernel_startup_health: result.startupHealth,
+          kernel_promotion_gate: {
+            ready: promotionReady,
+            reason: promotionReady
+              ? "primary_healthy"
+              : (result.execution.fallbackReason ??
+                (result.execution.usedPrimary ? "health_degraded" : "kernel_not_primary")),
+          },
           kernel_telemetry: result.telemetry,
           kernel_execution: result.execution,
           profile: suite.manifest.profile,

--- a/packages/cli/src/lib/kernel-client.ts
+++ b/packages/cli/src/lib/kernel-client.ts
@@ -86,6 +86,8 @@ interface KernelTelemetrySnapshot {
   divergence: number;
   divergenceByOperation: Record<string, number>;
   hashMismatch: number;
+  healthChecks: number;
+  healthCheckFailures: number;
 }
 
 export interface KernelExecutionMetadata {
@@ -94,6 +96,17 @@ export interface KernelExecutionMetadata {
   usedPrimary: boolean;
   shadowCompared: boolean;
   fallbackReason?: string;
+  health: "healthy" | "degraded";
+}
+
+export interface KernelStartupHealth {
+  healthy: boolean;
+  runnerMode: KernelRunnerMode;
+  durationMs: number;
+  reason?: string;
+  protocolVersion?: string;
+  kernelVersion?: string;
+  supportedOperations?: string[];
 }
 
 class KernelInvocationError extends Error {
@@ -120,6 +133,8 @@ const telemetry: KernelTelemetrySnapshot = {
   divergence: 0,
   divergenceByOperation: {},
   hashMismatch: 0,
+  healthChecks: 0,
+  healthCheckFailures: 0,
 };
 
 const handshakeCache = new Map<string, KernelHandshakeResult>();
@@ -419,6 +434,43 @@ async function ensureHandshake(runner: ResolvedKernelRunner, timeoutMs: number):
   handshakeCache.set(cacheKey, result);
 }
 
+export async function getKernelStartupHealth(timeoutMs = 1500): Promise<KernelStartupHealth> {
+  const startedAt = Date.now();
+  telemetry.healthChecks += 1;
+
+  const resolved = resolveKernelRunner();
+  if (!resolved.runner) {
+    telemetry.healthCheckFailures += 1;
+    return {
+      healthy: false,
+      runnerMode: resolved.mode,
+      reason: resolved.reason ?? "no_runner_available",
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  try {
+    await ensureHandshake(resolved.runner, timeoutMs);
+    const handshake = handshakeCache.get(runnerCacheKey(resolved.runner));
+    return {
+      healthy: Boolean(handshake),
+      runnerMode: resolved.runner.mode,
+      durationMs: Date.now() - startedAt,
+      protocolVersion: handshake?.protocol_version,
+      kernelVersion: handshake?.kernel_version,
+      supportedOperations: handshake?.supported_operations,
+    };
+  } catch (error) {
+    telemetry.healthCheckFailures += 1;
+    return {
+      healthy: false,
+      runnerMode: resolved.runner.mode,
+      durationMs: Date.now() - startedAt,
+      reason: classifyErrorReason(error, "handshake_failed"),
+    };
+  }
+}
+
 function ensureOperationSupport(runner: ResolvedKernelRunner, operation: KernelOperation): void {
   const handshake = handshakeCache.get(runnerCacheKey(runner));
   if (!handshake) {
@@ -528,6 +580,7 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "kernel_disabled",
+        health: "degraded",
       },
     };
   }
@@ -560,6 +613,7 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
           executionMode: flags.executionMode,
           usedPrimary: false,
           shadowCompared: true,
+          health: "healthy",
         },
       };
     } catch (error) {
@@ -578,6 +632,7 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
           usedPrimary: false,
           shadowCompared: true,
           fallbackReason: reason,
+          health: "degraded",
         },
       };
     }
@@ -596,6 +651,7 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "primary_not_allowed",
+        health: "degraded",
       },
     };
   }
@@ -614,6 +670,7 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
         executionMode: flags.executionMode,
         usedPrimary: true,
         shadowCompared: false,
+        health: "healthy",
       },
     };
   } catch (error) {
@@ -630,6 +687,7 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: reason,
+        health: "degraded",
       },
     };
   }
@@ -659,6 +717,7 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "kernel_disabled",
+        health: "degraded",
       },
     };
   }
@@ -676,6 +735,7 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "primary_not_allowed",
+        health: "degraded",
       },
     };
   }
@@ -695,6 +755,7 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
         executionMode: flags.executionMode,
         usedPrimary: true,
         shadowCompared: false,
+        health: "healthy",
       },
     };
   } catch (error) {
@@ -711,6 +772,7 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: reason,
+        health: "degraded",
       },
     };
   }
@@ -740,6 +802,7 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "kernel_disabled",
+        health: "degraded",
       },
     };
   }
@@ -757,6 +820,7 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "primary_not_allowed",
+        health: "degraded",
       },
     };
   }
@@ -776,6 +840,7 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
         executionMode: flags.executionMode,
         usedPrimary: true,
         shadowCompared: false,
+        health: "healthy",
       },
     };
   } catch (error) {
@@ -792,6 +857,7 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: reason,
+        health: "degraded",
       },
     };
   }
@@ -816,5 +882,7 @@ export function resetKernelTelemetry(): void {
   telemetry.divergence = 0;
   telemetry.divergenceByOperation = {};
   telemetry.hashMismatch = 0;
+  telemetry.healthChecks = 0;
+  telemetry.healthCheckFailures = 0;
   handshakeCache.clear();
 }

--- a/packages/cli/src/lib/reconciliation-foundry.ts
+++ b/packages/cli/src/lib/reconciliation-foundry.ts
@@ -3,8 +3,10 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import {
   canonicalizeHashWithFallback,
+  getKernelStartupHealth,
   getKernelTelemetrySnapshot,
   type KernelExecutionMetadata,
+  type KernelStartupHealth,
 } from "./kernel-client";
 
 export type SourceSystem =
@@ -674,8 +676,10 @@ export async function exportReconciliationSuiteWithKernel(
   durations: { kernel?: number; ts: number };
   telemetry: ReturnType<typeof getKernelTelemetrySnapshot>;
   execution: KernelExecutionMetadata;
+  startupHealth: KernelStartupHealth;
 }> {
   const exported = exportReconciliationSuite(suite, outputRoot);
+  const startupHealth = await getKernelStartupHealth();
   const kernel = await canonicalizeHashWithFallback({
     manifest: suite.manifest,
     golden: suite.golden,
@@ -690,6 +694,7 @@ export async function exportReconciliationSuiteWithKernel(
     durations: kernel.durationMs,
     telemetry: getKernelTelemetrySnapshot(),
     execution: kernel.metadata,
+    startupHealth,
   };
 }
 


### PR DESCRIPTION
### Motivation
- Provide a deterministic, auditable startup preflight for the Rust kernel so callers can validate runner readiness and handshake before using kernel operations.
- Make kernel fallback/health visible in per-operation metadata and telemetry so promotion decisions can be gated and rollbacks are explicit.
- Preserve existing TS fallback and safety boundaries while enabling CI/operational workflows to reason about kernel readiness.

### Description
- Added a startup health API `getKernelStartupHealth(timeoutMs?)` that resolves runner mode, performs handshake preflight, and returns `KernelStartupHealth` including `runnerMode`, `reason`, protocol/kernel versions and supported operations (file: `packages/cli/src/lib/kernel-client.ts`).
- Extended telemetry snapshot with startup counters `healthChecks` and `healthCheckFailures` and added `KernelExecutionMetadata.health` (`"healthy" | "degraded"`) to make per-operation health explicit (file: `packages/cli/src/lib/kernel-client.ts`).
- Integrated startup health into foundry export pipeline: `exportReconciliationSuiteWithKernel` now calls `getKernelStartupHealth()` and the `foundry` command emits `kernel_startup_health` and a `kernel_promotion_gate` (ready/reason) to indicate promotion-readiness (files: `packages/cli/src/lib/reconciliation-foundry.ts`, `packages/cli/src/commands/foundry.ts`).
- Added tests covering config precedence, startup health when binary is missing, protocol/version mismatch fallback, malformed kernel output handling, and timeout fallback, and updated existing tests to assert `metadata.health` on fallback paths (file: `packages/cli/src/__tests__/kernel-client.test.ts`).
- Documentation update: `packages/cli/KERNEL_RUNNER.md` now documents startup preflight usage and the new telemetry dimensions.

### Testing
- Ran unit tests: `pnpm --filter @settler/cli test -- kernel-client.test.ts`, all tests passed (14/14). ✅
- Type checking: `pnpm --filter @settler/cli typecheck` passed with no errors. ✅
- Lint: `pnpm --filter @settler/cli lint` ran and returned only pre-existing warnings (no new lint errors introduced). ⚠️
- Built package: `pnpm --filter @settler/cli build` completed successfully. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2135613c48328b4b07e6708330a82)