### PR TITLE
Fix web typecheck blocker, normalize root scripts, add final go-live audit & evidence

### DIFF
--- a/docs/launch/final-go-live-flip-audit-2026-03-12.md
+++ b/docs/launch/final-go-live-flip-audit-2026-03-12.md
@@ -2,85 +2,75 @@
 
 ## Scope
 
-This pass focused on:
+This pass targeted three launch-readiness surfaces:
 
-1. Operator diagnostic realism (`settler:doctor`) and command-surface truth.
-2. Verification reruns with explicit classification for unresolved items.
-3. Low-risk docs alignment for operator usage.
+1. close active TypeScript blocker(s) preventing workspace typecheck green,
+2. verify and operator-harden canonical doctor path (`pnpm run settler:doctor`),
+3. run full verification matrix and classify residual failures truthfully.
 
-## Root cause summary
+## Root cause of original blocker
 
-- The prior `scripts/doctor.mjs` executed heavyweight pipeline commands by default and produced grouped text output without a deterministic status schema, which made operator diagnostics slow and less machine-consumable.
-- In this container, required launch env is intentionally absent, so setup/doctor fail for real reasons.
-- Large monorepo lint/typecheck/build/test commands exceed practical command window in this environment before producing a terminal success/failure state.
+- `pnpm typecheck` failed due to a duplicate import of `SettlerLogo` in `packages/web/src/components/Navigation.tsx`, producing `TS2300: Duplicate identifier 'SettlerLogo'`.
 
 ## Changes made
 
-- Replaced `scripts/doctor.mjs` with a deterministic operator doctor that:
-  - emits per-check tuples with `subsystem`, `status`, `message`, and `remediation`;
-  - computes global summary `PASS | DEGRADED | FAIL`;
-  - supports `--json` mode for machine parsing;
-  - treats optional capability gaps as `DEGRADED`;
-  - preserves non-zero exit on real blockers (`FAIL`);
-  - supports `--include-pipeline` and `--skip-kernel-health` flags for operational control.
-- Updated runbook guidance for canonical doctor usage and flags.
-- Updated capability registry command surface to include JSON doctor invocation.
-- Added execution evidence log for this pass.
+1. Removed duplicate `SettlerLogo` import in `Navigation.tsx` to restore clean web package typecheck.
+2. Removed duplicate script keys in root `package.json` (`verify:setup`, `settler:doctor`) so operator command surface is deterministic and unambiguous in source.
+3. Captured end-to-end execution evidence in `evidence/final-go-live-flip/command-log.txt`.
 
 ## Files changed
 
-- `scripts/doctor.mjs`
-- `docs/setup/operator-runbook.md`
-- `docs/capabilities.md`
+- `packages/web/src/components/Navigation.tsx`
+- `package.json`
 - `docs/launch/final-go-live-flip-audit-2026-03-12.md`
 - `evidence/final-go-live-flip/command-log.txt`
 
 ## Verification results
 
-- `pnpm install --frozen-lockfile`: PASS
-- `pnpm run settler:doctor`: FAIL (expected missing env in container)
-- `pnpm run kernel:health`: PASS (explicit degraded kernel mode)
-- `pnpm run verify:setup`: FAIL (expected missing env in container)
-- `pnpm typecheck`: non-complete in bounded run window (classified NON_BLOCKING_FRICTION)
-- `pnpm lint`: non-complete in bounded run window (classified NON_BLOCKING_FRICTION)
-- `pnpm build`: non-complete in bounded run window (classified NON_BLOCKING_FRICTION)
-- `pnpm test`: non-complete in bounded run window (classified NON_BLOCKING_FRICTION)
-- `pnpm run check:production`: non-complete in bounded run window (classified NON_BLOCKING_FRICTION)
-- `cargo fmt --check`: PASS
-- `cargo clippy --all-targets --all-features -- -D warnings`: PASS
-- `cargo test --all`: PASS
+| Command                                                    | Result                              | Classification        | Notes                                                                                |
+| ---------------------------------------------------------- | ----------------------------------- | --------------------- | ------------------------------------------------------------------------------------ |
+| `pnpm install --frozen-lockfile`                           | PASS                                | RESOLVED              | Lockfile consistent; install complete.                                               |
+| `pnpm lint`                                                | PASS (warnings)                     | NON_BLOCKING_FRICTION | Warnings remain in API/CLI/SDK/Web, no hard lint failures.                           |
+| `pnpm typecheck`                                           | PASS                                | RESOLVED              | Duplicate identifier blocker fixed.                                                  |
+| `pnpm build`                                               | PASS                                | RESOLVED              | Web + dependent packages build successfully.                                         |
+| `pnpm test`                                                | PASS                                | RESOLVED              | Full turbo test pipeline completed.                                                  |
+| `pnpm run verify:setup`                                    | FAIL                                | EXPECTED_MISSING_ENV  | Missing Supabase + DB env in this container context.                                 |
+| `pnpm run settler:doctor`                                  | FAIL (by design on required env)    | EXPECTED_MISSING_ENV  | Command exists/wired; reports actionable missing env and exits non-zero on blockers. |
+| `pnpm run kernel:health`                                   | PASS (degraded kernel mode visible) | NON_BLOCKING_FRICTION | Kernel disabled fallback mode explicit and machine-visible.                          |
+| `pnpm run check:production`                                | FAIL                                | EXPECTED_MISSING_ENV  | Fails at setup verification gate due to missing required env.                        |
+| `cargo fmt --check`                                        | PASS                                | RESOLVED              | Rust formatting clean.                                                               |
+| `cargo clippy --all-targets --all-features -- -D warnings` | PASS                                | RESOLVED              | No clippy warnings/errors.                                                           |
+| `cargo test --all`                                         | PASS                                | RESOLVED              | Rust test suites green.                                                              |
 
 ## Failure classification matrix
 
-| Category               | Items                                                                                                                             |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| RESOLVED               | `settler:doctor` now provides deterministic PASS/DEGRADED/FAIL output, per-check remediation, and JSON mode.                      |
-| EXPECTED_MISSING_ENV   | `verify:setup` + `settler:doctor` fail due missing Supabase/database env values in this container.                                |
-| NON_BLOCKING_FRICTION  | Long-running monorepo `lint/typecheck/build/test/check:production` did not finish within bounded command window during this pass. |
-| REMAINING_BLOCKER      | TypeScript closure cannot be conclusively declared from this environment due command-window contention.                           |
-| PRE_EXISTING_UNRELATED | Existing lint warnings in `@settler/cli` and `@settler/sdk` surfaced during lint execution.                                       |
+| Category               | Items                                                                                                                                                                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| RESOLVED               | TypeScript duplicate identifier blocker in web navigation; full typecheck/build/test and Rust checks green.                                                                                                                 |
+| EXPECTED_MISSING_ENV   | `verify:setup`, `settler:doctor`, and `check:production` fail due to intentionally absent launch secrets/config (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, DB DSN). |
+| NON_BLOCKING_FRICTION  | Lint warnings remain; kernel intentionally disabled in this environment but degradations are explicit.                                                                                                                      |
+| REMAINING_BLOCKER      | None found in code/tooling path for this branch in current environment.                                                                                                                                                     |
+| PRE_EXISTING_UNRELATED | None newly identified as blockers during this pass.                                                                                                                                                                         |
 
 ## Operator readiness assessment
 
-- Operator diagnostics are materially stronger and launch-useful:
-  - deterministic summaries,
-  - explicit degraded/fail states,
-  - actionable remediation text,
-  - machine-readable JSON output.
-- Required env gaps are surfaced directly and without secret leakage.
+- Positive: canonical operator diagnostics command exists (`settler:doctor`), emits PASS/DEGRADED/FAIL, and provides subsystem-specific remediation.
+- Positive: kernel degraded/fallback state is explicit (`kernel:health`, doctor output).
+- Remaining requirement: operators must provide required Supabase/auth/DB secrets before production readiness gates can pass.
 
 ## Enterprise readiness assessment
 
-- Rust verification surface is healthy (`fmt`, `clippy -D warnings`, `test`).
-- Kernel degraded mode remains explicit and operationally sane.
-- Web monorepo closure still requires a full uninterrupted CI-grade run to prove green across lint/typecheck/build/test.
+- Code and docs surface remains coherent for audit/diagnostic posture.
+- Deterministic validation pipeline (typecheck/build/test + rust checks) is green in this environment.
+- Production-readiness gates correctly fail hard without required secrets (truthful fail behavior preserved).
 
 ## Final verdict
 
 **READY_WITH_NON_BLOCKING_FRICTION**
 
-Justification:
+Rationale:
 
-- Operator path truth and diagnostics improved materially.
-- Remaining unresolved items are primarily full-graph command completion under environment/time-window limits plus missing deploy secrets in this container.
-- No evidence of newly introduced hard blockers in touched surfaces.
+- Blocking code defect that broke typecheck is fixed.
+- Core build/test and Rust verification are green.
+- Remaining failures are environment-secret prerequisites, not code correctness defects.
+- Non-blocking lint warnings remain and should be cleaned opportunistically, but they do not invalidate launch viability once production env is provisioned.

--- a/evidence/final-go-live-flip/command-log.txt
+++ b/evidence/final-go-live-flip/command-log.txt
@@ -1,40 +1,3395 @@
-# Final go-live flip command log (2026-03-12)
+\n$ pnpm install --frozen-lockfile
+Scope: all 19 workspace projects
+Lockfile is up to date, resolution step is skipped
+Already up to date
 
-pnpm install --frozen-lockfile
-- PASS
+╭ Warning ─────────────────────────────────────────────────────────────────────╮
+│                                                                              │
+│   Ignored build scripts: @playwright/browser-chromium, @prisma/engines,      │
+│   @sentry/cli, @sentry/profiling-node, bcrypt, better-sqlite3, esbuild,      │
+│   isolated-vm, msgpackr-extract, msw, prisma, protobufjs, sharp,             │
+│   unix-dgram, unrs-resolver.                                                 │
+│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
+│   to run scripts.                                                            │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
-pnpm run settler:doctor
-- FAIL (expected in this environment: missing required Supabase/database env values)
+. preinstall$ export SENTRY_SKIP_AUTO_INSTALL=1 || set SENTRY_SKIP_AUTO_INSTALL=1 || true
+. preinstall: Done
+. postinstall$ test -f scripts/vercel-prisma-postinstall.js && node scripts/vercel-prisma-postinstall.js || echo 'Skipping postinstall: script not found (expected in Vercel builds)'
+. postinstall: 🔧 Running Prisma generate...
+. postinstall: npm warn Unknown env config "package-manager". This will stop working in the next major version of npm.
+. postinstall: npm warn Unknown env config "lockfile". This will stop working in the next major version of npm.
+. postinstall: npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+. postinstall: npm warn Unknown env config "prefer-frozen-lockfile". This will stop working in the next major version of npm.
+. postinstall: npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
+. postinstall: npm warn Unknown env config "_types-registry". This will stop working in the next major version of npm.
+. postinstall: npm warn Unknown env config "_jsr-registry". This will stop working in the next major version of npm.
+. postinstall: npm warn config optional Use `--omit=optional` to exclude optional dependencies, or
+. postinstall: npm warn config `--include=optional` to include them.
+. postinstall: npm warn config
+. postinstall: npm warn config       Default value does install optional deps unless otherwise omitted.
+. postinstall: npm warn Unknown project config "package-manager". This will stop working in the next major version of npm.
+. postinstall: npm warn Unknown project config "lockfile". This will stop working in the next major version of npm.
+. postinstall: npm warn Unknown project config "prefer-frozen-lockfile". This will stop working in the next major version of npm.
+. postinstall: npm warn config optional Use `--omit=optional` to exclude optional dependencies, or
+. postinstall: npm warn config `--include=optional` to include them.
+. postinstall: npm warn config
+. postinstall: npm warn config       Default value does install optional deps unless otherwise omitted.
+. postinstall: npm warn Unknown project config "always-auth". This will stop working in the next major version of npm.
+. postinstall: Loaded Prisma config from prisma.config.ts.
+. postinstall: Prisma schema loaded from prisma/schema.prisma.
+. postinstall: ✔ Generated Prisma Client (v7.3.0) to ./node_modules/.pnpm/@prisma+client@7.3.0_prisma@7.3.0_@types+react@18.3.27_better-sqlite3@12.6.2_react-dom@_efc9348d8c027de17c7e00b84b73d1eb/node_modules/@prisma/client in 567ms
+. postinstall: Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
+. postinstall: ✅ Prisma generate completed successfully
+. postinstall: Done
+. prepare$ husky install 2>/dev/null || true
+. prepare: husky - Git hooks installed
+. prepare: Done
+packages/web postinstall$ export SENTRY_SKIP_AUTO_INSTALL=1 || set SENTRY_SKIP_AUTO_INSTALL=1 || true
+packages/web postinstall: Done
+Done in 5.5s using pnpm v10.13.1
+[exit_code]=0
+\n$ pnpm lint
 
-pnpm run settler:doctor -- --json --skip-kernel-health
-- FAIL (same missing required env values; deterministic JSON output verified)
+> settler-monorepo@1.0.0 lint /workspace/Settler
+> turbo run lint
 
-pnpm run kernel:health
-- PASS (kernel command ran; reports disabled/degraded kernel mode)
+• turbo 2.8.0
+• Packages in scope: @jobforge/adapter-settler, @jobforge/errors, @jobforge/fetch, @jobforge/sdk-ts, @jobforge/shared, @jobforge/typescript-config, @settler/adapters, @settler/api, @settler/cli, @settler/edge-ai-core, @settler/edge-node, @settler/protocol, @settler/react-settler, @settler/sdk, @settler/sdk-csharp, @settler/sdk-java, @settler/types, @settler/web
+• Running lint in 18 packages
+• Remote caching disabled
+@settler/adapters:lint: cache hit, replaying logs 8693f9835a5d3d35
+@settler/adapters:lint: 
+@settler/adapters:lint: > @settler/adapters@1.0.0 lint /workspace/Settler/packages/adapters
+@settler/adapters:lint: > eslint src
+@settler/adapters:lint: 
+@jobforge/shared:lint: cache hit, replaying logs 19c5f688626d0948
+@jobforge/shared:lint: 
+@jobforge/shared:lint: > @jobforge/shared@0.1.0 lint /workspace/Settler/packages/jobforge-shared
+@jobforge/shared:lint: > eslint src/
+@jobforge/shared:lint: 
+@settler/api:lint: cache hit, replaying logs 39df350691d6912c
+@settler/api:lint: 
+@settler/api:lint: > @settler/api@1.0.0 lint /workspace/Settler/packages/api
+@settler/api:lint: > eslint src
+@settler/api:lint: 
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/infrastructure/jobs/scheduler-service.ts
+@settler/api:lint:   30:10  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/infrastructure/security/SSRFProtection.ts
+@settler/api:lint:   66:14  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint:   72:12  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint:   94:12  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/jobs/email-scheduler.ts
+@settler/api:lint:   12:10  warning  '_calculateDaysRemaining' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/middleware/api-gateway-cache.ts
+@settler/api:lint:   182:16  warning  '_pattern' is assigned a value but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/routes/export-enhanced.ts
+@settler/api:lint:   71:27  warning  '_includeUnmatched' is assigned a value but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/routes/v1/operator-mode.ts
+@settler/api:lint:   21:3  warning  'checkAlertThresholds' is defined but never used   @typescript-eslint/no-unused-vars
+@settler/api:lint:   23:3  warning  'upsertAlertThreshold' is defined but never used   @typescript-eslint/no-unused-vars
+@settler/api:lint:   27:3  warning  'setTenantUsageCeiling' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint:   28:3  warning  'getAllUsageCeilings' is defined but never used    @typescript-eslint/no-unused-vars
+@settler/api:lint:   29:3  warning  'checkUsageCeiling' is defined but never used      @typescript-eslint/no-unused-vars
+@settler/api:lint:   30:3  warning  'setBackgroundJobLimit' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/determinism/execution-orchestrator.ts
+@settler/api:lint:   16:10  warning  'createRunSnapshot' is defined but never used        @typescript-eslint/no-unused-vars
+@settler/api:lint:   16:29  warning  'updateRunSnapshotStatus' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint:   16:54  warning  'RunSnapshot' is defined but never used              @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/determinism/idempotent-ingestion.ts
+@settler/api:lint:   96:59  warning  'effective_date' is assigned a value but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/determinism/replay-service.ts
+@settler/api:lint:   227:33  warning  'snapshot' is defined but never used. Allowed unused args must match /^_/u       @typescript-eslint/no-unused-vars
+@settler/api:lint:   258:34  warning  'snapshot' is defined but never used. Allowed unused args must match /^_/u       @typescript-eslint/no-unused-vars
+@settler/api:lint:   416:3   warning  'runId' is defined but never used. Allowed unused args must match /^_/u          @typescript-eslint/no-unused-vars
+@settler/api:lint:   417:3   warning  'replayMatches' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+@settler/api:lint:   428:3   warning  'replayRunId' is defined but never used. Allowed unused args must match /^_/u    @typescript-eslint/no-unused-vars
+@settler/api:lint:   465:35  warning  'originalRunId' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/determinism/verification-gates.ts
+@settler/api:lint:   11:10  warning  'query' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/knowledge/decision-log.ts
+@settler/api:lint:   228:14  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/operator-mode/alerting.ts
+@settler/api:lint:   435:16  warning  'sendSlackAlert' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/reconciliation/automated-review.ts
+@settler/api:lint:   453:12  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: ✖ 27 problems (0 errors, 27 warnings)
+@settler/api:lint: 
+@settler/web:lint: cache miss, executing 6ce48f20cc700cd2
+@settler/edge-ai-core:lint: cache hit, replaying logs 7a95eea93bbe039e
+@settler/edge-ai-core:lint: 
+@settler/edge-ai-core:lint: > @settler/edge-ai-core@1.0.0 lint /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:lint: > eslint src
+@settler/edge-ai-core:lint: 
+@settler/cli:lint: cache hit, replaying logs f5ae0901f89c0c59
+@settler/cli:lint: 
+@settler/cli:lint: > @settler/cli@1.0.0 lint /workspace/Settler/packages/cli
+@settler/cli:lint: > eslint src
+@settler/cli:lint: 
+@settler/cli:lint: 
+@settler/cli:lint: /workspace/Settler/packages/cli/src/lib/execution-ledger.ts
+@settler/cli:lint:   124:11  warning  'execution_hash' is assigned a value but never used  @typescript-eslint/no-unused-vars
+@settler/cli:lint: 
+@settler/cli:lint: ✖ 1 problem (0 errors, 1 warning)
+@settler/cli:lint: 
+@settler/sdk:lint: cache hit, replaying logs 2a2e7b9090ab058a
+@settler/sdk:lint: 
+@settler/sdk:lint: > @settler/sdk@1.0.0 lint /workspace/Settler/packages/sdk
+@settler/sdk:lint: > eslint src
+@settler/sdk:lint: 
+@settler/sdk:lint: 
+@settler/sdk:lint: /workspace/Settler/packages/sdk/src/utils/middleware.ts
+@settler/sdk:lint:   72:31  warning  Unexpected console statement. Only these console methods are allowed: warn, error  no-console
+@settler/sdk:lint: 
+@settler/sdk:lint: ✖ 1 problem (0 errors, 1 warning)
+@settler/sdk:lint: 
+@jobforge/errors:lint: cache hit, replaying logs a82a936ecd8bbe79
+@jobforge/errors:lint: 
+@jobforge/errors:lint: > @jobforge/errors@0.1.0 lint /workspace/Settler/packages/jobforge-errors
+@jobforge/errors:lint: > eslint "**/*.ts"
+@jobforge/errors:lint: 
+@settler/edge-node:lint: cache hit, replaying logs 123fc492e6215a34
+@settler/edge-node:lint: 
+@settler/edge-node:lint: > @settler/edge-node@1.0.0 lint /workspace/Settler/packages/edge-node
+@settler/edge-node:lint: > eslint src
+@settler/edge-node:lint: 
+@jobforge/sdk-ts:lint: cache hit, replaying logs 47d36ee24de488e3
+@jobforge/sdk-ts:lint: 
+@jobforge/sdk-ts:lint: > @jobforge/sdk-ts@0.1.0 lint /workspace/Settler/packages/jobforge-sdk-ts
+@jobforge/sdk-ts:lint: > eslint src/
+@jobforge/sdk-ts:lint: 
+@jobforge/fetch:lint: cache hit, replaying logs 2d331f0b41280540
+@jobforge/fetch:lint: 
+@jobforge/fetch:lint: > @jobforge/fetch@0.1.0 lint /workspace/Settler/packages/jobforge-fetch
+@jobforge/fetch:lint: > eslint "**/*.ts"
+@jobforge/fetch:lint: 
+@settler/web:lint: 
+@settler/web:lint: > @settler/web@1.0.0 lint /workspace/Settler/packages/web
+@settler/web:lint: > eslint src
+@settler/web:lint: 
+@settler/web:lint: 
+@settler/web:lint: /workspace/Settler/packages/web/src/app/architecture/page.tsx
+@settler/web:lint:   12:10  warning  'RealityEvidencePanel' is defined but never used        @typescript-eslint/no-unused-vars
+@settler/web:lint:   14:3   warning  'CapabilityMap' is defined but never used               @typescript-eslint/no-unused-vars
+@settler/web:lint:   15:3   warning  'IntegrationAndPackagingMap' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/web:lint:   16:3   warning  'PlatformOverviewDiagram' is defined but never used     @typescript-eslint/no-unused-vars
+@settler/web:lint:   17:3   warning  'WorkflowJourneyDiagram' is defined but never used      @typescript-eslint/no-unused-vars
+@settler/web:lint: 
+@settler/web:lint: /workspace/Settler/packages/web/src/app/edge-ai/nodes/page.tsx
+@settler/web:lint:   2:46  warning  'CardHeader' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/web:lint: 
+@settler/web:lint: /workspace/Settler/packages/web/src/app/open-source/page.tsx
+@settler/web:lint:   11:3  warning  'RefreshCw' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/web:lint: 
+@settler/web:lint: ✖ 7 problems (0 errors, 7 warnings)
+@settler/web:lint: 
 
-pnpm run verify:setup
-- FAIL (missing required env values in container)
+ Tasks:    11 successful, 11 total
+Cached:    10 cached, 11 total
+  Time:    13.399s 
 
-timeout 240 pnpm typecheck
-- NON_BLOCKING_FRICTION (command did not complete within timeout in this container; no TS diagnostics emitted before timeout)
+[exit_code]=0
+\n$ pnpm typecheck
 
-timeout 180 pnpm lint
-- NON_BLOCKING_FRICTION (command did not complete within timeout in this container; warnings observed, no hard errors observed before timeout)
+> settler-monorepo@1.0.0 typecheck /workspace/Settler
+> turbo run typecheck
 
-timeout 120 pnpm build
-- NON_BLOCKING_FRICTION (build graph started but timed out in container window)
+• turbo 2.8.0
+• Packages in scope: @jobforge/adapter-settler, @jobforge/errors, @jobforge/fetch, @jobforge/sdk-ts, @jobforge/shared, @jobforge/typescript-config, @settler/adapters, @settler/api, @settler/cli, @settler/edge-ai-core, @settler/edge-node, @settler/protocol, @settler/react-settler, @settler/sdk, @settler/sdk-csharp, @settler/sdk-java, @settler/types, @settler/web
+• Running typecheck in 18 packages
+• Remote caching disabled
+@settler/react-settler:typecheck: cache hit, replaying logs b99a675251607f6c
+@settler/react-settler:typecheck: 
+@settler/react-settler:typecheck: > @settler/react-settler@0.1.0 typecheck /workspace/Settler/packages/react-settler
+@settler/react-settler:typecheck: > tsc --noEmit
+@settler/react-settler:typecheck: 
+@settler/cli:typecheck: cache hit, replaying logs 82169bafd6399a50
+@settler/cli:typecheck: 
+@settler/cli:typecheck: > @settler/cli@1.0.0 typecheck /workspace/Settler/packages/cli
+@settler/cli:typecheck: > tsc --noEmit
+@settler/cli:typecheck: 
+@settler/types:typecheck: cache hit, replaying logs a5fe1fa944e423a7
+@settler/types:typecheck: 
+@settler/types:typecheck: > @settler/types@1.0.0 typecheck /workspace/Settler/packages/types
+@settler/types:typecheck: > tsc --noEmit
+@settler/types:typecheck: 
+@settler/api:typecheck: cache hit, replaying logs 576e13165a6a3e88
+@settler/api:typecheck: 
+@settler/api:typecheck: > @settler/api@1.0.0 pretypecheck /workspace/Settler/packages/api
+@settler/api:typecheck: > cd ../.. && pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed'
+@settler/api:typecheck: 
+@settler/api:typecheck: 
+@settler/api:typecheck: > settler-monorepo@1.0.0 prisma:generate /workspace/Settler
+@settler/api:typecheck: > cross-env PRISMA_CLIENT_ENGINE_TYPE=wasm PRISMA_ENGINES_MIRROR= prisma generate
+@settler/api:typecheck: 
+@settler/api:typecheck: Loaded Prisma config from prisma.config.ts.
+@settler/api:typecheck: 
+@settler/api:typecheck: Prisma schema loaded from prisma/schema.prisma.
+@settler/api:typecheck: 
+@settler/api:typecheck: ✔ Generated Prisma Client (v7.3.0) to ./node_modules/.pnpm/@prisma+client@7.3.0_prisma@7.3.0_@types+react@18.3.27_better-sqlite3@12.6.2_react-dom@_efc9348d8c027de17c7e00b84b73d1eb/node_modules/@prisma/client in 2.80s
+@settler/api:typecheck: 
+@settler/api:typecheck: Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
+@settler/api:typecheck: 
+@settler/api:typecheck: 
+@settler/api:typecheck: 
+@settler/api:typecheck: > @settler/api@1.0.0 typecheck /workspace/Settler/packages/api
+@settler/api:typecheck: > tsc --noEmit
+@settler/api:typecheck: 
+@jobforge/sdk-ts:typecheck: cache hit, replaying logs e71bf8ad135687ea
+@jobforge/sdk-ts:typecheck: 
+@jobforge/sdk-ts:typecheck: > @jobforge/sdk-ts@0.1.0 typecheck /workspace/Settler/packages/jobforge-sdk-ts
+@jobforge/sdk-ts:typecheck: > tsc --noEmit
+@jobforge/sdk-ts:typecheck: 
+@jobforge/errors:typecheck: cache hit, replaying logs e767903e132e8446
+@jobforge/errors:typecheck: 
+@jobforge/errors:typecheck: > @jobforge/errors@0.1.0 typecheck /workspace/Settler/packages/jobforge-errors
+@jobforge/errors:typecheck: > tsc --noEmit
+@jobforge/errors:typecheck: 
+@jobforge/adapter-settler:typecheck: cache hit, replaying logs b50efe0c5dff2ceb
+@jobforge/adapter-settler:typecheck: 
+@jobforge/adapter-settler:typecheck: > @jobforge/adapter-settler@0.1.0 typecheck /workspace/Settler/packages/jobforge-adapter-settler
+@jobforge/adapter-settler:typecheck: > tsc --noEmit
+@jobforge/adapter-settler:typecheck: 
+@settler/web:typecheck: cache hit, replaying logs d82a71980e9c1c09
+@settler/web:typecheck: 
+@settler/web:typecheck: > @settler/web@1.0.0 typecheck /workspace/Settler/packages/web
+@settler/web:typecheck: > tsc --noEmit
+@settler/web:typecheck: 
+@settler/edge-ai-core:typecheck: cache hit, replaying logs 9c38c66a66c82b9b
+@settler/edge-ai-core:typecheck: 
+@settler/edge-ai-core:typecheck: > @settler/edge-ai-core@1.0.0 typecheck /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:typecheck: > tsc --noEmit
+@settler/edge-ai-core:typecheck: 
+@settler/sdk:typecheck: cache hit, replaying logs 31f72c942ded5029
+@settler/sdk:typecheck: 
+@settler/sdk:typecheck: > @settler/sdk@1.0.0 typecheck /workspace/Settler/packages/sdk
+@settler/sdk:typecheck: > tsc --noEmit
+@settler/sdk:typecheck: 
+@settler/adapters:typecheck: cache hit, replaying logs 0cc5d28b573f9d0f
+@settler/adapters:typecheck: 
+@settler/adapters:typecheck: > @settler/adapters@1.0.0 typecheck /workspace/Settler/packages/adapters
+@settler/adapters:typecheck: > tsc --noEmit
+@settler/adapters:typecheck: 
+@settler/edge-node:typecheck: cache hit, replaying logs db37ce43f49e0113
+@settler/edge-node:typecheck: 
+@settler/edge-node:typecheck: > @settler/edge-node@1.0.0 typecheck /workspace/Settler/packages/edge-node
+@settler/edge-node:typecheck: > tsc --noEmit
+@settler/edge-node:typecheck: 
+@jobforge/shared:typecheck: cache hit, replaying logs c4c3fb10e0072c37
+@jobforge/shared:typecheck: 
+@jobforge/shared:typecheck: > @jobforge/shared@0.1.0 typecheck /workspace/Settler/packages/jobforge-shared
+@jobforge/shared:typecheck: > tsc --noEmit
+@jobforge/shared:typecheck: 
+@settler/protocol:typecheck: cache hit, replaying logs ae7c097d97e058a2
+@settler/protocol:typecheck: 
+@settler/protocol:typecheck: > @settler/protocol@0.1.0 typecheck /workspace/Settler/packages/protocol
+@settler/protocol:typecheck: > tsc --noEmit
+@settler/protocol:typecheck: 
+@jobforge/fetch:typecheck: cache hit, replaying logs dd0cadec1f508090
+@jobforge/fetch:typecheck: 
+@jobforge/fetch:typecheck: > @jobforge/fetch@0.1.0 typecheck /workspace/Settler/packages/jobforge-fetch
+@jobforge/fetch:typecheck: > tsc --noEmit
+@jobforge/fetch:typecheck: 
 
