### PR TITLE
docs: add design-system integrity audit, enforcement plan, and dedup-focused component inventory

### DIFF
--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -1,432 +1,72 @@
-# Component Inventory
+# Component Inventory (Design-System Dedup Focus)
 
-This document provides a comprehensive inventory of all components in the Settler front-end, their usage, props, and standardization status.
+_Last updated: 2026-03-12_
 
-## Last Updated
-Phase 2 Front-End Overhaul - Design System Implementation
+## Objective
 
-## Core UI Components
+Inventory UI components that should converge into shared primitives for consistent behavior across console, docs, marketing, admin, and enterprise surfaces.
 
-### Button (`/src/components/ui/button.tsx`)
-**Status:** ✅ Normalized  
-**Usage:** Primary interactive element for user actions
+## Canonical library target
 
-**Props:**
-- `variant`: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'
-- `size`: 'default' | 'sm' | 'lg' | 'icon'
-- `fullWidth`: boolean
-- `asChild`: boolean (for composition)
-
-**Used in:**
-- Navigation.tsx
-- ConversionCTA.tsx
-- NewsletterSignup.tsx
-- All page components
-
-**Standardization:**
-- ✅ Consistent variants
-- ✅ Standardized sizes
-- ✅ Proper TypeScript types
-- ✅ Accessibility defaults
+Target convergence path: `packages/web/src/components/ui/*` and `packages/web/src/components/shared/*` as the primary source of reusable primitives, with `packages/react-settler/src/components/*` consuming shared tokens/variants rather than local inline style maps.
 
 ---
 
-### Input (`/src/components/ui/input.tsx`)
-**Status:** ✅ Normalized  
-**Usage:** Text input fields
+## Duplicate families and merge targets
 
-**Props:**
-- `size`: 'sm' | 'default' | 'lg'
-- `error`: boolean
-- `leftIcon`: React.ReactNode
-- `rightIcon`: React.ReactNode
-
-**Used in:**
-- NewsletterSignup.tsx
-- Forms across the application
-
-**Standardization:**
-- ✅ Consistent sizing
-- ✅ Error state support
-- ✅ Icon support
-- ✅ Accessibility defaults
+| Family               | Current duplicates                                                                                                                                                                                                                                                | Merge target                                                                                      | Priority |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------- |
+| Error Boundary       | `components/error-boundary.tsx`, `components/ui/error-boundary.tsx`, `components/shared/error-boundary.tsx`, `components/admin/error-boundary.tsx`, `components/console/ErrorBoundary.tsx`, `components/ops/ErrorBoundary.tsx`, `react-settler/ErrorBoundary.tsx` | One shared `ui/error-boundary.tsx` + thin wrappers only if context-specific messaging is required | P0       |
+| Empty State          | `components/EmptyState.tsx`, `components/shared/empty-state.tsx`, `components/ui/empty-state.tsx`, `components/console/EmptyState.tsx`                                                                                                                            | One canonical `ui/empty-state.tsx` with variant props                                             | P0       |
+| Loading              | `components/LoadingSpinner.tsx`, `components/ux/LoadingSpinner.tsx`, `components/ui/LoadingState.tsx`, `components/console/LoadingState.tsx`, `components/Skeleton.tsx`, `components/ui/skeleton.tsx`                                                             | One loading primitive family in `ui/`                                                             | P1       |
+| Progress             | `components/ProgressIndicator.tsx`, `components/feedback/ProgressIndicator.tsx`                                                                                                                                                                                   | One `ui/progress-indicator.tsx`                                                                   | P1       |
+| Comparison Table     | `components/landing/ComparisonTable.tsx`, `components/marketing/ComparisonTable.tsx`                                                                                                                                                                              | One `shared/comparison-table.tsx` + content props                                                 | P1       |
+| Rules Editor         | `components/RulesEditor.tsx`, `components/stitch-import/RulesEditor.tsx`                                                                                                                                                                                          | One tokenized editor shell + stitch adapter                                                       | P1       |
+| Social Proof Counter | `components/SocialProofCounter.tsx`, `components/marketing/SocialProofCounter.tsx`                                                                                                                                                                                | One animated/stat counter primitive                                                               | P2       |
 
 ---
 
