### PR TITLE
fix(cli): unify KernelExecutionMetadata health derivation

### DIFF
--- a/packages/cli/src/lib/kernel-client.ts
+++ b/packages/cli/src/lib/kernel-client.ts
@@ -100,6 +100,19 @@ export interface KernelExecutionMetadata {
   health: "healthy" | "degraded";
 }
 
+function buildKernelExecutionMetadata(input: {
+  operation: KernelOperation;
+  executionMode: KernelExecutionMode;
+  usedPrimary: boolean;
+  shadowCompared: boolean;
+  fallbackReason?: string;
+}): KernelExecutionMetadata {
+  return {
+    ...input,
+    health: input.fallbackReason ? "degraded" : "healthy",
+  };
+}
+
 export interface KernelStartupHealth {
   healthy: boolean;
   runnerMode: KernelRunnerMode;
@@ -675,14 +688,13 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
       mode: "ts",
       runnerMode: "disabled",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "canonicalize_hash",
         executionMode: "disabled",
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "kernel_disabled",
-        health: "degraded",
-      },
+      }),
     };
   }
 
@@ -693,14 +705,13 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
       mode: "ts",
       runnerMode: "disabled",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "canonicalize_hash",
         executionMode: flags.executionMode,
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "operation_disabled_env",
-        health: "degraded",
-      },
+      }),
     };
   }
 
@@ -727,13 +738,12 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
         runnerMode: rust.runnerMode,
         divergence: { normalizedHashMatch: match },
         durationMs: { kernel: rust.durationMs, ts: tsDuration },
-        metadata: {
+        metadata: buildKernelExecutionMetadata({
           operation: "canonicalize_hash",
           executionMode: flags.executionMode,
           usedPrimary: false,
           shadowCompared: true,
-          health: "healthy",
-        },
+        }),
       };
     } catch (error) {
       const reason = classifyErrorReason(error, "shadow_kernel_failed");
@@ -745,14 +755,13 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
         runnerMode: "fallback-ts",
         divergence: { normalizedHashMatch: false },
         durationMs: { ts: tsDuration },
-        metadata: {
+        metadata: buildKernelExecutionMetadata({
           operation: "canonicalize_hash",
           executionMode: flags.executionMode,
           usedPrimary: false,
           shadowCompared: true,
           fallbackReason: reason,
-          health: "degraded",
-        },
+        }),
       };
     }
   }
@@ -764,14 +773,13 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
       mode: "ts",
       runnerMode: "fallback-ts",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "canonicalize_hash",
         executionMode: flags.executionMode,
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "primary_not_allowed",
-        health: "degraded",
-      },
+      }),
     };
   }
 
@@ -784,13 +792,12 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
       mode: "rust_primary",
       runnerMode: rust.runnerMode,
       durationMs: { kernel: rust.durationMs, ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "canonicalize_hash",
         executionMode: flags.executionMode,
         usedPrimary: true,
         shadowCompared: false,
-        health: "healthy",
-      },
+      }),
     };
   } catch (error) {
     const reason = classifyErrorReason(error, "primary_kernel_failed");
@@ -800,14 +807,13 @@ export async function canonicalizeHashWithFallback(value: unknown): Promise<{
       mode: "ts",
       runnerMode: "fallback-ts",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "canonicalize_hash",
         executionMode: flags.executionMode,
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: reason,
-        health: "degraded",
-      },
+      }),
     };
   }
 }
@@ -830,14 +836,13 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
       mode: "ts",
       runnerMode: "disabled",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "proof_bundle_hash",
         executionMode: "disabled",
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "kernel_disabled",
-        health: "degraded",
-      },
+      }),
     };
   }
 
@@ -848,14 +853,13 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
       mode: "ts",
       runnerMode: "disabled",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "proof_bundle_hash",
         executionMode: flags.executionMode,
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "operation_disabled_env",
-        health: "degraded",
-      },
+      }),
     };
   }
 
@@ -866,14 +870,13 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
       mode: "ts",
       runnerMode: "fallback-ts",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "proof_bundle_hash",
         executionMode: flags.executionMode,
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "primary_not_allowed",
-        health: "degraded",
-      },
+      }),
     };
   }
 