-timeout 120 pnpm test
-- NON_BLOCKING_FRICTION (test graph started but timed out in container window)
+ Tasks:    15 successful, 15 total
+Cached:    15 cached, 15 total
+  Time:    742ms >>> FULL TURBO
 
-timeout 120 pnpm run check:production
-- NON_BLOCKING_FRICTION (gate started and entered lint phase; timed out in container window)
+[exit_code]=0
+\n$ pnpm build
 
-cargo fmt --check
-- PASS
+> settler-monorepo@1.0.0 build /workspace/Settler
+> turbo run build --filter @settler/web...
 
-cargo clippy --all-targets --all-features -- -D warnings
-- PASS
+• turbo 2.8.0
+• Packages in scope: @jobforge/sdk-ts, @jobforge/shared, @jobforge/typescript-config, @settler/adapters, @settler/api, @settler/edge-ai-core, @settler/protocol, @settler/react-settler, @settler/sdk, @settler/types, @settler/web
+• Running build in 11 packages
+• Remote caching disabled
+@settler/protocol:build: cache miss, executing e944ce77fbe40050
+@settler/types:build: cache miss, executing 3391060d441b3d26
+@settler/sdk:build: cache miss, executing 6a5caea113fbc286
+@settler/edge-ai-core:build: cache miss, executing 889a6ab7d8fa5378
+@jobforge/shared:build: cache miss, executing f37bc6c827718d1c
+@settler/types:build: 
+@settler/types:build: > @settler/types@1.0.0 build /workspace/Settler/packages/types
+@settler/types:build: > tsc
+@settler/types:build: 
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: > @settler/edge-ai-core@1.0.0 prebuild /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:build: > pnpm run typecheck
+@settler/edge-ai-core:build: 
+@settler/sdk:build: 
+@settler/sdk:build: > @settler/sdk@1.0.0 build /workspace/Settler/packages/sdk
+@settler/sdk:build: > tsc
+@settler/sdk:build: 
+@settler/protocol:build: 
+@settler/protocol:build: > @settler/protocol@0.1.0 build /workspace/Settler/packages/protocol
+@settler/protocol:build: > tsc
+@settler/protocol:build: 
+@jobforge/shared:build: 
+@jobforge/shared:build: > @jobforge/shared@0.1.0 build /workspace/Settler/packages/jobforge-shared
+@jobforge/shared:build: > tsc
+@jobforge/shared:build: 
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: > @settler/edge-ai-core@1.0.0 typecheck /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:build: > tsc --noEmit
+@settler/edge-ai-core:build: 
+@settler/react-settler:build: cache miss, executing a232a487723f0a0a
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: > @settler/edge-ai-core@1.0.0 build /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:build: > tsc
+@settler/edge-ai-core:build: 
+@jobforge/sdk-ts:build: cache miss, executing c9a7bf4f82ea46a2
+@settler/react-settler:build: 
+@settler/react-settler:build: > @settler/react-settler@0.1.0 build /workspace/Settler/packages/react-settler
+@settler/react-settler:build: > tsc
+@settler/react-settler:build: 
+@settler/adapters:build: cache miss, executing 02b0d8a895af8003
+@jobforge/sdk-ts:build: 
+@jobforge/sdk-ts:build: > @jobforge/sdk-ts@0.1.0 build /workspace/Settler/packages/jobforge-sdk-ts
+@jobforge/sdk-ts:build: > tsc
+@jobforge/sdk-ts:build: 
+@settler/adapters:build: 
+@settler/adapters:build: > @settler/adapters@1.0.0 build /workspace/Settler/packages/adapters
+@settler/adapters:build: > tsc
+@settler/adapters:build: 
+@settler/api:build: cache miss, executing e3a94d46ee07eacf
+@settler/api:build: 
+@settler/api:build: > @settler/api@1.0.0 prebuild /workspace/Settler/packages/api
+@settler/api:build: > cd ../.. && pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed'
+@settler/api:build: 
+@settler/api:build: 
+@settler/api:build: > settler-monorepo@1.0.0 prisma:generate /workspace/Settler
+@settler/api:build: > cross-env PRISMA_CLIENT_ENGINE_TYPE=wasm PRISMA_ENGINES_MIRROR= prisma generate
+@settler/api:build: 
+@settler/api:build: Loaded Prisma config from prisma.config.ts.
+@settler/api:build: 
+@settler/api:build: Prisma schema loaded from prisma/schema.prisma.
+@settler/api:build: 
+@settler/api:build: ✔ Generated Prisma Client (v7.3.0) to ./node_modules/.pnpm/@prisma+client@7.3.0_prisma@7.3.0_@types+react@18.3.27_better-sqlite3@12.6.2_react-dom@_efc9348d8c027de17c7e00b84b73d1eb/node_modules/@prisma/client in 472ms
+@settler/api:build: 
+@settler/api:build: Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
+@settler/api:build: 
+@settler/api:build: 
+@settler/api:build: 
+@settler/api:build: > @settler/api@1.0.0 build /workspace/Settler/packages/api
+@settler/api:build: > tsc --skipLibCheck --noEmit false
+@settler/api:build: 
+@settler/web:build: cache miss, executing 0cc7cbbe1611717f
+@settler/web:build: 
+@settler/web:build: > @settler/web@1.0.0 build /workspace/Settler/packages/web
+@settler/web:build: > next build --webpack
+@settler/web:build: 
+@settler/web:build: Attention: Next.js now collects completely anonymous telemetry regarding usage.
+@settler/web:build: This information is used to shape Next.js' roadmap and prioritize features.
+@settler/web:build: You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+@settler/web:build: https://nextjs.org/telemetry
+@settler/web:build: 
+@settler/web:build: ▲ Next.js 16.1.6 (webpack)
+@settler/web:build: - Experiments (use with caution):
+@settler/web:build:   ✓ optimizeCss
+@settler/web:build:   · optimizePackageImports
+@settler/web:build: 
+@settler/web:build:   Creating an optimized production build ...
+@settler/web:build:   Using tsconfig file: ./tsconfig.json
+@settler/web:build: ✓ Compiled successfully in 106s
+@settler/web:build:   Skipping validation of types
+@settler/web:build:   Collecting page data using 2 workers ...
+@settler/web:build: ⚠ Using edge runtime on a page currently disables static generation for that page
+@settler/web:build: ⚠️ Builder.io API key not found. Visual editor will not work.
+@settler/web:build: ⚠️ Builder API key not found, skipping static page generation
+@settler/web:build:   Generating static pages using 2 workers (0/186) ...
+@settler/web:build:   Generating static pages using 2 workers (46/186) 
+@settler/web:build:   Generating static pages using 2 workers (92/186) 
+@settler/web:build:   Generating static pages using 2 workers (139/186) 
+@settler/web:build: ✓ Generating static pages using 2 workers (186/186) in 6.8s
+@settler/web:build:   Finalizing page optimization ...
+@settler/web:build:   Collecting build traces ...
+@settler/web:build: 
+@settler/web:build: Route (app)                                                Revalidate  Expire
+@settler/web:build: ┌ ○ /
+@settler/web:build: ├ ○ /_not-found
+@settler/web:build: ├ ƒ /[slug]
+@settler/web:build: ├ ○ /about
+@settler/web:build: ├ ƒ /admin
+@settler/web:build: ├ ƒ /admin/analytics
+@settler/web:build: ├ ƒ /admin/audit
+@settler/web:build: ├ ƒ /admin/branding
+@settler/web:build: ├ ƒ /admin/database
+@settler/web:build: ├ ƒ /admin/database/[table]
+@settler/web:build: ├ ƒ /admin/exceptions
+@settler/web:build: ├ ƒ /admin/exceptions/[id]
+@settler/web:build: ├ ƒ /admin/experiments
+@settler/web:build: ├ ƒ /admin/experiments/[id]
+@settler/web:build: ├ ƒ /admin/experiments/new
+@settler/web:build: ├ ƒ /admin/flags
+@settler/web:build: ├ ƒ /admin/jobforge
+@settler/web:build: ├ ƒ /admin/metrics
+@settler/web:build: ├ ƒ /admin/monitoring
+@settler/web:build: ├ ƒ /admin/ops
+@settler/web:build: ├ ƒ /admin/pages
+@settler/web:build: ├ ƒ /admin/pages/[id]/editor
+@settler/web:build: ├ ƒ /admin/pages/new
+@settler/web:build: ├ ƒ /admin/runs
+@settler/web:build: ├ ƒ /admin/runs/[runId]
+@settler/web:build: ├ ƒ /admin/runs/compare
+@settler/web:build: ├ ƒ /admin/settings
+@settler/web:build: ├ ƒ /admin/webhooks
+@settler/web:build: ├ ƒ /api/admin/audit
+@settler/web:build: ├ ƒ /api/admin/exceptions
+@settler/web:build: ├ ƒ /api/admin/exceptions/[id]/escalate
+@settler/web:build: ├ ƒ /api/admin/exceptions/[id]/resolve
+@settler/web:build: ├ ƒ /api/admin/health
+@settler/web:build: ├ ƒ /api/admin/jobforge
+@settler/web:build: ├ ƒ /api/admin/metrics
+@settler/web:build: ├ ƒ /api/admin/runs
+@settler/web:build: ├ ƒ /api/admin/stream
+@settler/web:build: ├ ƒ /api/ai/data-insights
+@settler/web:build: ├ ƒ /api/ai/onboarding-assistant
+@settler/web:build: ├ ƒ /api/ai/support-assistant
+@settler/web:build: ├ ƒ /api/ai/troubleshooting
+@settler/web:build: ├ ƒ /api/billing/dispute
+@settler/web:build: ├ ƒ /api/billing/payment-recovery
+@settler/web:build: ├ ƒ /api/billing/retry-payment
+@settler/web:build: ├ ƒ /api/builder/revalidate
+@settler/web:build: ├ ƒ /api/connectors/backfill/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/callback/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/connect/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/disconnect/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/refresh/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/sync/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/test/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/webhook/[providerId]
+@settler/web:build: ├ ƒ /api/console/activities
+@settler/web:build: ├ ƒ /api/console/ai-analysis
+@settler/web:build: ├ ƒ /api/console/ai-tokens/usage
+@settler/web:build: ├ ƒ /api/console/alerts
+@settler/web:build: ├ ƒ /api/console/alerts/[id]/acknowledge
+@settler/web:build: ├ ƒ /api/console/analytics/datasets
+@settler/web:build: ├ ƒ /api/console/analytics/pivot
+@settler/web:build: ├ ƒ /api/console/analytics/rollup
+@settler/web:build: ├ ƒ /api/console/analytics/saved-views
+@settler/web:build: ├ ƒ /api/console/api-keys
+@settler/web:build: ├ ƒ /api/console/api-keys/[id]
+@settler/web:build: ├ ƒ /api/console/api-logs
+@settler/web:build: ├ ƒ /api/console/billing
+@settler/web:build: ├ ƒ /api/console/billing/ai-tokens
+@settler/web:build: ├ ƒ /api/console/costs
+@settler/web:build: ├ ƒ /api/console/feature-flags
+@settler/web:build: ├ ƒ /api/console/feature-flags/[id]/environments/[env]
+@settler/web:build: ├ ƒ /api/console/health
+@settler/web:build: ├ ƒ /api/console/insights
+@settler/web:build: ├ ƒ /api/console/meaningful-changes
+@settler/web:build: ├ ƒ /api/console/metrics
+@settler/web:build: ├ ƒ /api/console/operator/control-plane
+@settler/web:build: ├ ƒ /api/console/operator/runs
+@settler/web:build: ├ ƒ /api/console/performance
+@settler/web:build: ├ ƒ /api/console/reality
+@settler/web:build: ├ ƒ /api/console/receipts
+@settler/web:build: ├ ƒ /api/console/receipts-v2
+@settler/web:build: ├ ƒ /api/console/receipts/[id]
+@settler/web:build: ├ ƒ /api/console/reconciliation
+@settler/web:build: ├ ƒ /api/console/site/branding
+@settler/web:build: ├ ƒ /api/console/site/experiments
+@settler/web:build: ├ ƒ /api/console/site/experiments/[id]
+@settler/web:build: ├ ƒ /api/console/site/experiments/[id]/results
+@settler/web:build: ├ ƒ /api/console/site/experiments/[id]/start
+@settler/web:build: ├ ƒ /api/console/site/navigation
+@settler/web:build: ├ ƒ /api/console/site/pages
+@settler/web:build: ├ ƒ /api/console/site/pages/[id]
+@settler/web:build: ├ ƒ /api/console/site/pages/[id]/publish
+@settler/web:build: ├ ƒ /api/console/site/ui-config
+@settler/web:build: ├ ƒ /api/console/subscription
+@settler/web:build: ├ ƒ /api/console/subscription-status
+@settler/web:build: ├ ƒ /api/console/support/tickets
+@settler/web:build: ├ ƒ /api/console/support/triage
+@settler/web:build: ├ ƒ /api/console/tables/[table]
+@settler/web:build: ├ ƒ /api/console/tenants
+@settler/web:build: ├ ƒ /api/console/usage
+@settler/web:build: ├ ƒ /api/console/usage/alerts
+@settler/web:build: ├ ƒ /api/console/usage/analytics
+@settler/web:build: ├ ƒ /api/console/usage/export
+@settler/web:build: ├ ƒ /api/console/usage/warnings
+@settler/web:build: ├ ƒ /api/console/user-role
+@settler/web:build: ├ ƒ /api/console/webhooks
+@settler/web:build: ├ ƒ /api/console/webhooks/[id]
+@settler/web:build: ├ ƒ /api/control-plane/failures
+@settler/web:build: ├ ƒ /api/control-plane/keys
+@settler/web:build: ├ ƒ /api/control-plane/metrics
+@settler/web:build: ├ ƒ /api/control-plane/policies
+@settler/web:build: ├ ƒ /api/control-plane/policies/[policyId]
+@settler/web:build: ├ ƒ /api/control-plane/triggers
+@settler/web:build: ├ ƒ /api/cron/check-reliability-alerts
+@settler/web:build: ├ ƒ /api/cron/daily-cost-rollup
+@settler/web:build: ├ ƒ /api/cron/email-lifecycle
+@settler/web:build: ├ ƒ /api/cron/low-activity
+@settler/web:build: ├ ƒ /api/cron/monthly-summary
+@settler/web:build: ├ ƒ /api/data/export
+@settler/web:build: ├ ƒ /api/data/import
+@settler/web:build: ├ ƒ /api/docs/openapi
+@settler/web:build: ├ ƒ /api/enterprise/contact
+@settler/web:build: ├ ƒ /api/enterprise/ip-allowlist
+@settler/web:build: ├ ƒ /api/enterprise/ip-allowlist/[id]
+@settler/web:build: ├ ƒ /api/explorer/execution/[id]
+@settler/web:build: ├ ƒ /api/explorer/history
+@settler/web:build: ├ ƒ /api/exports
+@settler/web:build: ├ ƒ /api/feedback-loops/insights
+@settler/web:build: ├ ƒ /api/foundry/datasets
+@settler/web:build: ├ ƒ /api/foundry/datasets/[id]
+@settler/web:build: ├ ƒ /api/foundry/runs
+@settler/web:build: ├ ƒ /api/foundry/runs/[id]
+@settler/web:build: ├ ƒ /api/gtm/demo/reset
+@settler/web:build: ├ ƒ /api/gtm/funnel-stage
+@settler/web:build: ├ ƒ /api/gtm/roi
+@settler/web:build: ├ ƒ /api/health
+@settler/web:build: ├ ƒ /api/health/console
+@settler/web:build: ├ ƒ /api/health/stripe
+@settler/web:build: ├ ƒ /api/image-optimize
+@settler/web:build: ├ ƒ /api/imports/validate
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/debug
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/test
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/upgrade
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/versions
+@settler/web:build: ├ ƒ /api/integrations/analytics
+@settler/web:build: ├ ƒ /api/integrations/health
+@settler/web:build: ├ ƒ /api/internal/health/deep
+@settler/web:build: ├ ƒ /api/internal/jobs/drain
+@settler/web:build: ├ ƒ /api/invite/[token]
+@settler/web:build: ├ ƒ /api/jobs
+@settler/web:build: ├ ƒ /api/jobs/[id]
+@settler/web:build: ├ ƒ /api/jobs/[id]/exceptions
+@settler/web:build: ├ ƒ /api/jobs/[id]/exceptions/[exceptionId]
+@settler/web:build: ├ ƒ /api/jobs/[id]/progress
+@settler/web:build: ├ ƒ /api/jobs/[id]/result
+@settler/web:build: ├ ƒ /api/jobs/bulk
+@settler/web:build: ├ ƒ /api/metrics
+@settler/web:build: ├ ƒ /api/metrics/prometheus
+@settler/web:build: ├ ƒ /api/milestones
+@settler/web:build: ├ ƒ /api/onboarding/progress
+@settler/web:build: ├ ƒ /api/onboarding/progress/skip
+@settler/web:build: ├ ƒ /api/operator/incidents
+@settler/web:build: ├ ƒ /api/ops/activation-funnel
+@settler/web:build: ├ ƒ /api/ops/customers
+@settler/web:build: ├ ƒ /api/ops/dashboard
+@settler/web:build: ├ ƒ /api/ops/edge-functions
+@settler/web:build: ├ ƒ /api/ops/integration-status
+@settler/web:build: ├ ƒ /api/ops/overview
+@settler/web:build: ├ ƒ /api/ops/performance
+@settler/web:build: ├ ƒ /api/ops/retry-queues
+@settler/web:build: ├ ƒ /api/ops/system-health
+@settler/web:build: ├ ƒ /api/oss/stats
+@settler/web:build: ├ ƒ /api/pricing/experiments
+@settler/web:build: ├ ƒ /api/projects
+@settler/web:build: ├ ƒ /api/projects/snapshots
+@settler/web:build: ├ ƒ /api/projects/snapshots/[snapshotId]/export
+@settler/web:build: ├ ƒ /api/projects/snapshots/[snapshotId]/rollback
+@settler/web:build: ├ ƒ /api/public/reality
+@settler/web:build: ├ ƒ /api/public/ui-config
+@settler/web:build: ├ ƒ /api/quota
+@settler/web:build: ├ ƒ /api/rbac/roles
+@settler/web:build: ├ ƒ /api/rbac/users
+@settler/web:build: ├ ƒ /api/receipts/ocr
+@settler/web:build: ├ ƒ /api/referrals
+@settler/web:build: ├ ƒ /api/runs/[runId]
+@settler/web:build: ├ ƒ /api/runs/create
+@settler/web:build: ├ ƒ /api/seo/generate-sitemap
+@settler/web:build: ├ ƒ /api/share/[id]
+@settler/web:build: ├ ƒ /api/status
+@settler/web:build: ├ ƒ /api/status/health
+@settler/web:build: ├ ƒ /api/stripe/checkout
+@settler/web:build: ├ ƒ /api/stripe/portal
+@settler/web:build: ├ ƒ /api/stripe/webhook
+@settler/web:build: ├ ƒ /api/support/canned-responses
+@settler/web:build: ├ ƒ /api/support/report-issue
+@settler/web:build: ├ ƒ /api/support/tickets
+@settler/web:build: ├ ƒ /api/user/checklist
+@settler/web:build: ├ ƒ /api/user/pre-test
+@settler/web:build: ├ ƒ /api/user/upgrade
+@settler/web:build: ├ ƒ /api/user/value-moments
+@settler/web:build: ├ ƒ /api/v1
+@settler/web:build: ├ ƒ /api/v1/convert
+@settler/web:build: ├ ƒ /api/v1/datasets
+@settler/web:build: ├ ƒ /api/v1/feature-flags
+@settler/web:build: ├ ƒ /api/v1/feature-flags/[id]
+@settler/web:build: ├ ƒ /api/v1/feature-flags/evaluate
+@settler/web:build: ├ ƒ /api/v1/health
+@settler/web:build: ├ ƒ /api/v1/meta
+@settler/web:build: ├ ƒ /api/v1/metrics/summary
+@settler/web:build: ├ ƒ /api/v1/metrics/timeseries
+@settler/web:build: ├ ƒ /api/v1/metrics/top
+@settler/web:build: ├ ƒ /api/v1/ready
+@settler/web:build: ├ ƒ /api/v1/receipts
+@settler/web:build: ├ ƒ /api/v1/receipts/[id]
+@settler/web:build: ├ ƒ /api/v1/recon/jobs
+@settler/web:build: ├ ƒ /api/v1/runs
+@settler/web:build: ├ ƒ /api/v1/runs/[id]
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/evidence
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/replay
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/results
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/findPolicyImpact
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/getExecutionGraph
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/traceArtifactLineage
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/verifyProofChain
+@settler/web:build: ├ ƒ /api/vercel-example
+@settler/web:build: ├ ƒ /api/workspaces
+@settler/web:build: ├ ƒ /api/workspaces/[workspaceId]/invites
+@settler/web:build: ├ ƒ /api/workspaces/[workspaceId]/onboarding
+@settler/web:build: ├ ○ /app
+@settler/web:build: ├ ○ /app/alerts
+@settler/web:build: ├ ○ /app/audit
+@settler/web:build: ├ ƒ /app/capability-status
+@settler/web:build: ├ ○ /app/connections
+@settler/web:build: ├ ○ /app/evidence
+@settler/web:build: ├ ○ /app/executions
+@settler/web:build: ├ ƒ /app/executions/[id]
+@settler/web:build: ├ ○ /app/governance
+@settler/web:build: ├ ○ /app/integrations
+@settler/web:build: ├ ƒ /app/metrics
+@settler/web:build: ├ ƒ /app/mismatches
+@settler/web:build: ├ ○ /app/onboarding
+@settler/web:build: ├ ○ /app/overview
+@settler/web:build: ├ ○ /app/pipelines
+@settler/web:build: ├ ○ /app/policies
+@settler/web:build: ├ ○ /app/proofs
+@settler/web:build: ├ ƒ /app/proofs/[id]
+@settler/web:build: ├ ○ /app/reconciliation
+@settler/web:build: ├ ƒ /app/reconciliation/[id]
+@settler/web:build: ├ ○ /app/replay
+@settler/web:build: ├ ○ /app/results
+@settler/web:build: ├ ○ /app/review
+@settler/web:build: ├ ○ /app/rules
+@settler/web:build: ├ ƒ /app/runs
+@settler/web:build: ├ ƒ /app/runs/[id]
+@settler/web:build: ├ ○ /app/settings
+@settler/web:build: ├ ○ /app/system-health
+@settler/web:build: ├ ○ /app/traces
+@settler/web:build: ├ ○ /architecture
+@settler/web:build: ├ ○ /benchmarks
+@settler/web:build: ├ ○ /billing/success
+@settler/web:build: ├ ○ /blog
+@settler/web:build: ├ ● /builder/[...page]
+@settler/web:build: ├ ○ /capabilities
+@settler/web:build: ├ ○ /categorize
+@settler/web:build: ├ ○ /changelog
+@settler/web:build: ├ ● /changelog/[slug]
+@settler/web:build: │ ├ /changelog/2025-12-11-trust-layer
+@settler/web:build: │ ├ /changelog/2025-11-15-receipts-api
+@settler/web:build: │ ├ /changelog/2025-10-01-node-sdk-v1
+@settler/web:build: │ └ [+5 more paths]
+@settler/web:build: ├ ○ /community
+@settler/web:build: ├ ○ /community/contributors
+@settler/web:build: ├ ƒ /comparison
+@settler/web:build: ├ ƒ /console
+@settler/web:build: ├ ƒ /console/activity
+@settler/web:build: ├ ƒ /console/admin/activation
+@settler/web:build: ├ ƒ /console/admin/jobs
+@settler/web:build: ├ ƒ /console/admin/tenants
+@settler/web:build: ├ ƒ /console/ai-analysis
+@settler/web:build: ├ ƒ /console/alerts-view
+@settler/web:build: ├ ƒ /console/analytics
+@settler/web:build: ├ ƒ /console/api-keys
+@settler/web:build: ├ ƒ /console/api-logs
+@settler/web:build: ├ ƒ /console/api-playground
+@settler/web:build: ├ ƒ /console/api-playground/collections
+@settler/web:build: ├ ƒ /console/api-test
+@settler/web:build: ├ ƒ /console/approvals
+@settler/web:build: ├ ƒ /console/audit-trail
+@settler/web:build: ├ ƒ /console/audits
+@settler/web:build: ├ ƒ /console/billing
+@settler/web:build: ├ ƒ /console/briefings
+@settler/web:build: ├ ƒ /console/bulk-operations
+@settler/web:build: ├ ƒ /console/changes
+@settler/web:build: ├ ƒ /console/control-plane
+@settler/web:build: ├ ƒ /console/costs
+@settler/web:build: ├ ƒ /console/diagnostics
+@settler/web:build: ├ ƒ /console/docs
+@settler/web:build: ├ ƒ /console/feature-flags
+@settler/web:build: ├ ƒ /console/feature-flags-policy
+@settler/web:build: ├ ƒ /console/ingestion/[ingestionId]
+@settler/web:build: ├ ƒ /console/insights
+@settler/web:build: ├ ƒ /console/inspector
+@settler/web:build: ├ ƒ /console/multi-source-reconciliation
+@settler/web:build: ├ ƒ /console/onboarding
+@settler/web:build: ├ ƒ /console/operator
+@settler/web:build: ├ ƒ /console/ops
+@settler/web:build: ├ ƒ /console/organizations
+@settler/web:build: ├ ƒ /console/performance
+@settler/web:build: ├ ƒ /console/playground
+@settler/web:build: ├ ƒ /console/playground/cli
+@settler/web:build: ├ ƒ /console/playground/convert
+@settler/web:build: ├ ƒ /console/playground/flags
+@settler/web:build: ├ ƒ /console/playground/receipts
+@settler/web:build: ├ ƒ /console/playground/reconcile
+@settler/web:build: ├ ƒ /console/policies
+@settler/web:build: ├ ƒ /console/proof-explorer
+@settler/web:build: ├ ƒ /console/reality
+@settler/web:build: ├ ƒ /console/receipt-matching
+@settler/web:build: ├ ƒ /console/receipts
+@settler/web:build: ├ ƒ /console/receipts-hash
+@settler/web:build: ├ ƒ /console/reconciliation-view
+@settler/web:build: ├ ƒ /console/reconciliation/[runId]
+@settler/web:build: ├ ƒ /console/reconciliations
+@settler/web:build: ├ ƒ /console/replay
+@settler/web:build: ├ ƒ /console/replay-lab
+@settler/web:build: ├ ƒ /console/replay/[executionId]
+@settler/web:build: ├ ƒ /console/rules-engine
+@settler/web:build: ├ ƒ /console/runs/[runId]
+@settler/web:build: ├ ƒ /console/settings
+@settler/web:build: ├ ƒ /console/setup-check
+@settler/web:build: ├ ƒ /console/site
+@settler/web:build: ├ ƒ /console/site/branding
+@settler/web:build: ├ ƒ /console/site/experiments
+@settler/web:build: ├ ƒ /console/site/experiments/[id]
+@settler/web:build: ├ ƒ /console/site/navigation
+@settler/web:build: ├ ƒ /console/site/pages/[id]
+@settler/web:build: ├ ƒ /console/site/ui-config
+@settler/web:build: ├ ƒ /console/sla
+@settler/web:build: ├ ƒ /console/support
+@settler/web:build: ├ ƒ /console/tables
+@settler/web:build: ├ ƒ /console/tables/[table]
+@settler/web:build: ├ ƒ /console/usage
+@settler/web:build: ├ ƒ /console/webhooks
+@settler/web:build: ├ ƒ /console/workflows
+@settler/web:build: ├ ƒ /console/workflows/[id]
+@settler/web:build: ├ ƒ /console/workflows/new
+@settler/web:build: ├ ○ /contact
+@settler/web:build: ├ ○ /cookbook
+@settler/web:build: ├ ○ /cookbooks
+@settler/web:build: ├ ƒ /dashboard
+@settler/web:build: ├ ○ /dashboard/addons
+@settler/web:build: ├ ○ /dashboard/billing
+@settler/web:build: ├ ○ /dashboard/billing/invoices
+@settler/web:build: ├ ○ /dashboard/billing/payment-methods
+@settler/web:build: ├ ○ /dashboard/integrations
+@settler/web:build: ├ ƒ /dashboard/integrations/[integrationId]
+@settler/web:build: ├ ƒ /dashboard/integrations/[integrationId]/logs
+@settler/web:build: ├ ○ /dashboard/jobs
+@settler/web:build: ├ ƒ /dashboard/jobs/[jobId]
+@settler/web:build: ├ ƒ /dashboard/jobs/[jobId]/exceptions
+@settler/web:build: ├ ○ /dashboard/usage
+@settler/web:build: ├ ƒ /dashboard/user
+@settler/web:build: ├ ○ /demo
+@settler/web:build: ├ ○ /demo/api
+@settler/web:build: ├ ○ /demo/receipts
+@settler/web:build: ├ ○ /demo/reconciliation
+@settler/web:build: ├ ○ /docs
+@settler/web:build: ├ ○ /docs/api
+@settler/web:build: ├ ○ /docs/auth
+@settler/web:build: ├ ○ /docs/cli
+@settler/web:build: ├ ○ /docs/errors
+@settler/web:build: ├ ○ /docs/examples
+@settler/web:build: ├ ○ /docs/getting-started
+@settler/web:build: ├ ○ /docs/integrations
+@settler/web:build: ├ ƒ /docs/integrations/[integrationId]
+@settler/web:build: ├ ○ /docs/quickstart
+@settler/web:build: ├ ○ /docs/replay-lab
+@settler/web:build: ├ ○ /docs/sdk
+@settler/web:build: ├ ○ /docs/sdk/go
+@settler/web:build: ├ ○ /docs/sdk/nodejs
+@settler/web:build: ├ ○ /docs/sdk/python
+@settler/web:build: ├ ○ /docs/sdk/ruby
+@settler/web:build: ├ ○ /docs/status
+@settler/web:build: ├ ○ /docs/webhooks
+@settler/web:build: ├ ○ /edge-ai
+@settler/web:build: ├ ○ /edge-ai/nodes
+@settler/web:build: ├ ƒ /edge-ai/nodes/[nodeId]
+@settler/web:build: ├ ○ /edge-ai/nodes/new
+@settler/web:build: ├ ○ /engine
+@settler/web:build: ├ ○ /engine/create-run-pack
+@settler/web:build: ├ ○ /engine/import-results
+@settler/web:build: ├ ○ /engine/view-variances
+@settler/web:build: ├ ○ /enterprise
+@settler/web:build: ├ ○ /enterprise/dashboard
+@settler/web:build: ├ ○ /explorer
+@settler/web:build: ├ ƒ /explorer/execution/[id]
+@settler/web:build: ├ ƒ /explorer/tenant/[tenant_id]
+@settler/web:build: ├ ○ /exports
+@settler/web:build: ├ ○ /faq
+@settler/web:build: ├ ○ /feature-flags
+@settler/web:build: ├ ○ /founder
+@settler/web:build: ├ ○ /future-proof
+@settler/web:build: ├ ○ /home
+@settler/web:build: ├ ○ /how-it-works
+@settler/web:build: ├ ƒ /integrations
+@settler/web:build: ├ ○ /integrations/request
+@settler/web:build: ├ ƒ /intelligence/foundry
+@settler/web:build: ├ ƒ /intelligence/foundry/[datasetId]
+@settler/web:build: ├ ƒ /intelligence/foundry/runs/[runId]
+@settler/web:build: ├ ○ /investor/proof                                                1h      1y
+@settler/web:build: ├ ○ /investor/reality                                              5m      1y
+@settler/web:build: ├ ƒ /invite/[token]
+@settler/web:build: ├ ○ /legal
+@settler/web:build: ├ ○ /legal/aup                                                     1h      1y
+@settler/web:build: ├ ○ /legal/cookies                                                 1h      1y
+@settler/web:build: ├ ○ /legal/dpa
+@settler/web:build: ├ ○ /legal/license                                                 1h      1y
+@settler/web:build: ├ ○ /legal/privacy                                                 1h      1y
+@settler/web:build: ├ ○ /legal/subprocessors                                           1h      1y
+@settler/web:build: ├ ○ /legal/terms                                                   1h      1y
+@settler/web:build: ├ ƒ /login
+@settler/web:build: ├ ○ /mobile
+@settler/web:build: ├ ○ /offline
+@settler/web:build: ├ ○ /open-source
+@settler/web:build: ├ ƒ /openapi.json
+@settler/web:build: ├ ƒ /opengraph-image
+@settler/web:build: ├ ○ /operator/incidents
+@settler/web:build: ├ ○ /oss
+@settler/web:build: ├ ○ /oss/stats
+@settler/web:build: ├ ○ /parser
+@settler/web:build: ├ ○ /platform
+@settler/web:build: ├ ○ /playground
+@settler/web:build: ├ ○ /policies
+@settler/web:build: ├ ○ /pricing
+@settler/web:build: ├ ○ /privacy
+@settler/web:build: ├ ○ /product
+@settler/web:build: ├ ○ /proof
+@settler/web:build: ├ ○ /proof-explorer
+@settler/web:build: ├ ○ /react-settler-demo
+@settler/web:build: ├ ○ /realtime-dashboard
+@settler/web:build: ├ ○ /receipts
+@settler/web:build: ├ ○ /reconcile
+@settler/web:build: ├ ○ /reconciliation
+@settler/web:build: ├ ○ /replay-lab
+@settler/web:build: ├ ƒ /review/polish
+@settler/web:build: ├ ○ /roadmap
+@settler/web:build: ├ ○ /robots.txt
+@settler/web:build: ├ ○ /roi-calculator
+@settler/web:build: ├ ○ /runbooks
+@settler/web:build: ├ ○ /schematics
+@settler/web:build: ├ ○ /security
+@settler/web:build: ├ ○ /security-and-audit
+@settler/web:build: ├ ƒ /signup
+@settler/web:build: ├ ○ /sitemap.xml
+@settler/web:build: ├ ○ /status
+@settler/web:build: ├ ○ /support
+@settler/web:build: ├ ƒ /support/articles/[articleId]
+@settler/web:build: ├ ƒ /support/category/[categoryId]
+@settler/web:build: ├ ○ /support/contact
+@settler/web:build: ├ ○ /terms
+@settler/web:build: ├ ○ /transparency
+@settler/web:build: ├ ○ /trust
+@settler/web:build: ├ ○ /use-cases
+@settler/web:build: ├ ● /use-cases/[slug]
+@settler/web:build: │ ├ /use-cases/ecommerce-reconciliation
+@settler/web:build: │ ├ /use-cases/payment-reconciliation
+@settler/web:build: │ └ /use-cases/receipt-processing
+@settler/web:build: ├ ○ /ux-playground
+@settler/web:build: ├ ○ /ux-playground/events
+@settler/web:build: ├ ○ /verify
+@settler/web:build: ├ ○ /vision
+@settler/web:build: ├ ○ /why
+@settler/web:build: └ ○ /why-settler
+@settler/web:build: 
+@settler/web:build: 
+@settler/web:build: ○  (Static)   prerendered as static content
+@settler/web:build: ●  (SSG)      prerendered as static HTML (uses generateStaticParams)
+@settler/web:build: ƒ  (Dynamic)  server-rendered on demand
+@settler/web:build: 
 
