### PR TITLE
Add Settler SVG brand assets and SettlerLogo component; switch app to SVG favicons and centralized brand images

### DIFF
--- a/packages/web/public/brand/settler/logo-icon.svg
+++ b/packages/web/public/brand/settler/logo-icon.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="1" width="38" height="38" rx="10" fill="#0F172A" stroke="#334155"/>
+  <path d="M27.5 12.5C25.5 10.5 22.8 9.5 20 9.5C14.2 9.5 9.5 14.2 9.5 20C9.5 25.8 14.2 30.5 20 30.5C24.3 30.5 28.1 27.9 29.7 24" stroke="#22D3EE" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="20" cy="20" r="3" fill="#22D3EE"/>
+</svg>

--- a/packages/web/public/brand/settler/logo-primary-horizontal.svg
+++ b/packages/web/public/brand/settler/logo-primary-horizontal.svg
@@ -1,0 +1,12 @@
+<svg width="160" height="40" viewBox="0 0 160 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="1" width="38" height="38" rx="10" fill="#0F172A" stroke="#334155"/>
+  <path d="M27.5 12.5C25.5 10.5 22.8 9.5 20 9.5C14.2 9.5 9.5 14.2 9.5 20C9.5 25.8 14.2 30.5 20 30.5C24.3 30.5 28.1 27.9 29.7 24" stroke="#22D3EE" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="20" cy="20" r="3" fill="#22D3EE"/>
+  <path d="M50 26V14H54.2L58 21.6L61.8 14H66V26H62.8V19.8L59.7 26H56.3L53.2 19.8V26H50Z" fill="#0F172A"/>
+  <path d="M68.7 26V14H77.8V17H72V18.7H77.2V21.6H72V23H78V26H68.7Z" fill="#0F172A"/>
+  <path d="M80 26V14H83.3V23H88.6V26H80Z" fill="#0F172A"/>
+  <path d="M90 26V14H93.3V18.2H97.1V14H100.4V26H97.1V21.2H93.3V26H90Z" fill="#0F172A"/>
+  <path d="M102.7 26V14H111.8V17H106V18.7H111.2V21.6H106V23H112V26H102.7Z" fill="#0F172A"/>
+  <path d="M114.1 26V14H117.3L122.4 20.7V14H125.7V26H122.5L117.4 19.3V26H114.1Z" fill="#0F172A"/>
+  <path d="M127.6 26L132 14H136L140.4 26H136.9L136.2 23.8H131.8L131.1 26H127.6ZM132.7 21H135.3L134 16.9L132.7 21Z" fill="#0F172A"/>
+</svg>

--- a/packages/web/public/brand/settler/logo-square.svg
+++ b/packages/web/public/brand/settler/logo-square.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="1" width="62" height="62" rx="14" fill="#0F172A" stroke="#334155" stroke-width="2"/>
+  <path d="M44.5 20.5C41.9 17.8 38.4 16.5 34.8 16.5C27.2 16.5 21 22.7 21 30.3C21 37.9 27.2 44.1 34.8 44.1C40.5 44.1 45.4 40.7 47.5 35.9" stroke="#22D3EE" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="34.8" cy="30.3" r="4.2" fill="#22D3EE"/>
+</svg>

--- a/packages/web/public/brand/settler/logo-stacked.svg
+++ b/packages/web/public/brand/settler/logo-stacked.svg
@@ -1,0 +1,11 @@
+<svg width="160" height="72" viewBox="0 0 160 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="60" y="1" width="40" height="40" rx="10" fill="#0F172A" stroke="#334155"/>
+  <path d="M86.5 12.5C84.5 10.5 81.8 9.5 79 9.5C73.2 9.5 68.5 14.2 68.5 20C68.5 25.8 73.2 30.5 79 30.5C83.3 30.5 87.1 27.9 88.7 24" stroke="#22D3EE" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="79" cy="20" r="3" fill="#22D3EE"/>
+  <path d="M34 67V49H38.5V62.5H46V67H34Z" fill="currentColor"/>
+  <path d="M49 67V49H53.5V55.7H59.4V49H63.9V67H59.4V60.2H53.5V67H49Z" fill="currentColor"/>
+  <path d="M67.5 67V49H80V53H72V56H79.2V60H72V63H80.5V67H67.5Z" fill="currentColor"/>
+  <path d="M83 67V49H87.5V63H95V67H83Z" fill="currentColor"/>
+  <path d="M98 67V49H102.5V63H110V67H98Z" fill="currentColor"/>
+  <path d="M113 67V49H117.4L124 58.2V49H128.5V67H124.7L117.5 57.2V67H113Z" fill="currentColor"/>
+</svg>

