### PR TITLE
docs: add go-live env matrix, production env template, and operator runbooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # NEVER commit .env files with real secrets to version control
 # 
 # This file documents ALL environment variables used across the platform.
-# See config/env.schema.ts for detailed specifications.
+# See packages/api/src/config/validation.ts and docs/setup/env-matrix.md for detailed specifications.
 # ============================================================================
 
 # ----------------------------------------------------------------------------

--- a/.env.example.integrations
+++ b/.env.example.integrations
@@ -1,88 +1,32 @@
-# Integration Connectors - Environment Variables
-# Copy these to your .env.local file
+# Integration / Enterprise Environment Variables
+# Copy selected keys into `.env.local` or deployment env.
+# This file intentionally includes only keys that are referenced in runtime code.
 
-# Supabase (Required)
+# Core Supabase integration keys
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_URL=https://your-project.supabase.co
 
-# JobForge (Integration gating)
+# JobForge feature gates (off by default)
 JOBFORGE_INTEGRATION_ENABLED=false
 JOBFORGE_BUNDLE_EXECUTION_ENABLED=false
 
-# Credential Encryption (Required for production)
-CREDENTIAL_ENCRYPTION_KEY=your-32-byte-hex-encryption-key
-# Or use Supabase Vault
-SUPABASE_VAULT_KEY=your-vault-key
+# Credential encryption (required if storing third-party credentials)
+# Prefer CREDENTIAL_ENCRYPTION_KEY; SUPABASE_VAULT_KEY is fallback.
+CREDENTIAL_ENCRYPTION_KEY=replace-with-strong-secret
+SUPABASE_VAULT_KEY=optional-vault-fallback-secret
 
-# Plaid (Bank Feeds - North America)
-PLAID_CLIENT_ID=your-plaid-client-id
-PLAID_SECRET=your-plaid-secret
-PLAID_ENVIRONMENT=sandbox
-PLAID_WEBHOOK_SECRET=your-webhook-secret
+# Connector runtime controls
+CONNECTOR_TIMEOUT_MS=30000
+CONNECTOR_ALLOW_WALL_CLOCK_TIME=0
 
-# TrueLayer (Bank Feeds - EU/UK)
-TRUELAYER_CLIENT_ID=your-truelayer-client-id
-TRUELAYER_CLIENT_SECRET=your-truelayer-client-secret
-TRUELAYER_ENVIRONMENT=sandbox
-TRUELAYER_WEBHOOK_SECRET=your-webhook-secret
+# Optional webhook channel for alert fanout
+ALERT_WEBHOOK_URL=
 