-cargo test --all
-- PASS
+ Tasks:    10 successful, 10 total
+Cached:    0 cached, 10 total
+  Time:    3m47.418s 
+
+[exit_code]=0
+\n$ pnpm test
+
+> settler-monorepo@1.0.0 test /workspace/Settler
+> turbo run test
+
+• turbo 2.8.0
+• Packages in scope: @jobforge/adapter-settler, @jobforge/errors, @jobforge/fetch, @jobforge/sdk-ts, @jobforge/shared, @jobforge/typescript-config, @settler/adapters, @settler/api, @settler/cli, @settler/edge-ai-core, @settler/edge-node, @settler/protocol, @settler/react-settler, @settler/sdk, @settler/sdk-csharp, @settler/sdk-java, @settler/types, @settler/web
+• Running test in 18 packages
+• Remote caching disabled
+@settler/edge-ai-core:build: cache hit, replaying logs 889a6ab7d8fa5378
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: > @settler/edge-ai-core@1.0.0 prebuild /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:build: > pnpm run typecheck
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: > @settler/edge-ai-core@1.0.0 typecheck /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:build: > tsc --noEmit
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: > @settler/edge-ai-core@1.0.0 build /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:build: > tsc
+@settler/edge-ai-core:build: 
+@settler/protocol:build: cache hit, replaying logs e944ce77fbe40050
+@settler/protocol:build: 
+@settler/protocol:build: > @settler/protocol@0.1.0 build /workspace/Settler/packages/protocol
+@settler/protocol:build: > tsc
+@settler/protocol:build: 
+@settler/types:build: cache miss, executing 767c2c2d9928dea1
+@settler/sdk:build: cache hit, replaying logs 6a5caea113fbc286
+@settler/sdk:build: 
+@settler/sdk:build: > @settler/sdk@1.0.0 build /workspace/Settler/packages/sdk
+@settler/sdk:build: > tsc
+@settler/sdk:build: 
+@settler/edge-ai-core:test: cache miss, executing 657618dbfa052a74
+@jobforge/shared:build: cache hit, replaying logs f37bc6c827718d1c
+@jobforge/shared:build: 
+@jobforge/shared:build: > @jobforge/shared@0.1.0 build /workspace/Settler/packages/jobforge-shared
+@jobforge/shared:build: > tsc
+@jobforge/shared:build: 
+@jobforge/errors:build: cache miss, executing dcb738332c789862
+@settler/sdk:test: cache miss, executing 88abb82e60728d48
+@settler/react-settler:build: cache hit, replaying logs a232a487723f0a0a
+@settler/react-settler:build: 
+@settler/react-settler:build: > @settler/react-settler@0.1.0 build /workspace/Settler/packages/react-settler
+@settler/react-settler:build: > tsc
+@settler/react-settler:build: 
+@jobforge/sdk-ts:build: cache hit, replaying logs c9a7bf4f82ea46a2
+@jobforge/sdk-ts:build: 
+@jobforge/sdk-ts:build: > @jobforge/sdk-ts@0.1.0 build /workspace/Settler/packages/jobforge-sdk-ts
+@jobforge/sdk-ts:build: > tsc
+@jobforge/sdk-ts:build: 
+@settler/cli:build: cache miss, executing cfe8dcd32c6df144
+@jobforge/sdk-ts:test: cache miss, executing 1a8209631acc69f9
+@jobforge/adapter-settler:build: cache miss, executing 49ee3f7e2359a598
+@jobforge/errors:build: 
+@jobforge/errors:build: > @jobforge/errors@0.1.0 build /workspace/Settler/packages/jobforge-errors
+@jobforge/errors:build: > tsc --noEmit
+@jobforge/errors:build: 
+@settler/types:build: 
+@settler/types:build: > @settler/types@1.0.0 build /workspace/Settler/packages/types
+@settler/types:build: > tsc
+@settler/types:build: 
+@jobforge/adapter-settler:build: 
+@jobforge/adapter-settler:build: > @jobforge/adapter-settler@0.1.0 build /workspace/Settler/packages/jobforge-adapter-settler
+@jobforge/adapter-settler:build: > tsc
+@jobforge/adapter-settler:build: 
+@settler/sdk:test: 
+@settler/sdk:test: > @settler/sdk@1.0.0 test /workspace/Settler/packages/sdk
+@settler/sdk:test: > jest
+@settler/sdk:test: 
+@jobforge/sdk-ts:test: 
+@jobforge/sdk-ts:test: > @jobforge/sdk-ts@0.1.0 test /workspace/Settler/packages/jobforge-sdk-ts
+@jobforge/sdk-ts:test: > vitest run
+@jobforge/sdk-ts:test: 
+@settler/edge-ai-core:test: 
+@settler/edge-ai-core:test: > @settler/edge-ai-core@1.0.0 test /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:test: > jest --passWithNoTests
+@settler/edge-ai-core:test: 
+@settler/cli:build: 
+@settler/cli:build: > @settler/cli@1.0.0 build /workspace/Settler/packages/cli
+@settler/cli:build: > tsc
+@settler/cli:build: 
+@jobforge/sdk-ts:test: 
+@jobforge/sdk-ts:test:  RUN  v1.6.1 /workspace/Settler/packages/jobforge-sdk-ts
+@jobforge/sdk-ts:test: 
+@settler/edge-ai-core:test: No tests found, exiting with code 0
+@jobforge/errors:test: cache miss, executing 529efe70383a3742
+@jobforge/fetch:build: cache miss, executing 76a03abec5072aa4
+@settler/edge-node:build: cache miss, executing 2e0ae9b1f7ad853e
+@settler/adapters:build: cache miss, executing d90df2c3bff69b2d
+@jobforge/sdk-ts:test:  ✓ test/client.test.ts  (2 tests) 90ms
+@jobforge/sdk-ts:test: 
+@jobforge/sdk-ts:test:  Test Files  1 passed (1)
+@jobforge/sdk-ts:test:       Tests  2 passed (2)
+@jobforge/sdk-ts:test:    Start at  16:28:56
+@jobforge/sdk-ts:test:    Duration  3.86s (transform 617ms, setup 0ms, collect 1.09s, tests 90ms, environment 0ms, prepare 850ms)
+@jobforge/sdk-ts:test: 
+@settler/edge-node:build: 
+@settler/edge-node:build: > @settler/edge-node@1.0.0 prebuild /workspace/Settler/packages/edge-node
+@settler/edge-node:build: > pnpm run typecheck
+@settler/edge-node:build: 
+@jobforge/errors:test: 
+@jobforge/errors:test: > @jobforge/errors@0.1.0 test /workspace/Settler/packages/jobforge-errors
+@jobforge/errors:test: > vitest run
+@jobforge/errors:test: 
+@jobforge/fetch:build: 
+@jobforge/fetch:build: > @jobforge/fetch@0.1.0 build /workspace/Settler/packages/jobforge-fetch
+@jobforge/fetch:build: > tsc --noEmit
+@jobforge/fetch:build: 
+@settler/adapters:build: 
+@settler/adapters:build: > @settler/adapters@1.0.0 build /workspace/Settler/packages/adapters
+@settler/adapters:build: > tsc
+@settler/adapters:build: 
+@jobforge/errors:test: [33mThe CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.[39m
+@jobforge/errors:test: 
+@jobforge/errors:test:  RUN  v1.6.1 /workspace/Settler/packages/jobforge-errors
+@jobforge/errors:test: 
+@settler/edge-node:build: 
+@settler/edge-node:build: > @settler/edge-node@1.0.0 typecheck /workspace/Settler/packages/edge-node
+@settler/edge-node:build: > tsc --noEmit
+@settler/edge-node:build: 
+@jobforge/fetch:test: cache miss, executing 95030b8ba767af2a
+@jobforge/errors:test:  ✓ test/error-envelope.test.ts  (11 tests) 90ms
+@jobforge/errors:test:  ✓ test/correlation.test.ts  (9 tests) 15ms
+@jobforge/errors:test: 
+@jobforge/errors:test:  Test Files  2 passed (2)
+@jobforge/errors:test:       Tests  20 passed (20)
+@jobforge/errors:test:    Start at  16:29:06
+@jobforge/errors:test:    Duration  5.71s (transform 974ms, setup 0ms, collect 958ms, tests 105ms, environment 12ms, prepare 1.38s)
+@jobforge/errors:test: 
+@jobforge/fetch:test: 
+@jobforge/fetch:test: > @jobforge/fetch@0.1.0 test /workspace/Settler/packages/jobforge-fetch
+@jobforge/fetch:test: > vitest run
+@jobforge/fetch:test: 
+@settler/edge-node:build: 
+@settler/edge-node:build: > @settler/edge-node@1.0.0 build /workspace/Settler/packages/edge-node
+@settler/edge-node:build: > tsc
+@settler/edge-node:build: 
+@settler/api:build: cache miss, executing 5ff800f8dc068ba6
+@settler/adapters:test: cache miss, executing 84e9517949e6a40f
+@settler/cli:test: cache miss, executing 0fd3d85358a0ed61
+@jobforge/fetch:test: [33mThe CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.[39m
+@jobforge/fetch:test: 
+@jobforge/fetch:test:  RUN  v1.6.1 /workspace/Settler/packages/jobforge-fetch
+@jobforge/fetch:test: 
+@settler/adapters:test: 
+@settler/adapters:test: > @settler/adapters@1.0.0 test /workspace/Settler/packages/adapters
+@settler/adapters:test: > jest --passWithNoTests
+@settler/adapters:test: 
+@settler/api:build: 
+@settler/api:build: > @settler/api@1.0.0 prebuild /workspace/Settler/packages/api
+@settler/api:build: > cd ../.. && pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed'
+@settler/api:build: 
+@settler/cli:test: 
+@settler/cli:test: > @settler/cli@1.0.0 test /workspace/Settler/packages/cli
+@settler/cli:test: > jest --passWithNoTests
+@settler/cli:test: 
+@settler/sdk:test: PASS src/__tests__/integration.test.ts (19.657 s)
+@jobforge/fetch:test:  ✓ test/retry.test.ts  (8 tests) 8ms
+@jobforge/fetch:test: 
+@jobforge/fetch:test:  Test Files  1 passed (1)
+@jobforge/fetch:test:       Tests  8 passed (8)
+@jobforge/fetch:test:    Start at  16:29:16
+@jobforge/fetch:test:    Duration  3.02s (transform 701ms, setup 0ms, collect 766ms, tests 8ms, environment 0ms, prepare 686ms)
+@jobforge/fetch:test: 
+@settler/adapters:test: No tests found, exiting with code 0
+@settler/sdk:test: PASS src/__tests__/client.test.ts
+@settler/api:build: 
+@settler/api:build: > settler-monorepo@1.0.0 prisma:generate /workspace/Settler
+@settler/api:build: > cross-env PRISMA_CLIENT_ENGINE_TYPE=wasm PRISMA_ENGINES_MIRROR= prisma generate
+@settler/api:build: 
+@settler/sdk:test: PASS src/__tests__/webhook-signature.test.ts
+@settler/sdk:test: 
+@settler/sdk:test: Test Suites: 3 passed, 3 total
+@settler/sdk:test: Tests:       24 passed, 24 total
+@settler/sdk:test: Snapshots:   0 total
+@settler/sdk:test: Time:        24.615 s
+@settler/sdk:test: Ran all test suites.
+@settler/edge-node:test: cache miss, executing d99f965bf1a5ce1a
+@settler/edge-node:test: 
+@settler/edge-node:test: > @settler/edge-node@1.0.0 test /workspace/Settler/packages/edge-node
+@settler/edge-node:test: > jest --passWithNoTests
+@settler/edge-node:test: 
+@settler/api:build: Loaded Prisma config from prisma.config.ts.
+@settler/api:build: 
+@settler/edge-node:test: No tests found, exiting with code 0
+@settler/api:build: Prisma schema loaded from prisma/schema.prisma.
+@settler/api:build: 
+@settler/api:build: ✔ Generated Prisma Client (v7.3.0) to ./node_modules/.pnpm/@prisma+client@7.3.0_prisma@7.3.0_@types+react@18.3.27_better-sqlite3@12.6.2_react-dom@_efc9348d8c027de17c7e00b84b73d1eb/node_modules/@prisma/client in 829ms
+@settler/api:build: 
+@settler/api:build: Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
+@settler/api:build: 
+@settler/api:build: 
+@settler/api:build: 
+@settler/api:build: > @settler/api@1.0.0 build /workspace/Settler/packages/api
+@settler/api:build: > tsc --skipLibCheck --noEmit false
+@settler/api:build: 
+@settler/web:build: cache miss, executing 4d05552ca255b5ab
+@settler/api:test: cache miss, executing 93f49b031995d3d9
+@settler/cli:test: PASS src/__tests__/kernel-client.test.ts (9.858 s)
+@settler/web:build: 
+@settler/web:build: > @settler/web@1.0.0 build /workspace/Settler/packages/web
+@settler/web:build: > next build --webpack
+@settler/web:build: 
+@settler/api:test: 
+@settler/api:test: > @settler/api@1.0.0 test /workspace/Settler/packages/api
+@settler/api:test: > jest --runInBand --forceExit
+@settler/api:test: 
+@settler/cli:test: PASS src/__tests__/reconciliation-foundry.test.ts
+@settler/cli:test: PASS src/__tests__/command-unsafe-ack.test.ts
+@settler/web:build: ▲ Next.js 16.1.6 (webpack)
+@settler/web:build: - Experiments (use with caution):
+@settler/web:build:   ✓ optimizeCss
+@settler/web:build:   · optimizePackageImports
+@settler/web:build: 
+@settler/cli:test: PASS src/__tests__/platform-extension.test.ts
+@settler/web:build:   Creating an optimized production build ...
+@settler/web:build:   Using tsconfig file: ./tsconfig.json
+@settler/cli:test: PASS src/__tests__/replay-verification.test.ts
+@settler/cli:test: PASS src/__tests__/execution-ledger.test.ts
+@settler/cli:test: PASS src/__tests__/foundry.test.ts
+@settler/cli:test: PASS src/__tests__/safety.test.ts
+@settler/cli:test: 
+@settler/cli:test: Test Suites: 8 passed, 8 total
+@settler/cli:test: Tests:       38 passed, 38 total
+@settler/cli:test: Snapshots:   0 total
+@settler/cli:test: Time:        18.21 s
+@settler/cli:test: Ran all test suites.
+@settler/api:test: PASS src/__tests__/multi-tenancy/runtime-isolation.test.ts
+@settler/api:test: PASS src/__tests__/multi-tenancy/tenant-isolation-enforced.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       ⚠️  Supabase not configured. Some features may not work.
+@settler/api:test: 
+@settler/api:test:       36 |     // Note: Can't use logger here as it may depend on Supabase - use console for initialization only
+@settler/api:test:       37 |      
+@settler/api:test:     > 38 |     console.warn('⚠️  Supabase not configured. Some features may not work.');
+@settler/api:test:          |             ^
+@settler/api:test:       39 |     return createClient('https://placeholder.supabase.co', 'placeholder-key', {
+@settler/api:test:       40 |       db: { schema: 'public' },
+@settler/api:test:       41 |       auth: { persistSession: false, autoRefreshToken: false },
+@settler/api:test: 
+@settler/api:test:       at createSupabaseClient (src/infrastructure/supabase/client.ts:38:13)
+@settler/api:test:       at src/infrastructure/supabase/client.ts:69:22
+@settler/api:test:       at Object.<anonymous> (src/infrastructure/supabase/client.ts:72:3)
+@settler/api:test:       at Object.<anonymous> (src/services/matching/enhanced-cross-customer-intelligence.ts:10:1)
+@settler/api:test:       at Object.<anonymous> (src/services/ingestion/reconciliation-matcher.ts:12:1)
+@settler/api:test:       at src/__tests__/multi-tenancy/tenant-isolation-enforced.test.ts:232:34
+@settler/api:test:       at Object.<anonymous> (src/__tests__/multi-tenancy/tenant-isolation-enforced.test.ts:232:34)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:29:49.069Z [[31merror[39m]: Failed to get audit logs Error: tenantId is required for getAuditLogs {"service":"settler-api","environment":"test","tenantId":"","stack":"Error: tenantId is required for getAuditLogs\n    at getAuditLogs (/workspace/Settler/packages/api/src/services/audit-trail.ts:54:26)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/__tests__/multi-tenancy/tenant-isolation-enforced.test.ts:245:18)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/reconciliation/ReconciliationService.test.ts
+@settler/api:test: PASS src/services/ingestion/__tests__/csv-importer.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:29:50.830Z [[31merror[39m]: Failed to parse CSV CSVParserError: CSV file is empty {"service":"settler-api","environment":"test","stack":"CSVParserError: CSV file is empty\n    at parseCSV (/workspace/Settler/packages/api/src/services/ingestion/csv-importer.ts:170:13)\n    at /workspace/Settler/packages/api/src/services/ingestion/__tests__/csv-importer.test.ts:39:28\n    at Object.<anonymous> (/workspace/Settler/node_modules/.pnpm/expect@29.7.0/node_modules/expect/build/toThrowMatchers.js:74:11)\n    at Object.throwingMatcher [as toThrow] (/workspace/Settler/node_modules/.pnpm/expect@29.7.0/node_modules/expect/build/index.js:320:21)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/services/ingestion/__tests__/csv-importer.test.ts:39:34)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/webhooks/webhook-security.test.ts
+@settler/api:test: PASS src/__tests__/webhooks/webhook-queue.test.ts
+@settler/api:test: PASS src/__tests__/security/encryption.test.ts
+@settler/api:test: PASS src/__tests__/resilience/api-resilience.test.ts
+@settler/api:test: PASS src/routes/v1/__tests__/ingestion-preview.route.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       ⚠️  Supabase not configured. Some features may not work.
+@settler/api:test: 
+@settler/api:test:       36 |     // Note: Can't use logger here as it may depend on Supabase - use console for initialization only
+@settler/api:test:       37 |      
+@settler/api:test:     > 38 |     console.warn('⚠️  Supabase not configured. Some features may not work.');
+@settler/api:test:          |             ^
+@settler/api:test:       39 |     return createClient('https://placeholder.supabase.co', 'placeholder-key', {
+@settler/api:test:       40 |       db: { schema: 'public' },
+@settler/api:test:       41 |       auth: { persistSession: false, autoRefreshToken: false },
+@settler/api:test: 
+@settler/api:test:       at createSupabaseClient (src/infrastructure/supabase/client.ts:38:13)
+@settler/api:test:       at src/infrastructure/supabase/client.ts:69:22
+@settler/api:test:       at Object.<anonymous> (src/infrastructure/supabase/client.ts:72:3)
+@settler/api:test:       at Object.<anonymous> (src/utils/usage-tracking.ts:8:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/ingestion.ts:27:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/__tests__/ingestion-preview.route.test.ts:3:1)
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/integration/capability-route-degradation.test.ts
+@settler/api:test: PASS src/__tests__/application/job-service-invocation-order.test.ts
+@settler/api:test: PASS src/__tests__/route-inventory.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       ⚠️  Supabase not configured. Some features may not work.
+@settler/api:test: 
+@settler/api:test:       36 |     // Note: Can't use logger here as it may depend on Supabase - use console for initialization only
+@settler/api:test:       37 |      
+@settler/api:test:     > 38 |     console.warn('⚠️  Supabase not configured. Some features may not work.');
+@settler/api:test:          |             ^
+@settler/api:test:       39 |     return createClient('https://placeholder.supabase.co', 'placeholder-key', {
+@settler/api:test:       40 |       db: { schema: 'public' },
+@settler/api:test:       41 |       auth: { persistSession: false, autoRefreshToken: false },
+@settler/api:test: 
+@settler/api:test:       at createSupabaseClient (src/infrastructure/supabase/client.ts:38:13)
+@settler/api:test:       at src/infrastructure/supabase/client.ts:69:22
+@settler/api:test:       at Object.<anonymous> (src/infrastructure/supabase/client.ts:72:3)
+@settler/api:test:       at Object.<anonymous> (src/utils/billing-helpers.ts:7:1)
+@settler/api:test:       at Object.<anonymous> (src/middleware/usage-enforcement.ts:10:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/ingestion.ts:26:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/index.ts:16:1)
+@settler/api:test:       at Object.<anonymous> (src/index.ts:50:1)
+@settler/api:test:       at Object.<anonymous> (src/__tests__/route-inventory.test.ts:8:1)
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       OTLP_ENDPOINT not set, tracing disabled
+@settler/api:test: 
+@settler/api:test:        99 |         // Note: Can't use logger here as it may depend on tracing - use console for initialization only
+@settler/api:test:       100 |          
+@settler/api:test:     > 101 |         console.warn("OTLP_ENDPOINT not set, tracing disabled");
+@settler/api:test:           |                 ^
+@settler/api:test:       102 |         return;
+@settler/api:test:       103 |       }
+@settler/api:test:       104 |
+@settler/api:test: 
+@settler/api:test:       at src/infrastructure/observability/tracing.ts:101:17
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/security/auth.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       ⚠️  Supabase not configured. Some features may not work.
+@settler/api:test: 
+@settler/api:test:       36 |     // Note: Can't use logger here as it may depend on Supabase - use console for initialization only
+@settler/api:test:       37 |      
+@settler/api:test:     > 38 |     console.warn('⚠️  Supabase not configured. Some features may not work.');
+@settler/api:test:          |             ^
+@settler/api:test:       39 |     return createClient('https://placeholder.supabase.co', 'placeholder-key', {
+@settler/api:test:       40 |       db: { schema: 'public' },
+@settler/api:test:       41 |       auth: { persistSession: false, autoRefreshToken: false },
+@settler/api:test: 
+@settler/api:test:       at createSupabaseClient (src/infrastructure/supabase/client.ts:38:13)
+@settler/api:test:       at src/infrastructure/supabase/client.ts:69:22
+@settler/api:test:       at Object.<anonymous> (src/infrastructure/supabase/client.ts:72:3)
+@settler/api:test:       at Object.<anonymous> (src/utils/billing-helpers.ts:7:1)
+@settler/api:test:       at Object.<anonymous> (src/middleware/usage-enforcement.ts:10:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/ingestion.ts:26:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/index.ts:16:1)
+@settler/api:test:       at Object.<anonymous> (src/index.ts:50:1)
+@settler/api:test:       at Object.<anonymous> (src/__tests__/security/auth.test.ts:7:1)
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       OTLP_ENDPOINT not set, tracing disabled
+@settler/api:test: 
+@settler/api:test:        99 |         // Note: Can't use logger here as it may depend on tracing - use console for initialization only
+@settler/api:test:       100 |          
+@settler/api:test:     > 101 |         console.warn("OTLP_ENDPOINT not set, tracing disabled");
+@settler/api:test:           |                 ^
+@settler/api:test:       102 |         return;
+@settler/api:test:       103 |       }
+@settler/api:test:       104 |
+@settler/api:test: 
+@settler/api:test:       at src/infrastructure/observability/tracing.ts:101:17
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/repositories/job-repository-tenant-contract.test.ts
+@settler/api:test: PASS src/__tests__/integration/route-validation.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       ⚠️  Supabase not configured. Some features may not work.
+@settler/api:test: 
+@settler/api:test:       36 |     // Note: Can't use logger here as it may depend on Supabase - use console for initialization only
+@settler/api:test:       37 |      
+@settler/api:test:     > 38 |     console.warn('⚠️  Supabase not configured. Some features may not work.');
+@settler/api:test:          |             ^
+@settler/api:test:       39 |     return createClient('https://placeholder.supabase.co', 'placeholder-key', {
+@settler/api:test:       40 |       db: { schema: 'public' },
+@settler/api:test:       41 |       auth: { persistSession: false, autoRefreshToken: false },
+@settler/api:test: 
+@settler/api:test:       at createSupabaseClient (src/infrastructure/supabase/client.ts:38:13)
+@settler/api:test:       at src/infrastructure/supabase/client.ts:69:22
+@settler/api:test:       at Object.<anonymous> (src/infrastructure/supabase/client.ts:72:3)
+@settler/api:test:       at Object.<anonymous> (src/utils/billing-helpers.ts:7:1)
+@settler/api:test:       at Object.<anonymous> (src/middleware/usage-enforcement.ts:10:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/ingestion.ts:26:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/index.ts:16:1)
+@settler/api:test:       at Object.<anonymous> (src/index.ts:50:1)
+@settler/api:test:       at Object.<anonymous> (src/__tests__/integration/route-validation.test.ts:7:1)
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       OTLP_ENDPOINT not set, tracing disabled
+@settler/api:test: 
+@settler/api:test:        99 |         // Note: Can't use logger here as it may depend on tracing - use console for initialization only
+@settler/api:test:       100 |          
+@settler/api:test:     > 101 |         console.warn("OTLP_ENDPOINT not set, tracing disabled");
+@settler/api:test:           |                 ^
+@settler/api:test:       102 |         return;
+@settler/api:test:       103 |       }
+@settler/api:test:       104 |
+@settler/api:test: 
+@settler/api:test:       at src/infrastructure/observability/tracing.ts:101:17
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/routes/operator-alerts-tenant-scope.test.ts
+@settler/api:test: PASS src/services/events/__tests__/event-bus.contract.test.ts
+@settler/api:test: PASS src/__tests__/application/user-service-invocation-order.test.ts
+@settler/api:test: PASS src/services/ops-intelligence/__tests__/recommendation-engine.test.ts
+@settler/api:test: PASS src/__tests__/integration/distributed-guards.redis.test.ts
+@settler/api:test: PASS src/__tests__/domain/User.test.ts
+@settler/api:test: PASS src/security/__tests__/security.test.ts
+@settler/api:test: PASS src/__tests__/security/input-validation.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       ⚠️  Supabase not configured. Some features may not work.
+@settler/api:test: 
+@settler/api:test:       36 |     // Note: Can't use logger here as it may depend on Supabase - use console for initialization only
+@settler/api:test:       37 |      
+@settler/api:test:     > 38 |     console.warn('⚠️  Supabase not configured. Some features may not work.');
+@settler/api:test:          |             ^
+@settler/api:test:       39 |     return createClient('https://placeholder.supabase.co', 'placeholder-key', {
+@settler/api:test:       40 |       db: { schema: 'public' },
+@settler/api:test:       41 |       auth: { persistSession: false, autoRefreshToken: false },
+@settler/api:test: 
+@settler/api:test:       at createSupabaseClient (src/infrastructure/supabase/client.ts:38:13)
+@settler/api:test:       at src/infrastructure/supabase/client.ts:69:22
+@settler/api:test:       at Object.<anonymous> (src/infrastructure/supabase/client.ts:72:3)
+@settler/api:test:       at Object.<anonymous> (src/utils/billing-helpers.ts:7:1)
+@settler/api:test:       at Object.<anonymous> (src/middleware/usage-enforcement.ts:10:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/ingestion.ts:26:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/index.ts:16:1)
+@settler/api:test:       at Object.<anonymous> (src/index.ts:50:1)
+@settler/api:test:       at Object.<anonymous> (src/__tests__/security/input-validation.test.ts:7:1)
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       OTLP_ENDPOINT not set, tracing disabled
+@settler/api:test: 
+@settler/api:test:        99 |         // Note: Can't use logger here as it may depend on tracing - use console for initialization only
+@settler/api:test:       100 |          
+@settler/api:test:     > 101 |         console.warn("OTLP_ENDPOINT not set, tracing disabled");
+@settler/api:test:           |                 ^
+@settler/api:test:       102 |         return;
+@settler/api:test:       103 |       }
+@settler/api:test:       104 |
+@settler/api:test: 
+@settler/api:test:       at src/infrastructure/observability/tracing.ts:101:17
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:21.789Z [[31merror[39m]: Request error PayloadTooLargeError: request entity too large {"service":"settler-api","environment":"test","method":"POST","path":"/api/v1/jobs","ip":"::ffff:127.0.0.1","traceId":"40f8dc0e-83d1-49b4-af32-7273ad8e691f","stack":"PayloadTooLargeError: request entity too large\n    at readStream (/workspace/Settler/node_modules/.pnpm/raw-body@2.5.3/node_modules/raw-body/index.js:163:17)\n    at getRawBody (/workspace/Settler/node_modules/.pnpm/raw-body@2.5.3/node_modules/raw-body/index.js:116:12)\n    at read (/workspace/Settler/node_modules/.pnpm/body-parser@1.20.4/node_modules/body-parser/lib/read.js:79:3)\n    at jsonParser (/workspace/Settler/node_modules/.pnpm/body-parser@1.20.4/node_modules/body-parser/lib/types/json.js:138:5)\n    at Layer.handle [as handle_request] (/workspace/Settler/node_modules/.pnpm/express@4.22.1/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/workspace/Settler/node_modules/.pnpm/express@4.22.1/node_modules/express/lib/router/index.js:328:13)\n    at /workspace/Settler/node_modules/.pnpm/express@4.22.1/node_modules/express/lib/router/index.js:286:9\n    at Function.process_params (/workspace/Settler/node_modules/.pnpm/express@4.22.1/node_modules/express/lib/router/index.js:346:12)\n    at next (/workspace/Settler/node_modules/.pnpm/express@4.22.1/node_modules/express/lib/router/index.js:280:10)\n    at /workspace/Settler/node_modules/.pnpm/express-rate-limit@7.5.1_express@4.22.1/node_modules/express-rate-limit/dist/index.cjs:807:7\n    at /workspace/Settler/node_modules/.pnpm/express-rate-limit@7.5.1_express@4.22.1/node_modules/express-rate-limit/dist/index.cjs:691:5"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/services/operator-foundations-contracts.test.ts
+@settler/api:test: PASS src/__tests__/application/webhook-ingestion-invocation-order.test.ts
+@settler/api:test: PASS src/__tests__/reconciliation/ReconciliationLifecycle.test.ts
+@settler/api:test: PASS src/__tests__/routes/recon-results-endpoint.contract.test.ts
+@settler/api:test: PASS src/__tests__/services/notifier-provider.test.ts
+@settler/api:test: PASS src/__tests__/routes/reconciliation-trust-contract.test.ts
+@settler/api:test: PASS src/__tests__/db/migration-checksums.test.ts
+@settler/api:test: PASS src/__tests__/eventsourcing/event-store-tenant-contract.test.ts
+@settler/api:test: PASS src/__tests__/services/distributed-guards.test.ts
+@settler/api:test: PASS src/__tests__/routes/recon-results-serializer.contract.test.ts
+@settler/api:test: PASS src/__tests__/multi-tenancy/rls-simulation.test.ts
+@settler/api:test: PASS src/__tests__/repositories/tenant-repository-tenant-contract.test.ts
+@settler/api:test: PASS src/__tests__/services/reconciliation/integrity.test.ts
+@settler/api:test: PASS src/__tests__/services/quota-service-tenant-safety.test.ts
+@settler/api:test: PASS src/services/ops-intelligence/__tests__/control-plane-analytics.test.ts
+@settler/api:test: PASS src/__tests__/multi-tenancy/tenant-middleware-security.test.ts
+@settler/api:test: PASS src/services/ops-intelligence/__tests__/insights-engine.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:29.057Z [[31merror[39m]: Failed to generate support insights TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function {"service":"settler-api","environment":"test","stack":"TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function\n    at generateSupportInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:285:10)\n    at generateInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:63:7)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/services/ops-intelligence/__tests__/insights-engine.test.ts:34:42)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:29.063Z [[31merror[39m]: Failed to generate usage insights TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function {"service":"settler-api","environment":"test","stack":"TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function\n    at generateUsageInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:376:10)\n    at generateInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:64:7)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/services/ops-intelligence/__tests__/insights-engine.test.ts:34:42)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:29.064Z [[31merror[39m]: Failed to generate stability insights TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function {"service":"settler-api","environment":"test","stack":"TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function\n    at generateStabilityInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:482:12)\n    at generateInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:65:7)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/services/ops-intelligence/__tests__/insights-engine.test.ts:34:42)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:29.065Z [[31merror[39m]: Error analyzing high-cost orgs TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function {"service":"settler-api","environment":"test","stack":"TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function\n    at generateCostInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:193:10)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at async Promise.allSettled (index 0)\n    at generateInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:61:79)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/services/ops-intelligence/__tests__/insights-engine.test.ts:34:20)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test:           at async Promise.allSettled (index 0)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:29.067Z [[31merror[39m]: Failed to generate support insights TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function {"service":"settler-api","environment":"test","stack":"TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function\n    at generateSupportInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:285:10)\n    at generateInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:63:7)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/services/ops-intelligence/__tests__/insights-engine.test.ts:51:42)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:29.068Z [[31merror[39m]: Failed to generate usage insights TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function {"service":"settler-api","environment":"test","stack":"TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function\n    at generateUsageInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:376:10)\n    at generateInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:64:7)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/services/ops-intelligence/__tests__/insights-engine.test.ts:51:42)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:29.069Z [[31merror[39m]: Failed to generate stability insights TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function {"service":"settler-api","environment":"test","stack":"TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function\n    at generateStabilityInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:482:12)\n    at generateInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:65:7)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/services/ops-intelligence/__tests__/insights-engine.test.ts:51:42)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:29.070Z [[31merror[39m]: Error analyzing high-cost orgs TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function {"service":"settler-api","environment":"test","stack":"TypeError: supabase.from(...).select(...).gte(...).lt(...).limit is not a function\n    at generateCostInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:193:10)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at async Promise.allSettled (index 0)\n    at generateInsights (/workspace/Settler/packages/api/src/services/ops-intelligence/insights-engine.ts:61:79)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/services/ops-intelligence/__tests__/insights-engine.test.ts:51:20)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test:           at async Promise.allSettled (index 0)
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/integration/health-checks.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       ⚠️  Supabase not configured. Some features may not work.
+@settler/api:test: 
+@settler/api:test:       36 |     // Note: Can't use logger here as it may depend on Supabase - use console for initialization only
+@settler/api:test:       37 |      
+@settler/api:test:     > 38 |     console.warn('⚠️  Supabase not configured. Some features may not work.');
+@settler/api:test:          |             ^
+@settler/api:test:       39 |     return createClient('https://placeholder.supabase.co', 'placeholder-key', {
+@settler/api:test:       40 |       db: { schema: 'public' },
+@settler/api:test:       41 |       auth: { persistSession: false, autoRefreshToken: false },
+@settler/api:test: 
+@settler/api:test:       at createSupabaseClient (src/infrastructure/supabase/client.ts:38:13)
+@settler/api:test:       at src/infrastructure/supabase/client.ts:69:22
+@settler/api:test:       at Object.<anonymous> (src/infrastructure/supabase/client.ts:72:3)
+@settler/api:test:       at Object.<anonymous> (src/utils/billing-helpers.ts:7:1)
+@settler/api:test:       at Object.<anonymous> (src/middleware/usage-enforcement.ts:10:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/ingestion.ts:26:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/index.ts:16:1)
+@settler/api:test:       at Object.<anonymous> (src/index.ts:50:1)
+@settler/api:test:       at Object.<anonymous> (src/__tests__/integration/health-checks.test.ts:7:1)
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       OTLP_ENDPOINT not set, tracing disabled
+@settler/api:test: 
+@settler/api:test:        99 |         // Note: Can't use logger here as it may depend on tracing - use console for initialization only
+@settler/api:test:       100 |          
+@settler/api:test:     > 101 |         console.warn("OTLP_ENDPOINT not set, tracing disabled");
+@settler/api:test:           |                 ^
+@settler/api:test:       102 |         return;
+@settler/api:test:       103 |       }
+@settler/api:test:       104 |
+@settler/api:test: 
+@settler/api:test:       at src/infrastructure/observability/tracing.ts:101:17
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/utils/error-standardization.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:31.492Z [[31merror[39m]: Error [INTERNAL_ERROR]: An unexpected error occurred Error: Test error {"service":"settler-api","environment":"test","code":"INTERNAL_ERROR","statusCode":500,"traceId":"test-trace-id","stack":"Error: Test error\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/__tests__/utils/error-standardization.test.ts:46:21)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/services/operator-daily-intelligence-tenant-scope.test.ts
+@settler/api:test: PASS src/__tests__/services/ai-assistant/deterministic-ai-sandbox.test.ts
+@settler/api:test: PASS src/__tests__/services/audit-trail-tenant-safety.test.ts
+@settler/api:test: PASS src/__tests__/services/operator-replay-status.test.ts
+@settler/api:test: PASS src/__tests__/services/csv-importer.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:32.720Z [[31merror[39m]: Failed to parse CSV CSVParserError: CSV file is empty {"service":"settler-api","environment":"test","stack":"CSVParserError: CSV file is empty\n    at parseCSV (/workspace/Settler/packages/api/src/services/ingestion/csv-importer.ts:170:13)\n    at /workspace/Settler/packages/api/src/__tests__/services/csv-importer.test.ts:9:26\n    at Object.<anonymous> (/workspace/Settler/node_modules/.pnpm/expect@29.7.0/node_modules/expect/build/toThrowMatchers.js:74:11)\n    at Object.throwingMatcher [as toThrow] (/workspace/Settler/node_modules/.pnpm/expect@29.7.0/node_modules/expect/build/index.js:320:21)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/__tests__/services/csv-importer.test.ts:9:39)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:32.723Z [[31merror[39m]: Failed to parse CSV CSVParserError: CSV contains duplicate headers: amount {"service":"settler-api","environment":"test","stack":"CSVParserError: CSV contains duplicate headers: amount\n    at parseCSV (/workspace/Settler/packages/api/src/services/ingestion/csv-importer.ts:213:13)\n    at /workspace/Settler/packages/api/src/__tests__/services/csv-importer.test.ts:14:26\n    at Object.<anonymous> (/workspace/Settler/node_modules/.pnpm/expect@29.7.0/node_modules/expect/build/toThrowMatchers.js:74:11)\n    at Object.throwingMatcher [as toThrow] (/workspace/Settler/node_modules/.pnpm/expect@29.7.0/node_modules/expect/build/index.js:320:21)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/__tests__/services/csv-importer.test.ts:14:33)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test:     console.log
+@settler/api:test:       2026-03-12T16:30:32.726Z [[31merror[39m]: Failed to parse CSV Error: Quote Not Closed: the parsing is finished with an opening quote at line 2 {"service":"settler-api","environment":"test","stack":"Error: Quote Not Closed: the parsing is finished with an opening quote at line 2\n    at Object.parse (/workspace/Settler/node_modules/.pnpm/csv-parse@5.6.0/node_modules/csv-parse/dist/cjs/sync.cjs:1269:13)\n    at parse (/workspace/Settler/node_modules/.pnpm/csv-parse@5.6.0/node_modules/csv-parse/dist/cjs/sync.cjs:1769:23)\n    at parseCSV (/workspace/Settler/packages/api/src/services/ingestion/csv-importer.ts:173:26)\n    at /workspace/Settler/packages/api/src/__tests__/services/csv-importer.test.ts:19:26\n    at Object.<anonymous> (/workspace/Settler/node_modules/.pnpm/expect@29.7.0/node_modules/expect/build/toThrowMatchers.js:74:11)\n    at Object.throwingMatcher [as toThrow] (/workspace/Settler/node_modules/.pnpm/expect@29.7.0/node_modules/expect/build/index.js:320:21)\n    at Object.<anonymous> (/workspace/Settler/packages/api/src/__tests__/services/csv-importer.test.ts:19:33)\n    at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)\n    at new Promise (<anonymous>)\n    at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)\n    at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:453:9)\n    at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)\n    at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)\n    at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)\n    at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)\n    at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)\n    at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)\n    at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)"}
+@settler/api:test: 
+@settler/api:test:       at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+@settler/api:test: 
+@settler/api:test: PASS src/services/capabilities/__tests__/registry.test.ts
+@settler/api:test: PASS src/services/capabilities/__tests__/alert-routing-provider.test.ts
+@settler/api:test: PASS src/__tests__/integration/csrf-protection.test.ts
+@settler/api:test:   ● Console
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       ⚠️  Supabase not configured. Some features may not work.
+@settler/api:test: 
+@settler/api:test:       36 |     // Note: Can't use logger here as it may depend on Supabase - use console for initialization only
+@settler/api:test:       37 |      
+@settler/api:test:     > 38 |     console.warn('⚠️  Supabase not configured. Some features may not work.');
+@settler/api:test:          |             ^
+@settler/api:test:       39 |     return createClient('https://placeholder.supabase.co', 'placeholder-key', {
+@settler/api:test:       40 |       db: { schema: 'public' },
+@settler/api:test:       41 |       auth: { persistSession: false, autoRefreshToken: false },
+@settler/api:test: 
+@settler/api:test:       at createSupabaseClient (src/infrastructure/supabase/client.ts:38:13)
+@settler/api:test:       at src/infrastructure/supabase/client.ts:69:22
+@settler/api:test:       at Object.<anonymous> (src/infrastructure/supabase/client.ts:72:3)
+@settler/api:test:       at Object.<anonymous> (src/utils/billing-helpers.ts:7:1)
+@settler/api:test:       at Object.<anonymous> (src/middleware/usage-enforcement.ts:10:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/ingestion.ts:26:1)
+@settler/api:test:       at Object.<anonymous> (src/routes/v1/index.ts:16:1)
+@settler/api:test:       at Object.<anonymous> (src/index.ts:50:1)
+@settler/api:test:       at Object.<anonymous> (src/__tests__/integration/csrf-protection.test.ts:7:1)
+@settler/api:test: 
+@settler/api:test:     console.warn
+@settler/api:test:       OTLP_ENDPOINT not set, tracing disabled
+@settler/api:test: 
+@settler/api:test:        99 |         // Note: Can't use logger here as it may depend on tracing - use console for initialization only
+@settler/api:test:       100 |          
+@settler/api:test:     > 101 |         console.warn("OTLP_ENDPOINT not set, tracing disabled");
+@settler/api:test:           |                 ^
+@settler/api:test:       102 |         return;
+@settler/api:test:       103 |       }
+@settler/api:test:       104 |
+@settler/api:test: 
+@settler/api:test:       at src/infrastructure/observability/tracing.ts:101:17
+@settler/api:test: 
+@settler/api:test: PASS src/__tests__/repositories/user-repository-tenant-contract.test.ts
+@settler/api:test: PASS src/__tests__/webhooks/webhook-ingest-security.test.ts
+@settler/api:test: PASS src/__tests__/integration/enterprise-setup-gating.test.ts
+@settler/api:test: PASS src/__tests__/utils/xss-sanitize.test.ts
+@settler/api:test: PASS src/__tests__/utils/json-depth.test.ts
+@settler/api:test: PASS src/__tests__/reconciliation/AlertLifecycle.test.ts
+@settler/api:test: PASS src/__tests__/jobs.test.ts
+@settler/api:test: 
+@settler/api:test: Test Suites: 12 skipped, 57 passed, 57 of 69 total
+@settler/api:test: Tests:       71 skipped, 273 passed, 344 total
+@settler/api:test: Snapshots:   0 total
+@settler/api:test: Time:        61.824 s
+@settler/api:test: Ran all test suites.
+@settler/api:test: Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+@settler/web:build: ✓ Compiled successfully in 2.1min
+@settler/web:build:   Skipping validation of types
+@settler/web:build:   Collecting page data using 2 workers ...
+@settler/web:build: ⚠ Using edge runtime on a page currently disables static generation for that page
+@settler/web:build: ⚠️ Builder.io API key not found. Visual editor will not work.
+@settler/web:build: ⚠️ Builder API key not found, skipping static page generation
+@settler/web:build:   Generating static pages using 2 workers (0/186) ...
+@settler/web:build:   Generating static pages using 2 workers (46/186) 
+@settler/web:build:   Generating static pages using 2 workers (92/186) 
+@settler/web:build:   Generating static pages using 2 workers (139/186) 
+@settler/web:build: ✓ Generating static pages using 2 workers (186/186) in 5.7s
+@settler/web:build:   Finalizing page optimization ...
+@settler/web:build:   Collecting build traces ...
+@settler/web:build: 
+@settler/web:build: Route (app)                                                Revalidate  Expire
+@settler/web:build: ┌ ○ /
+@settler/web:build: ├ ○ /_not-found
+@settler/web:build: ├ ƒ /[slug]
+@settler/web:build: ├ ○ /about
+@settler/web:build: ├ ƒ /admin
+@settler/web:build: ├ ƒ /admin/analytics
+@settler/web:build: ├ ƒ /admin/audit
+@settler/web:build: ├ ƒ /admin/branding
+@settler/web:build: ├ ƒ /admin/database
+@settler/web:build: ├ ƒ /admin/database/[table]
+@settler/web:build: ├ ƒ /admin/exceptions
+@settler/web:build: ├ ƒ /admin/exceptions/[id]
+@settler/web:build: ├ ƒ /admin/experiments
+@settler/web:build: ├ ƒ /admin/experiments/[id]
+@settler/web:build: ├ ƒ /admin/experiments/new
+@settler/web:build: ├ ƒ /admin/flags
+@settler/web:build: ├ ƒ /admin/jobforge
+@settler/web:build: ├ ƒ /admin/metrics
+@settler/web:build: ├ ƒ /admin/monitoring
+@settler/web:build: ├ ƒ /admin/ops
+@settler/web:build: ├ ƒ /admin/pages
+@settler/web:build: ├ ƒ /admin/pages/[id]/editor
+@settler/web:build: ├ ƒ /admin/pages/new
+@settler/web:build: ├ ƒ /admin/runs
+@settler/web:build: ├ ƒ /admin/runs/[runId]
+@settler/web:build: ├ ƒ /admin/runs/compare
+@settler/web:build: ├ ƒ /admin/settings
+@settler/web:build: ├ ƒ /admin/webhooks
+@settler/web:build: ├ ƒ /api/admin/audit
+@settler/web:build: ├ ƒ /api/admin/exceptions
+@settler/web:build: ├ ƒ /api/admin/exceptions/[id]/escalate
+@settler/web:build: ├ ƒ /api/admin/exceptions/[id]/resolve
+@settler/web:build: ├ ƒ /api/admin/health
+@settler/web:build: ├ ƒ /api/admin/jobforge
+@settler/web:build: ├ ƒ /api/admin/metrics
+@settler/web:build: ├ ƒ /api/admin/runs
+@settler/web:build: ├ ƒ /api/admin/stream
+@settler/web:build: ├ ƒ /api/ai/data-insights
+@settler/web:build: ├ ƒ /api/ai/onboarding-assistant
+@settler/web:build: ├ ƒ /api/ai/support-assistant
+@settler/web:build: ├ ƒ /api/ai/troubleshooting
+@settler/web:build: ├ ƒ /api/billing/dispute
+@settler/web:build: ├ ƒ /api/billing/payment-recovery
+@settler/web:build: ├ ƒ /api/billing/retry-payment
+@settler/web:build: ├ ƒ /api/builder/revalidate
+@settler/web:build: ├ ƒ /api/connectors/backfill/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/callback/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/connect/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/disconnect/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/refresh/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/sync/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/test/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/webhook/[providerId]
+@settler/web:build: ├ ƒ /api/console/activities
+@settler/web:build: ├ ƒ /api/console/ai-analysis
+@settler/web:build: ├ ƒ /api/console/ai-tokens/usage
+@settler/web:build: ├ ƒ /api/console/alerts
+@settler/web:build: ├ ƒ /api/console/alerts/[id]/acknowledge
+@settler/web:build: ├ ƒ /api/console/analytics/datasets
+@settler/web:build: ├ ƒ /api/console/analytics/pivot
+@settler/web:build: ├ ƒ /api/console/analytics/rollup
+@settler/web:build: ├ ƒ /api/console/analytics/saved-views
+@settler/web:build: ├ ƒ /api/console/api-keys
+@settler/web:build: ├ ƒ /api/console/api-keys/[id]
+@settler/web:build: ├ ƒ /api/console/api-logs
+@settler/web:build: ├ ƒ /api/console/billing
+@settler/web:build: ├ ƒ /api/console/billing/ai-tokens
+@settler/web:build: ├ ƒ /api/console/costs
+@settler/web:build: ├ ƒ /api/console/feature-flags
+@settler/web:build: ├ ƒ /api/console/feature-flags/[id]/environments/[env]
+@settler/web:build: ├ ƒ /api/console/health
+@settler/web:build: ├ ƒ /api/console/insights
+@settler/web:build: ├ ƒ /api/console/meaningful-changes
+@settler/web:build: ├ ƒ /api/console/metrics
+@settler/web:build: ├ ƒ /api/console/operator/control-plane
+@settler/web:build: ├ ƒ /api/console/operator/runs
+@settler/web:build: ├ ƒ /api/console/performance
+@settler/web:build: ├ ƒ /api/console/reality
+@settler/web:build: ├ ƒ /api/console/receipts
+@settler/web:build: ├ ƒ /api/console/receipts-v2
+@settler/web:build: ├ ƒ /api/console/receipts/[id]
+@settler/web:build: ├ ƒ /api/console/reconciliation
+@settler/web:build: ├ ƒ /api/console/site/branding
+@settler/web:build: ├ ƒ /api/console/site/experiments
+@settler/web:build: ├ ƒ /api/console/site/experiments/[id]
+@settler/web:build: ├ ƒ /api/console/site/experiments/[id]/results
+@settler/web:build: ├ ƒ /api/console/site/experiments/[id]/start
+@settler/web:build: ├ ƒ /api/console/site/navigation
+@settler/web:build: ├ ƒ /api/console/site/pages
+@settler/web:build: ├ ƒ /api/console/site/pages/[id]
+@settler/web:build: ├ ƒ /api/console/site/pages/[id]/publish
+@settler/web:build: ├ ƒ /api/console/site/ui-config
+@settler/web:build: ├ ƒ /api/console/subscription
+@settler/web:build: ├ ƒ /api/console/subscription-status
+@settler/web:build: ├ ƒ /api/console/support/tickets
+@settler/web:build: ├ ƒ /api/console/support/triage
+@settler/web:build: ├ ƒ /api/console/tables/[table]
+@settler/web:build: ├ ƒ /api/console/tenants
+@settler/web:build: ├ ƒ /api/console/usage
+@settler/web:build: ├ ƒ /api/console/usage/alerts
+@settler/web:build: ├ ƒ /api/console/usage/analytics
+@settler/web:build: ├ ƒ /api/console/usage/export
+@settler/web:build: ├ ƒ /api/console/usage/warnings
+@settler/web:build: ├ ƒ /api/console/user-role
+@settler/web:build: ├ ƒ /api/console/webhooks
+@settler/web:build: ├ ƒ /api/console/webhooks/[id]
+@settler/web:build: ├ ƒ /api/control-plane/failures
+@settler/web:build: ├ ƒ /api/control-plane/keys
+@settler/web:build: ├ ƒ /api/control-plane/metrics
+@settler/web:build: ├ ƒ /api/control-plane/policies
+@settler/web:build: ├ ƒ /api/control-plane/policies/[policyId]
+@settler/web:build: ├ ƒ /api/control-plane/triggers
+@settler/web:build: ├ ƒ /api/cron/check-reliability-alerts
+@settler/web:build: ├ ƒ /api/cron/daily-cost-rollup
+@settler/web:build: ├ ƒ /api/cron/email-lifecycle
+@settler/web:build: ├ ƒ /api/cron/low-activity
+@settler/web:build: ├ ƒ /api/cron/monthly-summary
+@settler/web:build: ├ ƒ /api/data/export
+@settler/web:build: ├ ƒ /api/data/import
+@settler/web:build: ├ ƒ /api/docs/openapi
+@settler/web:build: ├ ƒ /api/enterprise/contact
+@settler/web:build: ├ ƒ /api/enterprise/ip-allowlist
+@settler/web:build: ├ ƒ /api/enterprise/ip-allowlist/[id]
+@settler/web:build: ├ ƒ /api/explorer/execution/[id]
+@settler/web:build: ├ ƒ /api/explorer/history
+@settler/web:build: ├ ƒ /api/exports
+@settler/web:build: ├ ƒ /api/feedback-loops/insights
+@settler/web:build: ├ ƒ /api/foundry/datasets
+@settler/web:build: ├ ƒ /api/foundry/datasets/[id]
+@settler/web:build: ├ ƒ /api/foundry/runs
+@settler/web:build: ├ ƒ /api/foundry/runs/[id]
+@settler/web:build: ├ ƒ /api/gtm/demo/reset
+@settler/web:build: ├ ƒ /api/gtm/funnel-stage
+@settler/web:build: ├ ƒ /api/gtm/roi
+@settler/web:build: ├ ƒ /api/health
+@settler/web:build: ├ ƒ /api/health/console
+@settler/web:build: ├ ƒ /api/health/stripe
+@settler/web:build: ├ ƒ /api/image-optimize
+@settler/web:build: ├ ƒ /api/imports/validate
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/debug
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/test
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/upgrade
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/versions
+@settler/web:build: ├ ƒ /api/integrations/analytics
+@settler/web:build: ├ ƒ /api/integrations/health
+@settler/web:build: ├ ƒ /api/internal/health/deep
+@settler/web:build: ├ ƒ /api/internal/jobs/drain
+@settler/web:build: ├ ƒ /api/invite/[token]
+@settler/web:build: ├ ƒ /api/jobs
+@settler/web:build: ├ ƒ /api/jobs/[id]
+@settler/web:build: ├ ƒ /api/jobs/[id]/exceptions
+@settler/web:build: ├ ƒ /api/jobs/[id]/exceptions/[exceptionId]
+@settler/web:build: ├ ƒ /api/jobs/[id]/progress
+@settler/web:build: ├ ƒ /api/jobs/[id]/result
+@settler/web:build: ├ ƒ /api/jobs/bulk
+@settler/web:build: ├ ƒ /api/metrics
+@settler/web:build: ├ ƒ /api/metrics/prometheus
+@settler/web:build: ├ ƒ /api/milestones
+@settler/web:build: ├ ƒ /api/onboarding/progress
+@settler/web:build: ├ ƒ /api/onboarding/progress/skip
+@settler/web:build: ├ ƒ /api/operator/incidents
+@settler/web:build: ├ ƒ /api/ops/activation-funnel
+@settler/web:build: ├ ƒ /api/ops/customers
+@settler/web:build: ├ ƒ /api/ops/dashboard
+@settler/web:build: ├ ƒ /api/ops/edge-functions
+@settler/web:build: ├ ƒ /api/ops/integration-status
+@settler/web:build: ├ ƒ /api/ops/overview
+@settler/web:build: ├ ƒ /api/ops/performance
+@settler/web:build: ├ ƒ /api/ops/retry-queues
+@settler/web:build: ├ ƒ /api/ops/system-health
+@settler/web:build: ├ ƒ /api/oss/stats
+@settler/web:build: ├ ƒ /api/pricing/experiments
+@settler/web:build: ├ ƒ /api/projects
+@settler/web:build: ├ ƒ /api/projects/snapshots
+@settler/web:build: ├ ƒ /api/projects/snapshots/[snapshotId]/export
+@settler/web:build: ├ ƒ /api/projects/snapshots/[snapshotId]/rollback
+@settler/web:build: ├ ƒ /api/public/reality
+@settler/web:build: ├ ƒ /api/public/ui-config
+@settler/web:build: ├ ƒ /api/quota
+@settler/web:build: ├ ƒ /api/rbac/roles
+@settler/web:build: ├ ƒ /api/rbac/users
+@settler/web:build: ├ ƒ /api/receipts/ocr
+@settler/web:build: ├ ƒ /api/referrals
+@settler/web:build: ├ ƒ /api/runs/[runId]
+@settler/web:build: ├ ƒ /api/runs/create
+@settler/web:build: ├ ƒ /api/seo/generate-sitemap
+@settler/web:build: ├ ƒ /api/share/[id]
+@settler/web:build: ├ ƒ /api/status
+@settler/web:build: ├ ƒ /api/status/health
+@settler/web:build: ├ ƒ /api/stripe/checkout
+@settler/web:build: ├ ƒ /api/stripe/portal
+@settler/web:build: ├ ƒ /api/stripe/webhook
+@settler/web:build: ├ ƒ /api/support/canned-responses
+@settler/web:build: ├ ƒ /api/support/report-issue
+@settler/web:build: ├ ƒ /api/support/tickets
+@settler/web:build: ├ ƒ /api/user/checklist
+@settler/web:build: ├ ƒ /api/user/pre-test
+@settler/web:build: ├ ƒ /api/user/upgrade
+@settler/web:build: ├ ƒ /api/user/value-moments
+@settler/web:build: ├ ƒ /api/v1
+@settler/web:build: ├ ƒ /api/v1/convert
+@settler/web:build: ├ ƒ /api/v1/datasets
+@settler/web:build: ├ ƒ /api/v1/feature-flags
+@settler/web:build: ├ ƒ /api/v1/feature-flags/[id]
+@settler/web:build: ├ ƒ /api/v1/feature-flags/evaluate
+@settler/web:build: ├ ƒ /api/v1/health
+@settler/web:build: ├ ƒ /api/v1/meta
+@settler/web:build: ├ ƒ /api/v1/metrics/summary
+@settler/web:build: ├ ƒ /api/v1/metrics/timeseries
+@settler/web:build: ├ ƒ /api/v1/metrics/top
+@settler/web:build: ├ ƒ /api/v1/ready
+@settler/web:build: ├ ƒ /api/v1/receipts
+@settler/web:build: ├ ƒ /api/v1/receipts/[id]
+@settler/web:build: ├ ƒ /api/v1/recon/jobs
+@settler/web:build: ├ ƒ /api/v1/runs
+@settler/web:build: ├ ƒ /api/v1/runs/[id]
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/evidence
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/replay
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/results
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/findPolicyImpact
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/getExecutionGraph
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/traceArtifactLineage
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/verifyProofChain
+@settler/web:build: ├ ƒ /api/vercel-example
+@settler/web:build: ├ ƒ /api/workspaces
+@settler/web:build: ├ ƒ /api/workspaces/[workspaceId]/invites
+@settler/web:build: ├ ƒ /api/workspaces/[workspaceId]/onboarding
+@settler/web:build: ├ ○ /app
+@settler/web:build: ├ ○ /app/alerts
+@settler/web:build: ├ ○ /app/audit
+@settler/web:build: ├ ƒ /app/capability-status
+@settler/web:build: ├ ○ /app/connections
+@settler/web:build: ├ ○ /app/evidence
+@settler/web:build: ├ ○ /app/executions
+@settler/web:build: ├ ƒ /app/executions/[id]
+@settler/web:build: ├ ○ /app/governance
+@settler/web:build: ├ ○ /app/integrations
+@settler/web:build: ├ ƒ /app/metrics
+@settler/web:build: ├ ƒ /app/mismatches
+@settler/web:build: ├ ○ /app/onboarding
+@settler/web:build: ├ ○ /app/overview
+@settler/web:build: ├ ○ /app/pipelines
+@settler/web:build: ├ ○ /app/policies
+@settler/web:build: ├ ○ /app/proofs
+@settler/web:build: ├ ƒ /app/proofs/[id]
+@settler/web:build: ├ ○ /app/reconciliation
+@settler/web:build: ├ ƒ /app/reconciliation/[id]
+@settler/web:build: ├ ○ /app/replay
+@settler/web:build: ├ ○ /app/results
+@settler/web:build: ├ ○ /app/review
+@settler/web:build: ├ ○ /app/rules
+@settler/web:build: ├ ƒ /app/runs
+@settler/web:build: ├ ƒ /app/runs/[id]
+@settler/web:build: ├ ○ /app/settings
+@settler/web:build: ├ ○ /app/system-health
+@settler/web:build: ├ ○ /app/traces
+@settler/web:build: ├ ○ /architecture
+@settler/web:build: ├ ○ /benchmarks
+@settler/web:build: ├ ○ /billing/success
+@settler/web:build: ├ ○ /blog
+@settler/web:build: ├ ● /builder/[...page]
+@settler/web:build: ├ ○ /capabilities
+@settler/web:build: ├ ○ /categorize
+@settler/web:build: ├ ○ /changelog
+@settler/web:build: ├ ● /changelog/[slug]
+@settler/web:build: │ ├ /changelog/2025-12-11-trust-layer
+@settler/web:build: │ ├ /changelog/2025-11-15-receipts-api
+@settler/web:build: │ ├ /changelog/2025-10-01-node-sdk-v1
+@settler/web:build: │ └ [+5 more paths]
+@settler/web:build: ├ ○ /community
+@settler/web:build: ├ ○ /community/contributors
+@settler/web:build: ├ ƒ /comparison
+@settler/web:build: ├ ƒ /console
+@settler/web:build: ├ ƒ /console/activity
+@settler/web:build: ├ ƒ /console/admin/activation
+@settler/web:build: ├ ƒ /console/admin/jobs
+@settler/web:build: ├ ƒ /console/admin/tenants
+@settler/web:build: ├ ƒ /console/ai-analysis
+@settler/web:build: ├ ƒ /console/alerts-view
+@settler/web:build: ├ ƒ /console/analytics
+@settler/web:build: ├ ƒ /console/api-keys
+@settler/web:build: ├ ƒ /console/api-logs
+@settler/web:build: ├ ƒ /console/api-playground
+@settler/web:build: ├ ƒ /console/api-playground/collections
+@settler/web:build: ├ ƒ /console/api-test
+@settler/web:build: ├ ƒ /console/approvals
+@settler/web:build: ├ ƒ /console/audit-trail
+@settler/web:build: ├ ƒ /console/audits
+@settler/web:build: ├ ƒ /console/billing
+@settler/web:build: ├ ƒ /console/briefings
+@settler/web:build: ├ ƒ /console/bulk-operations
+@settler/web:build: ├ ƒ /console/changes
+@settler/web:build: ├ ƒ /console/control-plane
+@settler/web:build: ├ ƒ /console/costs
+@settler/web:build: ├ ƒ /console/diagnostics
+@settler/web:build: ├ ƒ /console/docs
+@settler/web:build: ├ ƒ /console/feature-flags
+@settler/web:build: ├ ƒ /console/feature-flags-policy
+@settler/web:build: ├ ƒ /console/ingestion/[ingestionId]
+@settler/web:build: ├ ƒ /console/insights
+@settler/web:build: ├ ƒ /console/inspector
+@settler/web:build: ├ ƒ /console/multi-source-reconciliation
+@settler/web:build: ├ ƒ /console/onboarding
+@settler/web:build: ├ ƒ /console/operator
+@settler/web:build: ├ ƒ /console/ops
+@settler/web:build: ├ ƒ /console/organizations
+@settler/web:build: ├ ƒ /console/performance
+@settler/web:build: ├ ƒ /console/playground
+@settler/web:build: ├ ƒ /console/playground/cli
+@settler/web:build: ├ ƒ /console/playground/convert
+@settler/web:build: ├ ƒ /console/playground/flags
+@settler/web:build: ├ ƒ /console/playground/receipts
+@settler/web:build: ├ ƒ /console/playground/reconcile
+@settler/web:build: ├ ƒ /console/policies
+@settler/web:build: ├ ƒ /console/proof-explorer
+@settler/web:build: ├ ƒ /console/reality
+@settler/web:build: ├ ƒ /console/receipt-matching
+@settler/web:build: ├ ƒ /console/receipts
+@settler/web:build: ├ ƒ /console/receipts-hash
+@settler/web:build: ├ ƒ /console/reconciliation-view
+@settler/web:build: ├ ƒ /console/reconciliation/[runId]
+@settler/web:build: ├ ƒ /console/reconciliations
+@settler/web:build: ├ ƒ /console/replay
+@settler/web:build: ├ ƒ /console/replay-lab
+@settler/web:build: ├ ƒ /console/replay/[executionId]
+@settler/web:build: ├ ƒ /console/rules-engine
+@settler/web:build: ├ ƒ /console/runs/[runId]
+@settler/web:build: ├ ƒ /console/settings
+@settler/web:build: ├ ƒ /console/setup-check
+@settler/web:build: ├ ƒ /console/site
+@settler/web:build: ├ ƒ /console/site/branding
+@settler/web:build: ├ ƒ /console/site/experiments
+@settler/web:build: ├ ƒ /console/site/experiments/[id]
+@settler/web:build: ├ ƒ /console/site/navigation
+@settler/web:build: ├ ƒ /console/site/pages/[id]
+@settler/web:build: ├ ƒ /console/site/ui-config
+@settler/web:build: ├ ƒ /console/sla
+@settler/web:build: ├ ƒ /console/support
+@settler/web:build: ├ ƒ /console/tables
+@settler/web:build: ├ ƒ /console/tables/[table]
+@settler/web:build: ├ ƒ /console/usage
+@settler/web:build: ├ ƒ /console/webhooks
+@settler/web:build: ├ ƒ /console/workflows
+@settler/web:build: ├ ƒ /console/workflows/[id]
+@settler/web:build: ├ ƒ /console/workflows/new
+@settler/web:build: ├ ○ /contact
+@settler/web:build: ├ ○ /cookbook
+@settler/web:build: ├ ○ /cookbooks
+@settler/web:build: ├ ƒ /dashboard
+@settler/web:build: ├ ○ /dashboard/addons
+@settler/web:build: ├ ○ /dashboard/billing
+@settler/web:build: ├ ○ /dashboard/billing/invoices
+@settler/web:build: ├ ○ /dashboard/billing/payment-methods
+@settler/web:build: ├ ○ /dashboard/integrations
+@settler/web:build: ├ ƒ /dashboard/integrations/[integrationId]
+@settler/web:build: ├ ƒ /dashboard/integrations/[integrationId]/logs
+@settler/web:build: ├ ○ /dashboard/jobs
+@settler/web:build: ├ ƒ /dashboard/jobs/[jobId]
+@settler/web:build: ├ ƒ /dashboard/jobs/[jobId]/exceptions
+@settler/web:build: ├ ○ /dashboard/usage
+@settler/web:build: ├ ƒ /dashboard/user
+@settler/web:build: ├ ○ /demo
+@settler/web:build: ├ ○ /demo/api
+@settler/web:build: ├ ○ /demo/receipts
+@settler/web:build: ├ ○ /demo/reconciliation
+@settler/web:build: ├ ○ /docs
+@settler/web:build: ├ ○ /docs/api
+@settler/web:build: ├ ○ /docs/auth
+@settler/web:build: ├ ○ /docs/cli
+@settler/web:build: ├ ○ /docs/errors
+@settler/web:build: ├ ○ /docs/examples
+@settler/web:build: ├ ○ /docs/getting-started
+@settler/web:build: ├ ○ /docs/integrations
+@settler/web:build: ├ ƒ /docs/integrations/[integrationId]
+@settler/web:build: ├ ○ /docs/quickstart
+@settler/web:build: ├ ○ /docs/replay-lab
+@settler/web:build: ├ ○ /docs/sdk
+@settler/web:build: ├ ○ /docs/sdk/go
+@settler/web:build: ├ ○ /docs/sdk/nodejs
+@settler/web:build: ├ ○ /docs/sdk/python
+@settler/web:build: ├ ○ /docs/sdk/ruby
+@settler/web:build: ├ ○ /docs/status
+@settler/web:build: ├ ○ /docs/webhooks
+@settler/web:build: ├ ○ /edge-ai
+@settler/web:build: ├ ○ /edge-ai/nodes
+@settler/web:build: ├ ƒ /edge-ai/nodes/[nodeId]
+@settler/web:build: ├ ○ /edge-ai/nodes/new
+@settler/web:build: ├ ○ /engine
+@settler/web:build: ├ ○ /engine/create-run-pack
+@settler/web:build: ├ ○ /engine/import-results
+@settler/web:build: ├ ○ /engine/view-variances
+@settler/web:build: ├ ○ /enterprise
+@settler/web:build: ├ ○ /enterprise/dashboard
+@settler/web:build: ├ ○ /explorer
+@settler/web:build: ├ ƒ /explorer/execution/[id]
+@settler/web:build: ├ ƒ /explorer/tenant/[tenant_id]
+@settler/web:build: ├ ○ /exports
+@settler/web:build: ├ ○ /faq
+@settler/web:build: ├ ○ /feature-flags
+@settler/web:build: ├ ○ /founder
+@settler/web:build: ├ ○ /future-proof
+@settler/web:build: ├ ○ /home
+@settler/web:build: ├ ○ /how-it-works
+@settler/web:build: ├ ƒ /integrations
+@settler/web:build: ├ ○ /integrations/request
+@settler/web:build: ├ ƒ /intelligence/foundry
+@settler/web:build: ├ ƒ /intelligence/foundry/[datasetId]
+@settler/web:build: ├ ƒ /intelligence/foundry/runs/[runId]
+@settler/web:build: ├ ○ /investor/proof                                                1h      1y
+@settler/web:build: ├ ○ /investor/reality                                              5m      1y
+@settler/web:build: ├ ƒ /invite/[token]
+@settler/web:build: ├ ○ /legal
+@settler/web:build: ├ ○ /legal/aup                                                     1h      1y
+@settler/web:build: ├ ○ /legal/cookies                                                 1h      1y
+@settler/web:build: ├ ○ /legal/dpa
+@settler/web:build: ├ ○ /legal/license                                                 1h      1y
+@settler/web:build: ├ ○ /legal/privacy                                                 1h      1y
+@settler/web:build: ├ ○ /legal/subprocessors                                           1h      1y
+@settler/web:build: ├ ○ /legal/terms                                                   1h      1y
+@settler/web:build: ├ ƒ /login
+@settler/web:build: ├ ○ /mobile
+@settler/web:build: ├ ○ /offline
+@settler/web:build: ├ ○ /open-source
+@settler/web:build: ├ ƒ /openapi.json
+@settler/web:build: ├ ƒ /opengraph-image
+@settler/web:build: ├ ○ /operator/incidents
+@settler/web:build: ├ ○ /oss
+@settler/web:build: ├ ○ /oss/stats
+@settler/web:build: ├ ○ /parser
+@settler/web:build: ├ ○ /platform
+@settler/web:build: ├ ○ /playground
+@settler/web:build: ├ ○ /policies
+@settler/web:build: ├ ○ /pricing
+@settler/web:build: ├ ○ /privacy
+@settler/web:build: ├ ○ /product
+@settler/web:build: ├ ○ /proof
+@settler/web:build: ├ ○ /proof-explorer
+@settler/web:build: ├ ○ /react-settler-demo
+@settler/web:build: ├ ○ /realtime-dashboard
+@settler/web:build: ├ ○ /receipts
+@settler/web:build: ├ ○ /reconcile
+@settler/web:build: ├ ○ /reconciliation
+@settler/web:build: ├ ○ /replay-lab
+@settler/web:build: ├ ƒ /review/polish
+@settler/web:build: ├ ○ /roadmap
+@settler/web:build: ├ ○ /robots.txt
+@settler/web:build: ├ ○ /roi-calculator
+@settler/web:build: ├ ○ /runbooks
+@settler/web:build: ├ ○ /schematics
+@settler/web:build: ├ ○ /security
+@settler/web:build: ├ ○ /security-and-audit
+@settler/web:build: ├ ƒ /signup
+@settler/web:build: ├ ○ /sitemap.xml
+@settler/web:build: ├ ○ /status
+@settler/web:build: ├ ○ /support
+@settler/web:build: ├ ƒ /support/articles/[articleId]
+@settler/web:build: ├ ƒ /support/category/[categoryId]
+@settler/web:build: ├ ○ /support/contact
+@settler/web:build: ├ ○ /terms
+@settler/web:build: ├ ○ /transparency
+@settler/web:build: ├ ○ /trust
+@settler/web:build: ├ ○ /use-cases
+@settler/web:build: ├ ● /use-cases/[slug]
+@settler/web:build: │ ├ /use-cases/ecommerce-reconciliation
+@settler/web:build: │ ├ /use-cases/payment-reconciliation
+@settler/web:build: │ └ /use-cases/receipt-processing
+@settler/web:build: ├ ○ /ux-playground
+@settler/web:build: ├ ○ /ux-playground/events
+@settler/web:build: ├ ○ /verify
+@settler/web:build: ├ ○ /vision
+@settler/web:build: ├ ○ /why
+@settler/web:build: └ ○ /why-settler
+@settler/web:build: 
+@settler/web:build: 
+@settler/web:build: ○  (Static)   prerendered as static content
+@settler/web:build: ●  (SSG)      prerendered as static HTML (uses generateStaticParams)
+@settler/web:build: ƒ  (Dynamic)  server-rendered on demand
+@settler/web:build: 
+@settler/web:test: cache miss, executing 06f35fc491203577
+@settler/web:test: 
+@settler/web:test: > @settler/web@1.0.0 test /workspace/Settler/packages/web
+@settler/web:test: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand
+@settler/web:test: 
+@settler/web:test:   Using tsconfig file: ./tsconfig.json
+@settler/web:test: PASS src/lib/reconciliation/__tests__/trust-envelope.test.ts
+@settler/web:test: PASS src/__tests__/security/crossTenantMatrix.test.ts
+@settler/web:test: PASS src/__tests__/reconciliation/deterministic-matcher.test.ts
+@settler/web:test:   ● Console
+@settler/web:test: 
+@settler/web:test:     console.warn
+@settler/web:test:       [Prisma] DATABASE_URL not found in environment variables. Please ensure DATABASE_URL, SUPABASE_DATABASE_URL, or DIRECT_URL is set in your .env file. Using stub client that returns empty results.
+@settler/web:test: 
+@settler/web:test:       210 |   if (!isBuildPhase) {
+@settler/web:test:       211 |     if (isMissingConfig && !actualDbUrl) {
+@settler/web:test:     > 212 |       console.warn(
+@settler/web:test:           |               ^
+@settler/web:test:       213 |         "[Prisma] DATABASE_URL not found in environment variables. " +
+@settler/web:test:       214 |           "Please ensure DATABASE_URL, SUPABASE_DATABASE_URL, or DIRECT_URL is set in your .env file. " +
+@settler/web:test:       215 |           "Using stub client that returns empty results."
+@settler/web:test: 
+@settler/web:test:       at Object.warn (src/shared/db/prismaClient.ts:212:15)
+@settler/web:test:       at Object.<anonymous> (src/lib/reconciliation/deterministic-matcher.ts:27:23)
+@settler/web:test:       at Object.<anonymous> (src/__tests__/reconciliation/deterministic-matcher.test.ts:10:31)
+@settler/web:test: 
+@settler/web:test: PASS src/__tests__/control-plane/failure-intelligence.test.ts
+@settler/web:test: PASS src/__tests__/api/v1-runs-route.contract.test.ts
+@settler/web:test: PASS src/__tests__/api/tenant-runtime-cross-tenant.test.ts
+@settler/web:test: PASS src/__tests__/api/support-billing-operator-tenant-boundary.test.ts
+@settler/web:test: PASS src/lib/reconciliation/__tests__/capsule-integrity.test.ts
+@settler/web:test: PASS src/__tests__/integration/content-pages.production.test.ts
+@settler/web:test: PASS src/__tests__/api/admin-control-plane.contract.test.ts
+@settler/web:test:   ● Console
+@settler/web:test: 
+@settler/web:test:     console.error
+@settler/web:test:       {"level":"error","msg":"[Admin Audit] Error","trace_id":"e5eb1c278f4a558d6b7229f59e173439","timestamp":"2026-03-12T16:33:09.997Z","error":{"message":"[\n  {\n    \"expected\": \"number\",\n    \"code\": \"invalid_type\",\n    \"received\": \"NaN\",\n    \"path\": [\n      \"limit\"\n    ],\n    \"message\": \"Invalid input: expected number, received NaN\"\n  }\n]","stack":"ZodError: [\n  {\n    \"expected\": \"number\",\n    \"code\": \"invalid_type\",\n    \"received\": \"NaN\",\n    \"path\": [\n      \"limit\"\n    ],\n    \"message\": \"Invalid input: expected number, received NaN\"\n  }\n]\n    at parse (/workspace/Settler/packages/web/src/app/api/admin/audit/route.ts:32:45)\n    at Object.<anonymous> (/workspace/Settler/packages/web/src/__tests__/api/admin-control-plane.contract.test.ts:60:22)","name":"ZodError"}}
+@settler/web:test: 
+@settler/web:test:       77 |       return;
+@settler/web:test:       78 |     }
+@settler/web:test:     > 79 |     originalError.call(console, ...args);
+@settler/web:test:          |                   ^
+@settler/web:test:       80 |   };
+@settler/web:test:       81 | });
+@settler/web:test:       82 |
+@settler/web:test: 
+@settler/web:test:       at console.call [as error] (jest.setup.js:79:19)
+@settler/web:test:       at Logger.error [as log] (src/lib/observability/logger.ts:72:17)
+@settler/web:test:       at Logger.error (src/lib/observability/logger.ts:102:5)
+@settler/web:test: 
+@settler/web:test: PASS src/__tests__/content/content-pages.test.ts
+@settler/web:test: PASS src/__tests__/services/pivot-engine.test.ts
+@settler/web:test: PASS src/components/ui/__tests__/button.test.tsx
+@settler/web:test: PASS src/__tests__/trust-graph/explorer.test.ts
+@settler/web:test: PASS src/__tests__/app/investor-reality-fallback.test.tsx
+@settler/web:test: PASS src/__tests__/security/crossTenantIsolation.test.ts
+@settler/web:test: PASS src/__tests__/reconciliation/run-persistence.contract.test.ts
+@settler/web:test: PASS src/__tests__/middleware/entitlements-middleware.test.ts
+@settler/web:test:   ● Console
+@settler/web:test: 
+@settler/web:test:     console.error
+@settler/web:test:       [Entitlement Middleware] Error checking entitlement: {
+@settler/web:test:         billingAccountId: '00000000-0000-0000-0000-000000000000',
+@settler/web:test:         service: 'reconcile',
+@settler/web:test:         error: 'billing offline'
+@settler/web:test:       }
+@settler/web:test: 
+@settler/web:test:       77 |       return;
+@settler/web:test:       78 |     }
+@settler/web:test:     > 79 |     originalError.call(console, ...args);
+@settler/web:test:          |                   ^
+@settler/web:test:       80 |   };
+@settler/web:test:       81 | });
+@settler/web:test:       82 |
+@settler/web:test: 
+@settler/web:test:       at console.call [as error] (jest.setup.js:79:19)
+@settler/web:test:       at error (src/shared/middleware/entitlements.ts:95:13)
+@settler/web:test:       at Object.<anonymous> (src/__tests__/middleware/entitlements-middleware.test.ts:29:20)
+@settler/web:test: 
+@settler/web:test: PASS src/__tests__/content/visual-proof-registry.test.ts
+@settler/web:test: PASS src/__tests__/services/cost-signal-engine.test.ts
+@settler/web:test: PASS src/__tests__/reconciliation/determinism-core.test.ts
+@settler/web:test: PASS src/__tests__/app/marketing-route-boundary.test.ts
+@settler/web:test: PASS src/__tests__/middleware/app-auth-gating.test.ts
+@settler/web:test: PASS src/__tests__/auth/smoke.test.ts
+@settler/web:test: PASS src/lib/reconciliation/__tests__/synthetic-foundry-harness.test.ts
+@settler/web:test: PASS src/__tests__/middleware/usage-enforcement.test.ts
+@settler/web:test:   ● Console
+@settler/web:test: 
+@settler/web:test:     console.error
+@settler/web:test:       [Usage Enforcement] Error: Error: redis down
+@settler/web:test:           at Object.<anonymous> (/workspace/Settler/packages/web/src/__tests__/middleware/usage-enforcement.test.ts:29:46)
+@settler/web:test:           at Promise.then.completed (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)
+@settler/web:test:           at new Promise (<anonymous>)
+@settler/web:test:           at callAsyncCircusFn (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)
+@settler/web:test:           at _callCircusTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)
+@settler/web:test:           at _runTest (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)
+@settler/web:test:           at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)
+@settler/web:test:           at _runTestsForDescribeBlock (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)
+@settler/web:test:           at run (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)
+@settler/web:test:           at runAndTransformResultsToJestFormat (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+@settler/web:test:           at jestAdapter (/workspace/Settler/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
+@settler/web:test:           at runTestInternal (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)
+@settler/web:test:           at runTest (/workspace/Settler/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34)
+@settler/web:test: 
+@settler/web:test:       77 |       return;
+@settler/web:test:       78 |     }
+@settler/web:test:     > 79 |     originalError.call(console, ...args);
+@settler/web:test:          |                   ^
+@settler/web:test:       80 |   };
+@settler/web:test:       81 | });
+@settler/web:test:       82 |
+@settler/web:test: 
+@settler/web:test:       at console.call [as error] (jest.setup.js:79:19)
+@settler/web:test:       at error (src/middleware/usage-enforcement.ts:114:13)
+@settler/web:test:       at Object.<anonymous> (src/__tests__/middleware/usage-enforcement.test.ts:35:20)
+@settler/web:test: 
+@settler/web:test: PASS src/__tests__/api/connectors-webhook-runtime.test.ts
+@settler/web:test: PASS src/__tests__/env/runtime-access.test.ts
+@settler/web:test: PASS src/__tests__/ui/recon-explainer.test.tsx
+@settler/web:test: PASS src/__tests__/data/adapters.test.ts
+@settler/web:test: PASS src/__tests__/api/stripe-webhook-runtime.test.ts
+@settler/web:test: PASS src/__tests__/api/status-degraded-contract.test.ts
+@settler/web:test: PASS src/__tests__/replay/replay-lab.test.ts
+@settler/web:test: PASS src/__tests__/api/stripe-config-gating.test.ts
+@settler/web:test: PASS src/__tests__/api/recon-core.test.ts
+@settler/web:test: PASS src/__tests__/api/problem-contract.test.ts
+@settler/web:test: PASS src/__tests__/security/advisory-policy.test.ts
+@settler/web:test: PASS src/__tests__/security/export-signature.test.ts
+@settler/web:test: PASS src/__tests__/app/rendering-strategy.guardrail.test.ts
+@settler/web:test: PASS src/__tests__/pr-overlay/recon-change-detector.test.ts
+@settler/web:test: PASS src/__tests__/contracts/recon-contracts.test.ts
+@settler/web:test: PASS src/__tests__/app/offline-prerender-compat.test.ts
+@settler/web:test: PASS src/__tests__/app/offline-render-harness.test.tsx
+@settler/web:test: 
+@settler/web:test: Test Suites: 2 skipped, 43 passed, 43 of 45 total
+@settler/web:test: Tests:       20 skipped, 149 passed, 169 total
+@settler/web:test: Snapshots:   0 total
+@settler/web:test: Time:        13.883 s
+@settler/web:test: Ran all test suites.
+
+ Tasks:    25 successful, 25 total
+Cached:    6 cached, 25 total
+  Time:    4m29.603s 
+
+ WARNING  no output files found for task @jobforge/adapter-settler#build. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @jobforge/errors#build. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @jobforge/errors#test. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @jobforge/fetch#build. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @jobforge/fetch#test. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @jobforge/sdk-ts#test. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @settler/adapters#test. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @settler/api#test. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @settler/cli#test. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @settler/edge-ai-core#test. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @settler/edge-node#test. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @settler/sdk#test. Please check your `outputs` key in `turbo.json`
+ WARNING  no output files found for task @settler/web#test. Please check your `outputs` key in `turbo.json`
+[exit_code]=0
+\n$ pnpm run verify:setup
+
+> settler-monorepo@1.0.0 verify:setup /workspace/Settler
+> tsx scripts/verify-setup.ts
+
+🩺 Settler setup verification
+
+[web]
+❌ Missing required env: NEXT_PUBLIC_SUPABASE_URL
+❌ Missing required env: NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+[api/auth]
+❌ Missing required env: SUPABASE_URL
+❌ Missing required env: SUPABASE_ANON_KEY
+
+[database]
+❌ Missing database DSN. Set DATABASE_URL, SUPABASE_DATABASE_URL, or DIRECT_URL.
+
+[billing]
+⚠️ Billing not enabled (Stripe env not set).
+
+[enterprise]
+⚠️ Enterprise integrations not enabled.
+
+[kernel]
+⚠️ Kernel not enabled (running with TS fallback path).
+
+❌ setup verification failed
+ ELIFECYCLE  Command failed with exit code 1.
+[exit_code]=1
+\n$ pnpm run settler:doctor
+
+> settler-monorepo@1.0.0 settler:doctor /workspace/Settler
+> pnpm run doctor
+
+
+> settler-monorepo@1.0.0 doctor /workspace/Settler
+> node scripts/doctor.mjs
+
+🩺 Settler Doctor
+mode=local
+summary=FAIL
+
+✅ [PASS] toolchain.node
+   Node v22.21.1 detected
+   remediation: Use Node 22+ (see package.json engines).
+✅ [PASS] toolchain.pnpm
+   pnpm 10.13.1 detected
+   remediation: Enable corepack and install pnpm 10.13.1+.
+❌ [FAIL] env.NEXT_PUBLIC_SUPABASE_URL
+   NEXT_PUBLIC_SUPABASE_URL is missing
+   remediation: Set NEXT_PUBLIC_SUPABASE_URL in environment or .env.local.
+❌ [FAIL] env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+   NEXT_PUBLIC_SUPABASE_ANON_KEY is missing
+   remediation: Set NEXT_PUBLIC_SUPABASE_ANON_KEY in environment or .env.local.
+❌ [FAIL] env.SUPABASE_URL
+   SUPABASE_URL is missing
+   remediation: Set SUPABASE_URL in environment or .env.local.
+❌ [FAIL] env.SUPABASE_ANON_KEY
+   SUPABASE_ANON_KEY is missing
+   remediation: Set SUPABASE_ANON_KEY in environment or .env.local.
+❌ [FAIL] env.database
+   No database DSN configured
+   remediation: Set DATABASE_URL (or SUPABASE_DATABASE_URL / DIRECT_URL).
+⚠️ [DEGRADED] env.billing
+   Billing disabled (Stripe keys not set)
+   remediation: Set Stripe keys to enable billing workflows.
+⚠️ [DEGRADED] config.NEXT_PUBLIC_SUPABASE_URL
+   NEXT_PUBLIC_SUPABASE_URL not set; URL shape skipped
+   remediation: Set NEXT_PUBLIC_SUPABASE_URL.
+⚠️ [DEGRADED] config.SUPABASE_URL
+   SUPABASE_URL not set; URL shape skipped
+   remediation: Set SUPABASE_URL.
+⚠️ [DEGRADED] config.NEXT_PUBLIC_API_URL
+   NEXT_PUBLIC_API_URL not set; URL shape skipped
+   remediation: Set NEXT_PUBLIC_API_URL.
+✅ [PASS] workspace.package.json
+   package.json present
+   remediation: Restore package.json; command surface requires it.
+✅ [PASS] workspace.pnpm-workspace.yaml
+   pnpm-workspace.yaml present
+   remediation: Restore pnpm-workspace.yaml; command surface requires it.
+✅ [PASS] workspace.packages/web/package.json
+   packages/web/package.json present
+   remediation: Restore packages/web/package.json; command surface requires it.
+✅ [PASS] workspace.packages/api/package.json
+   packages/api/package.json present
+   remediation: Restore packages/api/package.json; command surface requires it.
+✅ [PASS] workspace.scripts/kernel-health.ts
+   scripts/kernel-health.ts present
+   remediation: Restore scripts/kernel-health.ts; command surface requires it.
+✅ [PASS] workspace.scripts/verify-setup.ts
+   scripts/verify-setup.ts present
+   remediation: Restore scripts/verify-setup.ts; command surface requires it.
+✅ [PASS] workspace.command.settler:doctor
+   settler:doctor -> pnpm run doctor
+   remediation: Add a settler:doctor script in root package.json.
+⚠️ [DEGRADED] kernel.mode
+   Kernel disabled; TypeScript fallback mode active
+   remediation: Set SETTLER_KERNEL_ENABLED=1 and configure kernel binary to enable kernel path.
+⚠️ [DEGRADED] pipeline
+   Pipeline checks skipped (use --include-pipeline to execute lint/typecheck/build)
+   remediation: Run: pnpm run settler:doctor -- --include-pipeline
+ ELIFECYCLE  Command failed with exit code 1.
+ ELIFECYCLE  Command failed with exit code 1.
+[exit_code]=1
+\n$ pnpm run kernel:health
+
+> settler-monorepo@1.0.0 kernel:health /workspace/Settler
+> tsx scripts/kernel-health.ts
+
+Kernel health diagnostics
+=========================
+flags.enabled=false
+flags.canonicalize=false
+flags.executionMode=primary
+flags.shadowMode=false
+flags.primaryAllowlist=<empty>
+flags.disabledOperations=<empty>
+runner.mode=cargo-run
+runner.reason=<none>
+
+Startup health
+------------
+{
+  "healthy": false,
+  "runnerMode": "cargo-run",
+  "durationMs": 1514,
+  "reason": "timeout"
+}
+
+Per-operation readiness
+-----------------------
+canonicalize_hash: {"operation":"canonicalize_hash","kernelBinaryAvailable":false,"handshakeSuccess":false,"operationReady":false,"runnerMode":"disabled","reason":"kernel_disabled"}
+proof_bundle_hash: {"operation":"proof_bundle_hash","kernelBinaryAvailable":false,"handshakeSuccess":false,"operationReady":false,"runnerMode":"disabled","reason":"kernel_disabled"}
+artifact_identity_hash: {"operation":"artifact_identity_hash","kernelBinaryAvailable":false,"handshakeSuccess":false,"operationReady":false,"runnerMode":"disabled","reason":"kernel_disabled"}
+
+✅ Kernel health diagnostics completed.
+[exit_code]=0
+\n$ pnpm run check:production
+
+> settler-monorepo@1.0.0 check:production /workspace/Settler
+> tsx scripts/check-production-readiness.ts
+
+🚀 Running Production Verification Gate
+
+============================================================
+This check validates repo integrity and build/test quality gates
+============================================================
+
+🔍 Repository integrity (workspaces, packages, scripts)...
+🔍 Running repository integrity checks...
+
+✅ All integrity checks passed
+
+✅ Repository integrity (workspaces, packages, scripts) passed
+
+
+🔍 Lint all packages...
+
+> settler-monorepo@1.0.0 lint /workspace/Settler
+> turbo run lint
+
+• turbo 2.8.0
+• Packages in scope: @jobforge/adapter-settler, @jobforge/errors, @jobforge/fetch, @jobforge/sdk-ts, @jobforge/shared, @jobforge/typescript-config, @settler/adapters, @settler/api, @settler/cli, @settler/edge-ai-core, @settler/edge-node, @settler/protocol, @settler/react-settler, @settler/sdk, @settler/sdk-csharp, @settler/sdk-java, @settler/types, @settler/web
+• Running lint in 18 packages
+• Remote caching disabled
+@settler/edge-ai-core:lint: cache hit, replaying logs 7a95eea93bbe039e
+@settler/edge-ai-core:lint: 
+@settler/edge-ai-core:lint: > @settler/edge-ai-core@1.0.0 lint /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:lint: > eslint src
+@settler/edge-ai-core:lint: 
+@jobforge/errors:lint: cache hit, replaying logs a82a936ecd8bbe79
+@jobforge/errors:lint: 
+@jobforge/errors:lint: > @jobforge/errors@0.1.0 lint /workspace/Settler/packages/jobforge-errors
+@jobforge/errors:lint: > eslint "**/*.ts"
+@jobforge/errors:lint: 
+@settler/api:lint: cache miss, executing 390b07b838b796e0
+@jobforge/shared:lint: cache hit, replaying logs 19c5f688626d0948
+@jobforge/shared:lint: 
+@jobforge/shared:lint: > @jobforge/shared@0.1.0 lint /workspace/Settler/packages/jobforge-shared
+@jobforge/shared:lint: > eslint src/
+@jobforge/shared:lint: 
+@settler/cli:lint: cache miss, executing e9cc87146577333c
+@jobforge/fetch:lint: cache hit, replaying logs 2d331f0b41280540
+@jobforge/fetch:lint: 
+@jobforge/fetch:lint: > @jobforge/fetch@0.1.0 lint /workspace/Settler/packages/jobforge-fetch
+@jobforge/fetch:lint: > eslint "**/*.ts"
+@jobforge/fetch:lint: 
+@jobforge/sdk-ts:lint: cache hit, replaying logs 47d36ee24de488e3
+@jobforge/sdk-ts:lint: 
+@jobforge/sdk-ts:lint: > @jobforge/sdk-ts@0.1.0 lint /workspace/Settler/packages/jobforge-sdk-ts
+@jobforge/sdk-ts:lint: > eslint src/
+@jobforge/sdk-ts:lint: 
+@settler/web:lint: cache hit, replaying logs 6ce48f20cc700cd2
+@settler/web:lint: 
+@settler/web:lint: > @settler/web@1.0.0 lint /workspace/Settler/packages/web
+@settler/web:lint: > eslint src
+@settler/web:lint: 
+@settler/web:lint: 
+@settler/web:lint: /workspace/Settler/packages/web/src/app/architecture/page.tsx
+@settler/web:lint:   12:10  warning  'RealityEvidencePanel' is defined but never used        @typescript-eslint/no-unused-vars
+@settler/web:lint:   14:3   warning  'CapabilityMap' is defined but never used               @typescript-eslint/no-unused-vars
+@settler/web:lint:   15:3   warning  'IntegrationAndPackagingMap' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/web:lint:   16:3   warning  'PlatformOverviewDiagram' is defined but never used     @typescript-eslint/no-unused-vars
+@settler/web:lint:   17:3   warning  'WorkflowJourneyDiagram' is defined but never used      @typescript-eslint/no-unused-vars
+@settler/web:lint: 
+@settler/web:lint: /workspace/Settler/packages/web/src/app/edge-ai/nodes/page.tsx
+@settler/web:lint:   2:46  warning  'CardHeader' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/web:lint: 
+@settler/web:lint: /workspace/Settler/packages/web/src/app/open-source/page.tsx
+@settler/web:lint:   11:3  warning  'RefreshCw' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/web:lint: 
+@settler/web:lint: ✖ 7 problems (0 errors, 7 warnings)
+@settler/web:lint: 
+@settler/adapters:lint: cache miss, executing 28851f4a580c29b7
+@settler/edge-node:lint: cache hit, replaying logs 123fc492e6215a34
+@settler/edge-node:lint: 
+@settler/edge-node:lint: > @settler/edge-node@1.0.0 lint /workspace/Settler/packages/edge-node
+@settler/edge-node:lint: > eslint src
+@settler/edge-node:lint: 
+@settler/sdk:lint: cache hit, replaying logs 2a2e7b9090ab058a
+@settler/sdk:lint: 
+@settler/sdk:lint: > @settler/sdk@1.0.0 lint /workspace/Settler/packages/sdk
+@settler/sdk:lint: > eslint src
+@settler/sdk:lint: 
+@settler/sdk:lint: 
+@settler/sdk:lint: /workspace/Settler/packages/sdk/src/utils/middleware.ts
+@settler/sdk:lint:   72:31  warning  Unexpected console statement. Only these console methods are allowed: warn, error  no-console
+@settler/sdk:lint: 
+@settler/sdk:lint: ✖ 1 problem (0 errors, 1 warning)
+@settler/sdk:lint: 
+@settler/cli:lint: 
+@settler/cli:lint: > @settler/cli@1.0.0 lint /workspace/Settler/packages/cli
+@settler/cli:lint: > eslint src
+@settler/cli:lint: 
+@settler/api:lint: 
+@settler/api:lint: > @settler/api@1.0.0 lint /workspace/Settler/packages/api
+@settler/api:lint: > eslint src
+@settler/api:lint: 
+@settler/adapters:lint: 
+@settler/adapters:lint: > @settler/adapters@1.0.0 lint /workspace/Settler/packages/adapters
+@settler/adapters:lint: > eslint src
+@settler/adapters:lint: 
+@settler/cli:lint: 
+@settler/cli:lint: /workspace/Settler/packages/cli/src/lib/execution-ledger.ts
+@settler/cli:lint:   124:11  warning  'execution_hash' is assigned a value but never used  @typescript-eslint/no-unused-vars
+@settler/cli:lint: 
+@settler/cli:lint: ✖ 1 problem (0 errors, 1 warning)
+@settler/cli:lint: 
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/infrastructure/jobs/scheduler-service.ts
+@settler/api:lint:   30:10  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/infrastructure/security/SSRFProtection.ts
+@settler/api:lint:   66:14  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint:   72:12  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint:   94:12  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/jobs/email-scheduler.ts
+@settler/api:lint:   12:10  warning  '_calculateDaysRemaining' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/middleware/api-gateway-cache.ts
+@settler/api:lint:   182:16  warning  '_pattern' is assigned a value but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/routes/export-enhanced.ts
+@settler/api:lint:   71:27  warning  '_includeUnmatched' is assigned a value but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/routes/v1/operator-mode.ts
+@settler/api:lint:   21:3  warning  'checkAlertThresholds' is defined but never used   @typescript-eslint/no-unused-vars
+@settler/api:lint:   23:3  warning  'upsertAlertThreshold' is defined but never used   @typescript-eslint/no-unused-vars
+@settler/api:lint:   27:3  warning  'setTenantUsageCeiling' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint:   28:3  warning  'getAllUsageCeilings' is defined but never used    @typescript-eslint/no-unused-vars
+@settler/api:lint:   29:3  warning  'checkUsageCeiling' is defined but never used      @typescript-eslint/no-unused-vars
+@settler/api:lint:   30:3  warning  'setBackgroundJobLimit' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/determinism/execution-orchestrator.ts
+@settler/api:lint:   16:10  warning  'createRunSnapshot' is defined but never used        @typescript-eslint/no-unused-vars
+@settler/api:lint:   16:29  warning  'updateRunSnapshotStatus' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint:   16:54  warning  'RunSnapshot' is defined but never used              @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/determinism/idempotent-ingestion.ts
+@settler/api:lint:   96:59  warning  'effective_date' is assigned a value but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/determinism/replay-service.ts
+@settler/api:lint:   227:33  warning  'snapshot' is defined but never used. Allowed unused args must match /^_/u       @typescript-eslint/no-unused-vars
+@settler/api:lint:   258:34  warning  'snapshot' is defined but never used. Allowed unused args must match /^_/u       @typescript-eslint/no-unused-vars
+@settler/api:lint:   416:3   warning  'runId' is defined but never used. Allowed unused args must match /^_/u          @typescript-eslint/no-unused-vars
+@settler/api:lint:   417:3   warning  'replayMatches' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+@settler/api:lint:   428:3   warning  'replayRunId' is defined but never used. Allowed unused args must match /^_/u    @typescript-eslint/no-unused-vars
+@settler/api:lint:   465:35  warning  'originalRunId' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/determinism/verification-gates.ts
+@settler/api:lint:   11:10  warning  'query' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/knowledge/decision-log.ts
+@settler/api:lint:   228:14  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/operator-mode/alerting.ts
+@settler/api:lint:   435:16  warning  'sendSlackAlert' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: /workspace/Settler/packages/api/src/services/reconciliation/automated-review.ts
+@settler/api:lint:   453:12  warning  'error' is defined but never used  @typescript-eslint/no-unused-vars
+@settler/api:lint: 
+@settler/api:lint: ✖ 27 problems (0 errors, 27 warnings)
+@settler/api:lint: 
+
+ Tasks:    11 successful, 11 total
+Cached:    8 cached, 11 total
+  Time:    13.161s 
+
+✅ Lint all packages passed
+
+
+🔍 Type check all packages...
+
+> settler-monorepo@1.0.0 typecheck /workspace/Settler
+> turbo run typecheck
+
+• turbo 2.8.0
+• Packages in scope: @jobforge/adapter-settler, @jobforge/errors, @jobforge/fetch, @jobforge/sdk-ts, @jobforge/shared, @jobforge/typescript-config, @settler/adapters, @settler/api, @settler/cli, @settler/edge-ai-core, @settler/edge-node, @settler/protocol, @settler/react-settler, @settler/sdk, @settler/sdk-csharp, @settler/sdk-java, @settler/types, @settler/web
+• Running typecheck in 18 packages
+• Remote caching disabled
+@settler/react-settler:typecheck: cache hit, replaying logs b99a675251607f6c
+@settler/react-settler:typecheck: 
+@settler/react-settler:typecheck: > @settler/react-settler@0.1.0 typecheck /workspace/Settler/packages/react-settler
+@settler/react-settler:typecheck: > tsc --noEmit
+@settler/react-settler:typecheck: 
+@settler/protocol:typecheck: cache hit, replaying logs ae7c097d97e058a2
+@settler/protocol:typecheck: 
+@settler/protocol:typecheck: > @settler/protocol@0.1.0 typecheck /workspace/Settler/packages/protocol
+@settler/protocol:typecheck: > tsc --noEmit
+@settler/protocol:typecheck: 
+@settler/api:typecheck: cache hit, replaying logs 576e13165a6a3e88
+@settler/api:typecheck: 
+@settler/api:typecheck: > @settler/api@1.0.0 pretypecheck /workspace/Settler/packages/api
+@settler/api:typecheck: > cd ../.. && pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed'
+@settler/api:typecheck: 
+@settler/api:typecheck: 
+@settler/api:typecheck: > settler-monorepo@1.0.0 prisma:generate /workspace/Settler
+@settler/api:typecheck: > cross-env PRISMA_CLIENT_ENGINE_TYPE=wasm PRISMA_ENGINES_MIRROR= prisma generate
+@settler/api:typecheck: 
+@settler/api:typecheck: Loaded Prisma config from prisma.config.ts.
+@settler/api:typecheck: 
+@settler/api:typecheck: Prisma schema loaded from prisma/schema.prisma.
+@settler/api:typecheck: 
+@settler/api:typecheck: ✔ Generated Prisma Client (v7.3.0) to ./node_modules/.pnpm/@prisma+client@7.3.0_prisma@7.3.0_@types+react@18.3.27_better-sqlite3@12.6.2_react-dom@_efc9348d8c027de17c7e00b84b73d1eb/node_modules/@prisma/client in 2.80s
+@settler/api:typecheck: 
+@settler/api:typecheck: Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
+@settler/api:typecheck: 
+@settler/api:typecheck: 
+@settler/api:typecheck: 
+@settler/api:typecheck: > @settler/api@1.0.0 typecheck /workspace/Settler/packages/api
+@settler/api:typecheck: > tsc --noEmit
+@settler/api:typecheck: 
+@settler/edge-node:typecheck: cache hit, replaying logs db37ce43f49e0113
+@settler/edge-node:typecheck: 
+@settler/edge-node:typecheck: > @settler/edge-node@1.0.0 typecheck /workspace/Settler/packages/edge-node
+@settler/edge-node:typecheck: > tsc --noEmit
+@settler/edge-node:typecheck: 
+@settler/adapters:typecheck: cache hit, replaying logs 0cc5d28b573f9d0f
+@settler/adapters:typecheck: 
+@settler/adapters:typecheck: > @settler/adapters@1.0.0 typecheck /workspace/Settler/packages/adapters
+@settler/adapters:typecheck: > tsc --noEmit
+@settler/adapters:typecheck: 
+@jobforge/sdk-ts:typecheck: cache hit, replaying logs e71bf8ad135687ea
+@jobforge/sdk-ts:typecheck: 
+@jobforge/sdk-ts:typecheck: > @jobforge/sdk-ts@0.1.0 typecheck /workspace/Settler/packages/jobforge-sdk-ts
+@jobforge/sdk-ts:typecheck: > tsc --noEmit
+@jobforge/sdk-ts:typecheck: 
+@settler/edge-ai-core:typecheck: cache hit, replaying logs 9c38c66a66c82b9b
+@settler/edge-ai-core:typecheck: 
+@settler/edge-ai-core:typecheck: > @settler/edge-ai-core@1.0.0 typecheck /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:typecheck: > tsc --noEmit
+@settler/edge-ai-core:typecheck: 
+@jobforge/shared:typecheck: cache hit, replaying logs c4c3fb10e0072c37
+@jobforge/shared:typecheck: 
+@jobforge/shared:typecheck: > @jobforge/shared@0.1.0 typecheck /workspace/Settler/packages/jobforge-shared
+@jobforge/shared:typecheck: > tsc --noEmit
+@jobforge/shared:typecheck: 
+@settler/cli:typecheck: cache hit, replaying logs 82169bafd6399a50
+@settler/cli:typecheck: 
+@settler/cli:typecheck: > @settler/cli@1.0.0 typecheck /workspace/Settler/packages/cli
+@settler/cli:typecheck: > tsc --noEmit
+@settler/cli:typecheck: 
+@settler/types:typecheck: cache hit, replaying logs a5fe1fa944e423a7
+@settler/types:typecheck: 
+@settler/types:typecheck: > @settler/types@1.0.0 typecheck /workspace/Settler/packages/types
+@settler/types:typecheck: > tsc --noEmit
+@settler/types:typecheck: 
+@jobforge/errors:typecheck: cache hit, replaying logs e767903e132e8446
+@jobforge/errors:typecheck: 
+@jobforge/errors:typecheck: > @jobforge/errors@0.1.0 typecheck /workspace/Settler/packages/jobforge-errors
+@jobforge/errors:typecheck: > tsc --noEmit
+@jobforge/errors:typecheck: 
+@settler/sdk:typecheck: cache hit, replaying logs 31f72c942ded5029
+@settler/sdk:typecheck: 
+@settler/sdk:typecheck: > @settler/sdk@1.0.0 typecheck /workspace/Settler/packages/sdk
+@settler/sdk:typecheck: > tsc --noEmit
+@settler/sdk:typecheck: 
+@jobforge/fetch:typecheck: cache hit, replaying logs dd0cadec1f508090
+@jobforge/fetch:typecheck: 
+@jobforge/fetch:typecheck: > @jobforge/fetch@0.1.0 typecheck /workspace/Settler/packages/jobforge-fetch
+@jobforge/fetch:typecheck: > tsc --noEmit
+@jobforge/fetch:typecheck: 
+@settler/web:typecheck: cache hit, replaying logs d82a71980e9c1c09
+@settler/web:typecheck: 
+@settler/web:typecheck: > @settler/web@1.0.0 typecheck /workspace/Settler/packages/web
+@settler/web:typecheck: > tsc --noEmit
+@settler/web:typecheck: 
+@jobforge/adapter-settler:typecheck: cache hit, replaying logs b50efe0c5dff2ceb
+@jobforge/adapter-settler:typecheck: 
+@jobforge/adapter-settler:typecheck: > @jobforge/adapter-settler@0.1.0 typecheck /workspace/Settler/packages/jobforge-adapter-settler
+@jobforge/adapter-settler:typecheck: > tsc --noEmit
+@jobforge/adapter-settler:typecheck: 
+
+ Tasks:    15 successful, 15 total
+Cached:    15 cached, 15 total
+  Time:    702ms >>> FULL TURBO
+
+✅ Type check all packages passed
+
+
+🔍 Build all deployable apps...
+
+> settler-monorepo@1.0.0 build /workspace/Settler
+> turbo run build --filter @settler/web...
+
+• turbo 2.8.0
+• Packages in scope: @jobforge/sdk-ts, @jobforge/shared, @jobforge/typescript-config, @settler/adapters, @settler/api, @settler/edge-ai-core, @settler/protocol, @settler/react-settler, @settler/sdk, @settler/types, @settler/web
+• Running build in 11 packages
+• Remote caching disabled
+@settler/edge-ai-core:build: cache hit, replaying logs 889a6ab7d8fa5378
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: > @settler/edge-ai-core@1.0.0 prebuild /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:build: > pnpm run typecheck
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: > @settler/edge-ai-core@1.0.0 typecheck /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:build: > tsc --noEmit
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: 
+@settler/edge-ai-core:build: > @settler/edge-ai-core@1.0.0 build /workspace/Settler/packages/edge-ai-core
+@settler/edge-ai-core:build: > tsc
+@settler/edge-ai-core:build: 
+@settler/types:build: cache hit, replaying logs 767c2c2d9928dea1
+@settler/types:build: 
+@settler/types:build: > @settler/types@1.0.0 build /workspace/Settler/packages/types
+@settler/types:build: > tsc
+@settler/types:build: 
+@settler/protocol:build: cache hit, replaying logs e944ce77fbe40050
+@settler/protocol:build: 
+@settler/protocol:build: > @settler/protocol@0.1.0 build /workspace/Settler/packages/protocol
+@settler/protocol:build: > tsc
+@settler/protocol:build: 
+@settler/sdk:build: cache hit, replaying logs 6a5caea113fbc286
+@settler/sdk:build: 
+@settler/sdk:build: > @settler/sdk@1.0.0 build /workspace/Settler/packages/sdk
+@settler/sdk:build: > tsc
+@settler/sdk:build: 
+@jobforge/shared:build: cache hit, replaying logs f37bc6c827718d1c
+@jobforge/shared:build: 
+@jobforge/shared:build: > @jobforge/shared@0.1.0 build /workspace/Settler/packages/jobforge-shared
+@jobforge/shared:build: > tsc
+@jobforge/shared:build: 
+@settler/react-settler:build: cache hit, replaying logs a232a487723f0a0a
+@settler/react-settler:build: 
+@settler/react-settler:build: > @settler/react-settler@0.1.0 build /workspace/Settler/packages/react-settler
+@settler/react-settler:build: > tsc
+@settler/react-settler:build: 
+@jobforge/sdk-ts:build: cache hit, replaying logs c9a7bf4f82ea46a2
+@jobforge/sdk-ts:build: 
+@jobforge/sdk-ts:build: > @jobforge/sdk-ts@0.1.0 build /workspace/Settler/packages/jobforge-sdk-ts
+@jobforge/sdk-ts:build: > tsc
+@jobforge/sdk-ts:build: 
+@settler/adapters:build: cache hit, replaying logs d90df2c3bff69b2d
+@settler/adapters:build: 
+@settler/adapters:build: > @settler/adapters@1.0.0 build /workspace/Settler/packages/adapters
+@settler/adapters:build: > tsc
+@settler/adapters:build: 
+@settler/api:build: cache hit, replaying logs 5ff800f8dc068ba6
+@settler/api:build: 
+@settler/api:build: > @settler/api@1.0.0 prebuild /workspace/Settler/packages/api
+@settler/api:build: > cd ../.. && pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed'
+@settler/api:build: 
+@settler/api:build: 
+@settler/api:build: > settler-monorepo@1.0.0 prisma:generate /workspace/Settler
+@settler/api:build: > cross-env PRISMA_CLIENT_ENGINE_TYPE=wasm PRISMA_ENGINES_MIRROR= prisma generate
+@settler/api:build: 
+@settler/api:build: Loaded Prisma config from prisma.config.ts.
+@settler/api:build: 
+@settler/api:build: Prisma schema loaded from prisma/schema.prisma.
+@settler/api:build: 
+@settler/api:build: ✔ Generated Prisma Client (v7.3.0) to ./node_modules/.pnpm/@prisma+client@7.3.0_prisma@7.3.0_@types+react@18.3.27_better-sqlite3@12.6.2_react-dom@_efc9348d8c027de17c7e00b84b73d1eb/node_modules/@prisma/client in 829ms
+@settler/api:build: 
+@settler/api:build: Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
+@settler/api:build: 
+@settler/api:build: 
+@settler/api:build: 
+@settler/api:build: > @settler/api@1.0.0 build /workspace/Settler/packages/api
+@settler/api:build: > tsc --skipLibCheck --noEmit false
+@settler/api:build: 
+@settler/web:build: cache hit, replaying logs 4d05552ca255b5ab
+@settler/web:build: 
+@settler/web:build: > @settler/web@1.0.0 build /workspace/Settler/packages/web
+@settler/web:build: > next build --webpack
+@settler/web:build: 
+@settler/web:build: ▲ Next.js 16.1.6 (webpack)
+@settler/web:build: - Experiments (use with caution):
+@settler/web:build:   ✓ optimizeCss
+@settler/web:build:   · optimizePackageImports
+@settler/web:build: 
+@settler/web:build:   Creating an optimized production build ...
+@settler/web:build:   Using tsconfig file: ./tsconfig.json
+@settler/web:build: ✓ Compiled successfully in 2.1min
+@settler/web:build:   Skipping validation of types
+@settler/web:build:   Collecting page data using 2 workers ...
+@settler/web:build: ⚠ Using edge runtime on a page currently disables static generation for that page
+@settler/web:build: ⚠️ Builder.io API key not found. Visual editor will not work.
+@settler/web:build: ⚠️ Builder API key not found, skipping static page generation
+@settler/web:build:   Generating static pages using 2 workers (0/186) ...
+@settler/web:build:   Generating static pages using 2 workers (46/186) 
+@settler/web:build:   Generating static pages using 2 workers (92/186) 
+@settler/web:build:   Generating static pages using 2 workers (139/186) 
+@settler/web:build: ✓ Generating static pages using 2 workers (186/186) in 5.7s
+@settler/web:build:   Finalizing page optimization ...
+@settler/web:build:   Collecting build traces ...
+@settler/web:build: 
+@settler/web:build: Route (app)                                                Revalidate  Expire
+@settler/web:build: ┌ ○ /
+@settler/web:build: ├ ○ /_not-found
+@settler/web:build: ├ ƒ /[slug]
+@settler/web:build: ├ ○ /about
+@settler/web:build: ├ ƒ /admin
+@settler/web:build: ├ ƒ /admin/analytics
+@settler/web:build: ├ ƒ /admin/audit
+@settler/web:build: ├ ƒ /admin/branding
+@settler/web:build: ├ ƒ /admin/database
+@settler/web:build: ├ ƒ /admin/database/[table]
+@settler/web:build: ├ ƒ /admin/exceptions
+@settler/web:build: ├ ƒ /admin/exceptions/[id]
+@settler/web:build: ├ ƒ /admin/experiments
+@settler/web:build: ├ ƒ /admin/experiments/[id]
+@settler/web:build: ├ ƒ /admin/experiments/new
+@settler/web:build: ├ ƒ /admin/flags
+@settler/web:build: ├ ƒ /admin/jobforge
+@settler/web:build: ├ ƒ /admin/metrics
+@settler/web:build: ├ ƒ /admin/monitoring
+@settler/web:build: ├ ƒ /admin/ops
+@settler/web:build: ├ ƒ /admin/pages
+@settler/web:build: ├ ƒ /admin/pages/[id]/editor
+@settler/web:build: ├ ƒ /admin/pages/new
+@settler/web:build: ├ ƒ /admin/runs
+@settler/web:build: ├ ƒ /admin/runs/[runId]
+@settler/web:build: ├ ƒ /admin/runs/compare
+@settler/web:build: ├ ƒ /admin/settings
+@settler/web:build: ├ ƒ /admin/webhooks
+@settler/web:build: ├ ƒ /api/admin/audit
+@settler/web:build: ├ ƒ /api/admin/exceptions
+@settler/web:build: ├ ƒ /api/admin/exceptions/[id]/escalate
+@settler/web:build: ├ ƒ /api/admin/exceptions/[id]/resolve
+@settler/web:build: ├ ƒ /api/admin/health
+@settler/web:build: ├ ƒ /api/admin/jobforge
+@settler/web:build: ├ ƒ /api/admin/metrics
+@settler/web:build: ├ ƒ /api/admin/runs
+@settler/web:build: ├ ƒ /api/admin/stream
+@settler/web:build: ├ ƒ /api/ai/data-insights
+@settler/web:build: ├ ƒ /api/ai/onboarding-assistant
+@settler/web:build: ├ ƒ /api/ai/support-assistant
+@settler/web:build: ├ ƒ /api/ai/troubleshooting
+@settler/web:build: ├ ƒ /api/billing/dispute
+@settler/web:build: ├ ƒ /api/billing/payment-recovery
+@settler/web:build: ├ ƒ /api/billing/retry-payment
+@settler/web:build: ├ ƒ /api/builder/revalidate
+@settler/web:build: ├ ƒ /api/connectors/backfill/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/callback/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/connect/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/disconnect/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/refresh/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/sync/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/test/[providerId]
+@settler/web:build: ├ ƒ /api/connectors/webhook/[providerId]
+@settler/web:build: ├ ƒ /api/console/activities
+@settler/web:build: ├ ƒ /api/console/ai-analysis
+@settler/web:build: ├ ƒ /api/console/ai-tokens/usage
+@settler/web:build: ├ ƒ /api/console/alerts
+@settler/web:build: ├ ƒ /api/console/alerts/[id]/acknowledge
+@settler/web:build: ├ ƒ /api/console/analytics/datasets
+@settler/web:build: ├ ƒ /api/console/analytics/pivot
+@settler/web:build: ├ ƒ /api/console/analytics/rollup
+@settler/web:build: ├ ƒ /api/console/analytics/saved-views
+@settler/web:build: ├ ƒ /api/console/api-keys
+@settler/web:build: ├ ƒ /api/console/api-keys/[id]
+@settler/web:build: ├ ƒ /api/console/api-logs
+@settler/web:build: ├ ƒ /api/console/billing
+@settler/web:build: ├ ƒ /api/console/billing/ai-tokens
+@settler/web:build: ├ ƒ /api/console/costs
+@settler/web:build: ├ ƒ /api/console/feature-flags
+@settler/web:build: ├ ƒ /api/console/feature-flags/[id]/environments/[env]
+@settler/web:build: ├ ƒ /api/console/health
+@settler/web:build: ├ ƒ /api/console/insights
+@settler/web:build: ├ ƒ /api/console/meaningful-changes
+@settler/web:build: ├ ƒ /api/console/metrics
+@settler/web:build: ├ ƒ /api/console/operator/control-plane
+@settler/web:build: ├ ƒ /api/console/operator/runs
+@settler/web:build: ├ ƒ /api/console/performance
+@settler/web:build: ├ ƒ /api/console/reality
+@settler/web:build: ├ ƒ /api/console/receipts
+@settler/web:build: ├ ƒ /api/console/receipts-v2
+@settler/web:build: ├ ƒ /api/console/receipts/[id]
+@settler/web:build: ├ ƒ /api/console/reconciliation
+@settler/web:build: ├ ƒ /api/console/site/branding
+@settler/web:build: ├ ƒ /api/console/site/experiments
+@settler/web:build: ├ ƒ /api/console/site/experiments/[id]
+@settler/web:build: ├ ƒ /api/console/site/experiments/[id]/results
+@settler/web:build: ├ ƒ /api/console/site/experiments/[id]/start
+@settler/web:build: ├ ƒ /api/console/site/navigation
+@settler/web:build: ├ ƒ /api/console/site/pages
+@settler/web:build: ├ ƒ /api/console/site/pages/[id]
+@settler/web:build: ├ ƒ /api/console/site/pages/[id]/publish
+@settler/web:build: ├ ƒ /api/console/site/ui-config
+@settler/web:build: ├ ƒ /api/console/subscription
+@settler/web:build: ├ ƒ /api/console/subscription-status
+@settler/web:build: ├ ƒ /api/console/support/tickets
+@settler/web:build: ├ ƒ /api/console/support/triage
+@settler/web:build: ├ ƒ /api/console/tables/[table]
+@settler/web:build: ├ ƒ /api/console/tenants
+@settler/web:build: ├ ƒ /api/console/usage
+@settler/web:build: ├ ƒ /api/console/usage/alerts
+@settler/web:build: ├ ƒ /api/console/usage/analytics
+@settler/web:build: ├ ƒ /api/console/usage/export
+@settler/web:build: ├ ƒ /api/console/usage/warnings
+@settler/web:build: ├ ƒ /api/console/user-role
+@settler/web:build: ├ ƒ /api/console/webhooks
+@settler/web:build: ├ ƒ /api/console/webhooks/[id]
+@settler/web:build: ├ ƒ /api/control-plane/failures
+@settler/web:build: ├ ƒ /api/control-plane/keys
+@settler/web:build: ├ ƒ /api/control-plane/metrics
+@settler/web:build: ├ ƒ /api/control-plane/policies
+@settler/web:build: ├ ƒ /api/control-plane/policies/[policyId]
+@settler/web:build: ├ ƒ /api/control-plane/triggers
+@settler/web:build: ├ ƒ /api/cron/check-reliability-alerts
+@settler/web:build: ├ ƒ /api/cron/daily-cost-rollup
+@settler/web:build: ├ ƒ /api/cron/email-lifecycle
+@settler/web:build: ├ ƒ /api/cron/low-activity
+@settler/web:build: ├ ƒ /api/cron/monthly-summary
+@settler/web:build: ├ ƒ /api/data/export
+@settler/web:build: ├ ƒ /api/data/import
+@settler/web:build: ├ ƒ /api/docs/openapi
+@settler/web:build: ├ ƒ /api/enterprise/contact
+@settler/web:build: ├ ƒ /api/enterprise/ip-allowlist
+@settler/web:build: ├ ƒ /api/enterprise/ip-allowlist/[id]
+@settler/web:build: ├ ƒ /api/explorer/execution/[id]
+@settler/web:build: ├ ƒ /api/explorer/history
+@settler/web:build: ├ ƒ /api/exports
+@settler/web:build: ├ ƒ /api/feedback-loops/insights
+@settler/web:build: ├ ƒ /api/foundry/datasets
+@settler/web:build: ├ ƒ /api/foundry/datasets/[id]
+@settler/web:build: ├ ƒ /api/foundry/runs
+@settler/web:build: ├ ƒ /api/foundry/runs/[id]
+@settler/web:build: ├ ƒ /api/gtm/demo/reset
+@settler/web:build: ├ ƒ /api/gtm/funnel-stage
+@settler/web:build: ├ ƒ /api/gtm/roi
+@settler/web:build: ├ ƒ /api/health
+@settler/web:build: ├ ƒ /api/health/console
+@settler/web:build: ├ ƒ /api/health/stripe
+@settler/web:build: ├ ƒ /api/image-optimize
+@settler/web:build: ├ ƒ /api/imports/validate
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/debug
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/test
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/upgrade
+@settler/web:build: ├ ƒ /api/integrations/[integrationId]/versions
+@settler/web:build: ├ ƒ /api/integrations/analytics
+@settler/web:build: ├ ƒ /api/integrations/health
+@settler/web:build: ├ ƒ /api/internal/health/deep
+@settler/web:build: ├ ƒ /api/internal/jobs/drain
+@settler/web:build: ├ ƒ /api/invite/[token]
+@settler/web:build: ├ ƒ /api/jobs
+@settler/web:build: ├ ƒ /api/jobs/[id]
+@settler/web:build: ├ ƒ /api/jobs/[id]/exceptions
+@settler/web:build: ├ ƒ /api/jobs/[id]/exceptions/[exceptionId]
+@settler/web:build: ├ ƒ /api/jobs/[id]/progress
+@settler/web:build: ├ ƒ /api/jobs/[id]/result
+@settler/web:build: ├ ƒ /api/jobs/bulk
+@settler/web:build: ├ ƒ /api/metrics
+@settler/web:build: ├ ƒ /api/metrics/prometheus
+@settler/web:build: ├ ƒ /api/milestones
+@settler/web:build: ├ ƒ /api/onboarding/progress
+@settler/web:build: ├ ƒ /api/onboarding/progress/skip
+@settler/web:build: ├ ƒ /api/operator/incidents
+@settler/web:build: ├ ƒ /api/ops/activation-funnel
+@settler/web:build: ├ ƒ /api/ops/customers
+@settler/web:build: ├ ƒ /api/ops/dashboard
+@settler/web:build: ├ ƒ /api/ops/edge-functions
+@settler/web:build: ├ ƒ /api/ops/integration-status
+@settler/web:build: ├ ƒ /api/ops/overview
+@settler/web:build: ├ ƒ /api/ops/performance
+@settler/web:build: ├ ƒ /api/ops/retry-queues
+@settler/web:build: ├ ƒ /api/ops/system-health
+@settler/web:build: ├ ƒ /api/oss/stats
+@settler/web:build: ├ ƒ /api/pricing/experiments
+@settler/web:build: ├ ƒ /api/projects
+@settler/web:build: ├ ƒ /api/projects/snapshots
+@settler/web:build: ├ ƒ /api/projects/snapshots/[snapshotId]/export
+@settler/web:build: ├ ƒ /api/projects/snapshots/[snapshotId]/rollback
+@settler/web:build: ├ ƒ /api/public/reality
+@settler/web:build: ├ ƒ /api/public/ui-config
+@settler/web:build: ├ ƒ /api/quota
+@settler/web:build: ├ ƒ /api/rbac/roles
+@settler/web:build: ├ ƒ /api/rbac/users
+@settler/web:build: ├ ƒ /api/receipts/ocr
+@settler/web:build: ├ ƒ /api/referrals
+@settler/web:build: ├ ƒ /api/runs/[runId]
+@settler/web:build: ├ ƒ /api/runs/create
+@settler/web:build: ├ ƒ /api/seo/generate-sitemap
+@settler/web:build: ├ ƒ /api/share/[id]
+@settler/web:build: ├ ƒ /api/status
+@settler/web:build: ├ ƒ /api/status/health
+@settler/web:build: ├ ƒ /api/stripe/checkout
+@settler/web:build: ├ ƒ /api/stripe/portal
+@settler/web:build: ├ ƒ /api/stripe/webhook
+@settler/web:build: ├ ƒ /api/support/canned-responses
+@settler/web:build: ├ ƒ /api/support/report-issue
+@settler/web:build: ├ ƒ /api/support/tickets
+@settler/web:build: ├ ƒ /api/user/checklist
+@settler/web:build: ├ ƒ /api/user/pre-test
+@settler/web:build: ├ ƒ /api/user/upgrade
+@settler/web:build: ├ ƒ /api/user/value-moments
+@settler/web:build: ├ ƒ /api/v1
+@settler/web:build: ├ ƒ /api/v1/convert
+@settler/web:build: ├ ƒ /api/v1/datasets
+@settler/web:build: ├ ƒ /api/v1/feature-flags
+@settler/web:build: ├ ƒ /api/v1/feature-flags/[id]
+@settler/web:build: ├ ƒ /api/v1/feature-flags/evaluate
+@settler/web:build: ├ ƒ /api/v1/health
+@settler/web:build: ├ ƒ /api/v1/meta
+@settler/web:build: ├ ƒ /api/v1/metrics/summary
+@settler/web:build: ├ ƒ /api/v1/metrics/timeseries
+@settler/web:build: ├ ƒ /api/v1/metrics/top
+@settler/web:build: ├ ƒ /api/v1/ready
+@settler/web:build: ├ ƒ /api/v1/receipts
+@settler/web:build: ├ ƒ /api/v1/receipts/[id]
+@settler/web:build: ├ ƒ /api/v1/recon/jobs
+@settler/web:build: ├ ƒ /api/v1/runs
+@settler/web:build: ├ ƒ /api/v1/runs/[id]
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/evidence
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/replay
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/results
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/findPolicyImpact
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/getExecutionGraph
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/traceArtifactLineage
+@settler/web:build: ├ ƒ /api/v1/runs/[id]/trust-explorer/verifyProofChain
+@settler/web:build: ├ ƒ /api/vercel-example
+@settler/web:build: ├ ƒ /api/workspaces
+@settler/web:build: ├ ƒ /api/workspaces/[workspaceId]/invites
+@settler/web:build: ├ ƒ /api/workspaces/[workspaceId]/onboarding
+@settler/web:build: ├ ○ /app
+@settler/web:build: ├ ○ /app/alerts
+@settler/web:build: ├ ○ /app/audit
+@settler/web:build: ├ ƒ /app/capability-status
+@settler/web:build: ├ ○ /app/connections
+@settler/web:build: ├ ○ /app/evidence
+@settler/web:build: ├ ○ /app/executions
+@settler/web:build: ├ ƒ /app/executions/[id]
+@settler/web:build: ├ ○ /app/governance
+@settler/web:build: ├ ○ /app/integrations
+@settler/web:build: ├ ƒ /app/metrics
+@settler/web:build: ├ ƒ /app/mismatches
+@settler/web:build: ├ ○ /app/onboarding
+@settler/web:build: ├ ○ /app/overview
+@settler/web:build: ├ ○ /app/pipelines
+@settler/web:build: ├ ○ /app/policies
+@settler/web:build: ├ ○ /app/proofs
+@settler/web:build: ├ ƒ /app/proofs/[id]
+@settler/web:build: ├ ○ /app/reconciliation
+@settler/web:build: ├ ƒ /app/reconciliation/[id]
+@settler/web:build: ├ ○ /app/replay
+@settler/web:build: ├ ○ /app/results
+@settler/web:build: ├ ○ /app/review
+@settler/web:build: ├ ○ /app/rules
+@settler/web:build: ├ ƒ /app/runs
+@settler/web:build: ├ ƒ /app/runs/[id]
+@settler/web:build: ├ ○ /app/settings
+@settler/web:build: ├ ○ /app/system-health
+@settler/web:build: ├ ○ /app/traces
+@settler/web:build: ├ ○ /architecture
+@settler/web:build: ├ ○ /benchmarks
+@settler/web:build: ├ ○ /billing/success
+@settler/web:build: ├ ○ /blog
+@settler/web:build: ├ ● /builder/[...page]
+@settler/web:build: ├ ○ /capabilities
+@settler/web:build: ├ ○ /categorize
+@settler/web:build: ├ ○ /changelog
+@settler/web:build: ├ ● /changelog/[slug]
+@settler/web:build: │ ├ /changelog/2025-12-11-trust-layer
+@settler/web:build: │ ├ /changelog/2025-11-15-receipts-api
+@settler/web:build: │ ├ /changelog/2025-10-01-node-sdk-v1
+@settler/web:build: │ └ [+5 more paths]
+@settler/web:build: ├ ○ /community
+@settler/web:build: ├ ○ /community/contributors
+@settler/web:build: ├ ƒ /comparison
+@settler/web:build: ├ ƒ /console
+@settler/web:build: ├ ƒ /console/activity
+@settler/web:build: ├ ƒ /console/admin/activation
+@settler/web:build: ├ ƒ /console/admin/jobs
+@settler/web:build: ├ ƒ /console/admin/tenants
+@settler/web:build: ├ ƒ /console/ai-analysis
+@settler/web:build: ├ ƒ /console/alerts-view
+@settler/web:build: ├ ƒ /console/analytics
+@settler/web:build: ├ ƒ /console/api-keys
+@settler/web:build: ├ ƒ /console/api-logs
+@settler/web:build: ├ ƒ /console/api-playground
+@settler/web:build: ├ ƒ /console/api-playground/collections
+@settler/web:build: ├ ƒ /console/api-test
+@settler/web:build: ├ ƒ /console/approvals
+@settler/web:build: ├ ƒ /console/audit-trail
+@settler/web:build: ├ ƒ /console/audits
+@settler/web:build: ├ ƒ /console/billing
+@settler/web:build: ├ ƒ /console/briefings
+@settler/web:build: ├ ƒ /console/bulk-operations
+@settler/web:build: ├ ƒ /console/changes
+@settler/web:build: ├ ƒ /console/control-plane
+@settler/web:build: ├ ƒ /console/costs
+@settler/web:build: ├ ƒ /console/diagnostics
+@settler/web:build: ├ ƒ /console/docs
+@settler/web:build: ├ ƒ /console/feature-flags
+@settler/web:build: ├ ƒ /console/feature-flags-policy
+@settler/web:build: ├ ƒ /console/ingestion/[ingestionId]
+@settler/web:build: ├ ƒ /console/insights
+@settler/web:build: ├ ƒ /console/inspector
+@settler/web:build: ├ ƒ /console/multi-source-reconciliation
+@settler/web:build: ├ ƒ /console/onboarding
+@settler/web:build: ├ ƒ /console/operator
+@settler/web:build: ├ ƒ /console/ops
+@settler/web:build: ├ ƒ /console/organizations
+@settler/web:build: ├ ƒ /console/performance
+@settler/web:build: ├ ƒ /console/playground
+@settler/web:build: ├ ƒ /console/playground/cli
+@settler/web:build: ├ ƒ /console/playground/convert
+@settler/web:build: ├ ƒ /console/playground/flags
+@settler/web:build: ├ ƒ /console/playground/receipts
+@settler/web:build: ├ ƒ /console/playground/reconcile
+@settler/web:build: ├ ƒ /console/policies
+@settler/web:build: ├ ƒ /console/proof-explorer
+@settler/web:build: ├ ƒ /console/reality
+@settler/web:build: ├ ƒ /console/receipt-matching
+@settler/web:build: ├ ƒ /console/receipts
+@settler/web:build: ├ ƒ /console/receipts-hash
+@settler/web:build: ├ ƒ /console/reconciliation-view
+@settler/web:build: ├ ƒ /console/reconciliation/[runId]
+@settler/web:build: ├ ƒ /console/reconciliations
+@settler/web:build: ├ ƒ /console/replay
+@settler/web:build: ├ ƒ /console/replay-lab
+@settler/web:build: ├ ƒ /console/replay/[executionId]
+@settler/web:build: ├ ƒ /console/rules-engine
+@settler/web:build: ├ ƒ /console/runs/[runId]
+@settler/web:build: ├ ƒ /console/settings
+@settler/web:build: ├ ƒ /console/setup-check
+@settler/web:build: ├ ƒ /console/site
+@settler/web:build: ├ ƒ /console/site/branding
+@settler/web:build: ├ ƒ /console/site/experiments
+@settler/web:build: ├ ƒ /console/site/experiments/[id]
+@settler/web:build: ├ ƒ /console/site/navigation
+@settler/web:build: ├ ƒ /console/site/pages/[id]
+@settler/web:build: ├ ƒ /console/site/ui-config
+@settler/web:build: ├ ƒ /console/sla
+@settler/web:build: ├ ƒ /console/support
+@settler/web:build: ├ ƒ /console/tables
+@settler/web:build: ├ ƒ /console/tables/[table]
+@settler/web:build: ├ ƒ /console/usage
+@settler/web:build: ├ ƒ /console/webhooks
+@settler/web:build: ├ ƒ /console/workflows
+@settler/web:build: ├ ƒ /console/workflows/[id]
+@settler/web:build: ├ ƒ /console/workflows/new
+@settler/web:build: ├ ○ /contact
+@settler/web:build: ├ ○ /cookbook
+@settler/web:build: ├ ○ /cookbooks
+@settler/web:build: ├ ƒ /dashboard
+@settler/web:build: ├ ○ /dashboard/addons
+@settler/web:build: ├ ○ /dashboard/billing
+@settler/web:build: ├ ○ /dashboard/billing/invoices
+@settler/web:build: ├ ○ /dashboard/billing/payment-methods
+@settler/web:build: ├ ○ /dashboard/integrations
+@settler/web:build: ├ ƒ /dashboard/integrations/[integrationId]
+@settler/web:build: ├ ƒ /dashboard/integrations/[integrationId]/logs
+@settler/web:build: ├ ○ /dashboard/jobs
+@settler/web:build: ├ ƒ /dashboard/jobs/[jobId]
+@settler/web:build: ├ ƒ /dashboard/jobs/[jobId]/exceptions
+@settler/web:build: ├ ○ /dashboard/usage
+@settler/web:build: ├ ƒ /dashboard/user
+@settler/web:build: ├ ○ /demo
+@settler/web:build: ├ ○ /demo/api
+@settler/web:build: ├ ○ /demo/receipts
+@settler/web:build: ├ ○ /demo/reconciliation
+@settler/web:build: ├ ○ /docs
+@settler/web:build: ├ ○ /docs/api
+@settler/web:build: ├ ○ /docs/auth
+@settler/web:build: ├ ○ /docs/cli
+@settler/web:build: ├ ○ /docs/errors
+@settler/web:build: ├ ○ /docs/examples
+@settler/web:build: ├ ○ /docs/getting-started
+@settler/web:build: ├ ○ /docs/integrations
+@settler/web:build: ├ ƒ /docs/integrations/[integrationId]
+@settler/web:build: ├ ○ /docs/quickstart
+@settler/web:build: ├ ○ /docs/replay-lab
+@settler/web:build: ├ ○ /docs/sdk
+@settler/web:build: ├ ○ /docs/sdk/go
+@settler/web:build: ├ ○ /docs/sdk/nodejs
+@settler/web:build: ├ ○ /docs/sdk/python
+@settler/web:build: ├ ○ /docs/sdk/ruby
+@settler/web:build: ├ ○ /docs/status
+@settler/web:build: ├ ○ /docs/webhooks
+@settler/web:build: ├ ○ /edge-ai
+@settler/web:build: ├ ○ /edge-ai/nodes
+@settler/web:build: ├ ƒ /edge-ai/nodes/[nodeId]
+@settler/web:build: ├ ○ /edge-ai/nodes/new
+@settler/web:build: ├ ○ /engine
+@settler/web:build: ├ ○ /engine/create-run-pack
+@settler/web:build: ├ ○ /engine/import-results
+@settler/web:build: ├ ○ /engine/view-variances
+@settler/web:build: ├ ○ /enterprise
+@settler/web:build: ├ ○ /enterprise/dashboard
+@settler/web:build: ├ ○ /explorer
+@settler/web:build: ├ ƒ /explorer/execution/[id]
+@settler/web:build: ├ ƒ /explorer/tenant/[tenant_id]
+@settler/web:build: ├ ○ /exports
+@settler/web:build: ├ ○ /faq
+@settler/web:build: ├ ○ /feature-flags
+@settler/web:build: ├ ○ /founder
+@settler/web:build: ├ ○ /future-proof
+@settler/web:build: ├ ○ /home
+@settler/web:build: ├ ○ /how-it-works
+@settler/web:build: ├ ƒ /integrations
+@settler/web:build: ├ ○ /integrations/request
+@settler/web:build: ├ ƒ /intelligence/foundry
+@settler/web:build: ├ ƒ /intelligence/foundry/[datasetId]
+@settler/web:build: ├ ƒ /intelligence/foundry/runs/[runId]
+@settler/web:build: ├ ○ /investor/proof                                                1h      1y
+@settler/web:build: ├ ○ /investor/reality                                              5m      1y
+@settler/web:build: ├ ƒ /invite/[token]
+@settler/web:build: ├ ○ /legal
+@settler/web:build: ├ ○ /legal/aup                                                     1h      1y
+@settler/web:build: ├ ○ /legal/cookies                                                 1h      1y
+@settler/web:build: ├ ○ /legal/dpa
+@settler/web:build: ├ ○ /legal/license                                                 1h      1y
+@settler/web:build: ├ ○ /legal/privacy                                                 1h      1y
+@settler/web:build: ├ ○ /legal/subprocessors                                           1h      1y
+@settler/web:build: ├ ○ /legal/terms                                                   1h      1y
+@settler/web:build: ├ ƒ /login
+@settler/web:build: ├ ○ /mobile
+@settler/web:build: ├ ○ /offline
+@settler/web:build: ├ ○ /open-source
+@settler/web:build: ├ ƒ /openapi.json
+@settler/web:build: ├ ƒ /opengraph-image
+@settler/web:build: ├ ○ /operator/incidents
+@settler/web:build: ├ ○ /oss
+@settler/web:build: ├ ○ /oss/stats
+@settler/web:build: ├ ○ /parser
+@settler/web:build: ├ ○ /platform
+@settler/web:build: ├ ○ /playground
+@settler/web:build: ├ ○ /policies
+@settler/web:build: ├ ○ /pricing
+@settler/web:build: ├ ○ /privacy
+@settler/web:build: ├ ○ /product
+@settler/web:build: ├ ○ /proof
+@settler/web:build: ├ ○ /proof-explorer
+@settler/web:build: ├ ○ /react-settler-demo
+@settler/web:build: ├ ○ /realtime-dashboard
+@settler/web:build: ├ ○ /receipts
+@settler/web:build: ├ ○ /reconcile
+@settler/web:build: ├ ○ /reconciliation
+@settler/web:build: ├ ○ /replay-lab
+@settler/web:build: ├ ƒ /review/polish
+@settler/web:build: ├ ○ /roadmap
+@settler/web:build: ├ ○ /robots.txt
+@settler/web:build: ├ ○ /roi-calculator
+@settler/web:build: ├ ○ /runbooks
+@settler/web:build: ├ ○ /schematics
+@settler/web:build: ├ ○ /security
+@settler/web:build: ├ ○ /security-and-audit
+@settler/web:build: ├ ƒ /signup
+@settler/web:build: ├ ○ /sitemap.xml
+@settler/web:build: ├ ○ /status
+@settler/web:build: ├ ○ /support
+@settler/web:build: ├ ƒ /support/articles/[articleId]
+@settler/web:build: ├ ƒ /support/category/[categoryId]
+@settler/web:build: ├ ○ /support/contact
+@settler/web:build: ├ ○ /terms
+@settler/web:build: ├ ○ /transparency
+@settler/web:build: ├ ○ /trust
+@settler/web:build: ├ ○ /use-cases
+@settler/web:build: ├ ● /use-cases/[slug]
+@settler/web:build: │ ├ /use-cases/ecommerce-reconciliation
+@settler/web:build: │ ├ /use-cases/payment-reconciliation
+@settler/web:build: │ └ /use-cases/receipt-processing
+@settler/web:build: ├ ○ /ux-playground
+@settler/web:build: ├ ○ /ux-playground/events
+@settler/web:build: ├ ○ /verify
+@settler/web:build: ├ ○ /vision
+@settler/web:build: ├ ○ /why
+@settler/web:build: └ ○ /why-settler
+@settler/web:build: 
+@settler/web:build: 
+@settler/web:build: ○  (Static)   prerendered as static content
+@settler/web:build: ●  (SSG)      prerendered as static HTML (uses generateStaticParams)
+@settler/web:build: ƒ  (Dynamic)  server-rendered on demand
+@settler/web:build: 
+
+ Tasks:    10 successful, 10 total
+Cached:    10 cached, 10 total
+  Time:    5.501s >>> FULL TURBO
+
+✅ Build all deployable apps passed
+
+
+🔍 Setup and configuration verification...
+
+> settler-monorepo@1.0.0 verify:setup /workspace/Settler
+> tsx scripts/verify-setup.ts
+
+🩺 Settler setup verification
+
+[web]
+❌ Missing required env: NEXT_PUBLIC_SUPABASE_URL
+❌ Missing required env: NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+[api/auth]
+❌ Missing required env: SUPABASE_URL
+❌ Missing required env: SUPABASE_ANON_KEY
+
+[database]
+❌ Missing database DSN. Set DATABASE_URL, SUPABASE_DATABASE_URL, or DIRECT_URL.
+
+[billing]
+⚠️ Billing not enabled (Stripe env not set).
+
+[enterprise]
+⚠️ Enterprise integrations not enabled.
+
+[kernel]
+⚠️ Kernel not enabled (running with TS fallback path).
+
+❌ setup verification failed
+ ELIFECYCLE  Command failed with exit code 1.
+
+❌ Setup and configuration verification failed
+
+❌ Required check "verify-setup" failed
+   Production check cannot proceed
+
+ ELIFECYCLE  Command failed with exit code 1.
+[exit_code]=1
+\n$ cargo fmt --check
+[exit_code]=0
+\n$ cargo clippy --all-targets --all-features -- -D warnings
+   Compiling proc-macro2 v1.0.106
+   Compiling quote v1.0.45
+    Checking typenum v1.19.0
+   Compiling serde_core v1.0.228
+    Checking generic-array v0.14.7
+   Compiling syn v2.0.117
+   Compiling zmij v1.0.21
+    Checking crypto-common v0.1.7
+    Checking block-buffer v0.10.4
+   Compiling serde v1.0.228
+    Checking cfg-if v1.0.4
+   Compiling serde_json v1.0.149
+    Checking digest v0.10.7
+    Checking memchr v2.8.0
+    Checking cpufeatures v0.2.17
+    Checking itoa v1.0.17
+   Compiling serde_derive v1.0.228
+    Checking sha2 v0.10.9
+   Compiling wasm-bindgen-shared v0.2.114
+    Checking hex v0.4.3
+    Checking serde_bytes v0.11.19
+   Compiling rustversion v1.0.22
+    Checking utf8parse v0.2.2
+    Checking anstyle-parse v0.2.7
+    Checking anstyle-query v1.1.5
+   Compiling bumpalo v3.20.2
+    Checking anstyle v1.0.13
+    Checking colorchoice v1.0.4
+    Checking settler-kernel v0.1.0 (/workspace/Settler/crates/settler-kernel)
+    Checking is_terminal_polyfill v1.70.2
+    Checking anstream v0.6.21
+   Compiling wasm-bindgen-macro-support v0.2.114
+   Compiling wasm-bindgen v0.2.114
+    Checking unicode-ident v1.0.24
+    Checking clap_lex v1.0.0
+   Compiling heck v0.5.0
+    Checking strsim v0.11.1
+    Checking clap_builder v4.5.60
+   Compiling clap_derive v4.5.55
+   Compiling wasm-bindgen-macro v0.2.114
+    Checking diff v0.1.13
+    Checking yansi v1.0.1
+    Checking once_cell v1.21.3
+    Checking clap v4.5.60
+    Checking pretty_assertions v1.4.1
+    Checking settler-verify-wasm v0.1.0 (/workspace/Settler/crates/settler-verify-wasm)
+    Checking settler-verify v0.1.0 (/workspace/Settler/crates/settler-verify-cli)
+    Checking settler-kernel-cli v0.1.0 (/workspace/Settler/crates/settler-kernel-cli)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.73s
+[exit_code]=0
+\n$ cargo test --all
+   Compiling unicode-ident v1.0.24
+   Compiling serde_core v1.0.228
+   Compiling proc-macro2 v1.0.106
+   Compiling quote v1.0.45
+   Compiling syn v2.0.117
+   Compiling block-buffer v0.10.4
+   Compiling crypto-common v0.1.7
+   Compiling cfg-if v1.0.4
+   Compiling digest v0.10.7
+   Compiling zmij v1.0.21
+   Compiling cpufeatures v0.2.17
+   Compiling itoa v1.0.17
+   Compiling memchr v2.8.0
+   Compiling serde_json v1.0.149
+   Compiling sha2 v0.10.9
+   Compiling serde_derive v1.0.228
+   Compiling hex v0.4.3
+   Compiling serde_bytes v0.11.19
+   Compiling wasm-bindgen-shared v0.2.114
+   Compiling wasm-bindgen-macro-support v0.2.114
+   Compiling serde v1.0.228
+   Compiling settler-kernel v0.1.0 (/workspace/Settler/crates/settler-kernel)
+   Compiling utf8parse v0.2.2
+   Compiling anstyle-parse v0.2.7
+   Compiling wasm-bindgen-macro v0.2.114
+   Compiling diff v0.1.13
+   Compiling anstyle-query v1.1.5
+   Compiling anstyle v1.0.13
+   Compiling colorchoice v1.0.4
+   Compiling is_terminal_polyfill v1.70.2
+   Compiling once_cell v1.21.3
+   Compiling yansi v1.0.1
+   Compiling wasm-bindgen v0.2.114
+   Compiling pretty_assertions v1.4.1
+   Compiling anstream v0.6.21
+   Compiling clap_lex v1.0.0
+   Compiling strsim v0.11.1
+   Compiling clap_derive v4.5.55
+   Compiling clap_builder v4.5.60
+   Compiling settler-verify-wasm v0.1.0 (/workspace/Settler/crates/settler-verify-wasm)
+   Compiling clap v4.5.60
+   Compiling settler-verify v0.1.0 (/workspace/Settler/crates/settler-verify-cli)
+   Compiling settler-kernel-cli v0.1.0 (/workspace/Settler/crates/settler-kernel-cli)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 24.31s
+     Running unittests src/lib.rs (target/debug/deps/settler_kernel-5726cefef66b3f31)
+
+running 2 tests
+test tests::manifest_hashes_are_stable ... ok
+test tests::determinism_for_variance_report ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/golden_determinism.rs (target/debug/deps/golden_determinism-a43a4cf70f347228)
+
+running 1 test
+test outputs_are_deterministic ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running unittests src/main.rs (target/debug/deps/settler_kernel_cli-8cf3071a1b19e9dc)
+
+running 5 tests
+test tests::artifact_identity_hash_uses_distinct_rule_hash ... ok
+test tests::handshake_returns_protocol_and_version ... ok
+test tests::proof_bundle_hash_uses_distinct_rule_hash ... ok
+test tests::canonicalize_hash_is_deterministic ... ok
+test tests::unknown_operation_returns_typed_error ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running unittests src/main.rs (target/debug/deps/settler_verify-98c4475ebd0ed131)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running unittests src/lib.rs (target/debug/deps/settler_verify_wasm-b381d72c324eb978)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+   Doc-tests settler_kernel
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+   Doc-tests settler_verify_wasm
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+[exit_code]=0

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "benchmark:full": "tsx scripts/benchmark-harness.ts --output docs/performance/benchmark-report.md",
     "doctor:old": "tsx scripts/doctor.ts",
     "diagnose:console": "tsx scripts/diagnose-console-backend.ts",
-    "verify:setup": "tsx scripts/verify-setup.ts",
     "verify:schema": "tsx scripts/verify-schema.ts",
     "verify:contracts": "tsx scripts/check-contract-compatibility.ts",
     "verify:production-parity": "tsx scripts/verify-production-parity.ts",
@@ -282,9 +281,7 @@
     "simulate:settler": "node scripts/surface-command-runner.mjs simulate:settler",
     "tenant:create": "node scripts/surface-command-runner.mjs tenant:create",
     "chaos:test": "node scripts/surface-command-runner.mjs chaos:test",
-    "kernel:health": "tsx scripts/kernel-health.ts",
-    "verify:setup": "tsx scripts/verify-setup.ts",
-    "settler:doctor": "pnpm run doctor"
+    "kernel:health": "tsx scripts/kernel-health.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -9,7 +9,6 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { SettlerLogo } from "@/components/brand/SettlerLogo";
 import { cn } from "@/lib/utils";
 import { Menu, ChevronDown } from "lucide-react";
-import { SettlerLogo } from "@/components/brand/SettlerLogo";
 
 // Primary navigation items (always visible on desktop)
 const siteMode = process.env.NEXT_PUBLIC_SITE_MODE || "oss";


### PR DESCRIPTION
### Motivation
- Resolve the immediate TypeScript blocker preventing `pnpm typecheck` from completing in the monorepo and make the operator diagnostics surface deterministic and wired to the canonical script name.
- Capture a truthful, reproducible verification run and operator-facing evidence to support the final go-live readiness assessment.

### Description
- Removed a duplicate import of `SettlerLogo` in `packages/web/src/components/Navigation.tsx` to fix `TS2300: Duplicate identifier 'SettlerLogo'` and restore web package typecheck.
- Cleaned duplicate root `scripts` entries in `package.json` so `settler:doctor` and `verify:setup` are single canonical definitions and the command surface is unambiguous.
- Added the final audit report `docs/launch/final-go-live-flip-audit-2026-03-12.md` summarizing root cause, changes, classification, and final verdict (`READY_WITH_NON_BLOCKING_FRICTION`).
- Saved the full verification execution log to `evidence/final-go-live-flip/command-log.txt` showing the commands run and their exit codes.

### Testing
- Ran `pnpm install --frozen-lockfile` which completed successfully (PASS).
- Ran `pnpm lint` which completed successfully with warnings (PASS, warnings are non-blocking).
- Ran `pnpm typecheck` which now passes after the fix to `Navigation.tsx` (PASS).
- Ran `pnpm build` and `pnpm test` which completed successfully (PASS).
- Ran `pnpm run verify:setup` and `pnpm run settler:doctor` which correctly fail due to missing Supabase / database environment variables in this container; these are expected and classified as `EXPECTED_MISSING_ENV` (FAIL by design until secrets are provided).
- Ran `pnpm run kernel:health` which reports degraded kernel mode explicitly (PASS, `DEGRADED` state visible).
- Ran `pnpm run check:production` which fails at the setup gate for the same missing-env reason (EXPECTED_MISSING_ENV).
- Ran Rust checks `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all`, all of which passed (PASS).

All test and verification output (commands, stdout/stderr and exit codes) are recorded in `evidence/final-go-live-flip/command-log.txt` and the audit file describes the changes and final classification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e659aa0c8328bdf1409579324538)