### PR TITLE
Clarify enterprise & security messaging, tighten AI KB claims, and add adversarial launch-readiness gap reports

### DIFF
--- a/docs/launch/enterprise-buyer-gaps.md
+++ b/docs/launch/enterprise-buyer-gaps.md
@@ -1,0 +1,33 @@
+# Enterprise Buyer Gap Assessment
+
+## Current strengths
+
+- Product narrative consistently emphasizes deterministic reconciliation and replayable evidence.
+- Pricing and enterprise surfaces now describe premium value as operational support + control-plane workflows rather than "different logic".
+- Console route surface includes enterprise-relevant workflows (approvals, audit trail, operator plane, replay).
+
+## Current weaknesses
+
+- Buyer-facing packaging is still engagement-model heavy and weak on outcome framing (time-to-resolution, incident reduction, governance throughput).
+- The website does not yet show concrete enterprise case evidence (reference architectures, measured pilot deltas, sample rollout plans).
+- Managed-service scope remains high level; shared-responsibility details are still not contract-grade.
+
+## Fixes completed
+
+- Rewrote enterprise page to clarify premium differentiation and managed/shared-responsibility boundaries.
+- Added explicit in-product workflow mapping (replay, approvals, operator, admin surfaces).
+
+## Fixes deferred
+
+- Publish enterprise reference architecture diagrams tied to real deployment topologies.
+- Add a measurable pilot success rubric with baselines and acceptance thresholds.
+- Add public-facing SLA and support response matrix with realistic qualifiers.
+
+## Launch blockers
+
+- **Blocker:** Missing hard evidence of enterprise outcomes (before/after operating metrics) for skeptical procurement review.
+
+## Non-blockers
+
+- Detailed packaging granularity and pricing transparency improvements.
+- Additional persona-specific case studies.

--- a/docs/launch/launch-readiness-verdict.md
+++ b/docs/launch/launch-readiness-verdict.md
@@ -1,0 +1,34 @@
+# Adversarial Launch Readiness Verdict
+
+## Verdict
+
+**Not launch-ready for hard-nosed enterprise/security scrutiny yet.**
+
+This pass reduced key credibility risk (especially over-claiming in public/AI surfaces), but material blockers remain around evidence-backed enterprise outcomes, canonical operator onboarding, and cross-surface trust consistency.
+
+## What improved in this pass
+
+- Enterprise positioning now better explains premium value as managed operations + governance workflows (not alternate core logic).
+- Security narrative now has clearer trust boundaries and explicit non-guarantees.
+- AI knowledge-base responses were narrowed to avoid unsupported compliance and precision claims.
+
+## Remaining launch blockers
+
+1. Lack of public enterprise proof with measurable operational outcomes.
+2. No single canonical operator bootstrap + rollback + verification path.
+3. Trust/safety messaging still inconsistent across all public surfaces.
+
+## Recommended pre-launch gate
+
+Ship only after these are complete:
+
+- Publish an evidence-backed enterprise pilot rubric with real metrics.
+- Publish one canonical operator runbook with strict pass/fail deployment checks.
+- Complete trust-claim harmonization and claim-to-evidence mapping across surfaces.
+
+## Residual risk if launched now
+
+- Enterprise buyers may see strong claims but insufficient operating proof.
+- OSS reviewers may interpret breadth as lack of canonical architectural discipline.
+- Operators may hesitate due to setup/rollback discovery cost.
+- Security evaluators may flag trust posture inconsistencies as governance immaturity.

