### PR TITLE
Surface enterprise console capabilities across nav, overview, and pricing

### DIFF
--- a/packages/web/src/app/console/page.tsx
+++ b/packages/web/src/app/console/page.tsx
@@ -9,7 +9,16 @@ import { Suspense } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Activity, Key, Receipt, ArrowRight } from "lucide-react";
+import {
+  Activity,
+  Key,
+  Receipt,
+  ArrowRight,
+  ShieldCheck,
+  ScanSearch,
+  ClipboardCheck,
+  Bot,
+} from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { getUsageSummary } from "@/domain/console/usage";
 import { listApiKeys } from "@/domain/console/apiKeys";
@@ -557,6 +566,47 @@ async function ConsoleOverviewContent() {
             </Button>
           </div>
         </div>
+
+        <Card className="border-electric-cyan/30 bg-gradient-to-r from-electric-cyan/5 to-transparent">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-electric-cyan" />
+              Enterprise Capability Surfaces
+            </CardTitle>
+            <CardDescription>
+              Deterministic traceability, governance controls, and operator intelligence available
+              in the console.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+              <Button asChild variant="outline" className="justify-start">
+                <Link href="/console/replay">
+                  <ScanSearch className="w-4 h-4 mr-2" />
+                  Replay Lab
+                </Link>
+              </Button>
+              <Button asChild variant="outline" className="justify-start">
+                <Link href="/console/audit-trail">
+                  <ShieldCheck className="w-4 h-4 mr-2" />
+                  Audit Trail
+                </Link>
+              </Button>
+              <Button asChild variant="outline" className="justify-start">
+                <Link href="/console/bulk-operations">
+                  <ClipboardCheck className="w-4 h-4 mr-2" />
+                  Bulk Operations
+                </Link>
+              </Button>
+              <Button asChild variant="outline" className="justify-start">
+                <Link href="/console/operator">
+                  <Bot className="w-4 h-4 mr-2" />
+                  Operator Console
+                </Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
 
         {/* Quick Stats - Only show if data exists */}
         <RBACGate requiredTier="unsubscribed" feature="Dashboard Stats">

--- a/packages/web/src/app/pricing/page.tsx
+++ b/packages/web/src/app/pricing/page.tsx
@@ -23,7 +23,12 @@ import {
   Phone,
 } from "lucide-react";
 import { ErrorBoundary } from "@/components/shared/error-boundary";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
 export const metadata: Metadata = {
   title: "Engagement Models - Settler",
@@ -118,15 +123,23 @@ export default function Pricing() {
       <div className="min-h-screen bg-background">
         <Navigation />
 
-        <Section className="pt-20" containerClassName="max-w-4xl text-center" aria-labelledby="pricing-heading">
+        <Section
+          className="pt-20"
+          containerClassName="max-w-4xl text-center"
+          aria-labelledby="pricing-heading"
+        >
           <Badge className="mb-6 px-4 py-2 text-sm font-medium" variant="default">
             Structured for Serious Operators
           </Badge>
-          <h1 id="pricing-heading" className="mb-5 text-fluid-4xl font-bold leading-tight tracking-tight text-foreground">
+          <h1
+            id="pricing-heading"
+            className="mb-5 text-fluid-4xl font-bold leading-tight tracking-tight text-foreground"
+          >
             Engagement Models That Scale With Complexity
           </h1>
           <p className="mx-auto mb-8 max-w-3xl text-lg leading-relaxed text-muted-foreground">
-            Designed to scale with workflow complexity. Built for integration depth. Every deployment is structured around your operational requirements.
+            Designed to scale with workflow complexity. Built for integration depth. Every
+            deployment is structured around your operational requirements.
           </p>
           <div className="relative mx-auto mb-8 max-w-4xl overflow-hidden rounded-2xl border border-border">
             <Image
@@ -150,7 +163,9 @@ export default function Pricing() {
                 <Card
                   key={model.name}
                   className={`relative flex flex-col ${
-                    model.highlight ? "border-2 border-foreground/80 shadow-xl" : "border border-border"
+                    model.highlight
+                      ? "border-2 border-foreground/80 shadow-xl"
+                      : "border border-border"
                   }`}
                 >
                   {model.highlight ? (
@@ -162,15 +177,25 @@ export default function Pricing() {
                     <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-muted">
                       <Icon className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
                     </div>
-                    <CardTitle className="text-xl text-foreground md:text-2xl">{model.name}</CardTitle>
-                    <p className="mt-1 text-sm font-medium text-muted-foreground">{model.positioning}</p>
-                    <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{model.description}</p>
+                    <CardTitle className="text-xl text-foreground md:text-2xl">
+                      {model.name}
+                    </CardTitle>
+                    <p className="mt-1 text-sm font-medium text-muted-foreground">
+                      {model.positioning}
+                    </p>
+                    <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                      {model.description}
+                    </p>
                   </CardHeader>
                   <CardContent className="flex flex-1 flex-col space-y-4">
                     <div className="flex-1 border-t border-border pt-4">
                       <FeatureList items={model.capabilities} />
                     </div>
-                    <Button asChild variant={model.highlight ? "default" : "outline"} className="mt-4 w-full">
+                    <Button
+                      asChild
+                      variant={model.highlight ? "default" : "outline"}
+                      className="mt-4 w-full"
+                    >
                       <UiLink href={model.ctaLink}>
                         {model.cta} <ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
                       </UiLink>
@@ -182,13 +207,72 @@ export default function Pricing() {
           </div>
         </Section>
 
+        <Section aria-label="Console and governance capabilities" containerClassName="max-w-6xl">
+          <div className="mb-8 text-center">
+            <h2 className="text-fluid-2xl font-bold tracking-tight text-foreground">
+              What Premium Unlocks in Product Surfaces
+            </h2>
+            <p className="mx-auto mt-3 max-w-3xl text-muted-foreground">
+              Premium tiers expose additional console surfaces for replay traceability, governance
+              workflows, and operator intelligence.
+            </p>
+          </div>
+          <div className="overflow-x-auto rounded-2xl border border-border bg-card">
+            <table className="min-w-full text-sm">
+              <thead className="bg-muted/40">
+                <tr>
+                  <th className="px-4 py-3 text-left font-semibold">Capability</th>
+                  <th className="px-4 py-3 text-left font-semibold">Self-Serve</th>
+                  <th className="px-4 py-3 text-left font-semibold">Managed</th>
+                  <th className="px-4 py-3 text-left font-semibold">Enterprise</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-t border-border">
+                  <td className="px-4 py-3">Replay Lab and execution trace diff</td>
+                  <td className="px-4 py-3 text-muted-foreground">Limited</td>
+                  <td className="px-4 py-3">Included</td>
+                  <td className="px-4 py-3">Included + guided rollout</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="px-4 py-3">Bulk operations and approvals</td>
+                  <td className="px-4 py-3 text-muted-foreground">Basic tooling</td>
+                  <td className="px-4 py-3">Included</td>
+                  <td className="px-4 py-3">Included + governance workflows</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="px-4 py-3">Audit trail and evidence export</td>
+                  <td className="px-4 py-3">Deterministic logs</td>
+                  <td className="px-4 py-3">Extended retention</td>
+                  <td className="px-4 py-3">Extended retention + SLA</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="px-4 py-3">Operator control plane and failure intelligence</td>
+                  <td className="px-4 py-3 text-muted-foreground">—</td>
+                  <td className="px-4 py-3">Available</td>
+                  <td className="px-4 py-3">Available + managed support</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Button asChild variant="outline">
+              <UiLink href="/console">Open Console Overview</UiLink>
+            </Button>
+            <Button asChild variant="outline">
+              <UiLink href="/console/replay">View Replay Surface</UiLink>
+            </Button>
+          </div>
+        </Section>
+
         <Section className="bg-muted/30" aria-label="Engagement pathways">
           <div className="mb-12 text-center md:mb-16">
             <h2 className="mb-4 text-fluid-3xl font-bold tracking-tight text-foreground">
               Flexible Engagement Pathways
             </h2>
             <p className="mx-auto max-w-2xl text-lg leading-relaxed text-muted-foreground">
-              Multiple pathways to deployment. Choose the option that matches your operational maturity and integration requirements.
+              Multiple pathways to deployment. Choose the option that matches your operational
+              maturity and integration requirements.
             </p>
           </div>
 
@@ -196,14 +280,21 @@ export default function Pricing() {
             {engagementPathways.map((pathway) => {
               const Icon = pathway.icon;
               return (
-                <div key={pathway.title} className="rounded-2xl border border-border bg-card p-6 md:p-8">
+                <div
+                  key={pathway.title}
+                  className="rounded-2xl border border-border bg-card p-6 md:p-8"
+                >
                   <div className="flex items-start gap-4">
                     <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-muted">
                       <Icon className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
                     </div>
                     <div>
-                      <h3 className="mb-2 text-lg font-semibold text-foreground">{pathway.title}</h3>
-                      <p className="text-sm leading-relaxed text-muted-foreground">{pathway.description}</p>
+                      <h3 className="mb-2 text-lg font-semibold text-foreground">
+                        {pathway.title}
+                      </h3>
+                      <p className="text-sm leading-relaxed text-muted-foreground">
+                        {pathway.description}
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -212,13 +303,22 @@ export default function Pricing() {
           </div>
         </Section>
 
-        <Section className="bg-slate-900 text-white" containerClassName="max-w-4xl text-center" aria-label="Strategic consultation">
+        <Section
+          className="bg-slate-900 text-white"
+          containerClassName="max-w-4xl text-center"
+          aria-label="Strategic consultation"
+        >
           <h2 className="mb-4 text-fluid-3xl font-bold tracking-tight">Not Sure Where to Start?</h2>
           <p className="mx-auto mb-8 max-w-2xl text-lg leading-relaxed text-slate-300">
-            Schedule a complimentary 30-minute strategic session. We will review your reconciliation architecture and recommend an engagement model matched to your operational requirements.
+            Schedule a complimentary 30-minute strategic session. We will review your reconciliation
+            architecture and recommend an engagement model matched to your operational requirements.
           </p>
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <Button size="lg" asChild className="w-full bg-white px-8 py-6 text-lg font-semibold text-slate-900 hover:bg-slate-100 sm:w-auto">
+            <Button
+              size="lg"
+              asChild
+              className="w-full bg-white px-8 py-6 text-lg font-semibold text-slate-900 hover:bg-slate-100 sm:w-auto"
+            >
               <UiLink href="/contact">
                 Schedule a Strategic Session <ArrowRight className="h-5 w-5" aria-hidden="true" />
               </UiLink>
@@ -235,14 +335,23 @@ export default function Pricing() {
         </Section>
 
         <Section aria-label="Frequently asked questions" containerClassName="max-w-3xl">
-          <h2 className="mb-8 text-center text-fluid-2xl font-bold text-foreground md:mb-10">Common Questions</h2>
+          <h2 className="mb-8 text-center text-fluid-2xl font-bold text-foreground md:mb-10">
+            Common Questions
+          </h2>
           <Accordion type="single" collapsible className="w-full space-y-3">
-            <AccordionItem value="how-pricing-works" className="rounded-xl border border-border bg-card px-6">
+            <AccordionItem
+              value="how-pricing-works"
+              className="rounded-xl border border-border bg-card px-6"
+            >
               <AccordionTrigger className="py-4 text-base font-semibold hover:no-underline md:text-lg">
                 How does Settler structure its engagement?
               </AccordionTrigger>
               <AccordionContent className="pb-4 text-sm leading-relaxed text-muted-foreground md:text-base">
-                Settler offers multiple deployment pathways matched to workflow complexity and integration depth. Self-serve onboarding provides immediate API access. Managed deployments include priority support and guided implementation. Enterprise contracts are structured around custom requirements with dedicated infrastructure and governance controls. All models scale with operational throughput.
+                Settler offers multiple deployment pathways matched to workflow complexity and
+                integration depth. Self-serve onboarding provides immediate API access. Managed
+                deployments include priority support and guided implementation. Enterprise contracts
+                are structured around custom requirements with dedicated infrastructure and
+                governance controls. All models scale with operational throughput.
               </AccordionContent>
             </AccordionItem>
             <AccordionItem value="pilot" className="rounded-xl border border-border bg-card px-6">
@@ -250,31 +359,50 @@ export default function Pricing() {
                 Can I start with a pilot?
               </AccordionTrigger>
               <AccordionContent className="pb-4 text-sm leading-relaxed text-muted-foreground md:text-base">
-                Yes. Pilot programs are designed to validate integration feasibility and measure operational impact before committing to a full deployment. Pilots typically run for 30-60 days and include dedicated technical support to ensure your evaluation is conclusive.
+                Yes. Pilot programs are designed to validate integration feasibility and measure
+                operational impact before committing to a full deployment. Pilots typically run for
+                30-60 days and include dedicated technical support to ensure your evaluation is
+                conclusive.
               </AccordionContent>
             </AccordionItem>
-            <AccordionItem value="enterprise-needs" className="rounded-xl border border-border bg-card px-6">
+            <AccordionItem
+              value="enterprise-needs"
+              className="rounded-xl border border-border bg-card px-6"
+            >
               <AccordionTrigger className="py-4 text-base font-semibold hover:no-underline md:text-lg">
                 What if I need custom integrations?
               </AccordionTrigger>
               <AccordionContent className="pb-4 text-sm leading-relaxed text-muted-foreground md:text-base">
-                Custom integration engagements are available for teams with specific adapter requirements, proprietary data formats, or regulatory constraints. Contact us to discuss your integration architecture and we will scope a custom engagement.
+                Custom integration engagements are available for teams with specific adapter
+                requirements, proprietary data formats, or regulatory constraints. Contact us to
+                discuss your integration architecture and we will scope a custom engagement.
               </AccordionContent>
             </AccordionItem>
-            <AccordionItem value="self-host" className="rounded-xl border border-border bg-card px-6">
+            <AccordionItem
+              value="self-host"
+              className="rounded-xl border border-border bg-card px-6"
+            >
               <AccordionTrigger className="py-4 text-base font-semibold hover:no-underline md:text-lg">
                 Can I self-host Settler?
               </AccordionTrigger>
               <AccordionContent className="pb-4 text-sm leading-relaxed text-muted-foreground md:text-base">
-                Settler is open source under Apache 2.0. Self-hosting is a first-class deployment model. Your data never leaves your infrastructure. Managed and enterprise engagements provide additional operational tooling and support for self-hosted deployments.
+                Settler is open source under Apache 2.0. Self-hosting is a first-class deployment
+                model. Your data never leaves your infrastructure. Managed and enterprise
+                engagements provide additional operational tooling and support for self-hosted
+                deployments.
               </AccordionContent>
             </AccordionItem>
-            <AccordionItem value="consultation" className="rounded-xl border border-border bg-card px-6">
+            <AccordionItem
+              value="consultation"
+              className="rounded-xl border border-border bg-card px-6"
+            >
               <AccordionTrigger className="py-4 text-base font-semibold hover:no-underline md:text-lg">
                 What is included in the strategic consultation?
               </AccordionTrigger>
               <AccordionContent className="pb-4 text-sm leading-relaxed text-muted-foreground md:text-base">
-                A complimentary 30-minute session with a Settler solutions architect. We review your current reconciliation workflows, identify failure surfaces, and recommend an engagement model aligned with your operational requirements. No commitment required.
+                A complimentary 30-minute session with a Settler solutions architect. We review your
+                current reconciliation workflows, identify failure surfaces, and recommend an
+                engagement model aligned with your operational requirements. No commitment required.
               </AccordionContent>
             </AccordionItem>
           </Accordion>

--- a/packages/web/src/components/console/ConsoleLayout.tsx
+++ b/packages/web/src/components/console/ConsoleLayout.tsx
@@ -30,12 +30,17 @@ import {
   Database,
   FileText,
   Building2,
+  ShieldCheck,
+  Gavel,
+  ScanSearch,
+  ClipboardCheck,
+  Bot,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { BackendHealthBadge } from "./BackendHealthBadge";
 
-const consoleNavItems = [
+const coreNavItems = [
   { href: "/console", label: "Overview", icon: LayoutDashboard },
   { href: "/console/api-test", label: "API Test Console", icon: Code },
   { href: "/console/api-playground", label: "API Playground", icon: Code },
@@ -49,12 +54,22 @@ const consoleNavItems = [
   { href: "/console/usage", label: "Usage & Metrics", icon: BarChart3 },
   { href: "/console/performance", label: "Performance", icon: Activity },
   { href: "/console/insights", label: "AI Insights", icon: Sparkles },
+  { href: "/console/analytics", label: "Analytics Studio", icon: BarChart3 },
   { href: "/console/webhooks", label: "Webhooks", icon: Webhook },
   { href: "/console/billing", label: "Billing & Plan", icon: CreditCard },
   { href: "/console/receipts", label: "Receipts", icon: Receipt },
   { href: "/console/feature-flags", label: "Feature Flags", icon: ToggleLeft },
   { href: "/console/site", label: "Site Designer", icon: Palette },
   { href: "/console/docs", label: "Docs & Examples", icon: BookOpen },
+];
+
+const enterpriseNavItems = [
+  { href: "/console/replay", label: "Replay Lab", icon: ScanSearch },
+  { href: "/console/audit-trail", label: "Audit Trail", icon: ShieldCheck },
+  { href: "/console/bulk-operations", label: "Bulk Operations", icon: ClipboardCheck },
+  { href: "/console/approvals", label: "Approvals", icon: Gavel },
+  { href: "/console/rules-engine", label: "Rules Engine", icon: Shield },
+  { href: "/console/operator", label: "Operator Console", icon: Bot },
 ];
 
 const adminNavItems = [
@@ -94,7 +109,42 @@ export function ConsoleLayout({ children }: ConsoleLayoutProps) {
           Console
         </h3>
       </div>
-      {consoleNavItems.map((item) => {
+      {coreNavItems.map((item) => {
+        const Icon = item.icon;
+        const isActive = pathname === item.href || pathname?.startsWith(item.href + "/");
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={() => setOpen(false)}
+            className={cn(
+              "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
+              isActive
+                ? "bg-electric-cyan/10 text-electric-cyan dark:bg-electric-cyan/20 dark:text-electric-cyan shadow-sm"
+                : "text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700/50 hover:translate-x-0.5"
+            )}
+          >
+            <Icon className={cn("w-5 h-5 transition-transform", isActive && "scale-110")} />
+            {item.label}
+            {isActive && (
+              <span className="ml-auto w-1.5 h-1.5 rounded-full bg-electric-cyan animate-pulse" />
+            )}
+          </Link>
+        );
+      })}
+
+      <div className="pt-4 mt-4 border-t border-slate-200 dark:border-slate-700">
+        <div className="px-3 py-2 mt-2 mb-1 flex items-center justify-between">
+          <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+            Enterprise
+          </h3>
+          <span className="text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-electric-cyan/10 text-electric-cyan">
+            Premium
+          </span>
+        </div>
+      </div>
+      {enterpriseNavItems.map((item) => {
         const Icon = item.icon;
         const isActive = pathname === item.href || pathname?.startsWith(item.href + "/");
 

--- a/reports/enterprise-console-surface-audit.md
+++ b/reports/enterprise-console-surface-audit.md
@@ -1,0 +1,73 @@
+# Enterprise Surface Audit — Console / Cloud / Web
+
+Date: 2026-03-12
+Branch: `feat/parallel-enterprise-console-surfacing`
+
+## Scope
+
+- Console navigation and discoverability (`/console/*`).
+- Console overview feature surfacing and premium differentiation.
+- Public pricing communication for premium/enterprise value.
+
+## Current-state findings (before changes)
+
+1. **Enterprise surfaces existed but were under-discoverable in console navigation.**
+   - Replay Lab, Audit Trail, Bulk Operations, Approvals, Rules Engine, and Operator Console pages existed as routes, but were not consistently surfaced in the main sidebar.
+2. **Overview page lacked a clear “enterprise capabilities” entry panel.**
+   - Core metrics were visible, but enterprise workflows (traceability/governance/operator intelligence) required route knowledge.
+3. **Pricing page communicated engagement models, but not a product-surface capability comparison.**
+   - Enterprise value language existed, but with limited mapping to real console surfaces.
+
+## Implemented upgrades
+
+1. **Console IA / navigation upgrade**
+   - Added an `Enterprise` section in the sidebar with premium callout badge.
+   - Surfaced routes:
+     - Replay Lab
+     - Audit Trail
+     - Bulk Operations
+     - Approvals
+     - Rules Engine
+     - Operator Console
+   - Added Analytics Studio to core navigation for better reporting discovery.
+
+2. **Console overview enterprise surfacing**
+   - Added an “Enterprise Capability Surfaces” card on `/console` with direct entry points to:
+     - Replay Lab
+     - Audit Trail
+     - Bulk Operations
+     - Operator Console
+   - Keeps feature claims tied to existing, routed pages.
+
+3. **Pricing communication upgrade (truthful productization)**
+   - Added a capability comparison table on `/pricing` that maps tier value to real surfaces:
+     - Replay / trace diff
+     - Bulk ops + approvals
+     - Audit trail / retention
+     - Operator control plane / failure intelligence
+   - Added direct CTA links to console and replay surfaces to reduce claim-to-proof distance.
+
+## CLI-to-UI gap notes
+
+The following capability classes are now explicitly surfaced in UI navigation and/or pricing:
+
+- Replay / deterministic traceability
+- Bulk governance operations
+- Approval workflows
+- Operator intelligence surfaces
+
+Residual gaps still not fully productized in a dedicated UI flow (recommend next track):
+
+- CLI `tenant-check` style isolation diagnostics surfaced as tenant safety scorecards in console.
+- CLI `verify-export` evidence integrity surfaced as guided verification reports in console.
+- CLI `lineage` artifacts surfaced as visual topology explorer in console.
+
+## Verification run
+
+- `pnpm -C packages/web exec eslint src/components/console/ConsoleLayout.tsx src/app/console/page.tsx src/app/pricing/page.tsx`
+- `pnpm -C packages/web typecheck`
+
+## Residual risk
+
+- Navigation additions increase route visibility but do not alter authorization semantics; route-level and API-level gating remain the enforcement boundary.
+- Pricing comparison wording remains qualitative for managed/enterprise custom contracts; this is intentional to avoid fabricating fixed contract guarantees.


### PR DESCRIPTION
### Motivation
- Improve discoverability of premium/enterprise capabilities in the Developer Console by surfacing existing, product-real routes in the primary navigation and overview UX. 
- Make pricing claims verifiable by mapping engagement tiers to real console surfaces rather than abstract wording. 
- Keep authorization and gating semantics unchanged while highlighting operator, traceability, and governance surfaces for enterprise users. 

### Description
- Add an Enterprise section to the console sidebar and surface enterprise routes (Replay Lab, Audit Trail, Bulk Operations, Approvals, Rules Engine, Operator Console) and add `Analytics Studio` to core nav in `packages/web/src/components/console/ConsoleLayout.tsx`. 
- Add an "Enterprise Capability Surfaces" card to the console overview at `/console` with direct entry buttons to Replay, Audit Trail, Bulk Operations, and Operator Console in `packages/web/src/app/console/page.tsx`. 
- Add a capability comparison table to the public pricing page that maps Self-Serve / Managed / Enterprise tiers to concrete product surfaces (replay/trace diff, bulk+approvals, audit/evidence, operator intelligence) in `packages/web/src/app/pricing/page.tsx`. 
- Include a written audit/report `reports/enterprise-console-surface-audit.md` documenting findings, implemented upgrades, CLI→UI gap notes, verification commands, and residual risk. 

### Testing
- Ran ESLint against the modified files with `pnpm -C packages/web exec eslint src/components/console/ConsoleLayout.tsx src/app/console/page.tsx src/app/pricing/page.tsx`, which ran and completed (fixes applied where appropriate). 
- Ran TypeScript typecheck with `pnpm -C packages/web typecheck` and the check completed without type errors. 
- Started the local dev server and captured screenshots of `/pricing` and `/console` via an automated Playwright script, which succeeded; the dev server emitted pre-existing environment warnings about missing Supabase vars and an Edge-runtime Node import warning that did not block rendering for the surfaced pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21363971c83289e501bb9e226bd69)