--- a/packages/web/public/brand/settler/logo-wordmark.svg
+++ b/packages/web/public/brand/settler/logo-wordmark.svg
@@ -1,0 +1,9 @@
+<svg width="92" height="16" viewBox="0 0 92 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1 15V3H5.2L9 10.6L12.8 3H17V15H13.8V8.8L10.7 15H7.3L4.2 8.8V15H1Z" fill="currentColor"/>
+  <path d="M19.7 15V3H28.8V6H23V7.7H28.2V10.6H23V12H29V15H19.7Z" fill="currentColor"/>
+  <path d="M31 15V3H34.3V12H39.6V15H31Z" fill="currentColor"/>
+  <path d="M41 15V3H44.3V7.2H48.1V3H51.4V15H48.1V10.2H44.3V15H41Z" fill="currentColor"/>
+  <path d="M53.7 15V3H62.8V6H57V7.7H62.2V10.6H57V12H63V15H53.7Z" fill="currentColor"/>
+  <path d="M65.1 15V3H68.3L73.4 9.7V3H76.7V15H73.5L68.4 8.3V15H65.1Z" fill="currentColor"/>
+  <path d="M78.6 15L83 3H87L91.4 15H87.9L87.2 12.8H82.8L82.1 15H78.6ZM83.7 10H86.3L85 5.9L83.7 10Z" fill="currentColor"/>
+</svg>

--- a/packages/web/public/manifest.json
+++ b/packages/web/public/manifest.json
@@ -9,39 +9,39 @@
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "/assets/images/settler-favicon.webp",
+      "src": "/brand/settler/logo-icon.svg",
       "sizes": "680x680",