--- a/docs/launch/operator-readiness-gaps.md
+++ b/docs/launch/operator-readiness-gaps.md
@@ -1,0 +1,32 @@
+# Operator Readiness Gap Assessment
+
+## Current strengths
+
+- Repo includes substantial ops and runbook documentation.
+- Security verification scripts and evidence-level semantics (`VERIFIED/DEGRADED/...`) are explicit.
+- Console includes operator-oriented surfaces (diagnostics, operator, control plane, incidents, setup checks).
+
+## Current weaknesses
+
+- Operator onboarding still requires too much doc discovery across many files.
+- Clear "first 24 hours" deployment and rollback procedure is not obvious from a single entrypoint.
+- Health/failure behavior expectations are documented, but not yet consolidated into one operator checklist with hard gates.
+
+## Fixes completed
+
+- Updated enterprise/security public pages to better describe managed boundaries and non-guarantees so operator expectations are set correctly.
+
+## Fixes deferred
+
+- Create one canonical "operator bootstrap" runbook with required env keys, health gates, rollback, and escalation steps.
+- Publish concise monitoring baseline (golden signals, alert thresholds, dashboards, ownership).
+- Add explicit failure-mode matrix linking user-visible symptoms to remediation commands.
+
+## Launch blockers
+
+- **Blocker:** No single deterministic operator entrypoint for setup + rollback + production verification.
+
+## Non-blockers
+
+- Extra convenience scripts for local quality-of-life.
+- Expanded incident examples.

--- a/docs/launch/oss-reviewer-gaps.md
+++ b/docs/launch/oss-reviewer-gaps.md
@@ -1,0 +1,33 @@
+# OSS Reviewer Gap Assessment
+
+## Current strengths
+
+- Monorepo includes substantial implementation surface (web, API, CLI, Rust kernel, SDKs).
+- Determinism and evidence concepts are repeatedly documented across product/security pages.
+- Kernel-vs-control-plane distinction is stated in public pages.
+
+## Current weaknesses
+
+- Narrative density is high, and many docs overlap, making canonical architecture paths harder to identify quickly.
+- Some generated/marketing-like text in the repo still weakens technical signal.
+- Route and feature breadth can appear sprawling versus clearly tiered "core vs optional" paths.
+
+## Fixes completed
+
+- Tightened enterprise/security content to reduce over-claim risk and improve architecture truthfulness.
+- Removed overconfident AI knowledge-base claims (certification/pricing/integration count assertions).
+
+## Fixes deferred
+
+- Create a single "technical north star" doc that maps canonical architecture docs and deprecates duplicates.
+- Add an explicit "minimum credible OSS path" from clone → run → verify replay proof.
+- Add a maintained repo map for what is production path vs experimental path.
+
+## Launch blockers
+
+- **Blocker:** Lack of a sharply curated canonical doc path for external technical reviewers under time pressure.
+
+## Non-blockers
+
+- Refactoring of broad route/content inventory.
+- Optional visual system unification work.

--- a/docs/launch/security-trust-gaps.md
+++ b/docs/launch/security-trust-gaps.md
@@ -1,0 +1,33 @@
+# Security / Trust / Governance Gap Assessment
+
+## Current strengths
+
+- Security posture now clearly states evidence model and non-guarantees.
+- Proof artifacts and replay semantics are explicit and inspectable.
+- Tenant-boundary intent and RLS verification artifact locations are documented.
+
+## Current weaknesses
+
+- Broader trust marketing surfaces still contain assumptions and SLO-style assertions that may exceed presently demonstrated evidence.
+- Certification/compliance posture is not uniformly represented across all user-facing content.
+- Governance controls are present but not yet presented as a full trust-control catalog with evidence pointers.
+
+## Fixes completed
+
+- Strengthened security page trust-model language and deployment-boundary clarity.
+- Removed unsupported compliance claim text from AI knowledge-base responses.
+
+## Fixes deferred
+
+- Build a trust-control index mapping each claim to verification artifact and freshness timestamp.
+- Add machine-readable security posture page with environment-specific evidence state.
+- Harmonize trust messaging across `/trust`, `/security-and-audit`, and AI assistant knowledge contexts.
+
+## Launch blockers
+
+- **Blocker:** Cross-surface claim inconsistency risks undermining trust with security evaluators.
+
+## Non-blockers
+
+- Additional governance UX polish.
+- Expanded legal/support FAQ depth.

--- a/packages/web/content/pages/enterprise.mdx
+++ b/packages/web/content/pages/enterprise.mdx
@@ -1,23 +1,50 @@
 ---
 title: Enterprise
-description: Optional hosted infrastructure and scale for organizations that want managed deployment.
+description: Optional hosted infrastructure for teams that need managed operations, governance controls, and higher-confidence rollout workflows.
 ---
 
