### PR TITLE
fix(web): ensure production content integration test cleans up Next child process to prevent Jest hang

### DIFF
--- a/packages/web/src/__tests__/integration/content-pages.production.test.ts
+++ b/packages/web/src/__tests__/integration/content-pages.production.test.ts
@@ -21,7 +21,12 @@ function runCommand(command: string, args: string[], cwd: string): Promise<void>
       stdio: "pipe",
     });
 
+    let stdoutOutput = "";
     let stderrOutput = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdoutOutput += chunk.toString();
+    });
 
     child.stderr.on("data", (chunk) => {
       stderrOutput += chunk.toString();
@@ -33,7 +38,9 @@ function runCommand(command: string, args: string[], cwd: string): Promise<void>
         return;
       }
 
-      reject(new Error(`Command failed: ${command} ${args.join(" ")}\n${stderrOutput}`));
+      reject(
+        new Error(`Command failed: ${command} ${args.join(" ")}\n${stdoutOutput}\n${stderrOutput}`)
+      );
     });
 
     child.on("error", reject);
@@ -73,8 +80,10 @@ describe("content pages in production build mode", () => {
     serverProcess = spawn("pnpm", ["exec", "next", "start", "-p", String(PRODUCTION_PORT)], {
       cwd: WEB_PACKAGE_DIR,
       env: { ...process.env, NODE_ENV: "production" },
-      stdio: "pipe",
+      stdio: "ignore",
     });
+
+    serverProcess.unref();
 
     await waitForServer(`${BASE_URL}/product`);
   });
@@ -82,9 +91,21 @@ describe("content pages in production build mode", () => {
   afterAll(async () => {
     if (serverProcess && !serverProcess.killed) {
       serverProcess.kill("SIGTERM");
-    }
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          serverProcess?.once("exit", () => resolve());
+        }),
+        new Promise<void>((resolve) => {
+          setTimeout(() => {
+            if (serverProcess && !serverProcess.killed) {
+              serverProcess.kill("SIGKILL");
+            }
+            resolve();
+          }, 2_000);
+        }),
+      ]);
+    }
   });
 
   it("serves all MDX-backed content routes without hard-500 errors", async () => {


### PR DESCRIPTION
### Motivation
- Prevent top-level `pnpm test` from hanging by fixing a non-deterministic teardown in the web integration test that spawned a production Next.js server and left child-process handles open.

### Description
- Capture both `stdout` and `stderr` in `runCommand` to improve diagnostic output when `pnpm run build` fails and to make failures actionable (file: `packages/web/src/__tests__/integration/content-pages.production.test.ts`).
- Spawn the production `next start` process with `stdio: "ignore"` and call `serverProcess.unref()` so inherited stdio does not keep Jest alive.
- Replace the previous fixed-delay teardown with a deterministic shutdown: send `SIGTERM`, wait for the child's `exit` event, and escalate to `SIGKILL` after a 2s timeout if needed.

### Testing
- Ran the targeted web integration test with diagnostics using `pnpm --filter @settler/web exec jest --runInBand --detectOpenHandles src/__tests__/integration/content-pages.production.test.ts` to exercise the build + start lifecycle and verify the server process is started and subsequently torn down without leaving a `.next/lock` in the workspace (observed during the run).
- Executed `pnpm --filter @settler/web run build` to verify the build step completes under the environment and to validate captured stdout/stderr when build issues occur (build completed during the verification run).
- Exercised package-level diagnostics (`pnpm --filter @settler/api exec jest --runInBand --detectOpenHandles`) to narrow the hang to the web integration path and confirm other packages still run normally (diagnostic runs produced expected test outputs).
- Ran a bounded top-level run (`timeout 600 pnpm test`) to observe monorepo test orchestration progress and confirm the fix removes the previously isolated web-suite child-process leak during the observed window, while full monorepo completion is long-running and may require CI verification for final confirmation.

Files changed:
- packages/web/src/__tests__/integration/content-pages.production.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b230e359d883288d34b480a411b933)