-### Card (`/src/components/ui/card.tsx`)
-**Status:** ✅ Normalized  
-**Usage:** Container component for grouped content
+## Shared primitives status
 
-**Props:**
-- `elevation`: 'none' | 'sm' | 'default' | 'lg'
-- `hover`: boolean
+## Buttons
 
-**Sub-components:**
-- `CardHeader`
-- `CardTitle`
-- `CardDescription`
-- `CardContent`
-- `CardFooter`
+- Current state: multiple button-like implementations still use custom wrappers/inline styles outside `ui/button` patterns.
+- Required: enforce a single button variant matrix (size, tone, intent, loading state).
 
-**Used in:**
-- ConversionCTA.tsx
-- NewsletterSignup.tsx
-- Dashboard components
-- Feature cards
+## Cards
 
-**Standardization:**
-- ✅ Consistent elevation system
-- ✅ Composable sub-components
-- ✅ Proper semantic HTML
+- Current state: repeated `rounded + border + shadow` combinations with different values per feature.
+- Required: one `SurfaceCard` primitive with semantic variants (`default`, `interactive`, `critical`, `elevated`).
 
----
+## Tables
 
-### Badge (`/src/components/ui/badge.tsx`)
-**Status:** ✅ Normalized  
-**Usage:** Status indicators, labels, tags
+- Current state: mixed table structures (Tailwind tables, inline-styled tables, stitch-derived shells, virtualized table variants).
+- Required: one `DataTableShell` + optional virtualization adapter.
 
-**Props:**
-- `variant`: 'default' | 'secondary' | 'destructive' | 'outline' | 'success' | 'warning'
-- `size`: 'sm' | 'default' | 'lg'
+## Badges / Alerts
 
-**Used in:**
-- Status indicators
-- Feature tags
-- Version badges
+- Current state: consistent enough in tokenized pages, but variants drift in stitch-import and explainers.
+- Required: strict semantic variants only (`info`, `success`, `warning`, `error`, `neutral`).
 
-**Standardization:**
-- ✅ Consistent variants
-- ✅ Standardized sizes
-- ✅ Semantic colors
+## Navigation
+
+- Current state: tenant-aware and console-specific navigation patterns exist, but color/theme handling still uses hardcoded fallback literals in places.
+- Required: central nav theming contract bound to semantic token aliases.
 
 ---
 
-### Select (`/src/components/ui/select.tsx`)
-**Status:** ✅ Normalized  
-**Usage:** Dropdown selection inputs
+## Known high-risk divergence zones
 
-**Props:**
-- `onValueChange`: (value: string) => void
-
-**Sub-components:**
-- `SelectTrigger`
-- `SelectValue`
-- `SelectContent`
-- `SelectItem`
-
-**Used in:**
-- Form components
-- Filter components
-
-**Standardization:**
-- ✅ Consistent API
-- ✅ Composable structure
+1. `packages/react-settler/src/components/*` (inline-style heavy, token bypass risk).
+2. `packages/web/src/components/stitch-import/*` (export-faithful visuals with literal values).
+3. `ui/explainers/*` (hardcoded colors/borders not tied to token semantics).
 
 ---
 
