### PR TITLE
docs: add governance meta, label legacy docs, and consolidate launch surfaces

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,9 @@
 # Settler Architecture
 
+> **Status:** SUPERSEDED
+> **Canonical architecture authority:** [`docs/architecture/platform-architecture.md`](./architecture/platform-architecture.md)
+> **Compatibility note:** Retained for legacy links; re-validate details against canonical architecture docs.
+
 ## Overview
 
 Settler is a **Open Source Reconciliation Engine API** built with TypeScript, Express, and PostgreSQL. The architecture follows **Hexagonal Architecture** (Ports & Adapters) with **CQRS** (Command Query Responsibility Segregation) and **Event-Driven** patterns. This ensures separation of concerns, testability, and maintainability.
@@ -16,6 +20,7 @@ The core business logic, independent of infrastructure.
 - **Repository Interfaces**: Contracts for data persistence (ports)
 
 **Key Principles:**
+
 - No dependencies on external frameworks
 - Pure business logic
 - Rich domain models with behavior
@@ -33,6 +38,7 @@ Orchestrates domain objects to fulfill use cases.
 - **DTOs**: Data Transfer Objects for API boundaries
 
 **Key Principles:**
+
 - Thin layer that delegates to domain
 - Transaction boundaries
 - Use case orchestration
@@ -50,6 +56,7 @@ Implements technical concerns and adapters.
 - **DI Container**: Dependency injection
 
 **Key Principles:**
+
 - Implements interfaces defined in domain/application
 - Can be swapped without changing business logic
 - Handles technical concerns
@@ -64,6 +71,7 @@ HTTP adapters that expose the application to the outside world.
 - **Validation**: Input validation with Zod
 
 **Key Principles:**
+
 - Thin adapters that translate HTTP to application calls
 - Input validation and output formatting
 - Error handling and status codes
@@ -342,12 +350,14 @@ HTTP adapters that expose the application to the outside world.
 See `config/env.schema.ts` for complete documentation.
 
 **Required for production:**