-# FreshBooks (Accounting)
-FRESHBOOKS_CLIENT_ID=your-freshbooks-client-id
-FRESHBOOKS_CLIENT_SECRET=your-freshbooks-client-secret
-
-# Wave (Accounting)
-WAVE_API_KEY=your-wave-api-key
-WAVE_BUSINESS_ID=your-business-id
-
-# Chargebee (Subscription Billing)
-CHARGEBEE_API_KEY=your-chargebee-api-key
-CHARGEBEE_SITE=your-site-name
-CHARGEBEE_WEBHOOK_SECRET=your-webhook-secret
-
-# Recurly (Subscription Billing)
-RECURLY_API_KEY=your-recurly-api-key
-RECURLY_SUBDOMAIN=your-subdomain
-RECURLY_WEBHOOK_SECRET=your-webhook-secret
-
-# Stripe Connect (Marketplaces)
-STRIPE_CONNECT_CLIENT_ID=your-stripe-connect-client-id
-STRIPE_CONNECT_CLIENT_SECRET=your-stripe-connect-client-secret
-STRIPE_CONNECT_WEBHOOK_SECRET=your-webhook-secret
-
-# Amazon Seller (Marketplaces)
-AMAZON_SP_API_CLIENT_ID=your-sp-api-client-id
-AMAZON_SP_API_CLIENT_SECRET=your-sp-api-client-secret
-AMAZON_SP_API_REFRESH_TOKEN=your-refresh-token
-AMAZON_SP_API_ROLE_ARN=your-role-arn
-
-# Etsy (Marketplaces)
-ETSY_CLIENT_ID=your-etsy-client-id
-ETSY_CLIENT_SECRET=your-etsy-client-secret
-
-# eBay (Marketplaces)
-EBAY_CLIENT_ID=your-ebay-client-id
-EBAY_CLIENT_SECRET=your-ebay-client-secret
-EBAY_ENVIRONMENT=sandbox
-
-# NetSuite (ERP)
-NETSUITE_ACCOUNT_ID=your-account-id
-NETSUITE_CONSUMER_KEY=your-consumer-key
-NETSUITE_CONSUMER_SECRET=your-consumer-secret
-NETSUITE_TOKEN_ID=your-token-id
-NETSUITE_TOKEN_SECRET=your-token-secret
-NETSUITE_ENVIRONMENT=production
-
-# SAP (ERP)
-SAP_ODATA_URL=https://your-sap-server.com/sap/opu/odata
-SAP_USERNAME=your-username
-SAP_PASSWORD=your-password
-SAP_CLIENT=your-client-number
-
-# Avalara (Tax)
-AVALARA_ACCOUNT_ID=your-account-id
-AVALARA_LICENSE_KEY=your-license-key
-AVALARA_ENVIRONMENT=sandbox
-
-# TaxJar (Tax)
-TAXJAR_API_KEY=your-taxjar-api-key
-TAXJAR_ENVIRONMENT=sandbox
+# Optional provider keys currently read by API integration services/routes
+QB_CLIENT_ID=
+QB_CLIENT_SECRET=
+QB_REALM_ID=
+SHOPIFY_API_KEY=
+PAYPAL_CLIENT_ID=
+STRIPE_SECRET_KEY=

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,36 @@
+# Settler production environment baseline
+NODE_ENV=production
+DEPLOYMENT_ENV=production
+PORT=3000
+HOST=0.0.0.0
+
+# Required core secrets
+DATABASE_URL=postgresql://user:password@host:5432/settler
+JWT_SECRET=replace-with-strong-random-32-plus
+ENCRYPTION_KEY=replace-with-exactly-32-chars
+
+# Supabase
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=replace-with-anon-key
+SUPABASE_SERVICE_ROLE_KEY=replace-with-service-role-key
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=replace-with-anon-key
+
+# Security hardening
+ALLOWED_ORIGINS=https://app.your-domain.com
+SECURE_COOKIES=true
+TRUST_PROXY=true
+
+# Optional but recommended operational services
+REDIS_URL=rediss://default:password@host:6379
+SENTRY_DSN=
+RESEND_API_KEY=
+
+# Billing (only when billing is enabled)
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# Kernel rollout controls (optional)
+# SETTLER_KERNEL_ENABLED=1
+# SETTLER_KERNEL_CANONICALIZE=1
+# SETTLER_KERNEL_EXECUTION_MODE=shadow