-## Hosted infrastructure, optional by design
+## Enterprise Cloud is optional infrastructure, not a different engine
 
-Enterprise Cloud is an optional hosted deployment of the same reconciliation engine. It does **not** change core logic or rules behavior; it only changes how infrastructure is operated.
+Settler Enterprise Cloud runs the same reconciliation kernel and rule semantics as OSS/self-hosted deployments. The premium difference is operational support, control-plane surfaces, and managed reliability workflows.
 
-## What it provides
+If your team prefers full ownership, self-hosted remains first-class.
 
-- Managed deployment and upgrades
-- Scale controls for high-volume workloads
-- Private networking options
-- Dedicated support channels
+## What enterprise teams can do in the console
 
-## What it does not change
+Enterprise-focused workflows are surfaced in operator/admin routes so teams can manage risk and rollout safely:
 
-- Deterministic reconciliation logic
-- Rule definitions
-- Evidence and variance outputs
+- **Replay and traceability** (`/console/replay`, `/console/replay-lab`, `/console/proof-explorer`) for run-to-run diffing and evidence review.
+- **Governance and approvals** (`/console/approvals`, `/console/audit-trail`, `/console/policies`) for controlled changes.
+- **Bulk and operator workflows** (`/console/bulk-operations`, `/console/operator`, `/console/control-plane`) for incident and high-volume handling.
+- **Organization and admin boundaries** (`/console/organizations`, `/console/admin/tenants`) for tenant-level operational management.
 
-If you prefer self-hosting, the OSS engine remains the primary path.
+## What managed deployment removes from your team
+
+Enterprise Cloud primarily reduces operational burden:
+
+- Managed deployment and upgrade coordination
+- Managed runbook support for incidents and rollout gates
+- Capacity planning support for high-volume reconciliation windows
+- Dedicated support channels for operator and admin workflows
+
+## Shared responsibility model (plain language)
+
+### Settler manages (Enterprise Cloud)
+
+- Service deployment operations
+- Managed upgrades and rollback coordination
+- Core reliability runbooks and incident escalation paths
+
+### You manage
+
+- Rule quality and approval policy
+- Data classification, retention policy decisions, and tenant governance
+- Final exception decisions and downstream accounting controls
+
+## What enterprise does **not** change
+
+- Deterministic reconciliation behavior
+- Rule definitions and replay semantics
+- Evidence artifact formats and non-guarantees
+
+Enterprise Cloud improves operating posture; it does not convert reconciliation output into accounting certification or audit conclusions.

--- a/packages/web/content/pages/security-and-audit.mdx
+++ b/packages/web/content/pages/security-and-audit.mdx
@@ -1,11 +1,19 @@
 ---
 title: Security & Audit
-description: How Settler approaches security, audit evidence, and disclosure without making guarantees.
+description: How Settler handles security verification, audit evidence, and trust boundaries without over-claiming guarantees.
 ---
 
 ## Security posture
 
 Settler is designed to be conservative and auditable. The engine emphasizes deterministic behavior and explicit rule configuration over implicit automation. Every run produces machine-readable evidence artifacts that can be independently inspected and replayed.
+
+## Trust model
+
+Settler's trust model is intentionally narrow:
+
+- Settler proves **what the engine executed** (inputs, rules, outputs, hashes).
+- Settler does **not** prove business correctness, accounting policy correctness, or regulatory compliance outcomes.
+- Human operators remain accountable for approvals, exception handling, and downstream reporting.
 
 ## Audit evidence, not audit results
 
@@ -39,28 +47,29 @@ System-level security artifacts are written to:
 - `security/rls-evidence.json`
 - `security/security-verdict.json`
 
