### PR TITLE
Reality pass: verify route/dataflow surfaces and fix console premium seams

### DIFF
--- a/docs/verification/dataflow-health-report.md
+++ b/docs/verification/dataflow-health-report.md
@@ -1,0 +1,25 @@
+# Dataflow Health Report
+
+Date: 2026-03-12
+
+## Dataflow Verification Sources
+
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm build`
+- existing targeted tests in `packages/api` and `packages/web`
+
+## Dynamic Surface Dataflow Status
+
+| Surface                                | Data source                                          | Contract alignment                    | Empty/error behavior                                     | Status                              |
+| -------------------------------------- | ---------------------------------------------------- | ------------------------------------- | -------------------------------------------------------- | ----------------------------------- |
+| `/console` overview                    | Supabase auth + usage/api keys/receipts domain calls | Typecheck + build pass                | Explicit auth panel, env error panel, safe mode fallback | Healthy with graceful degrade       |
+| `/api/console/*` family                | Console API handlers                                 | Built routes + web API contract tests | Tested degraded/problem contracts                        | Healthy (contract-level)            |
+| Tenant isolation paths (`api` + `web`) | Tenant-scoped repositories/services                  | Multi-tenancy tests pass              | Isolation failures surfaced as explicit errors           | Healthy                             |
+| Billing/entitlements enforcement       | Usage middleware + billing helpers                   | Middleware tests pass                 | Explicit error logs and fallback paths                   | Healthy with explicit degraded mode |
+| Replay/proof paths                     | Replay + reconciliation modules                      | Replay/proof tests pass               | Fallback behavior covered in tests                       | Healthy                             |
+
+## Known Environment-Limited Gaps
+
+- Playwright route-reality run starts with startup validation warning for missing required env (`DATABASE_URL`/`NEXT_PUBLIC_SUPABASE_URL`), so end-to-end browser data verification is not considered reliable in this container.
+- `pnpm test` suite completes tests but can hang after completion due open handles in web Jest process; functional pass is visible in output, but process cleanup remains imperfect.

--- a/docs/verification/degraded-mode-behavior.md
+++ b/docs/verification/degraded-mode-behavior.md
@@ -1,0 +1,32 @@
+# Degraded Mode Behavior Verification
+
+Date: 2026-03-12
+
+## Kernel and Fallback Paths
+
+### Kernel metadata enforcement
+
+- Fixed kernel fallback metadata to always include `health` during operation-disabled fallback paths in CLI kernel client.
+- This keeps degraded states machine-visible and type-safe across canonicalize/proof/artifact hash fallback responses.
+
+### UI degraded behavior
+
+- Console overview includes:
+  - env validation panel when required env vars are missing
+  - authentication-required fallback
+  - safe-mode non-destructive fallback content
+
+### API degraded behavior evidence
+
+- Web/API tests include explicit degraded/problem contract checks (`status-degraded-contract`, middleware enforcement, tenant boundaries).
+- Error paths are observable via structured logging in tests rather than silent success.
+
+## Verified No-Hard-500 Direction
+
+- Build route manifest completes for all major routes (including enterprise, docs, console, trust surfaces).
+- Dedicated browser E2E route gate could not be trusted due missing startup env requirements in this environment; this is documented as an execution limitation, not marked green.
+
+## Follow-up Recommendation
+
+1. Provide minimal CI-safe env fixture for Playwright reality gates (stub `DATABASE_URL`/`NEXT_PUBLIC_SUPABASE_URL`) so degraded-mode browser assertions can run deterministically.
+2. Add explicit `--forceExit` (or open-handle cleanup) in web test runner path used by root `pnpm test` to avoid post-pass hangs.

--- a/docs/verification/premium-surface-reality-report.md
+++ b/docs/verification/premium-surface-reality-report.md
@@ -1,0 +1,38 @@
+# Premium Surface Reality Report
+
+Date: 2026-03-12
+
+## Scope
+
+Validated discoverability + route viability for premium/enterprise claims:
+
+- bulk audit/operations
+- proof/replay/traceability
+- governance/policy
+- reporting/export
+- enterprise admin/org/team
+- trust/security
+- managed service/support
+
+## Findings
+
+| Capability                                                          | Discoverable                 | Actionable route exists | Data-backed evidence                                        | Docs linked              | Reality status                   |
+| ------------------------------------------------------------------- | ---------------------------- | ----------------------- | ----------------------------------------------------------- | ------------------------ | -------------------------------- |
+| Bulk operations (`/console/bulk-operations`)                        | Yes (console enterprise nav) | Yes (route built)       | Partial (API/runtime not fully exercised in env)            | Partial                  | **Present, partially proven**    |
+| Audits (`/console/audits`, `/app/audit`)                            | Yes                          | Yes                     | Tenant-isolation/audit tests in API pass                    | Yes                      | **Operationally credible**       |
+| Proof explorer (`/proof-explorer`, `/app/proofs`)                   | Yes                          | Yes                     | Replay/proof related tests pass                             | Yes (`/docs/replay-lab`) | **Operationally credible**       |
+| Replay lab (`/console/replay`, `/replay-lab`)                       | Yes                          | Yes                     | Replay test coverage exists                                 | Yes                      | **Operationally credible**       |
+| Governance/policies (`/console/policies`, `/app/policies`)          | Yes                          | Yes                     | API/policy routes build + contracts compile                 | Partial                  | **Present, contract-proven**     |
+| Reporting/export (`/console/usage/export`)                          | Yes                          | Yes                     | Usage/export routes built; middleware tests pass            | Partial                  | **Present, backend E2E pending** |
+| Admin org/team (`/console/organizations`, `/console/admin/tenants`) | Yes                          | Yes                     | Role-aware rendering in console layout + user-role API      | Partial                  | **Present, role-dependent**      |
+| Trust/security/governance pages                                     | Yes                          | Yes                     | Static + tested support contracts                           | Yes                      | **Present and coherent**         |
+| Managed service/support (`/support`, `/api/console/support/*`)      | Yes                          | Yes                     | API routes present; full ticket flow not e2e-validated here | Yes                      | **Present, partially proven**    |
+
+## High-Leverage Fixes Applied
+
+1. **Console nav runtime correctness fix:** restored valid icon imports and corrected the nav array reference (`coreNavItems` -> `consoleNavItems`) to remove type/runtime break risk.
+2. **Premium evidence links fix:** removed dead internal package links from visual proof registry by remapping to live docs routes, eliminating false discoverability claims.
+
+## Residual Risk
+
+- Browser E2E reality gate currently blocked by missing required startup env vars in this container; this prevents a full “click-through” truth statement for premium actions.

--- a/docs/verification/route-flow-matrix.md
+++ b/docs/verification/route-flow-matrix.md
@@ -1,0 +1,33 @@
+# Route + Flow Matrix (Reality Pass)
+
+Date: 2026-03-12
+
+## Method
+
+- Built route inventory from `qa/route-registry.json` (`pnpm qa:routes`).
+- Verified compile-time route viability with `pnpm build` (Next.js route manifest).
+- Verified navigational integrity with `pnpm qa:links`.
+- Spot-checked dynamic and enterprise-relevant surfaces via source contracts and test coverage.
+
+## Matrix
+
+| Route / Flow                              | Purpose                            | Static / Dynamic                | Data dependency                                 | Enterprise relevance | Nav reachable | Render verified         | Data verified                                         | Action path verified                  | Degraded behavior known               |
+| ----------------------------------------- | ---------------------------------- | ------------------------------- | ----------------------------------------------- | -------------------- | ------------- | ----------------------- | ----------------------------------------------------- | ------------------------------------- | ------------------------------------- |
+| `/`                                       | Marketing entry                    | Static                          | Structured marketing content                    | Medium               | Yes           | Yes (build)             | N/A                                                   | CTA links verified by dead-link check | N/A                                   |
+| `/pricing`                                | Plan/commercial surface            | Static                          | Pricing config/content                          | High                 | Yes           | Yes (build)             | Content-level only                                    | Links verified                        | N/A                                   |
+| `/enterprise`                             | Enterprise narrative + positioning | Static (site-mode gated)        | `SITE_MODE` gating                              | High                 | Yes           | Yes (build)             | Gate logic verified in code                           | CTA links verified                    | Yes (explicit unavailable panel)      |
+| `/docs`                                   | Documentation entry                | Static                          | Docs cards/content                              | High                 | Yes           | Yes (build)             | Content-level only                                    | Internal doc links verified           | N/A                                   |
+| `/console`                                | Operator dashboard                 | Dynamic (`force-dynamic`)       | Supabase auth + usage/api keys/receipts domains | High                 | Yes           | Yes (build + typecheck) | Contract-level via tests                              | Sign-in and safe-mode paths present   | Yes (auth/env fallback panels)        |
+| `/console/replay` + `/replay-lab`         | Replay/traceability                | Dynamic + static docs/marketing | Replay domain + evidence routes                 | High                 | Yes           | Yes (build)             | Replay tests pass                                     | Reachable from console + public route | Partial (depends on backend health)   |
+| `/console/audits` + `/app/audit`          | Audit trails                       | Dynamic                         | Audit APIs + tenant scope                       | High                 | Yes           | Yes (build)             | Tenant-isolation tests pass                           | Navigation verified                   | Yes (API error handling under tests)  |
+| `/console/bulk-operations`                | Bulk action workflows              | Dynamic surface                 | Batch operation APIs                            | High                 | Yes           | Yes (build)             | Route present; end-to-end data not proven in this env | Nav reachability verified             | Unknown (requires full env)           |
+| `/console/policies` + `/app/policies`     | Governance/policy controls         | Dynamic                         | Policy APIs                                     | High                 | Yes           | Yes (build)             | API contract compile + tests                          | Nav path verified                     | Partial                               |
+| `/console/usage` + `/api/console/usage/*` | Reporting/export/usage governance  | Dynamic                         | Usage telemetry + export APIs                   | High                 | Yes           | Yes (build)             | Middleware + API tests pass                           | Export endpoints present              | Yes (degraded behavior test coverage) |
+| `/trust`, `/status`, `/transparency`      | Trust/security disclosures         | Static                          | Content + status API hooks                      | High                 | Yes           | Yes (build)             | Content-level only                                    | Linked from proof registry and nav    | N/A                                   |
+| `/support` + `/support/contact`           | Managed service touchpoints        | Static + dynamic article pages  | Support content + ticket APIs                   | High                 | Yes           | Yes (build)             | API routes present; runtime backend not proven        | Contact path reachable                | Partial                               |
+
+## Key Truth Split
+
+- **Renders confirmed:** major site, docs, console, and enterprise surfaces compile and appear in Next route manifest.
+- **Works confirmed (data/contracts):** API/data behavior mostly proven at contract/unit level (`api`, `web`, `cli` tests), including tenant isolation and degraded behavior tests.
+- **Not fully proven in this environment:** full browser E2E reality run due missing required startup env (`DATABASE_URL` / `NEXT_PUBLIC_SUPABASE_URL`).

--- a/packages/cli/src/lib/kernel-client.ts
+++ b/packages/cli/src/lib/kernel-client.ts
@@ -699,6 +699,7 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "operation_disabled_env",
+        health: "degraded",
       },
     };
   }
@@ -853,6 +854,7 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "operation_disabled_env",
+        health: "degraded",
       },
     };
   }
@@ -955,6 +957,7 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "operation_disabled_env",
+        health: "degraded",
       },
     };
   }

--- a/packages/web/src/components/console/ConsoleLayout.tsx
+++ b/packages/web/src/components/console/ConsoleLayout.tsx
@@ -27,6 +27,7 @@ import {
   Zap,
   Shield,
   Search,
+  ScanSearch,
   Database,
   FileText,
   Building2,
@@ -35,6 +36,8 @@ import {
   ClipboardCheck,
   Scale,
   Settings,
+  Gavel,
+  Bot,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -116,7 +119,7 @@ export function ConsoleLayout({ children }: ConsoleLayoutProps) {
           Console
         </h3>
       </div>
-      {coreNavItems.map((item) => {
+      {consoleNavItems.map((item) => {
         const Icon = item.icon;
         const isActive = pathname === item.href || pathname?.startsWith(item.href + "/");
 

--- a/packages/web/src/lib/public/visual-proof-registry.ts
+++ b/packages/web/src/lib/public/visual-proof-registry.ts
@@ -27,9 +27,9 @@ export const visualProofRegistry: Record<string, VisualProofEntry[]> = {
       detail:
         "Adapter, SDK, and protocol packages back deterministic execution and integration boundaries.",
       refs: [
-        { label: "packages/adapters", href: "packages/adapters", type: "package" },
-        { label: "packages/sdk", href: "packages/sdk", type: "package" },
-        { label: "packages/protocol", href: "packages/protocol", type: "package" },
+        { label: "Adapter docs", href: "/docs/integrations", type: "route" },
+        { label: "SDK docs", href: "/docs/sdk", type: "route" },
+        { label: "API protocol docs", href: "/docs/api", type: "route" },
       ],
     },
   ],


### PR DESCRIPTION
### Motivation

- Run a full end-to-end reality pass to verify that major routes, premium surfaces, and kernel-backed operations render, degrade safely, and are discoverable.
- Fix real runtime/typebreaks and false claims surfaced by the reality checks so the console and premium surfaces are credible.

### Description

- Ensure kernel fallback metadata always includes `health` for operation-disabled fallbacks in `canonicalizeHashWithFallback`, `proofBundleHashWithFallback`, and `artifactIdentityHashWithFallback` to keep degraded states machine-visible and type-safe (`packages/cli/src/lib/kernel-client.ts`).
- Fix console navigation runtime/type break by importing missing Lucide icons (`ScanSearch`, `Gavel`, `Bot`) and rendering the correct nav collection (`consoleNavItems` instead of `coreNavItems`) to prevent render/type failures (`packages/web/src/components/console/ConsoleLayout.tsx`).
- Remove dead internal package links from the premium visual-proof registry and remap to live docs routes so evidence links are navigable (`packages/web/src/lib/public/visual-proof-registry.ts`).
- Add reality-pass verification artifacts documenting routes, premium surface reality, dataflow health, and degraded-mode behavior (`docs/verification/route-flow-matrix.md`, `docs/verification/premium-surface-reality-report.md`, `docs/verification/dataflow-health-report.md`, `docs/verification/degraded-mode-behavior.md`).

### Testing

- Ran `pnpm install --frozen-lockfile` (success) and `pnpm lint` (success; warnings only).
- Ran `pnpm typecheck` (success) and `pnpm build` (success), confirming compile and route manifest generation.
- Ran `pnpm test` (test suites passed across packages, but noted the root test runner can hang after completion due to open handles in the web Jest process — functional tests passed but process-cleanup risk remains).
- Ran route/link checks: `pnpm qa:routes` (success) and `pnpm qa:links` (success after remapping dead links).
- Attempted browser reality run `pnpm test:e2e:reality` / Playwright (environment-limited); startup validation failed because required env (`DATABASE_URL` / `NEXT_PUBLIC_SUPABASE_URL`) were not set so E2E route reality was not fully provable in this container and a Playwright screenshot attempt timed out.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21f9f775883289a65b1d28e5900f7)