### PR TITLE
web: use stacked Settler logo in main header

### DIFF
--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -155,8 +155,8 @@ export function Navigation() {
             >
               <div className="relative overflow-hidden rounded">
                 <SettlerLogo
-                  variant="horizontal"
-                  className="h-8 w-auto relative z-10 transition-all duration-300 group-hover:brightness-110 group-hover:drop-shadow-lg"
+                  variant="stacked"
+                  className="h-10 w-auto relative z-10 transition-all duration-300 group-hover:brightness-110 group-hover:drop-shadow-lg"
                   priority
                 />
                 {/* Shine effect overlay */}

--- a/packages/web/src/components/brand/SettlerLogo.tsx
+++ b/packages/web/src/components/brand/SettlerLogo.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 
-type SettlerLogoVariant = "horizontal" | "icon" | "wordmark";
+type SettlerLogoVariant = "horizontal" | "icon" | "wordmark" | "stacked";
 
 interface SettlerLogoProps {
   variant?: SettlerLogoVariant;
@@ -29,6 +29,12 @@ const LOGO_CONFIG = {
     dark: "/brand/settler/logo-horizontal.svg",
     width: 520,
     height: 160,
+  },
+  stacked: {
+    light: "/brand/settler/logo-stacked.svg",
+    dark: "/brand/settler/logo-stacked.svg",
+    width: 160,
+    height: 72,
   },
 } as const;
 

--- a/tests/ui/landing.spec.ts
+++ b/tests/ui/landing.spec.ts
@@ -225,18 +225,17 @@ test.describe("Landing page reality pass", () => {
   test("logo renders in dark mode", async ({ page }) => {
     await page.goto("/");
 
+    // Logo should render in light mode
+    const logo = page.locator('img[src="/brand/settler/logo-stacked.svg"]').first();
+    await expect(logo).toBeVisible();
+
     // Switch to dark mode
     const toggle = page.getByRole("button", { name: "Toggle dark mode" });
     await toggle.click();
     await expect(page.locator("html")).toHaveClass(/dark/);
 
-    // Dark logo should be visible (light logo hidden)
-    const darkLogo = page.locator('img[src="/brand/settler/logo-horizontal-dark.svg"]').first();
-    await expect(darkLogo).toBeVisible();
-
-    // Light logo should be hidden in dark mode
-    const lightLogo = page.locator('img[src="/brand/settler/logo-horizontal.svg"]').first();
-    await expect(lightLogo).toBeHidden();
+    // Stacked logo should remain visible in dark mode
+    await expect(logo).toBeVisible();
 
     // Reset to light
     await toggle.click();


### PR DESCRIPTION
### Motivation
- The marketing header should show the stacked/square brand mark in the top-left of the main page instead of the horizontal-only variant to match design intent. 
- Provide a minimal, deterministic change to the shared logo component so other consumers can opt into the stacked mark. 
- Update UI tests to reflect the header change and ensure dark-mode behavior remains correct.

### Description
- Added a new `stacked` variant to `SettlerLogo` mapped to `/brand/settler/logo-stacked.svg` with dimensions `160x72` in `packages/web/src/components/brand/SettlerLogo.tsx`.
- Switched the marketing navigation header to use `variant="stacked"` and increased the displayed height (`h-10`) in `packages/web/src/components/Navigation.tsx`.
- Updated the landing page Playwright test to assert the stacked logo is visible and remains visible when dark mode is toggled in `tests/ui/landing.spec.ts`.
- Change is limited to front-end presentation; no backend, tenancy, auth, or policy logic was modified.

### Testing
- Ran `pnpm --filter @settler/web lint` which completed (only pre-existing warnings in the repo reported).
- Pre-commit validation (conflict-marker check + `lint-staged` and scoped turborepo lint) executed during commit and passed for the changed files.
- Attempted `pnpm playwright test tests/ui/landing.spec.ts` but the app startup reported missing env (either `DATABASE_URL` or `NEXT_PUBLIC_SUPABASE_URL`) and the full test run could not complete in this environment.
- Started the local dev server to visually validate the header (server started with the repo's startup validation warnings) and attempted a Playwright screenshot run which timed out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2f5f575f08328aa91bff03d38db50)