### PR TITLE
docs: add final platform closure audit and launch verdict

### DIFF
--- a/docs/launch/final-platform-closure-audit.md
+++ b/docs/launch/final-platform-closure-audit.md
@@ -1,0 +1,122 @@
+# Final Platform Closure Audit (Evidence-Based)
+
+Date: 2026-03-12  
+Branch: `feat/final-platform-closure`
+
+## Scope executed
+
+This audit re-validated platform truth documents, launch artifacts, command surfaces, and verification gates against the current repository state.
+
+Reviewed documents:
+
+- `docs/platform-index.md`
+- `docs/capabilities.md`
+- `docs/architecture/platform-architecture.md`
+- `docs/setup/env-matrix.md`
+- `docs/setup/operator-runbook.md`
+- launch docs under `docs/launch/`
+
+Reviewed implementation surfaces:
+
+- verification scripts under `scripts/`
+- web console route tree under `packages/web/src/app`
+- CLI command registry under `packages/cli/src/index.ts`
+- brand assets under `packages/web/public/brand` and related public assets
+
+## Phase 1 gate execution (recorded)
+
+### JavaScript/TypeScript gates
+
+- `pnpm install --frozen-lockfile` ✅ pass
+- `pnpm lint` ✅ pass with warnings (no hard errors)
+- `pnpm typecheck` ⚠️ command repeatedly stalled on long-running `tsc --noEmit` in turbo flow (no final success/fail signal observed in this environment run)
+- `pnpm build` ⚠️ timed out in scripted pass (`timeout 300`) while `@settler/web`/Next build and monorepo tasks were still executing
+- `pnpm test` ⚠️ timed out in scripted pass (`timeout 300`) after many package suites passed; no final global completion signal before timeout
+- `pnpm run verify:setup` ❌ fail (missing required environment keys and DB URL)
+- `pnpm run settler:doctor` ❌ fail (`Missing script: settler:doctor`)
+- `pnpm run kernel:health` ✅ pass (diagnostics completed, kernel intentionally disabled)
+- `pnpm run check:production` ⚠️ began successfully (repo-integrity + lint phase succeeded) but was interrupted due long-running chained checks in this run window
+
+### Rust gates
+
+- `cargo fmt --check` ✅ pass
+- `cargo clippy --all-targets --all-features -- -D warnings` ✅ pass
+- `cargo test --all` ✅ pass
+
+## Phase 2 failure classification
+
+| Command                      | Subsystem                          | Classification        | Evidence                                                                                                                      |
+| ---------------------------- | ---------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm run verify:setup`      | setup/env validation               | EXPECTED_MISSING_ENV  | missing `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and DB DSN variable |
+| `pnpm run settler:doctor`    | command surface / operator tooling | STRUCTURAL_BLOCKER    | script name does not exist in root `package.json`                                                                             |
+| `pnpm typecheck`             | monorepo quality gate              | NON_BLOCKING_FRICTION | repeated long-running stall behavior in this run; no deterministic completion captured                                        |
+| `pnpm build` (`timeout 300`) | monorepo build orchestration       | NON_BLOCKING_FRICTION | timed out during long multi-package build/test dependency flow                                                                |
+| `pnpm test` (`timeout 300`)  | monorepo tests                     | NON_BLOCKING_FRICTION | timed out after partial successful suite execution                                                                            |
+| `pnpm lint` warnings         | API/CLI/Web lint policy            | NON_BLOCKING_FRICTION | warnings only, no lint errors                                                                                                 |
+
+## Phase 3 operator readiness evaluation
+
+### Result: **Mostly ready with friction**
+
+A new operator can:
+
+- identify required variables from a centralized matrix (`docs/setup/env-matrix.md`)
+- follow startup and incident steps in a canonical runbook (`docs/setup/operator-runbook.md`)
+- run kernel diagnostics (`pnpm run kernel:health`) and interpret degraded kernel-disabled signals
+
+Friction observed:
+
+- command naming mismatch in external run instructions (`settler:doctor` is not present; `doctor` exists)
+- some all-in-one verification flows are long-running/noisy and may need bounded CI presets for first-day operators
+
+## Phase 4 enterprise readiness evaluation
+
+### Result: **Credible but not frictionless**
+
+Enterprise evaluator clarity is strong on paper:
+
+- architecture boundaries are explicit (kernel vs control plane vs CLI vs console)
+- capability map is explicit and tied to command/documentation surfaces
+- launch folder has canonical artifact/checklist documents
+
+Residual friction:
+
+- final green status for full JS/TS gate sequence was not deterministically captured in this run due timeouts/stalls
+- environment-dependent setup checks fail until production/staging secrets are supplied (expected)
+
+## Phase 5 final blocker matrix
+
+### RESOLVED
+
+- Rust quality and tests pass (`fmt`, `clippy -D warnings`, `cargo test --all`).
+- Kernel health command is executable and machine-readable.
+- Core docs for architecture/setup/capabilities are present and cross-linked.
+
+### EXPECTED_MISSING_ENV
+
+- Supabase/browser + server vars and DB DSN absent in this environment (`verify:setup` failure).
+
+### REMAINING_BLOCKERS
+
+- `pnpm run settler:doctor` command does not exist (script surface mismatch).
+
+### NON_BLOCKING_FRICTION
+
+- lint warnings across web/api/cli/sdk
+- long-running monorepo typecheck/build/test flows that exceeded bounded audit timeouts in this environment
+- `check:production` is comprehensive but lengthy; difficult to use as quick iterative go/no-go signal without a fast profile
+
+### PRE_EXISTING_UNRELATED
+
+- pnpm install warning about ignored package build scripts (standard hardened install behavior; not introduced by this audit)
+
+## Phase 6 final verdict
+
+## **READY_WITH_MINOR_FRICTION**
+
+The platform is close to go-live, but this audit cannot honestly issue `READY_FOR_GO_LIVE` because:
+
+1. one requested operator command surface is currently invalid (`settler:doctor` missing), and
+2. the full JS/TS gate set did not complete deterministically inside bounded audit windows.
+
+If environment secrets are populated and command-surface mismatch is resolved (or runbook/instructions standardized to `pnpm run doctor -- --first-run`), remaining issues are predominantly operational friction rather than hard architectural defects.


### PR DESCRIPTION
### Motivation
- Provide a single, evidence-backed production handoff audit capturing the final platform readiness assessment and operator/enterprise guidance without changing runtime code.

### Description
- Add `docs/launch/final-platform-closure-audit.md` containing the phase-by-phase audit, failure classification matrix, operator/enterprise readiness evaluations, and the final verdict (`READY_WITH_MINOR_FRICTION`).

### Testing
- Re-ran primary verification gates and recorded outcomes: `pnpm install --frozen-lockfile` (pass), `pnpm lint` (pass with warnings), `pnpm typecheck` (stalled/long-running in this run), `pnpm build` (timed out under bounded audit window), `pnpm test` (timed out after partial progress), `pnpm run verify:setup` (failed — expected missing env), `pnpm run settler:doctor` (failed — script missing), `pnpm run kernel:health` (pass), `pnpm run check:production` (partial progress), and Rust checks `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all` (all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b23e0513888328ab649172fe239905)