+## Deployment model boundaries
+
+Data handling depends on your deployment model:
+
+- **Self-hosted (OSS):** your data stays in your infrastructure. You control retention, access, and configuration.
+- **Managed cloud:** data is processed in Settler infrastructure. You should validate data residency, retention settings, and contractual controls (DPA/privacy terms) before production use.
+
+Always review configuration, retention, and access control policies for your environment before processing sensitive financial data.
+
+## Access controls and tenant boundaries
+
+The engine enforces tenant isolation through row-level security (RLS) and tenant-scoped query boundaries. Access controls are policy-gated, and audit logs should be monitored as part of your control environment.
+
 ## Non-guarantees
 
 Settler does **not**:
 
 - guarantee correctness or completeness,
 - replace professional judgment,
-- or provide compliance certification.
+- provide compliance certification,
+- or eliminate operator review requirements.
 
 You are responsible for review, approval, and downstream reporting.
-
-## Data handling
-
-Data handling depends on your deployment model:
-
-- **Self-hosted (OSS):** your data stays in your infrastructure. You control retention, access, and configuration.
-- **Managed cloud:** data is processed in Settler's infrastructure. Review the privacy policy and DPA for your deployment.
-
-Always review configuration, retention, and access control policies for your environment before processing sensitive financial data.
-
-## Access controls
-
-The engine enforces tenant isolation through row-level security (RLS) on all data queries. Policy-based access controls gate reconciliation workflow execution. Access logs are written as part of the audit trail.
 
 ## Responsible disclosure
 