-### Table (`/src/components/ui/table.tsx`)
-**Status:** ✅ New Component  
-**Usage:** Data tables and lists
-
-**Props:**
-- `striped`: boolean
-- `hover`: boolean
-- `size`: 'sm' | 'default' | 'lg'
-
-**Sub-components:**
-- `TableHeader`
-- `TableBody`
-- `TableFooter`
-- `TableHead`
-- `TableRow`
-- `TableCell`
-- `TableCaption`
-
-**Used in:**
-- Data displays
-- Transaction tables
-- Dashboard tables
-
-**Standardization:**
-- ✅ Consistent structure
-- ✅ Accessibility defaults
-
----
-
-### Modal (`/src/components/ui/modal.tsx`)
-**Status:** ✅ New Component  
-**Usage:** Dialog modals and overlays
-
-**Props:**
-- `open`: boolean
-- `onClose`: () => void
-- `title`: string
-- `description`: string
-- `size`: 'sm' | 'default' | 'lg' | 'xl' | 'full'
-- `showCloseButton`: boolean
-- `closeOnBackdropClick`: boolean
-- `closeOnEscape`: boolean
-
-**Used in:**
-- Confirmation dialogs
-- Form modals
-- Detail views
-
-**Standardization:**
-- ✅ Accessibility defaults
-- ✅ Keyboard navigation
-- ✅ Focus management
-
----
-
-### Loading (`/src/components/ui/loading.tsx`)
-**Status:** ✅ New Component  
-**Usage:** Loading states and skeletons
-
-**Props:**
-- `size`: 'sm' | 'default' | 'lg'
-- `text`: string
-- `showSpinner`: boolean
-- `fullScreen`: boolean
-
-**Sub-components:**
-- `Skeleton`
-
-**Used in:**
-- Data fetching states
-- Form submission states
-- Page loading states
-
-**Standardization:**
-- ✅ Consistent loading indicators
-- ✅ Accessible loading states
-
----
-
-### EmptyState (`/src/components/ui/empty-state.tsx`)
-**Status:** ✅ New Component  
-**Usage:** Empty state displays
-
-**Props:**
-- `icon`: React.ReactNode
-- `iconVariant`: 'default' | 'search' | 'inbox' | 'alert'
-- `title`: string
-- `description`: string
-- `action`: { label: string; onClick: () => void; variant?: ButtonProps['variant'] }
-- `secondaryAction`: { label: string; onClick: () => void; variant?: ButtonProps['variant'] }
-
-**Used in:**
-- Empty lists
-- No results states
-- Error recovery
-
-**Standardization:**
-- ✅ Consistent empty states
-- ✅ Action support
-
----
-
-### ErrorBoundary (`/src/components/ui/error-boundary.tsx`)
-**Status:** ✅ New Component  
-**Usage:** Error boundary wrapper
-
-**Props:**
-- `children`: React.ReactNode
-- `fallback`: React.ComponentType<ErrorFallbackProps>
-- `onError`: (error: Error, errorInfo: React.ErrorInfo) => void
-
-**Used in:**
-- Page-level error handling
-- Component error recovery
-
-**Standardization:**
-- ✅ Consistent error handling
-- ✅ User-friendly error display
-
----
-
-## Design System Components
-
-### Container (`/src/design-system/components/Container.tsx`)
-**Status:** ✅ New Component  
-**Usage:** Page container with max-width and padding
-
-**Props:**
-- `maxWidth`: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full'
-- `padding`: 'none' | 'sm' | 'default' | 'lg'
-- `center`: boolean
-
-**Used in:**
-- Page layouts
-- Section containers
-
----
-
-### Section (`/src/design-system/components/Section.tsx`)
-**Status:** ✅ New Component  
-**Usage:** Page sections with consistent spacing
-
-**Props:**
-- `padding`: 'none' | 'sm' | 'default' | 'lg' | 'xl'
-- `background`: 'default' | 'muted' | 'accent' | 'transparent'
-- `container`: boolean
-- `containerProps`: ContainerProps
-- `as`: 'section' | 'div' | 'article' | 'aside' | 'header' | 'footer' | 'main'
-
-**Used in:**
-- Page sections
-- Content blocks
-
----
-
-### Textarea (`/src/design-system/components/Textarea.tsx`)
-**Status:** ✅ New Component  
-**Usage:** Multi-line text input
-
-**Props:**
-- `size`: 'sm' | 'default' | 'lg'
-- `error`: boolean
-
-**Used in:**
-- Form components
-- Comment inputs
-
----
-
-### Heading (`/src/design-system/components/Heading.tsx`)
-**Status:** ✅ New Component  
-**Usage:** Semantic headings with consistent styling
-
-**Props:**
-- `level`: 1 | 2 | 3 | 4 | 5 | 6
-- `size`: 'xs' | 'sm' | 'base' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl'
-- `weight`: 'normal' | 'medium' | 'semibold' | 'bold' | 'extrabold'
-- `align`: 'left' | 'center' | 'right'
-
-**Used in:**
-- Page headings
-- Section titles
-
----
-
-## Specialized Components
-
-### Navigation (`/src/components/Navigation.tsx`)
-**Status:** ⚠️ Needs Refactoring  
-**Usage:** Main site navigation
-
-**Issues:**
-- Ad-hoc styling (gradient classes)
-- Should use design tokens
-- Mobile menu could be extracted
-
-**Recommendations:**
-- Extract mobile menu to separate component
-- Use design token colors instead of hardcoded gradients
-- Normalize link styling
-
----
-
-### ConversionCTA (`/src/components/ConversionCTA.tsx`)
-**Status:** ⚠️ Needs Refactoring  
-**Usage:** Call-to-action sections
-
-**Issues:**
-- Ad-hoc gradient styling
-- Multiple variants with duplicated code
-- Should use design tokens
-
-**Recommendations:**
-- Extract gradient variant to design tokens
-- Consolidate variant logic
-- Use normalized Button component
-
----
-
-### NewsletterSignup (`/src/components/NewsletterSignup.tsx`)
-**Status:** ✅ Refactored  
-**Usage:** Newsletter subscription form
-
-**Improvements:**
-- ✅ Uses normalized Input component
-- ✅ Uses design token colors
-- Still uses gradient Card (acceptable for this use case)
-
----
-
-## Component Statistics
-
-- **Total Components:** 47 TSX files
-- **Total Lines:** ~6,400 lines
-- **Normalized Components:** 15+
-- **Components Needing Refactoring:** ~10
-- **New Components Created:** 8
-
-## Standardization Status
-
-### ✅ Fully Normalized
-- Button
-- Input
-- Card
-- Badge
-- Select
-- Label
-- Checkbox
-- Tabs
-- Table
-- Modal
-- Loading
-- EmptyState
-- ErrorBoundary
-- Container
-- Section
-- Textarea
-- Heading
-
-### ⚠️ Partially Normalized
-- Navigation
-- ConversionCTA
-- NewsletterSignup (recently refactored)
-
-### 📋 Pending Review
-- AnimatedCodeBlock
-- AnimatedCounter
-- AnimatedFAQ
-- AnimatedFeatureCard
-- AnimatedHero
-- AnimatedPageWrapper
-- AnimatedPricingCard
-- AnimatedSidebar
-- AnimatedStatCard
-- AuditTrail
-- Dashboard
-- ExceptionQueue
-- FeatureComparison
-- Footer
-- OnboardingFlow
-- Playground
-- RulesEditor
-- SecureMobileApp
-- SEOHead
-- SocialProof
-- StatsSection
-- StructuredData
-- TrustBadges
-
-## Usage Guidelines
-
-1. **Always use normalized components** from `/src/components/ui` or `/src/design-system/components`
-2. **Use design tokens** from `/src/design-system/tokens.ts` for colors, spacing, typography
-3. **Follow component prop APIs** as documented above
-4. **Ensure accessibility** - all interactive components have proper ARIA labels and keyboard navigation
-5. **Use semantic HTML** - prefer semantic elements over divs where appropriate
-
-## Migration Path
-
-For components marked as "Needs Refactoring":
-1. Replace ad-hoc styling with design tokens
-2. Use normalized UI components
-3. Extract repeated patterns into reusable components
-4. Ensure TypeScript types are complete
-5. Add accessibility attributes
-6. Update this inventory
+## Merge sequencing
+
+1. **P0:** ErrorBoundary + EmptyState family consolidation.
+2. **P1:** Loading/Progress/Table/Card primitive normalization.
+3. **P1:** Stitch-import adapter layer conversion to canonical primitives.
+4. **P2:** Marketing duplicate consolidation (comparison/stat counters).
+5. **P2:** `react-settler` adoption of shared token contract and optional CSS-variable bridge.