--- a/docs/setup/deployment-readiness.md
+++ b/docs/setup/deployment-readiness.md
@@ -1,0 +1,60 @@
+# Deployment Readiness (Operator Truth)
+
+This document defines the minimum verifiable path to deploy Settler without hidden assumptions.
+
+## 1) Preconditions
+
+- Node `>=22` and pnpm `>=10.13.1`.
+- Postgres/Supabase credentials available.
+- Vercel and Supabase CI credentials available if using GitHub Actions deployments.
+
+## 2) Local readiness
+
+1. Copy env template:
+   - `cp .env.local.example .env.local`
+2. Fill required local keys:
+   - `DATABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+3. Install and verify baseline:
+   - `pnpm install --frozen-lockfile`
+   - `pnpm lint && pnpm typecheck && pnpm build`
+4. Start stack:
+   - `pnpm dev:stack`
+
+## 3) CI readiness
+
+Ensure GitHub secrets are populated for workflows you intend to run:
+
+- Build/deploy: `TURBO_TOKEN`, `TURBO_TEAM`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
+- Supabase migration: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_REF`, `SUPABASE_DB_PASSWORD`, `DATABASE_URL`
+- Billing: `STRIPE_SECRET_KEY` (and webhook secret when webhook verification is tested)
+
+## 4) Staging/production runtime readiness
+
+### Mandatory before production cutover
+
+- `JWT_SECRET` is strong/non-default.
+- `ENCRYPTION_KEY` is exactly 32 chars.
+- `ALLOWED_ORIGINS` is restricted (not `*`).
+- `DATABASE_URL` points to production DB.
+- `SUPABASE_SERVICE_ROLE_KEY` set for privileged API jobs.
+
+### Conditional by feature
+
+- Billing: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`
+- Email: `RESEND_API_KEY`, sender fields
+- Redis-backed performance/rate-limit path: `REDIS_URL` or Upstash pair
+- Enterprise adapter credential crypto: `CREDENTIAL_ENCRYPTION_KEY` or `SUPABASE_VAULT_KEY`
+
+## 5) Rollback posture
+
+- Kernel emergency disable: set `SETTLER_DISABLE_KERNEL=1`.
+- Kernel shadow mode: set `SETTLER_KERNEL_EXECUTION_MODE=shadow`.
+- Disable specific kernel operations: `SETTLER_DISABLE_OPERATION=<comma-separated-ops>`.
+
+## 6) Misconfiguration behavior to expect
+
+- API env validation throws on critical prod key violations (`JWT_SECRET`, `ENCRYPTION_KEY`, `DB_PASSWORD` placeholder state).
+- Web Supabase client bootstrap throws when public Supabase env is absent.
+- Billing webhook verification fails closed when webhook secret is missing.

--- a/docs/setup/enterprise-enablement.md
+++ b/docs/setup/enterprise-enablement.md
@@ -1,0 +1,23 @@
+# Enterprise Enablement
+
+This file documents enterprise/premium-only env controls that are active in code.
+
+## Required for enterprise integrations
+
+- `JOBFORGE_INTEGRATION_ENABLED=1`
+- `JOBFORGE_BUNDLE_EXECUTION_ENABLED=1` (only if bundle execution is intended)
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `CREDENTIAL_ENCRYPTION_KEY` **or** `SUPABASE_VAULT_KEY`
+
+## Optional but common for enterprise operations
+
+- `SETTLER_OPERATOR_INTELLIGENCE_PROVIDER_MODULE`
+- `SETTLER_OPERATOR_API_KEY`
+- Alert channel hooks (`SLACK_ALERT_WEBHOOK_URL`, `TEAMS_ALERT_WEBHOOK_URL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`)
+
+## Security expectations
+
+- Do not enable JobForge flags without credential encryption keying.
+- Keep service-role keys out of `NEXT_PUBLIC_*` scope.
+- For multi-tenant safety, keep schema and tenant controls aligned with verified migration state before enabling tenant-specific schema behavior.

--- a/docs/setup/env-matrix.md
+++ b/docs/setup/env-matrix.md
@@ -1,0 +1,73 @@
+# Settler Environment and Secret Matrix (Go-Live Truth)
+
+This matrix is the operator-facing source of truth for runtime configuration.
+It is based on active code references in `packages/api`, `packages/web`, `packages/cli`, `packages/adapters`, and CI workflows.
+
+## Legend
+
+- **Required**: `yes`, `no`, or `conditional`
+- **Scope**: `local`, `ci`, `staging`, `prod`, `enterprise`
+- **Sensitivity**: `public`, `internal`, `secret`
+
+## Core runtime (API/Web)
+
+| Name                            | Required           | Scope                     | Subsystem             | Default / fallback if absent                                                        | Safe fallback    | Sensitivity | Example format                                      |
+| ------------------------------- | ------------------ | ------------------------- | --------------------- | ----------------------------------------------------------------------------------- | ---------------- | ----------- | --------------------------------------------------- |
+| `NODE_ENV`                      | no                 | local, ci, prod           | runtime               | defaults to `development` in API validation                                         | yes              | internal    | `production`                                        |
+| `PORT`                          | no                 | local, prod               | api/web server        | defaults to `3000`                                                                  | yes              | internal    | `4000`                                              |
+| `HOST`                          | no                 | local, prod               | api server            | defaults to `0.0.0.0`                                                               | yes              | internal    | `0.0.0.0`                                           |
+| `DATABASE_URL`                  | conditional        | local, ci, prod           | database              | required by migration and DB scripts if Supabase URL fallback is unavailable        | partial          | secret      | `postgresql://user:pass@host:5432/db`               |
+| `DIRECT_URL`                    | no                 | ci, prod                  | migrations            | optional direct DB path for Prisma/migration operations                             | yes              | secret      | `postgresql://...`                                  |
+| `SUPABASE_URL`                  | conditional        | local, ci, prod           | auth/database         | used as primary Supabase URL; many scripts fallback from `NEXT_PUBLIC_SUPABASE_URL` | partial          | internal    | `https://project.supabase.co`                       |
+| `SUPABASE_ANON_KEY`             | conditional        | local, ci, prod           | auth/client bootstrap | used by API/web and CI; web can also use `NEXT_PUBLIC_SUPABASE_ANON_KEY`            | partial          | public      | `eyJ...`                                            |
+| `SUPABASE_SERVICE_ROLE_KEY`     | conditional        | ci, staging, prod         | server-side Supabase  | no safe fallback for privileged operations                                          | no               | secret      | `eyJ...`                                            |
+| `NEXT_PUBLIC_SUPABASE_URL`      | yes (web)          | local, ci, prod           | web client            | web validator throws if missing unless alternate server-only flow                   | no               | public      | `https://project.supabase.co`                       |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | yes (web)          | local, ci, prod           | web client            | web validator throws if missing unless alternate server-only flow                   | no               | public      | `eyJ...`                                            |
+| `JWT_SECRET`                    | yes (prod runtime) | prod                      | auth                  | API validation rejects insecure/default values in production                        | no               | secret      | `base64-or-random-32+`                              |
+| `JWT_REFRESH_SECRET`            | no                 | prod                      | auth                  | falls back to `JWT_SECRET` in validated config                                      | yes              | secret      | `base64-or-random-32+`                              |
+| `ENCRYPTION_KEY`                | yes (prod runtime) | prod                      | encryption            | API validation rejects non-32-char key in production                                | no               | secret      | `32-char-string`                                    |
+| `ALLOWED_ORIGINS`               | conditional        | prod                      | api security          | defaults to `*`; API warns in production                                            | partial          | internal    | `https://app.example.com,https://admin.example.com` |
+| `REDIS_URL`                     | conditional        | staging, prod             | cache/rate-limit      | local fallbacks (`REDIS_HOST`, etc.) exist; some workloads degrade without Redis    | partial          | secret      | `rediss://default:pass@host:6379`                   |
+| `UPSTASH_REDIS_REST_URL`        | no                 | ci, prod                  | upstash rest          | if absent, code can use `REDIS_URL`/`REDIS_TOKEN`                                   | yes              | internal    | `https://<db>.upstash.io`                           |
+| `UPSTASH_REDIS_REST_TOKEN`      | no                 | ci, prod                  | upstash rest          | if absent, code can use `REDIS_TOKEN`                                               | partial          | secret      | `AXXXXX`                                            |
+| `STRIPE_SECRET_KEY`             | conditional        | staging, prod, enterprise | billing               | billing routes become non-operational without it                                    | no for billing   | secret      | `sk_live_...`                                       |
+| `STRIPE_WEBHOOK_SECRET`         | conditional        | staging, prod             | billing webhooks      | webhook signature verification fails without it                                     | no for webhooks  | secret      | `whsec_...`                                         |
+| `RESEND_API_KEY`                | conditional        | prod                      | email delivery        | email sending disabled/fails when absent                                            | yes for core app | secret      | `re_...`                                            |
+| `SENTRY_DSN`                    | no                 | staging, prod             | observability         | error telemetry disabled when absent                                                | yes              | secret      | `https://...@sentry.io/...`                         |
+| `NEXT_PUBLIC_SENTRY_DSN`        | no                 | prod                      | web observability     | client telemetry disabled when absent                                               | yes              | public      | `https://...@sentry.io/...`                         |
+
+## Feature, kernel, and operator controls
+
+| Name                                | Required    | Scope                | Subsystem                 | Default / fallback if absent                                                   | Safe fallback         | Sensitivity | Example                               |
+| ----------------------------------- | ----------- | -------------------- | ------------------------- | ------------------------------------------------------------------------------ | --------------------- | ----------- | ------------------------------------- |
+| `SKIP_ENV_VALIDATION`               | no          | ci/build-only        | build safety              | disables env validation gate during build contexts                             | dangerous if overused | internal    | `true`                                |
+| `JOBFORGE_INTEGRATION_ENABLED`      | no          | enterprise           | integration gating        | defaults to off (`0/false`)                                                    | yes                   | internal    | `1`                                   |
+| `JOBFORGE_BUNDLE_EXECUTION_ENABLED` | no          | enterprise           | integration gating        | defaults to off (`0/false`)                                                    | yes                   | internal    | `1`                                   |
+| `CREDENTIAL_ENCRYPTION_KEY`         | conditional | enterprise, prod     | adapter credential crypto | adapters try `SUPABASE_VAULT_KEY` fallback                                     | partial               | secret      | `hex-or-random-key`                   |
+| `SUPABASE_VAULT_KEY`                | no          | enterprise           | adapter credential crypto | fallback source when `CREDENTIAL_ENCRYPTION_KEY` is absent                     | yes                   | secret      | `vault-secret`                        |
+| `SETTLER_KERNEL_ENABLED`            | no          | local, staging, prod | kernel control            | disabled unless explicitly enabled                                             | yes                   | internal    | `1`                                   |
+| `SETTLER_KERNEL_CANONICALIZE`       | no          | staging, prod        | kernel control            | canonicalization remains TS-only unless enabled                                | yes                   | internal    | `1`                                   |
+| `SETTLER_KERNEL_EXECUTION_MODE`     | no          | staging, prod        | kernel control            | defaults to `primary`; accepts `disabled`, `compare_only`, `shadow`, `primary` | yes                   | internal    | `shadow`                              |
+| `SETTLER_DISABLE_KERNEL`            | no          | rollback             | kernel kill switch        | immediate kernel disable and TS fallback                                       | yes                   | internal    | `1`                                   |
+| `SETTLER_KERNEL_BIN`                | no          | staging, prod        | kernel binary             | if missing, CLI may use cargo fallback (non-prod) or TS fallback               | partial               | internal    | `/usr/local/bin/settler-kernel-cli`   |
+| `SETTLER_KERNEL_ALLOW_CARGO`        | no          | local                | kernel fallback policy    | allows cargo-run fallback for missing binary                                   | yes                   | internal    | `1`                                   |
+| `SETTLER_KERNEL_PRIMARY_ALLOWLIST`  | no          | staging, prod        | kernel routing            | empty allowlist prevents primary-kernel path for ops                           | yes                   | internal    | `canonicalize_hash,proof_bundle_hash` |
+| `SETTLER_DISABLE_OPERATION`         | no          | rollback             | kernel routing            | disables specific kernel operations                                            | yes                   | internal    | `proof_bundle_hash`                   |
+| `SETTLER_BASE_URL`                  | no          | local, prod          | CLI/API target            | defaults to `https://api.settler.io` in CLI commands                           | yes                   | internal    | `https://api.example.com`             |
+| `SETTLER_API_KEY`                   | conditional | local, ci, prod      | CLI/operator auth         | required for most authenticated CLI commands                                   | no for auth flows     | secret      | `stlr_...`                            |
+
+## CI / deployment-specific secrets
+
+| Name                                                                    | Required      | Scope          | Subsystem                 | Notes                                                 |
+| ----------------------------------------------------------------------- | ------------- | -------------- | ------------------------- | ----------------------------------------------------- |
+| `TURBO_TOKEN`, `TURBO_TEAM`                                             | conditional   | ci             | build cache               | used across quality/deploy workflows for remote cache |
+| `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`                    | conditional   | ci/prod deploy | web deploy                | required by Vercel deploy jobs                        |
+| `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_REF`, `SUPABASE_DB_PASSWORD` | conditional   | ci deploy      | migrations/edge functions | required by Supabase CLI workflows                    |
+| `PRODUCTION_URL`                                                        | conditional   | ci deploy      | post-deploy checks        | used by deployment health checks                      |
+| `GITHUB_TOKEN`                                                          | yes (actions) | ci             | release automation        | used by release and automation workflows              |
+
+## Drift findings (fixed in this pass)
+
+- `.env.example.integrations` contained a large speculative keyset (Plaid/TrueLayer/NetSuite/etc.) that is not referenced by current runtime code. It has been reduced to keys currently read by adapters/CLI runtime.
+- `.env.production.example` was missing; operators had no concise production-only template. Added in this pass.
+- Setup guidance was fragmented across many docs; setup path is consolidated under `docs/setup/*`.