--- a/packages/web/src/lib/ai/knowledge-base.ts
+++ b/packages/web/src/lib/ai/knowledge-base.ts
@@ -7,7 +7,7 @@ export interface KnowledgeBaseEntry {
   id: string;
   title: string;
   content: string;
-  category: 'faq' | 'docs' | 'pricing' | 'features' | 'legal' | 'support' | 'oss';
+  category: "faq" | "docs" | "pricing" | "features" | "legal" | "support" | "oss";
   source: string;
   keywords: string[];
   metadata?: Record<string, any>;
@@ -21,68 +21,76 @@ export async function loadFAQEntries(): Promise<KnowledgeBaseEntry[]> {
   // For now, return structured FAQ data
   return [
     {
-      id: 'faq-1',
-      title: 'What problem does Settler solve?',
-      content: 'Settler automates financial reconciliation across multiple e-commerce and payment platforms. Businesses waste 10+ hours per week manually matching transactions—Settler does this in minutes with 99.7% accuracy.',
-      category: 'faq',
-      source: 'investor-faq.md',
-      keywords: ['problem', 'reconciliation', 'automation', 'accuracy'],
+      id: "faq-1",
+      title: "What problem does Settler solve?",
+      content:
+        "Settler provides deterministic reconciliation workflows across multiple payment and ledger sources. It focuses on explicit rules, replayable evidence, and operator review instead of opaque automation.",
+      category: "faq",
+      source: "investor-faq.md",
+      keywords: ["problem", "reconciliation", "automation", "accuracy"],
     },
     {
-      id: 'faq-2',
-      title: 'What is the difference between OSS SDK and SaaS?',
-      content: 'OSS SDK is free, MIT-licensed, and can be self-hosted. Settler.dev SaaS provides cloud hosting, AI insights, managed infrastructure, and priority support. OSS includes core features but not AI insights or managed hosting.',
-      category: 'faq',
-      source: 'oss-comparison',
-      keywords: ['oss', 'saas', 'difference', 'comparison', 'self-hosted'],
+      id: "faq-2",
+      title: "What is the difference between OSS SDK and SaaS?",
+      content:
+        "OSS SDK is free, MIT-licensed, and can be self-hosted. Settler.dev SaaS provides cloud hosting, AI insights, managed infrastructure, and priority support. OSS includes core features but not AI insights or managed hosting.",
+      category: "faq",
+      source: "oss-comparison",
+      keywords: ["oss", "saas", "difference", "comparison", "self-hosted"],
     },
     {
-      id: 'faq-3',
-      title: 'How do I install the SDK?',
-      content: 'Install via npm: npm install @settler/sdk, yarn: yarn add @settler/sdk, or pnpm: pnpm add @settler/sdk. See /docs/quickstart for detailed instructions.',
-      category: 'docs',
-      source: 'installation',
-      keywords: ['install', 'sdk', 'npm', 'yarn', 'pnpm'],
+      id: "faq-3",
+      title: "How do I install the SDK?",
+      content:
+        "Install via npm: npm install @settler/sdk, yarn: yarn add @settler/sdk, or pnpm: pnpm add @settler/sdk. See /docs/quickstart for detailed instructions.",
+      category: "docs",
+      source: "installation",
+      keywords: ["install", "sdk", "npm", "yarn", "pnpm"],
     },
     {
-      id: 'faq-4',
-      title: 'What are the pricing plans?',
-      content: 'Free: $0/month (1,000 reconciliations), Commercial: $99/month (10,000 reconciliations), Pro: $499/month (100,000 reconciliations), Enterprise: Custom pricing. All plans include 14-day free trial, no credit card required.',
-      category: 'pricing',
-      source: 'pricing-page',
-      keywords: ['pricing', 'plans', 'free', 'commercial', 'enterprise'],
+      id: "faq-4",
+      title: "What are the pricing plans?",
+      content:
+        "Settler offers self-serve and enterprise engagement paths. Packaging and limits can change over time; use /pricing for the current plan matrix and contact path.",
+      category: "pricing",
+      source: "pricing-page",
+      keywords: ["pricing", "plans", "free", "commercial", "enterprise"],
     },
     {
-      id: 'faq-5',
-      title: 'What platforms does Settler integrate with?',
-      content: 'Settler integrates with Stripe, Shopify, PayPal, QuickBooks, Xero, Square, WooCommerce, BigCommerce, Magento, Salesforce, and 50+ other platforms. See /docs/integrations for the full list.',
-      category: 'features',
-      source: 'integrations',
-      keywords: ['integrations', 'platforms', 'stripe', 'shopify', 'paypal'],
+      id: "faq-5",
+      title: "What platforms does Settler integrate with?",
+      content:
+        "Settler ships adapter-driven integrations for common payment and accounting systems. Coverage evolves; refer to /docs/integrations for the current supported set.",
+      category: "features",
+      source: "integrations",
+      keywords: ["integrations", "platforms", "stripe", "shopify", "paypal"],
     },
     {
-      id: 'faq-6',
-      title: 'Is Settler secure and compliant?',
-      content: 'Yes. Settler is ISO 27001 and SOC 2 compliant. We use encryption at rest and in transit, follow security best practices, and offer DPA for enterprise customers. See /security for details.',
-      category: 'legal',
-      source: 'security-page',
-      keywords: ['security', 'compliance', 'iso', 'soc2', 'encryption'],
+      id: "faq-6",
+      title: "Is Settler secure and compliant?",
+      content:
+        "Settler publishes its security model, evidence verification approach, and non-guarantees at /security-and-audit. If you require specific certifications or contractual controls, validate current status directly with the team before relying on them.",
+      category: "legal",
+      source: "security-page",
+      keywords: ["security", "compliance", "iso", "soc2", "encryption"],
     },
     {
-      id: 'faq-7',
-      title: 'How do I use the playground?',
-      content: 'Visit /console/playground to try Settler without signing up. You can test reconciliation, receipt parsing, feature flags, currency conversion, and CLI commands. No account required.',
-      category: 'support',
-      source: 'playground',
-      keywords: ['playground', 'try', 'test', 'demo'],
+      id: "faq-7",
+      title: "How do I use the playground?",
+      content:
+        "Visit /console/playground to try Settler without signing up. You can test reconciliation, receipt parsing, feature flags, currency conversion, and CLI commands. No account required.",
+      category: "support",
+      source: "playground",
+      keywords: ["playground", "try", "test", "demo"],
     },
     {
-      id: 'faq-8',
-      title: 'What is the OSS license?',
-      content: 'Settler SDK is licensed under MIT License. You can use, modify, and distribute it freely. See /legal/license for full license text.',
-      category: 'oss',
-      source: 'license',
-      keywords: ['license', 'mit', 'oss', 'open source'],
+      id: "faq-8",
+      title: "What is the OSS license?",
+      content:
+        "Settler SDK is licensed under MIT License. You can use, modify, and distribute it freely. See /legal/license for full license text.",
+      category: "oss",
+      source: "license",
+      keywords: ["license", "mit", "oss", "open source"],
     },
   ];
 }
@@ -96,36 +104,36 @@ export function searchKnowledgeBase(
   limit: number = 5
 ): KnowledgeBaseEntry[] {
   const lowerQuery = query.toLowerCase();
-  
+
   // Score entries based on relevance
   const scored = entries.map((entry) => {
     let score = 0;
-    
+
     // Title match (highest weight)
     if (entry.title.toLowerCase().includes(lowerQuery)) {
       score += 10;
     }
-    
+
     // Content match
     if (entry.content.toLowerCase().includes(lowerQuery)) {
       score += 5;
     }
-    
+
     // Keyword match
     entry.keywords.forEach((keyword) => {
       if (keyword.toLowerCase().includes(lowerQuery)) {
         score += 3;
       }
     });
-    
+
     // Category match
     if (entry.category.toLowerCase().includes(lowerQuery)) {
       score += 2;
     }
-    
+
     return { entry, score };
   });
-  
+
   // Sort by score and return top results
   return scored
     .filter((item: any) => item.score > 0)
@@ -143,14 +151,12 @@ export function getKnowledgeBaseContext(
   maxEntries: number = 3
 ): string {
   const relevant = searchKnowledgeBase(query, entries, maxEntries);
-  
+
   if (relevant.length === 0) {
-    return 'No relevant information found in knowledge base.';
+    return "No relevant information found in knowledge base.";
   }
-  
+
   return relevant
-    .map(
-      (entry) => `Title: ${entry.title}\nContent: ${entry.content}\nCategory: ${entry.category}`
-    )
-    .join('\n\n---\n\n');
+    .map((entry) => `Title: ${entry.title}\nContent: ${entry.content}\nCategory: ${entry.category}`)
+    .join("\n\n---\n\n");
 }


### PR DESCRIPTION
### Motivation

- Reduce over-claiming and tighten trust boundaries by clarifying enterprise differentiation and explicit non-guarantees in security messaging.
- Make premium value concrete by surfacing the console/operator surfaces enterprise teams will use for governance and replay.
- Remove unsupported knowledge claims from the AI knowledge base so assistant responses align with verifiable repo state.
- Produce an adversarial, evidence-focused launch-readiness gap list to make remaining blockers explicit for enterprise/security reviewers.

### Description

- Rewrote and expanded the enterprise page at `packages/web/content/pages/enterprise.mdx` to clarify that Enterprise Cloud is managed infrastructure (not different engine logic), list console routes that support enterprise workflows, and add a shared-responsibility plain-language model.
- Rewrote `packages/web/content/pages/security-and-audit.mdx` to add a concise trust model, emphasize what Settler proves versus what it does not prove, and make deployment-model boundaries and non-guarantees explicit.
- Narrowed and corrected claims in the AI knowledge base at `packages/web/src/lib/ai/knowledge-base.ts`, replacing overstated security/pricing/integration text with conservative, verifiable guidance and normalizing string/formatting style.
- Added an adversarial launch-readiness folder with five new reports under `docs/launch/`: `enterprise-buyer-gaps.md`, `oss-reviewer-gaps.md`, `operator-readiness-gaps.md`, `security-trust-gaps.md`, and `launch-readiness-verdict.md` describing strengths, weaknesses, completed fixes, deferred work, and blockers.

### Testing

- Ran `pnpm install --frozen-lockfile` which completed successfully and generated required client code (Prisma client generation completed in postinstall). 
- Ran `pnpm lint` which completed successfully but produced warnings across several packages (no blocking errors were reported). 
- Ran `pnpm typecheck` which failed due to TypeScript errors in `packages/cli/src/lib/kernel-client.ts` where the `KernelExecutionMetadata` typed objects are missing the required `health` property (errors reported at the call sites flagged in the run). 
- Started `pnpm build` (web and related packages), which progressed but full verification was not completed because the typecheck step surfaced a blocking TS error that should be fixed before a complete verify/build pass can be considered green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21fb79b1c8328bc02a505487a7e90)