--- a/docs/design-system-audit.md
+++ b/docs/design-system-audit.md
@@ -1,0 +1,130 @@
+# Design System Integrity Audit
+
+_Last updated: 2026-03-12_
+
+## Scope
+
+Audit performed across the web UI surfaces in this repository:
+
+- **Console / in-product app routes** (`packages/web/src/app/console/**`, `packages/web/src/app/app/**`)
+- **Docs routes** (`packages/web/src/app/docs/**`)
+- **Marketing routes/components** (`packages/web/src/app/(marketing)/**`, `packages/web/src/components/marketing/**`)
+- **Admin/operations components** (`packages/web/src/components/admin/**`, `packages/web/src/components/ops/**`)
+- **Enterprise/dashboard surfaces** (`packages/web/src/app/dashboard/**`, `packages/web/src/app/investor/**`)
+- **Shared UI and SDK-facing React UI** (`packages/web/src/components/**`, `packages/react-settler/src/components/**`, `ui/explainers/**`)
+
+---
+
+## Phase 1 — Token Discovery (Current State)
+
+## Canonical token sources found
+
+1. `design-system/css-tokens.css` defines the canonical CSS-variable token system and explicitly declares itself as the single source of truth.
+2. `packages/web/src/app/globals.css` imports canonical tokens and layers Tailwind/component utilities.
+3. `packages/web/tailwind.config.js` maps utilities to CSS-variable tokens.
+4. `design-system/tokens.json` and `design/tokens.json` both exist as JSON token definitions.
+
+## Token drift found
+
+Multiple parallel token systems are active:
+
+- `design-system/tokens.json` (blue-first palette)
+- `design-system/css-tokens.css` (teal/dark-first canonical CSS vars)
+- `packages/web/src/design-system/tokens.ts` (electric token set with additional values)
+- `packages/web/src/lib/readylayer/themes.ts` (provider/theme constants with hardcoded hex)
+- `packages/web/src/lib/tenant/colorTokens.ts` (hardcoded defaults + dynamic RGB generation)
+
+**Conclusion:** token intent is centralized, but implementation is fragmented across CSS vars, JSON tokens, and TypeScript token maps.
+
+---
+
+## Phase 2 — Token Usage Audit (Violations)
+
+Automated static scan of UI code found significant non-token usage in key surfaces.
+
+## Violation summary (counts)
+
+| Surface              | Hex literals | rgba/hsl literals | Custom shadow expressions | Inline style blocks |
+| -------------------- | -----------: | ----------------: | ------------------------: | ------------------: |
+| Console              |           15 |                 0 |                         1 |                  15 |
+| Docs                 |            0 |                 0 |                         0 |                   1 |
+| Marketing            |            0 |                 1 |                         0 |                  10 |
+| Admin                |            0 |                 0 |                         0 |                   2 |
+| Enterprise/dashboard |            0 |                 0 |                         0 |                   2 |
+| Shared/platform-wide |          238 |                41 |                         9 |                 210 |
+
+## High-signal violation locations
+
+- `packages/web/src/app/console/site/branding/page.tsx` (hardcoded brand defaults and inline style-heavy form)
+- `packages/web/src/components/stitch-import/*` (hardcoded colors and ad-hoc visual styles in imported panels)
+- `packages/web/src/components/ui/SpotlightCard.tsx` and `RippleButton.tsx` (hardcoded rgba defaults)
+- `packages/react-settler/src/components/*` (extensive inline styles with hardcoded spacing/border/color)
+- `ui/explainers/*` (literal color palette and border tokens in inline style)
+
+---
+
+## Phase 3 — Component Deduplication Findings
+
+Duplicate components exist with divergent implementations and naming conventions.
+
+### Duplicate component families detected
+
+- **Error boundaries:** `error-boundary.tsx`, `ErrorBoundary.tsx` variants across `ui`, `shared`, `admin`, `console`, `ops`, and `react-settler`
+- **Empty states:** `EmptyState.tsx`, `empty-state.tsx` in multiple domains
+- **Loading patterns:** `LoadingSpinner.tsx`, `LoadingState.tsx`, `Skeleton.tsx`
+- **Progress indicators:** top-level and feature-local variants
+- **Rules/Comparison tables:** duplicated in landing/marketing and stitch-import/top-level implementations
+
+**Conclusion:** design primitives are not yet universally consumed; local copies proliferate across product domains.
+
+---
+
+## Phase 4 — Layout Normalization Findings
+
+Layout conventions are inconsistent:
+
+- Mixed container widths and ad-hoc paddings in page-level route files
+- Repeated custom card wrappers with different radius/shadow/border semantics
+- Typography hierarchy partly normalized via base styles, but frequently overridden via route-local classes and inline styles
+
+### Needed normalized primitives
+
+- `PageContainer` (`max-w`, responsive horizontal padding)
+- `PageSection` (standardized section spacing)
+- `SurfaceCard` (single border/radius/shadow profile)
+- `DataTableShell` (shared table container/header/body spacing)
+
+---
+
+## Phase 5 — Stitch Screen Validation
+
+Stitch export assets were found under `_import/stitch_panels/**` and consumed through `packages/web/src/components/stitch-import/**`.
+
+Validation result:
+
+- Stitch-derived surfaces are present.
+- They currently preserve many literal visual values from export code.
+- They are **not yet fully normalized** onto the canonical token set used by `globals.css` + Tailwind mapping.
+
+---
+
+## Phase 6 — Token Migration Status
+
+Migration is **partial**:
+
+- Base web shell and many Tailwind paths use tokenized values.
+- Significant portions of console branding, stitch-import components, reusable SDK UI (`react-settler`), and explainers still use hardcoded values.
+
+No broad-risk mass refactor was applied in this audit pass; instead this report defines precise enforcement and migration sequencing in `docs/token-enforcement-plan.md`.
+
+---
+
+## Phase 7 — End-State Definition (Acceptance)
+
+Design system integrity is considered complete when:
+
+1. All app surfaces consume one canonical token source (CSS vars + generated typed bindings).
+2. New raw color/shadow/spacing literals are blocked in CI for UI code.
+3. Shared primitives own button/card/table/badge/alert/navigation behaviors.
+4. Stitch-import screens are mapped to semantic tokens, not preserved literals.
+5. Visual QA passes for representative routes in console, docs, marketing, admin, and enterprise dashboards.