--- a/docs/setup/feature-flag-matrix.md
+++ b/docs/setup/feature-flag-matrix.md
@@ -1,0 +1,18 @@
+# Feature Flag Matrix
+
+This matrix tracks environment-controlled flags that alter runtime behavior.
+
+| Flag                                | Subsystem              | Default              | Effect when enabled                                            | Failure/rollback note                                    |
+| ----------------------------------- | ---------------------- | -------------------- | -------------------------------------------------------------- | -------------------------------------------------------- |
+| `ENABLE_SCHEMA_PER_TENANT`          | API tenancy            | `false`              | Enables schema-per-tenant behavior                             | keep `false` unless migration/tenancy model is validated |
+| `ENABLE_REQUEST_TIMEOUT`            | API runtime            | `true`               | Enforces API request timeout behavior                          | disable only for controlled diagnostics                  |
+| `ENABLE_API_DOCS`                   | API docs surface       | `true`               | Exposes API docs endpoints                                     | can disable for hardened prod surface                    |
+| `JOBFORGE_INTEGRATION_ENABLED`      | Enterprise integration | `false`              | Enables JobForge integration path                              | keep off for OSS baseline                                |
+| `JOBFORGE_BUNDLE_EXECUTION_ENABLED` | Enterprise integration | `false`              | Enables JobForge bundle execution path                         | keep off unless operator-approved                        |
+| `SETTLER_KERNEL_ENABLED`            | Kernel runtime         | `false` (unless set) | Allows kernel usage path                                       | can be overridden by `SETTLER_DISABLE_KERNEL=1`          |
+| `SETTLER_KERNEL_CANONICALIZE`       | Kernel runtime         | `false` (unless set) | Enables kernel canonicalization path                           | fallback remains TS canonicalization                     |
+| `SETTLER_KERNEL_SHADOW_MODE`        | Kernel runtime         | `false`              | Runs kernel in shadow mode                                     | safe for production comparison rollout                   |
+| `SETTLER_KERNEL_EXECUTION_MODE`     | Kernel runtime         | `primary`            | Explicit mode: `disabled`, `compare_only`, `shadow`, `primary` | use `shadow` or `disabled` for rollback                  |
+| `SETTLER_DISABLE_KERNEL`            | Kernel kill switch     | `false`              | Forces kernel off and fallback path                            | primary emergency rollback control                       |
+| `SAFE_MODE`                         | Web safety mode        | `false`              | Enables conservative/safe behavior toggles                     | use in incident response if needed                       |
+| `ALERT_NOTIFIER_DRY_RUN`            | Alerting               | `false`              | suppresses outbound notification sends                         | use during channel setup verification                    |