+
 - `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (or `DATABASE_URL`)
 - `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` (or `REDIS_URL`)
 - `JWT_SECRET` (min 32 chars)
 - `ENCRYPTION_KEY` (exactly 32 chars)
 
 **Optional:**
+
 - `SENTRY_DSN` (error tracking)
 - `LOG_LEVEL` (default: `info`)
 - `OTLP_ENDPOINT` (distributed tracing)

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,5 +1,9 @@
 # Architecture Overview
 
+> **Status:** SUPERSEDED
+> **Canonical architecture authority:** [`docs/architecture/platform-architecture.md`](./architecture/platform-architecture.md)
+> **Compatibility note:** Retained for historical context and inbound links.
+
 **Last Updated:** January 2026  
 **Audience:** Engineers, Architects, Technical Evaluators
 
@@ -44,12 +48,14 @@ Settler follows a **Hexagonal Architecture** (Ports & Adapters) pattern with **C
 **Purpose:** Core business logic, independent of infrastructure.
 
 **Components:**
+
 - **Entities:** Core business objects (User, Job, Execution, ApiKey, Tenant)
 - **Value Objects:** Immutable objects representing domain concepts
 - **Domain Events:** Events representing business occurrences
 - **Repository Interfaces:** Contracts for data persistence (ports)
 
 **Principles:**
+
 - No dependencies on external frameworks
 - Pure business logic
 - Rich domain models with behavior
@@ -62,6 +68,7 @@ Settler follows a **Hexagonal Architecture** (Ports & Adapters) pattern with **C
 **Purpose:** Orchestrates domain objects to fulfill use cases.
 
 **Components:**
+
 - **Services:** Application services orchestrating domain logic
 - **Commands:** CQRS command handlers (write operations)
 - **Queries:** Read operations
@@ -70,6 +77,7 @@ Settler follows a **Hexagonal Architecture** (Ports & Adapters) pattern with **C
 - **DTOs:** Data Transfer Objects for API boundaries
 
 **Principles:**
+
 - Thin layer that delegates to domain
 - Transaction boundaries
 - Use case orchestration
@@ -81,6 +89,7 @@ Settler follows a **Hexagonal Architecture** (Ports & Adapters) pattern with **C
 **Purpose:** Implements technical concerns and adapters.
 
 **Components:**
+
 - **Repositories:** Database implementations of repository interfaces
 - **Database:** PostgreSQL connection and queries
 - **Events:** Event bus implementation
@@ -89,6 +98,7 @@ Settler follows a **Hexagonal Architecture** (Ports & Adapters) pattern with **C
 - **Resilience:** Retry, circuit breakers, dead letter queues
 
 **Principles:**
+
 - Implements interfaces defined in domain/application
 - Can be swapped without changing business logic
 - Handles technical concerns
@@ -100,6 +110,7 @@ Settler follows a **Hexagonal Architecture** (Ports & Adapters) pattern with **C
 **Purpose:** HTTP adapters exposing the application to the outside world.
 
 **Components:**
+
 - **Routes:** Express route handlers
 - **Middleware:** Auth, validation, error handling
 - **Controllers:** Thin controllers calling application services
@@ -107,6 +118,7 @@ Settler follows a **Hexagonal Architecture** (Ports & Adapters) pattern with **C
 - **Web App:** Next.js application with Developer Console
 
 **Principles:**
+
 - Thin adapters translating HTTP to application calls
 - Input validation and output formatting
 - Error handling and status codes

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,5 +1,9 @@
 # Documentation Index (Role-Based)
 
+> **Status:** SUPPORTING
+> **Canonical entrypoint:** [`docs/platform-index.md`](./platform-index.md)
+> **Note:** This role-based map is a convenience navigator and does not override canonical documents.
+
 > Legend: **[OSS]** available in open-source runtime, **[Operator]** operator/admin surface, **[Enterprise]** optional enterprise surface.
 
 ## Developer

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,9 @@ This directory is the canonical documentation surface for Settler.
 ## Documentation governance surfaces
 
 - Documentation map: `docs/_meta/DOC_MAP.md`
+- Governance map: `docs/_meta/document-governance-map.md`
+- Status matrix: `docs/_meta/document-status-matrix.md`
+- Path normalization notes: `docs/_meta/path-normalization-notes.md`
 - Governance rules: `docs/_meta/DOCS_GOVERNANCE.md`
 - Full inventory: `docs/_meta/doc-inventory.md` + `docs/_meta/doc-inventory.json`
 - Overlap clusters: `docs/_meta/doc-clusters.md`

--- a/docs/SOURCE_OF_TRUTH.md
+++ b/docs/SOURCE_OF_TRUTH.md
@@ -1,5 +1,9 @@
 # Source of Truth Documentation
 
+> **Status:** SUPERSEDED
+> **Replaced by:** [`docs/platform-index.md`](./platform-index.md), [`docs/capabilities.md`](./capabilities.md), [`docs/architecture/platform-architecture.md`](./architecture/platform-architecture.md), and `docs/setup/*`.
+> **Compatibility note:** Retained to avoid broken links from external references.
+
 ## Overview
 
 This document defines the authoritative sources of truth for Settler Enterprise.
@@ -53,16 +57,19 @@ This document defines the authoritative sources of truth for Settler Enterprise.
 ## Code as Source of Truth
 
 ### Database Schema
+
 - **Location**: `supabase/migrations/`
 - **Format**: SQL migration files
 - **Authority**: Migrations define actual schema
 
 ### API Contracts
+
 - **Location**: `packages/web/src/app/api/`
 - **Format**: TypeScript route handlers
 - **Authority**: Code defines actual API behavior
 
 ### Type Definitions
+
 - **Location**: `packages/web/src/types/`
 - **Format**: TypeScript type definitions
 - **Authority**: Types define data structures
@@ -70,16 +77,19 @@ This document defines the authoritative sources of truth for Settler Enterprise.
 ## Documentation Standards
 
 ### Markdown Files
+
 - Use Markdown format
 - Include code examples
 - Keep up to date with code
 
 ### Code Comments
+
 - JSDoc for functions
 - Inline comments for complex logic
 - No commented-out code
 
 ### README Files
+
 - One README per directory
 - Explain purpose and usage
 - Link to related docs
@@ -87,11 +97,13 @@ This document defines the authoritative sources of truth for Settler Enterprise.
 ## Version Control
 
 ### Git Tags
+
 - Tag releases: `v1.0.0`
 - Tag major changes
 - Include release notes
 
 ### Branch Strategy
+
 - `main` - Production-ready code
 - `develop` - Development branch
 - Feature branches for new work
@@ -99,11 +111,13 @@ This document defines the authoritative sources of truth for Settler Enterprise.
 ## Maintenance
 
 ### Regular Updates
+
 - Update docs with code changes
 - Review quarterly
 - Archive outdated docs
 
 ### Documentation Review
+
 - Code review includes docs
 - Update docs before release
 - Verify examples work

--- a/docs/_meta/DOCS_CONSOLIDATION_CHANGELOG.md
+++ b/docs/_meta/DOCS_CONSOLIDATION_CHANGELOG.md
@@ -13,30 +13,32 @@ _Date: 2026-03-11_
 
 ## 2) Canonical docs created/updated
 
-| Path | Why canonical now | Source inputs |
-|---|---|---|
-| `README.md` | Clean external/repo entrypoint with deterministic quickstart and docs routing. | Prior duplicated README content + launch quickstart cluster. |
-| `CONTRIBUTING.md` | Stable contributor gate + docs governance integration. | Existing contributing flow + docs governance requirements from this pass. |
-| `docs/README.md` | Explicit docs hub and meta-index for discoverability. | Existing docs hub + new governance/meta outputs. |
-| `docs/_meta/DOC_MAP.md` | Canonical map of documentation categories. | Repo structure review from inventory pass. |
-| `docs/_meta/DOCS_GOVERNANCE.md` | Anti-entropy rules for future doc growth. | Consolidation policy from this pass. |
-| `docs/archive/README.md` | Archive rationale and revival/indexing policy. | Existing archive note + governance requirements. |
-| `docs/prompts/README.md` | Prompt asset curation policy and indexing pointer. | Existing `prompts/` directory + prompt handling rules. |
+| Path                            | Why canonical now                                                              | Source inputs                                                             |
+| ------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `README.md`                     | Clean external/repo entrypoint with deterministic quickstart and docs routing. | Prior duplicated README content + launch quickstart cluster.              |
+| `CONTRIBUTING.md`               | Stable contributor gate + docs governance integration.                         | Existing contributing flow + docs governance requirements from this pass. |
+| `docs/README.md`                | Explicit docs hub and meta-index for discoverability.                          | Existing docs hub + new governance/meta outputs.                          |
+| `docs/_meta/DOC_MAP.md`         | Canonical map of documentation categories.                                     | Repo structure review from inventory pass.                                |
+| `docs/_meta/DOCS_GOVERNANCE.md` | Anti-entropy rules for future doc growth.                                      | Consolidation policy from this pass.                                      |
+| `docs/archive/README.md`        | Archive rationale and revival/indexing policy.                                 | Existing archive note + governance requirements.                          |
+| `docs/prompts/README.md`        | Prompt asset curation policy and indexing pointer.                             | Existing `prompts/` directory + prompt handling rules.                    |
 
 ## 3) Merges performed
 
-| Source | Destination | Retained content summary |
-|---|---|---|
-| Duplicated root README blocks | `README.md` | Consolidated deterministic quickstart, repo structure, and docs map while removing repeated sections. |
-| Root launch/summary cluster (high-level orientation) | `README.md`, `docs/README.md`, governance/meta docs | Preserved durable entrypoint guidance; moved milestone-specific details to archive. |
+| Source                                               | Destination                                         | Retained content summary                                                                              |
+| ---------------------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Duplicated root README blocks                        | `README.md`                                         | Consolidated deterministic quickstart, repo structure, and docs map while removing repeated sections. |
+| Root launch/summary cluster (high-level orientation) | `README.md`, `docs/README.md`, governance/meta docs | Preserved durable entrypoint guidance; moved milestone-specific details to archive.                   |
 
 ## 4) Archives created
 
 See canonical index:
+
 - `docs/_meta/archive-index.md`
 - `docs/_meta/archive-index.json`
 
 This pass archived 13 superseded root docs to:
+
 - `docs/archive/2026-03/root-superseded/`
 
 ## 5) Deletions
@@ -63,6 +65,7 @@ Primary unresolved clusters requiring additional human-domain review:
 - `onboarding-setup`
 
 Supporting artifacts:
+
 - `docs/_meta/doc-clusters.md`
 - `docs/_meta/doc-inventory.json`
 - `docs/_meta/orphan-docs.md`
@@ -159,3 +162,34 @@ Updated references in touched docs to point to canonical active paths, including
 ### Safety notes
 
 - No markdown deletions were executed in this pass because no verified exact content-equivalent duplicate case-collision pairs were found.
+
+---
+
+## 11) Repo packaging + governance cleanup (2026-03-12)
+
+### Scope
+
+- Canonical-index reinforcement and legacy authority deconfliction.
+- Documentation status-model standardization.
+- Compatibility-safe labeling for superseded docs.
+
+### Actions completed
+
+- Added governance artifacts:
+  - `docs/_meta/document-governance-map.md`
+  - `docs/_meta/document-status-matrix.md`
+  - `docs/_meta/path-normalization-notes.md`
+- Updated `docs/platform-index.md` to explicitly classify legacy competing docs and route launch authority to `docs/launch/`.
+- Updated `docs/README.md` governance section to include new status/governance artifacts.
+- Added explicit status headers to legacy docs retained for compatibility:
+  - `docs/INDEX.md` (supporting)
+  - `docs/SOURCE_OF_TRUTH.md` (superseded)
+  - `docs/ARCHITECTURE.md` (superseded)
+  - `docs/ARCHITECTURE_OVERVIEW.md` (superseded)
+- Added `launch/README.md` marking root launch docs as superseded compatibility artifacts and redirecting to canonical `docs/launch/`.
+- Extended `docs/_meta/DOCS_GOVERNANCE.md` with an explicit status model and canonical tie-breaker rule.
+
+### Safety notes
+
+- No destructive deletions were performed in this pass.
+- Legacy files were retained in-place and labeled to avoid breaking inbound links.

--- a/docs/_meta/DOCS_GOVERNANCE.md
+++ b/docs/_meta/DOCS_GOVERNANCE.md
@@ -16,11 +16,26 @@ This policy keeps Settler docs navigable, truthful, and low-entropy.
 ## When to create a new doc
 
 Create a new doc only when one of these is true:
+
 1. the topic is durable and distinct from existing canonical docs;
 2. the audience and ownership are clear;
 3. cross-linking from a hub location is added in the same change.
 
 Otherwise, extend an existing canonical doc.
+
+## Documentation status model
+
+Use these labels consistently where status clarity matters:
+
+- **CANONICAL**: active source of truth.
+- **SUPPORTING**: non-authoritative supporting reference.
+- **SUPERSEDED**: replaced by newer canonical docs; must point to replacement.
+- **ARCHIVED**: historical artifact under `docs/archive/`.
+- **GENERATED**: reproducible machine-generated/report output.
+- **DRAFT**: in-progress or exploratory content not yet validated.
+- **META**: governance and repository-hygiene artifacts under `docs/_meta/`.
+
+Canonical tie-breaker is always `docs/platform-index.md`.
 
 ## Naming conventions
 
@@ -37,6 +52,7 @@ Otherwise, extend an existing canonical doc.
 ## Archive requirements
 
 Any archived doc must be represented in both:
+
 - `docs/_meta/archive-index.md`
 - `docs/_meta/archive-index.json`
 
@@ -45,6 +61,7 @@ Each entry must include original path, archived path, reason, merge target (if a
 ## Deletion criteria
 
 Delete markdown only when at least one condition is provable:
+
 - empty/trivial placeholder;
 - exact duplicate with no unique context;
 - fully merged content with no forensic value;
@@ -60,5 +77,6 @@ When uncertain: `merge > archive > manual-review > delete`.
 ## Change traceability
 
 For significant doc moves/archives/deletions, update:
+
 - `docs/_meta/DOCS_CONSOLIDATION_CHANGELOG.md`
 - `docs/_meta/archive-index.*` (if archiving)

--- a/docs/_meta/document-governance-map.md
+++ b/docs/_meta/document-governance-map.md
@@ -1,0 +1,37 @@
+# Document Governance Map
+
+## Purpose
+
+This map defines how to classify and route Settler documentation so readers can quickly identify what is authoritative versus historical.
+
+Primary canonical spine:
+
+- `docs/platform-index.md`
+- `docs/capabilities.md`
+- `docs/architecture/platform-architecture.md`
+- `docs/setup/*`
+- `docs/launch/*` for launch/readiness execution assets
+
+## Status model
+
+| Status         | Meaning                                                       | Expected location                                                                                     | Index behavior                                                           |
+| -------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **CANONICAL**  | Current source of truth for a platform domain.                | `docs/` canonical paths (`platform-index`, `capabilities`, `architecture/`, `setup/`, core runbooks). | Must be linked from `docs/platform-index.md` and/or `docs/README.md`.    |
+| **SUPPORTING** | Useful working reference that complements canonical docs.     | Domain folders in `docs/` (`reference/`, `reports/`, `security/`, etc).                               | Linked from local domain indexes; not positioned as repo-wide authority. |
+| **SUPERSEDED** | Previously authoritative guidance replaced by canonical docs. | Kept in place with explicit superseded banner or moved under `docs/archive/`.                         | Must point to replacement canonical doc.                                 |
+| **ARCHIVED**   | Historical artifacts kept for provenance.                     | `docs/archive/` with index entries in `docs/_meta/archive-index.*`.                                   | Should not appear as primary entrypoints.                                |
+| **GENERATED**  | Machine-generated or reproducible evidence artifacts.         | `docs/_meta/`, `reports/`, tool output directories.                                                   | Clearly labeled as generated/evidence; never treated as policy truth.    |
+| **DRAFT**      | Exploratory or in-progress material pending validation.       | Prefer domain folder with draft marker in header.                                                     | Excluded from canonical indexes unless needed for active review.         |
+| **META**       | Governance, inventory, and repository hygiene documentation.  | `docs/_meta/`.                                                                                        | Linked from `docs/README.md` governance section only.                    |
+
+## Canonical authority routing
+
+- Platform entry and tie-breaker: `docs/platform-index.md`.
+- Capability authority: `docs/capabilities.md`.
+- Architecture authority: `docs/architecture/platform-architecture.md`.
+- Setup/operator truth: `docs/setup/`.
+- Launch/readiness execution set: `docs/launch/README.md` + linked launch docs.
+
+## Compatibility notes
+
+Some legacy files remain in original paths to avoid link breakage. These files must be explicitly marked **SUPERSEDED** and point to canonical replacements.

--- a/docs/_meta/document-status-matrix.md
+++ b/docs/_meta/document-status-matrix.md
@@ -1,0 +1,21 @@
+# Document Status Matrix
+
+Snapshot of high-signal docs and their intended trust level.
+
+| Path                                         | Domain                         | Status     | Canonical replacement / pointer              | Action                                                     |
+| -------------------------------------------- | ------------------------------ | ---------- | -------------------------------------------- | ---------------------------------------------------------- |
+| `docs/platform-index.md`                     | Global docs navigation         | CANONICAL  | N/A                                          | Keep as primary entrypoint.                                |
+| `docs/capabilities.md`                       | Capability registry            | CANONICAL  | N/A                                          | Keep authoritative capability map.                         |
+| `docs/architecture/platform-architecture.md` | Architecture                   | CANONICAL  | N/A                                          | Keep as architecture authority.                            |
+| `docs/setup/env-matrix.md`                   | Setup                          | CANONICAL  | N/A                                          | Keep in setup spine.                                       |
+| `docs/setup/operator-runbook.md`             | Operations                     | CANONICAL  | N/A                                          | Keep in setup spine.                                       |
+| `docs/launch/README.md`                      | Launch/readiness               | CANONICAL  | N/A                                          | Keep as launch hub.                                        |
+| `docs/README.md`                             | Docs hub                       | SUPPORTING | `docs/platform-index.md`                     | Keep as discovery hub; defer authority to platform index.  |
+| `docs/INDEX.md`                              | Role-based navigation          | SUPPORTING | `docs/platform-index.md`                     | Marked non-canonical to avoid authority split.             |
+| `docs/DOCUMENTATION_INDEX.md`                | Legacy index                   | SUPERSEDED | `docs/platform-index.md`                     | Retained as redirect-style pointer.                        |
+| `docs/SOURCE_OF_TRUTH.md`                    | Legacy source-of-truth framing | SUPERSEDED | `docs/platform-index.md` + canonical spine   | Marked superseded and narrowed.                            |
+| `docs/ARCHITECTURE.md`                       | Legacy architecture narrative  | SUPERSEDED | `docs/architecture/platform-architecture.md` | Marked superseded with compatibility retention.            |
+| `docs/ARCHITECTURE_OVERVIEW.md`              | Legacy architecture overview   | SUPERSEDED | `docs/architecture/platform-architecture.md` | Marked superseded with compatibility retention.            |
+| `launch/*.md` (repo root)                    | Legacy social launch drafts    | SUPERSEDED | `docs/launch/`                               | Scoped as historical campaign artifacts.                   |
+| `docs/archive/**`                            | Historical docs                | ARCHIVED   | N/A                                          | Continue index discipline in `docs/_meta/archive-index.*`. |
+| `docs/_meta/**`                              | Governance/inventory artifacts | META       | N/A                                          | Keep explicitly meta; never canonical product truth.       |

--- a/docs/_meta/path-normalization-notes.md
+++ b/docs/_meta/path-normalization-notes.md
@@ -1,0 +1,18 @@
+# Path Normalization Notes
+
+## Intent
+
+Normalize documentation discoverability without unsafe mass renames that could break deep links, scripts, or external references.
+
+## Current compatibility exceptions
+
+1. Uppercase legacy docs (example: `docs/ARCHITECTURE.md`) are retained for compatibility but explicitly marked as **SUPERSEDED**.
+2. Root-level `launch/` folder is retained as historical campaign collateral while canonical launch operations live under `docs/launch/`.
+3. Legacy index-style docs are retained as redirect surfaces rather than removed.
+
+## Normalization rule going forward
+
+- New docs should prefer lowercase kebab-case naming.
+- New canonical docs belong in explicit domain folders under `docs/`.
+- New historical snapshots should go to `docs/archive/` with archive-index entries.
+- New governance or inventory artifacts should go under `docs/_meta/` and be labeled **META**.

--- a/docs/platform-index.md
+++ b/docs/platform-index.md
@@ -94,6 +94,14 @@ Additional operational verification:
 
 ## 13) Document Consolidation and Cleanup Decisions
 
-- Legacy `docs/DOCUMENTATION_INDEX.md` is now superseded by this index and retained as a pointer to avoid broken links.
+- Legacy `docs/DOCUMENTATION_INDEX.md` is superseded and retained only as a pointer to this index.
+- Legacy `docs/SOURCE_OF_TRUTH.md`, `docs/ARCHITECTURE.md`, and `docs/ARCHITECTURE_OVERVIEW.md` are compatibility-retained and explicitly superseded.
+- Root-level `launch/` files are treated as historical campaign artifacts; canonical launch/readiness docs live in `docs/launch/`.
 - Canonical setup guidance is consolidated under `docs/setup/`.
 - Canonical architecture guidance is consolidated under `docs/architecture/` with `platform-architecture.md` as the authoritative summary.
+
+## 14) Documentation Governance References
+
+- Governance map: [`docs/_meta/document-governance-map.md`](./_meta/document-governance-map.md)
+- Status matrix: [`docs/_meta/document-status-matrix.md`](./_meta/document-status-matrix.md)
+- Path normalization notes: [`docs/_meta/path-normalization-notes.md`](./_meta/path-normalization-notes.md)

--- a/launch/README.md
+++ b/launch/README.md
@@ -1,0 +1,8 @@
+# Legacy Launch Artifacts (Compatibility Surface)
+
+> **Status:** SUPERSEDED
+> **Canonical launch hub:** [`docs/launch/README.md`](../docs/launch/README.md)
+
+This folder retains historical social launch drafts and execution snapshots that were originally kept at repository root.
+
+Use `docs/launch/` for active launch/readiness truth. Keep these files only for provenance and link compatibility.


### PR DESCRIPTION
### Motivation

- Reduce ambiguity between competing documentation authorities by establishing a small, explicit governance layer. 
- Make the canonical documentation spine and discovery surfaces obvious while preserving historic artifacts for traceability. 
- Avoid destructive moves or deletions and keep compatibility with external links and scripts.

### Description

- Added governance/meta artifacts under `docs/_meta/`: `document-governance-map.md`, `document-status-matrix.md`, and `path-normalization-notes.md` to define status categories and routing. 
- Reinforced canonical routing and references in `docs/platform-index.md` and surfaced the new governance artifacts from `docs/README.md`. 
- Marked legacy/competing docs with explicit status banners (`SUPPORTING` / `SUPERSEDED`) including `docs/INDEX.md`, `docs/SOURCE_OF_TRUTH.md`, `docs/ARCHITECTURE.md`, and `docs/ARCHITECTURE_OVERVIEW.md`. 
- Added `launch/README.md` at the repo root to classify root-level launch collateral as a superseded compatibility surface and updated the consolidation changelog and governance doc to record the pass.

### Testing

- Ran `pnpm lint` which completed successfully (existing warnings remain and were not introduced by this change). 
- Ran `pnpm verify:docs` which completed and reported `✅ Docs verification passed.`. 
- Invoked `pnpm verify:links` / link scan and executed the repository link checks (the scan ran without surfacing blocking dead-link failures during this run). 
- `pnpm typecheck`, `pnpm build`, and `pnpm test` were invoked during verification activity but did not reach a full, clean terminal completion in the execution window and are therefore not claimed as fully completed in this pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b22ce6a11483289dcf0316a0317599)