--- a/docs/token-enforcement-plan.md
+++ b/docs/token-enforcement-plan.md
@@ -1,0 +1,94 @@
+# Token Enforcement Plan
+
+_Last updated: 2026-03-12_
+
+## Goal
+
+Make token usage deterministic and enforceable so all UI surfaces render from one visual language.
+
+## Non-goals
+
+- No large, high-risk visual rewrites in one batch.
+- No deletion of feature behavior to force visual consistency.
+
+---
+
+## Enforcement architecture
+
+## 1) Canonical source contract
+
+- Keep `design-system/css-tokens.css` as the runtime source of truth.
+- Generate typed token bindings for TS/TSX consumers from that source (build-time artifact).
+- Treat `design-system/tokens.json`, `design/tokens.json`, and `packages/web/src/design-system/tokens.ts` as derived artifacts or deprecate duplicates.
+
+## 2) CI static policy
+
+Introduce repo checks that fail on non-token style literals in UI paths:
+
+- Block raw hex colors in UI TSX/CSS except approved token definition files.
+- Block inline style color/border/shadow literals outside explicit allowlist files.
+- Block arbitrary Tailwind color/shadow values (`bg-[#...]`, `shadow-[...]`) unless tokenized indirection is used.
+
+## 3) Shared primitive policy
+
+New page/component work must use shared primitives for:
+
+- button
+- card
+- table
+- badge
+- alert
+- empty/error/loading states
+- page container/section wrappers
+
+Any exception must include rationale and expiry date in code comments.
+
+---
+
+## Migration plan (phased)
+
+## Phase A (P0, immediate)
+
+1. Consolidate ErrorBoundary and EmptyState families.
+2. Normalize console branding defaults to semantic token aliases rather than route-local hex literals.
+3. Add CI audit script + baseline file for controlled rollout.
+
+## Phase B (P1)
+
+1. Migrate stitch-import components to tokenized primitives (`SurfaceCard`, semantic badges/alerts, standardized tables).
+2. Replace custom shadow/border literals with token aliases.
+3. Standardize page layout wrappers across console/docs/marketing/dashboard.
+
+## Phase C (P1/P2)
+
+1. Migrate `react-settler` inline-style components to token variables or shared primitives.
+2. Migrate `ui/explainers` to token-aware styles.
+3. Remove duplicate token maps and enforce generated bindings.
+
+## Phase D (P2 hardening)
+
+1. Add visual regression coverage for representative routes by surface.
+2. Add “token drift” report in CI artifact output.
+3. Require design-system approval for new primitive variants.
+
+---
+
+## Verification matrix
+
+Each migration batch should prove:
+
+- **Lint/type/build pass** for touched packages.
+- **UI token policy checks pass** (no new hardcoded literals).
+- **Route smoke pass** for affected surfaces.
+- **Visual snapshot diff reviewed** for meaningful UI pages.
+- **Graceful degradation preserved** (no route hard-500 behavior introduced).
+
+---
+
+## Residual risk
+
+- Legacy surfaces with inline styles may pass functional tests but still violate visual consistency.
+- Tenant/theme customization paths can reintroduce literal values unless constrained by typed token APIs.
+- Stitch-import refreshes may reintroduce export literals without adapter-level guards.
+
+Mitigation: enforce policy at CI + adapter boundaries, not only at manual review.