--- a/docs/setup/operator-runbook.md
+++ b/docs/setup/operator-runbook.md
@@ -1,0 +1,45 @@
+# Operator Runbook
+
+## Startup checks
+
+1. Validate env file against `docs/setup/env-matrix.md`.
+2. Verify API env parsing by running `pnpm typecheck` and API startup command.
+3. Verify web can initialize Supabase client (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`).
+
+## Health checklist
+
+- API health endpoints return success (if enabled by `HEALTH_CHECK_ENABLED=true`).
+- Database connectivity succeeds using `DATABASE_URL`.
+- Redis path (if configured) accepts read/write.
+- Stripe webhook signature verification succeeds in staging before production rollout.
+
+## Failure modes and immediate actions
+
+### Missing/invalid auth or encryption secrets
+
+- Symptom: runtime boot failure in production.
+- Action: rotate/fix `JWT_SECRET` and `ENCRYPTION_KEY`, redeploy.
+
+### Kernel binary unavailable
+
+- Symptom: kernel readiness reports `binary_unavailable` or fallback reason.
+- Action:
+  - set `SETTLER_DISABLE_KERNEL=1` for hard fallback, or
+  - set `SETTLER_KERNEL_EXECUTION_MODE=shadow` while restoring binary.
+
+### Supabase privileged operations failing
+
+- Symptom: service-role operations fail with authorization errors.
+- Action: validate `SUPABASE_SERVICE_ROLE_KEY` and project URL pairing.
+
+### Billing webhook failures
+
+- Symptom: webhook endpoint rejects valid Stripe events.
+- Action: re-sync `STRIPE_WEBHOOK_SECRET` from Stripe dashboard.
+
+## Rollback and safe-mode controls
+
+- Disable kernel globally: `SETTLER_DISABLE_KERNEL=1`
+- Shadow-only kernel execution: `SETTLER_KERNEL_EXECUTION_MODE=shadow`
+- Disable one kernel operation: `SETTLER_DISABLE_OPERATION=proof_bundle_hash`
+- Keep app operational without optional subsystems: leave optional keys unset (Sentry, PostHog, GA4, alert webhooks)


### PR DESCRIPTION
### Motivation

- Eliminate configuration ambiguity by creating a single operator-facing source of truth for environment variables, secrets, feature flags, rollout controls, and operator actions required for go-live.
- Provide a concise, production-safe `.env` baseline and explicit guidance so an operator can configure, deploy, and remediate without guessing.
- Remove speculative/inactive integration keys from integration templates so examples match runtime code references.

### Description

- Added an operator-focused docs set under `docs/setup/`: `env-matrix.md`, `deployment-readiness.md`, `operator-runbook.md`, `feature-flag-matrix.md`, and `enterprise-enablement.md` that consolidate env/flag matrices, operator steps, failure modes, and rollback controls.
- Added a production baseline template ` .env.production.example` with the minimal required production secrets and hardening knobs.
- Reconciled `.env.example.integrations` to include only integration keys referenced by runtime code and removed the large speculative keyset.
- Updated `.env.example` header to point to the canonical validator at `packages/api/src/config/validation.ts` and the new `docs/setup/env-matrix.md`.

### Testing

- Ran `pnpm install --frozen-lockfile` which completed successfully.
- Ran `pnpm lint` which completed successfully (only warnings were reported).
- Ran `pnpm typecheck` which failed due to pre-existing TypeScript errors in `packages/cli` (missing `health` property in `KernelExecutionMetadata`).
- Ran `pnpm build` which initially encountered a stale Next lock then completed on a subsequent run (warning-grade issue from lockfile contention).
- Ran `pnpm test` which failed because the `typecheck` errors in `packages/cli` block the test graph.
- Ran Rust checks: `cargo fmt --check` ✅, `cargo clippy --all-targets --all-features -- -D warnings` ✅, and `cargo test --all` ✅.
- Ran repository production check `pnpm run check:production` which failed due to existing repo-integrity script path mismatches (pre-existing issues unrelated to the docs changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21f91684c8328aae1c9405bf81a02)