@@ -887,13 +890,12 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
       mode: "rust_primary",
       runnerMode: rust.runnerMode,
       durationMs: { kernel: rust.durationMs, ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "proof_bundle_hash",
         executionMode: flags.executionMode,
         usedPrimary: true,
         shadowCompared: false,
-        health: "healthy",
-      },
+      }),
     };
   } catch (error) {
     const reason = classifyErrorReason(error, "primary_kernel_failed");
@@ -903,14 +905,13 @@ export async function proofBundleHashWithFallback(value: unknown): Promise<{
       mode: "ts",
       runnerMode: "fallback-ts",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "proof_bundle_hash",
         executionMode: flags.executionMode,
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: reason,
-        health: "degraded",
-      },
+      }),
     };
   }
 }
@@ -933,14 +934,13 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
       mode: "ts",
       runnerMode: "disabled",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "artifact_identity_hash",
         executionMode: "disabled",
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "kernel_disabled",
-        health: "degraded",
-      },
+      }),
     };
   }
 
@@ -951,14 +951,13 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
       mode: "ts",
       runnerMode: "disabled",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "artifact_identity_hash",
         executionMode: flags.executionMode,
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "operation_disabled_env",
-        health: "degraded",
-      },
+      }),
     };
   }
 
@@ -969,14 +968,13 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
       mode: "ts",
       runnerMode: "fallback-ts",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "artifact_identity_hash",
         executionMode: flags.executionMode,
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: "primary_not_allowed",
-        health: "degraded",
-      },
+      }),
     };
   }
 
@@ -990,13 +988,12 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
       mode: "rust_primary",
       runnerMode: rust.runnerMode,
       durationMs: { kernel: rust.durationMs, ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "artifact_identity_hash",
         executionMode: flags.executionMode,
         usedPrimary: true,
         shadowCompared: false,
-        health: "healthy",
-      },
+      }),
     };
   } catch (error) {
     const reason = classifyErrorReason(error, "primary_kernel_failed");
@@ -1006,14 +1003,13 @@ export async function artifactIdentityHashWithFallback(value: unknown): Promise<
       mode: "ts",
       runnerMode: "fallback-ts",
       durationMs: { ts: tsDuration },
-      metadata: {
+      metadata: buildKernelExecutionMetadata({
         operation: "artifact_identity_hash",
         executionMode: flags.executionMode,
         usedPrimary: false,
         shadowCompared: false,
         fallbackReason: reason,
-        health: "degraded",
-      },
+      }),
     };
   }
 }


### PR DESCRIPTION
### Motivation
- Remove contract drift where multiple hand-built `KernelExecutionMetadata` objects led to inconsistent or missing `health` values and blocked typecheck confidence. 
- Centralize the health derivation to ensure fallback semantics remain explicit (`fallbackReason` => `degraded`, otherwise `healthy`).
- Verify that the new canonical docs surface (`docs/platform-index.md`) is internally consistent and not pointing at missing canonical paths.

### Description
- Added a single constructor helper `buildKernelExecutionMetadata(...)` to `packages/cli/src/lib/kernel-client.ts` that always derives `health` from `fallbackReason` and returns a well-formed `KernelExecutionMetadata` object. 
- Replaced all inline `metadata` object literals in `canonicalizeHashWithFallback`, `proofBundleHashWithFallback`, and `artifactIdentityHashWithFallback` with calls to `buildKernelExecutionMetadata(...)` to enforce a single source-of-truth for metadata production. 
- Validated and confirmed the canonical documentation index and primary docs (`docs/platform-index.md`, `docs/capabilities.md`, `docs/architecture/platform-architecture.md`) only reference existing canonical paths and that `docs/DOCUMENTATION_INDEX.md` remains a superseded pointer. 
- Files changed: `packages/cli/src/lib/kernel-client.ts`.

### Testing
- Ran `pnpm lint` and observed only warnings, no blocking errors. 
- Ran `pnpm typecheck` which completed successfully with no type errors. 
- Ran `pnpm build` which completed successfully. 
- Ran `pnpm test` where all test suites passed; observed existing Jest/turbo open-handle warnings that can keep the top-level process alive (existing repo behavior, not introduced here). 
- Ran Rust checks `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b228f44380832887c133b8f5658de0)