### PR DESCRIPTION
### Motivation

- Establish a single, auditable picture of token sources and token drift across the repo to enable deterministic design-system rollouts.  
- Surface concrete violations (hardcoded colors, inline styles, custom shadows) and duplicate component families so migration work can be planned safely.  
- Provide an actionable, phased enforcement plan that can be automated in CI to stop further drift and guide incremental migration.

### Description

- Added `docs/design-system-audit.md` containing a 7-phase audit across Console, Docs, Marketing, Admin, Enterprise, and shared UI surfaces summarizing canonical token sources, token drift, violation counts, component-duplication findings, stitch-import validation, and an acceptance end-state.  
- Added `docs/token-enforcement-plan.md` that defines the canonical contract (`design-system/css-tokens.css`), CI static policy rules (block raw hex, inline style literals, ad-hoc Tailwind values), shared-primitive requirements, and a phased migration/verification matrix.  
- Replaced the prior `docs/component-inventory.md` with a deduplication-focused inventory that lists duplicate component families, merge targets, priorities, and a recommended merge sequencing.  
- Applied repository formatting to the new/modified docs using `prettier` and committed the changes; commit includes automated pre-commit checks executed by lint-staged.

### Testing

- Ran formatting and validation: `pnpm prettier --write docs/design-system-audit.md docs/component-inventory.md docs/token-enforcement-plan.md` (succeeded) and `pnpm prettier --check docs/design-system-audit.md docs/component-inventory.md docs/token-enforcement-plan.md` (succeeded).  
- Commit-time hooks executed `node scripts/check-conflict-markers.mjs` to verify no unresolved merge markers (passed) and ran `lint-staged` which applied `prettier` to staged MD files (passed).  
- No behavioral code changes were made; no unit or UI tests were altered in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b214b50e848328897375d9a14285fa)