-      "type": "image/webp",
+      "type": "image/svg+xml",
       "purpose": "any"
     },
     {
-      "src": "/assets/images/settler-favicon.png",
+      "src": "/brand/settler/logo-icon.svg",
       "sizes": "680x680",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "purpose": "any"
     },
     {
-      "src": "/assets/images/settler-favicon.webp",
+      "src": "/brand/settler/logo-icon.svg",
       "sizes": "192x192",
-      "type": "image/webp",
+      "type": "image/svg+xml",
       "purpose": "any maskable"
     },
     {
-      "src": "/assets/images/settler-favicon.png",
+      "src": "/brand/settler/logo-icon.svg",
       "sizes": "192x192",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "purpose": "any maskable"
     },
     {
-      "src": "/assets/images/settler-favicon.webp",
+      "src": "/brand/settler/logo-icon.svg",
       "sizes": "512x512",
-      "type": "image/webp",
+      "type": "image/svg+xml",
       "purpose": "any maskable"
     },
     {
-      "src": "/assets/images/settler-favicon.png",
+      "src": "/brand/settler/logo-icon.svg",
       "sizes": "512x512",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "purpose": "any maskable"
     },
     {

--- a/packages/web/src/app/[slug]/page.tsx
+++ b/packages/web/src/app/[slug]/page.tsx
@@ -110,11 +110,7 @@ export default async function TenantPageRoute({ params }: PageProps) {
       tenantSlug={tenantContext.tenantSlug}
     >
       <div className="min-h-screen">
-        <TenantNavigation
-          navItems={tenantContext.navigation?.navItems || []}
-          {...(tenantContext.branding?.logoUrl ? { logoUrl: tenantContext.branding.logoUrl } : {})}
-          tenantName={tenantContext.tenantSlug || "Settler"}
-        />
+        <TenantNavigation navItems={tenantContext.navigation?.navItems || []} />
         <main className="pt-16">
           <PageRenderer blocks={page.blocks} />
         </main>

--- a/packages/web/src/app/app/layout.tsx
+++ b/packages/web/src/app/app/layout.tsx
@@ -1,9 +1,8 @@
 import Link from "next/link";
-import Image from "next/image";
 import { EnvErrorPanel } from "@/components/env/EnvErrorPanel";
 import { getAppEnvStatus } from "@/lib/env/runtime-access";
 import { createClient } from "@/lib/supabase/server";
-import { SETTLER_IMAGES } from "@/lib/images/image-config";
+import { SettlerLogo } from "@/components/brand/SettlerLogo";
 
 function SignedOutScreen() {
   return (
@@ -77,14 +76,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     <div className="flex h-screen bg-background-light">
       <aside className="w-72 border-r border-slate-200 bg-white">
         <Link href="/" className="flex border-b border-slate-200 p-4">
-          <Image
-            src={SETTLER_IMAGES.logoMain.webpPath || SETTLER_IMAGES.logoMain.path}
-            alt={SETTLER_IMAGES.logoMain.alt}
-            width={130}
-            height={34}
-            className="h-8 w-auto"
-            priority
-          />
+          <SettlerLogo variant="horizontal" className="h-8 w-auto" priority />
         </Link>
         <nav className="space-y-4 p-3">
           {navSections.map((section) => (

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -46,45 +46,14 @@ export const metadata: Metadata = {
   },
   icons: {
     icon: [
-      // WebP version for modern browsers (better performance)
-      ...(SETTLER_IMAGES.favicon.webpPath
-        ? [
-            {
-              url: SETTLER_IMAGES.favicon.webpPath,
-              type: "image/webp",
-              sizes: `${SETTLER_IMAGES.favicon.width}x${SETTLER_IMAGES.favicon.height}`,
-            },
-          ]
-        : []),
       {
         url: SETTLER_IMAGES.favicon.path,
         type: SETTLER_IMAGES.favicon.mimeType,
         sizes: `${SETTLER_IMAGES.favicon.width}x${SETTLER_IMAGES.favicon.height}`,
       },
-      ...(SETTLER_IMAGES.favicon192.webpPath
-        ? [{ url: SETTLER_IMAGES.favicon192.webpPath, type: "image/webp", sizes: "192x192" }]
-        : []),
-      {
-        url: SETTLER_IMAGES.favicon192.path,
-        type: SETTLER_IMAGES.favicon192.mimeType,
-        sizes: "192x192",
-      },
-      ...(SETTLER_IMAGES.favicon512.webpPath
-        ? [{ url: SETTLER_IMAGES.favicon512.webpPath, type: "image/webp", sizes: "512x512" }]
-        : []),
-      {
-        url: SETTLER_IMAGES.favicon512.path,
-        type: SETTLER_IMAGES.favicon512.mimeType,
-        sizes: "512x512",
-      },
-      { url: "/favicon.svg", type: "image/svg+xml" },
     ],
     apple: [
-      {
-        url: SETTLER_IMAGES.favicon192.path,
-        type: SETTLER_IMAGES.favicon192.mimeType,
-        sizes: "192x192",
-      },
+      { url: SETTLER_IMAGES.favicon.path, type: SETTLER_IMAGES.favicon.mimeType, sizes: "180x180" },
     ],
   },
   openGraph: {

--- a/packages/web/src/components/Footer.tsx
+++ b/packages/web/src/components/Footer.tsx
@@ -1,6 +1,6 @@
-import Image from "next/image";
 import { StatusIndicator } from "@/components/monitoring/StatusIndicator";
 import { UiLink } from "@/components/ui/link";
+import { SettlerLogo } from "@/components/brand/SettlerLogo";
 
 const footerSections = [
   {
@@ -48,24 +48,7 @@ export function Footer() {
         <div className="mb-8 grid grid-cols-1 gap-8 md:grid-cols-4">
           <div>
             <UiLink href="/" aria-label="Settler homepage" className="mb-4 inline-flex">
-              {/* Light mode logo */}
-              <Image
-                src="/logo.svg"
-                alt="Settler Logo"
-                width={130}
-                height={34}
-                className="h-10 w-auto dark:hidden"
-                priority
-              />
-              {/* Dark mode logo */}
-              <Image
-                src="/logo-dark.svg"
-                alt="Settler Logo"
-                width={130}
-                height={34}
-                className="h-10 w-auto hidden dark:block"
-                priority
-              />
+              <SettlerLogo variant="horizontal" className="h-10 w-auto" priority />
             </UiLink>
             <p className="text-sm text-muted-foreground">
               Open-source reconciliation engine for deterministic, inspectable financial data

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
@@ -9,6 +8,7 @@ import { DarkModeToggle } from "@/components/DarkModeToggle";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { Menu, ChevronDown } from "lucide-react";
+import { SettlerLogo } from "@/components/brand/SettlerLogo";
 
 // Primary navigation items (always visible on desktop)
 const siteMode = process.env.NEXT_PUBLIC_SITE_MODE || "oss";
@@ -154,22 +154,9 @@ export function Navigation() {
               aria-label="Settler homepage"
             >
               <div className="relative overflow-hidden rounded">
-                {/* Light mode logo */}
-                <Image
-                  src="/logo.svg"
-                  alt="Settler Logo"
-                  width={130}
-                  height={34}
-                  className="h-8 w-auto relative z-10 transition-all duration-300 group-hover:brightness-110 group-hover:drop-shadow-lg dark:hidden"
-                  priority
-                />
-                {/* Dark mode logo */}
-                <Image
-                  src="/logo-dark.svg"
-                  alt="Settler Logo"
-                  width={130}
-                  height={34}
-                  className="h-8 w-auto relative z-10 transition-all duration-300 group-hover:brightness-110 group-hover:drop-shadow-lg hidden dark:block"
+                <SettlerLogo
+                  variant="horizontal"
+                  className="h-8 w-auto relative z-10 transition-all duration-300 group-hover:brightness-110 group-hover:drop-shadow-lg"
                   priority
                 />
                 {/* Shine effect overlay */}

--- a/packages/web/src/components/SEOHead.tsx
+++ b/packages/web/src/components/SEOHead.tsx
@@ -45,12 +45,8 @@ export function SEOHead({
       {canonical && <link rel="canonical" href={canonical} />}
 
       {/* Favicon */}
-      {SETTLER_IMAGES.favicon.webpPath && (
-        <link rel="icon" type="image/webp" href={SETTLER_IMAGES.favicon.webpPath} />
-      )}
       <link rel="icon" type={SETTLER_IMAGES.favicon.mimeType} href={SETTLER_IMAGES.favicon.path} />
-      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-      <link rel="apple-touch-icon" href={SETTLER_IMAGES.favicon192.path} />
+      <link rel="apple-touch-icon" href={SETTLER_IMAGES.favicon.path} />
 
       {/* Structured Data */}
       <script

--- a/packages/web/src/components/brand/SettlerLogo.tsx
+++ b/packages/web/src/components/brand/SettlerLogo.tsx
@@ -1,0 +1,59 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+type SettlerLogoVariant = "horizontal" | "stacked" | "icon" | "wordmark";
+
+interface SettlerLogoProps {
+  variant?: SettlerLogoVariant;
+  className?: string;
+  priority?: boolean;
+}
+
+const BRAND_LOGOS: Record<
+  SettlerLogoVariant,
+  { src: string; alt: string; width: number; height: number }
+> = {
+  horizontal: {
+    src: "/brand/settler/logo-primary-horizontal.svg",
+    alt: "Settler logo",
+    width: 160,
+    height: 40,
+  },
+  stacked: {
+    src: "/brand/settler/logo-stacked.svg",
+    alt: "Settler stacked logo",
+    width: 680,
+    height: 680,
+  },
+  icon: {
+    src: "/brand/settler/logo-icon.svg",
+    alt: "Settler icon",
+    width: 40,
+    height: 40,
+  },
+  wordmark: {
+    src: "/brand/settler/logo-wordmark.svg",
+    alt: "Settler wordmark",
+    width: 92,
+    height: 16,
+  },
+};
+
+export function SettlerLogo({
+  variant = "horizontal",
+  className,
+  priority = false,
+}: SettlerLogoProps) {
+  const logo = BRAND_LOGOS[variant];
+
+  return (
+    <Image
+      src={logo.src}
+      alt={logo.alt}
+      width={logo.width}
+      height={logo.height}
+      className={cn("h-auto w-auto", className)}
+      priority={priority}
+    />
+  );
+}

--- a/packages/web/src/components/tenant/TenantNavigation.tsx
+++ b/packages/web/src/components/tenant/TenantNavigation.tsx
@@ -1,15 +1,14 @@
 /**
  * Tenant-Aware Navigation Component
- * 
+ *
  * Replaces hard-coded Navigation.tsx with tenant-aware version.
  * Reads from TenantNavigation.navItems and .footerItems.
  * Falls back to default if not configured.
  */
 
-'use client';
+"use client";
 
 import Link from "next/link";
-import Image from "next/image";
 import { useState } from "react";
 import type { CSSProperties } from "react";
 import { Button } from "@/components/ui/button";
@@ -17,44 +16,39 @@ import { DarkModeToggle } from "@/components/DarkModeToggle";
 import { cn } from "@/lib/utils";
 import { Menu, X } from "lucide-react";
 import { useTenantTheme } from "./TenantThemeProvider";
+import { SettlerLogo } from "@/components/brand/SettlerLogo";
 import { TenantNavigationItem } from "@/shared/tenant/types";
 
 // Default navigation items (fallback)
 const defaultNavigationItems: TenantNavigationItem[] = [
-  { href: '/docs', label: 'Docs', type: 'internal' },
-  { href: '/cookbooks', label: 'Cookbooks', type: 'internal' },
-  { href: '/receipts', label: 'Receipts API', type: 'internal' },
-  { href: '/feature-flags', label: 'Feature Flags', type: 'internal' },
-  { href: '/console', label: 'Console', type: 'internal' },
-  { href: '/pricing', label: 'Pricing', type: 'internal' },
-  { href: '/enterprise', label: 'Enterprise', type: 'internal' },
-  { href: '/community', label: 'Community', type: 'internal' },
-  { href: '/support', label: 'Support', type: 'internal' },
-  { href: '/playground', label: 'Playground', type: 'internal' },
+  { href: "/docs", label: "Docs", type: "internal" },
+  { href: "/cookbooks", label: "Cookbooks", type: "internal" },
+  { href: "/receipts", label: "Receipts API", type: "internal" },
+  { href: "/feature-flags", label: "Feature Flags", type: "internal" },
+  { href: "/console", label: "Console", type: "internal" },
+  { href: "/pricing", label: "Pricing", type: "internal" },
+  { href: "/enterprise", label: "Enterprise", type: "internal" },
+  { href: "/community", label: "Community", type: "internal" },
+  { href: "/support", label: "Support", type: "internal" },
+  { href: "/playground", label: "Playground", type: "internal" },
 ];
 
 interface TenantNavigationProps {
   navItems?: TenantNavigationItem[];
-  logoUrl?: string;
-  tenantName?: string;
 }
 
-export function TenantNavigation({
-  navItems = defaultNavigationItems,
-  logoUrl,
-  tenantName = 'Settler',
-}: TenantNavigationProps) {
+export function TenantNavigation({ navItems = defaultNavigationItems }: TenantNavigationProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { theme } = useTenantTheme();
 
-  const primaryColor = theme?.colors.primary || '#2563eb';
+  const primaryColor = theme?.colors.primary || "#2563eb";
 
   return (
     <nav
       className={cn(
-        'fixed top-0 w-full z-50',
-        'bg-background/80 backdrop-blur-lg',
-        'border-b border-border'
+        "fixed top-0 w-full z-50",
+        "bg-background/80 backdrop-blur-lg",
+        "border-b border-border"
       )}
       role="navigation"
       aria-label="Main navigation"
@@ -64,49 +58,14 @@ export function TenantNavigation({
           <Link
             href="/"
             className={cn(
-              'flex items-center space-x-2',
-              'transition-transform hover:scale-105',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-              'rounded'
+              "flex items-center",
+              "transition-transform hover:scale-105",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              "rounded"
             )}
-            aria-label={`${tenantName} homepage`}
+            aria-label="Settler homepage"
           >
-            {logoUrl ? (
-              <Image
-                src={logoUrl}
-                alt={`${tenantName} logo`}
-                width={128}
-                height={32}
-                className="h-8 w-auto"
-                priority
-              />
-            ) : (
-              <div
-                className={cn(
-                  'w-8 h-8 rounded-lg flex items-center justify-center',
-                  'bg-gradient-to-br'
-                )}
-                style={{
-                  background: `linear-gradient(to bottom right, ${primaryColor}, ${theme?.colors.secondary || '#7c3aed'})`,
-                }}
-                aria-hidden="true"
-              >
-                <span className="text-white font-bold text-lg">
-                  {tenantName.charAt(0).toUpperCase()}
-                </span>
-              </div>
-            )}
-            <span
-              className={cn('text-xl font-bold')}
-              style={{
-                background: `linear-gradient(to right, ${primaryColor}, ${theme?.colors.secondary || '#7c3aed'})`,
-                WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent',
-                backgroundClip: 'text',
-              }}
-            >
-              {tenantName}
-            </span>
+            <SettlerLogo variant="horizontal" className="h-8 w-auto" priority />
           </Link>
 
           {/* Desktop Navigation */}
@@ -116,12 +75,12 @@ export function TenantNavigation({
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  'text-muted-foreground hover:text-primary-600 dark:hover:text-primary-400',
-                  'transition-colors duration-200 ease-out',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                  'focus-visible:ring-offset-background',
-                  'rounded px-2 py-1',
-                  'motion-reduce:transition-none'
+                  "text-muted-foreground hover:text-primary-600 dark:hover:text-primary-400",
+                  "transition-colors duration-200 ease-out",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                  "focus-visible:ring-offset-background",
+                  "rounded px-2 py-1",
+                  "motion-reduce:transition-none"
                 )}
                 style={{ ["--hover-color" as any]: primaryColor } as CSSProperties}
               >
@@ -137,7 +96,7 @@ export function TenantNavigation({
                 backgroundColor: primaryColor,
               }}
             >
-              <Link href="/console/playground" aria-label={`Get started with ${tenantName}`}>
+              <Link href="/console/playground" aria-label="Get started with Settler">
                 Get Started
               </Link>
             </Button>
@@ -149,14 +108,14 @@ export function TenantNavigation({
             <button
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               className={cn(
-                'p-2 rounded-md',
-                'text-muted-foreground hover:bg-muted',
-                'transition-colors duration-200 ease-out',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                'focus-visible:ring-offset-background',
-                'motion-reduce:transition-none'
+                "p-2 rounded-md",
+                "text-muted-foreground hover:bg-muted",
+                "transition-colors duration-200 ease-out",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                "focus-visible:ring-offset-background",
+                "motion-reduce:transition-none"
               )}
-              aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+              aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
               aria-expanded={mobileMenuOpen}
               aria-controls="mobile-menu"
               type="button"
@@ -175,9 +134,9 @@ export function TenantNavigation({
           <div
             id="mobile-menu"
             className={cn(
-              'md:hidden py-4 border-t border-border',
-              'motion-safe:animate-in motion-safe:slide-in-from-top-2 motion-safe:fade-in-0',
-              'motion-reduce:animate-none'
+              "md:hidden py-4 border-t border-border",
+              "motion-safe:animate-in motion-safe:slide-in-from-top-2 motion-safe:fade-in-0",
+              "motion-reduce:animate-none"
             )}
             role="menu"
             aria-label="Mobile navigation menu"
@@ -188,12 +147,12 @@ export function TenantNavigation({
                   key={item.href}
                   href={item.href}
                   className={cn(
-                    'text-muted-foreground hover:text-primary-600 dark:hover:text-primary-400',
-                    'transition-colors duration-200 ease-out',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                    'focus-visible:ring-offset-background',
-                    'rounded px-2 py-1',
-                    'motion-reduce:transition-none'
+                    "text-muted-foreground hover:text-primary-600 dark:hover:text-primary-400",
+                    "transition-colors duration-200 ease-out",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                    "focus-visible:ring-offset-background",
+                    "rounded px-2 py-1",
+                    "motion-reduce:transition-none"
                   )}
                   onClick={() => setMobileMenuOpen(false)}
                 >
@@ -209,7 +168,7 @@ export function TenantNavigation({
                   backgroundColor: primaryColor,
                 }}
               >
-                <Link href="/console/playground" aria-label={`Get started with ${tenantName}`}>
+                <Link href="/console/playground" aria-label="Get started with Settler">
                   Get Started
                 </Link>
               </Button>

--- a/packages/web/src/lib/images/image-config.ts
+++ b/packages/web/src/lib/images/image-config.ts
@@ -22,49 +22,49 @@ export interface ImageConfig {
 
 /**
  * Settler brand images configuration
- * All images are located in /public/assets/images/
+ * Brand assets are centralized in /public/brand/settler and /public/assets/images
  */
 const SETTLER_IMAGES_CONFIG = {
   // Favicons
   favicon: {
-    path: "/assets/images/settler-favicon.png",
-    width: 680,
-    height: 680,
+    path: "/brand/settler/logo-icon.svg",
+    width: 64,
+    height: 64,
     alt: "Settler Favicon",
     category: "favicon" as const,
-    mimeType: "image/png",
-    webpPath: "/assets/images/settler-favicon.webp",
+    mimeType: "image/svg+xml",
+    webpPath: "/brand/settler/logo-icon.svg",
   },
   favicon192: {
-    path: "/assets/images/settler-favicon.png",
+    path: "/brand/settler/logo-icon.svg",
     width: 192,
     height: 192,
     alt: "Settler Icon 192x192",
     category: "favicon" as const,
-    mimeType: "image/png",
-    webpPath: "/assets/images/settler-favicon.webp",
+    mimeType: "image/svg+xml",
+    webpPath: "/brand/settler/logo-icon.svg",
   },
   favicon512: {
-    path: "/assets/images/settler-favicon.png",
+    path: "/brand/settler/logo-icon.svg",
     width: 512,
     height: 512,
     alt: "Settler Icon 512x512",
     category: "favicon" as const,
-    mimeType: "image/png",
-    webpPath: "/assets/images/settler-favicon.webp",
+    mimeType: "image/svg+xml",
+    webpPath: "/brand/settler/logo-icon.svg",
   },
 
   // Social Media Images
   ogImage: {
-    path: "/assets/images/social/settler-og-image.jpg",
+    path: "/assets/images/Settler_seo.png",
     width: 1200,
     height: 630,
     alt: "Settler - Financial Infrastructure for Developers",
     category: "social" as const,
-    mimeType: "image/jpeg",
+    mimeType: "image/png",
   },
   twitterCard: {
-    path: "/assets/images/social/settler-twitter-card.png",
+    path: "/assets/images/Settler_seo.png",
     width: 1200,
     height: 630,
     alt: "Settler - Financial Infrastructure for Developers",
@@ -74,7 +74,7 @@ const SETTLER_IMAGES_CONFIG = {
 
   // Logos
   logoMain: {
-    path: "/logo.svg",
+    path: "/brand/settler/logo-primary-horizontal.svg",
     width: 160,
     height: 40,
     alt: "Settler Logo",


### PR DESCRIPTION
### Motivation
- Centralize the Settler brand assets as SVGs and standardize how logos and favicons are referenced across the app.
- Replace ad-hoc image usage and tenant-specific logo rendering with a single `SettlerLogo` component to simplify branding and ensure consistent variants.

### Description
- Added new SVG brand assets under `public/brand/settler/` (`logo-icon.svg`, `logo-primary-horizontal.svg`, `logo-square.svg`, `logo-stacked.svg`, `logo-wordmark.svg`).
- Introduced `SettlerLogo` component (`src/components/brand/SettlerLogo.tsx`) that exposes `horizontal | stacked | icon | wordmark` variants and is used in `Navigation`, `Footer`, `AppLayout`, and `TenantNavigation` to replace prior hard-coded images.
- Updated image configuration (`src/lib/images/image-config.ts`) and `public/manifest.json` to point favicons and logo paths to the new brand SVGs and set appropriate MIME types and sizes.
- Simplified tenant navigation and tenant page rendering by removing `logoUrl`/`tenantName` props and consistently using the `SettlerLogo` component; updated `SEOHead` and layout metadata to use the revised favicon configuration.

### Testing
- Ran lint with `pnpm -w -s lint` and the linter completed successfully.
- Ran type checking with `pnpm -w -s typecheck` and TypeScript checks passed.
- Performed a production build with `pnpm -w -s build` which completed without errors.
- Executed the test suite with `pnpm -w -s test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b22e66a8a48328820779308dd7f19c)