### PR TITLE
Harden web env pipeline: canonical key groups + strict build gate

### DIFF
--- a/docs/setup/env-matrix.md
+++ b/docs/setup/env-matrix.md
@@ -4,6 +4,11 @@
 
 This matrix is the single source of truth for runtime environment variables and secrets used by core platform operation.
 
+## Operator note (env truth + build gate)
+
+- **Canonical env truth** lives in this file (`docs/setup/env-matrix.md`) and is enforced in code via `packages/web/scripts/assert-build-env.mjs` (build-time gate) and `packages/web/src/lib/env/keys.ts` (shared env key groups).
+- **Canonical production build path** is `pnpm --filter @settler/web run build` (invokes `assert-build-env.mjs` before `next build`).
+
 ## Security level legend
 
 - `public`: safe for browser/client exposure.

--- a/packages/web/scripts/assert-build-env.mjs
+++ b/packages/web/scripts/assert-build-env.mjs
@@ -3,12 +3,12 @@
 const REQUIRED_GROUPS = [
   {
     label: "Supabase URL (public)",
-    keys: ["NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_URL"],
+    keys: ["NEXT_PUBLIC_SUPABASE_URL"],
     visibility: "public",
   },
   {
     label: "Supabase anon key (public)",
-    keys: ["NEXT_PUBLIC_SUPABASE_ANON_KEY", "SUPABASE_ANON_KEY"],
+    keys: ["NEXT_PUBLIC_SUPABASE_ANON_KEY"],
     visibility: "public",
   },
   {
@@ -18,20 +18,45 @@ const REQUIRED_GROUPS = [
   },
 ];
 
+const SECRET_PUBLIC_COLLISION_KEYS = [
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "DATABASE_URL",
+  "DIRECT_URL",
+  "JWT_SECRET",
+  "JWT_REFRESH_SECRET",
+  "ENCRYPTION_KEY",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "RESEND_API_KEY",
+  "OPENAI_API_KEY",
+];
+
 function hasValue(key) {
   const value = process.env[key];
   return Boolean(value && value.trim().length > 0);
 }
 
 const missing = REQUIRED_GROUPS.filter((group) => !group.keys.some((key) => hasValue(key)));
+const leakedToClient = SECRET_PUBLIC_COLLISION_KEYS.filter((key) => hasValue(`NEXT_PUBLIC_${key}`));
 
-if (missing.length > 0) {
+if (missing.length > 0 || leakedToClient.length > 0) {
   console.error("❌ Build-time environment validation failed.");
-  console.error("Missing required environment key groups:");
-  for (const group of missing) {
-    console.error(`  - ${group.label} [${group.visibility}]: ${group.keys.join(" or ")}`);
+
+  if (missing.length > 0) {
+    console.error("Missing required environment key groups:");
+    for (const group of missing) {
+      console.error(`  - ${group.label} [${group.visibility}]: ${group.keys.join(" or ")}`);
+    }
   }
-  console.error("Set these keys in the build environment (Vercel project env / CI env injection).");
+
+  if (leakedToClient.length > 0) {
+    console.error("Detected secret-like keys leaked with NEXT_PUBLIC_ prefix:");
+    for (const leakedKey of leakedToClient) {
+      console.error(`  - NEXT_PUBLIC_${leakedKey}`);
+    }
+  }
+
+  console.error("Set these keys in build env and keep secret keys server-only.");
   process.exit(1);
 }
 

--- a/packages/web/src/lib/env-build-helper.ts
+++ b/packages/web/src/lib/env-build-helper.ts
@@ -5,6 +5,12 @@
  * without causing build failures for runtime-only variables.
  */
 
+import {
+  BUILD_REQUIRED_ENV_GROUPS,
+  RUNTIME_REQUIRED_SERVER_KEYS,
+  hasConfiguredValue,
+} from "./env/keys";
+
 /**
  * Check if we're currently in a build context
  */
@@ -22,14 +28,8 @@ export function isBuildTime(): boolean {
 /**
  * Build-time required environment variables
  * These are needed during the build process
- *
- * Note: DATABASE_URL is needed for Prisma client generation and build-time queries,
- * but Prisma will handle missing DATABASE_URL gracefully during build if engineType is "binary"
  */
-export const BUILD_TIME_REQUIRED = [
-  ["NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_URL"],
-  ["NEXT_PUBLIC_SUPABASE_ANON_KEY", "SUPABASE_ANON_KEY"],
-] as const;
+export const BUILD_TIME_REQUIRED = BUILD_REQUIRED_ENV_GROUPS.map((group) => group.keys);
 
 /**
  * Runtime-only environment variables
@@ -37,12 +37,10 @@ export const BUILD_TIME_REQUIRED = [
  */
 export const RUNTIME_ONLY = [
   "DB_PASSWORD",
-  "ENCRYPTION_KEY",
-  "JWT_SECRET",
   "JWT_REFRESH_SECRET",
   "JOBFORGE_INTEGRATION_ENABLED",
   "JOBFORGE_BUNDLE_EXECUTION_ENABLED",
-  "SUPABASE_SERVICE_ROLE_KEY",
+  ...RUNTIME_REQUIRED_SERVER_KEYS,
   "STRIPE_SECRET_KEY",
   "STRIPE_WEBHOOK_SECRET",
 ] as const;
@@ -95,7 +93,7 @@ export function validateBuildEnv(): { valid: boolean; errors: string[]; warnings
 
   // Check build-time required variables
   for (const keyGroup of BUILD_TIME_REQUIRED) {
-    const hasAny = keyGroup.some((key) => Boolean(process.env[key]));
+    const hasAny = keyGroup.some((key) => hasConfiguredValue(key));
     if (!hasAny) {
       errors.push(`Missing build-time required variable: ${keyGroup.join(" or ")}`);
     }
@@ -103,7 +101,7 @@ export function validateBuildEnv(): { valid: boolean; errors: string[]; warnings
 
   // Warn about runtime-only variables (non-blocking)
   for (const name of RUNTIME_ONLY) {
-    if (!process.env[name]) {
+    if (!hasConfiguredValue(name)) {
       warnings.push(`Missing runtime-only variable (will be required at runtime): ${name}`);
     }
   }

--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -9,6 +9,11 @@
  * Uses build-time detection to skip validation for runtime-only variables during build.
  */
 import { isBuildTime, RUNTIME_ONLY } from "./env-build-helper";
+import {
+  BUILD_REQUIRED_ENV_GROUPS,
+  RUNTIME_REQUIRED_SERVER_KEYS,
+  hasConfiguredValue,
+} from "./env/keys";
 
 /**
  * Safe environment variable getter that never throws during render
@@ -103,14 +108,11 @@ export function validateEnv(): { valid: boolean; errors: string[] } {
 
   // During build, only validate build-time required vars
   if (isBuild) {
-    const buildRequired = [
-      ["NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_URL"],
-      ["NEXT_PUBLIC_SUPABASE_ANON_KEY", "SUPABASE_ANON_KEY"],
-    ] as const;
+    const buildRequired = BUILD_REQUIRED_ENV_GROUPS.map((group) => group.keys);
     const errors: string[] = [];
 
     for (const keys of buildRequired) {
-      if (!keys.some((name) => process.env[name])) {
+      if (!keys.some((name) => hasConfiguredValue(name))) {
         errors.push(`Missing build-time required variable: ${keys.join(" or ")}`);
       }
     }
@@ -123,10 +125,14 @@ export function validateEnv(): { valid: boolean; errors: string[] } {
 
   const errors: string[] = [];
 
-  const required = ["SUPABASE_URL", "SUPABASE_ANON_KEY", "SUPABASE_SERVICE_ROLE_KEY"];
+  for (const group of BUILD_REQUIRED_ENV_GROUPS.slice(0, 2)) {
+    if (!group.keys.some((name) => hasConfiguredValue(name))) {
+      errors.push(`Missing required environment variable: ${group.keys.join(" or ")}`);
+    }
+  }
 
-  for (const name of required) {
-    if (!process.env[name]) {
+  for (const name of RUNTIME_REQUIRED_SERVER_KEYS) {
+    if (!hasConfiguredValue(name)) {
       errors.push(`Missing required environment variable: ${name}`);
     }
   }

--- a/packages/web/src/lib/env/keys.ts
+++ b/packages/web/src/lib/env/keys.ts
@@ -1,0 +1,50 @@
+export const SUPABASE_URL_KEYS = ["NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_URL"] as const;
+export const SUPABASE_ANON_KEY_KEYS = [
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  "SUPABASE_ANON_KEY",
+] as const;
+
+export const BUILD_REQUIRED_ENV_GROUPS = [
+  {
+    label: "Supabase URL",
+    keys: SUPABASE_URL_KEYS,
+  },
+  {
+    label: "Supabase anon key",
+    keys: SUPABASE_ANON_KEY_KEYS,
+  },
+  {
+    label: "Database connection",
+    keys: ["DATABASE_URL", "SUPABASE_DATABASE_URL", "DIRECT_URL"] as const,
+  },
+] as const;
+
+export const RUNTIME_REQUIRED_SERVER_KEYS = [
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "JWT_SECRET",
+  "ENCRYPTION_KEY",
+] as const;
+
+export const SERVER_SECRET_KEYS = [
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "DATABASE_URL",
+  "SUPABASE_DATABASE_URL",
+  "DIRECT_URL",
+  "JWT_SECRET",
+  "JWT_REFRESH_SECRET",
+  "ENCRYPTION_KEY",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "RESEND_API_KEY",
+  "UPSTASH_REDIS_REST_TOKEN",
+  "OPENAI_API_KEY",
+] as const;
+
+export function hasConfiguredValue(key: string): boolean {
+  const value = process.env[key];
+  return Boolean(value && value.trim().length > 0);
+}
+
+export function isAnyConfigured(keys: readonly string[]): boolean {
+  return keys.some((key) => hasConfiguredValue(key));
+}

--- a/packages/web/src/lib/env/runtime-access.ts
+++ b/packages/web/src/lib/env/runtime-access.ts
@@ -1,13 +1,12 @@
+import { SUPABASE_ANON_KEY_KEYS, SUPABASE_URL_KEYS } from "./keys";
+
 export const MARKETING_OPTIONAL_ENV_KEYS = [
-  ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_URL'],
-  ['NEXT_PUBLIC_SUPABASE_ANON_KEY', 'SUPABASE_ANON_KEY'],
-  ['NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY'],
+  SUPABASE_URL_KEYS,
+  SUPABASE_ANON_KEY_KEYS,
+  ["NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY"],
 ] as const;
 
-export const APP_REQUIRED_ENV_KEYS = [
-  ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_URL'],
-  ['NEXT_PUBLIC_SUPABASE_ANON_KEY', 'SUPABASE_ANON_KEY'],
-] as const;
+export const APP_REQUIRED_ENV_KEYS = [SUPABASE_URL_KEYS, SUPABASE_ANON_KEY_KEYS] as const;
 
 type EnvKeyGroup = readonly string[];
 
@@ -19,9 +18,7 @@ function isConfigured(keys: EnvKeyGroup): boolean {
 }
 
 function findMissing(keyGroups: readonly EnvKeyGroup[]): string[] {
-  return keyGroups
-    .filter((keys) => !isConfigured(keys))
-    .map((keys) => keys.join(' or '));
+  return keyGroups.filter((keys) => !isConfigured(keys)).map((keys) => keys.join(" or "));
 }
 
 export function getMarketingEnvStatus(): { ok: boolean; missing: string[] } {

--- a/packages/web/src/lib/env/validator.ts
+++ b/packages/web/src/lib/env/validator.ts
@@ -8,6 +8,8 @@
  * and makes configuration auditing trivial.
  */
 
+import { SUPABASE_ANON_KEY_KEYS, SUPABASE_URL_KEYS, hasConfiguredValue } from "./keys";
+
 export interface EnvValidationResult {
   isValid: boolean;
   missing: string[];
@@ -23,7 +25,7 @@ export interface EnvValidationResult {
  */
 export interface AppEnv {
   // Node environment
-  nodeEnv: 'development' | 'production' | 'test';
+  nodeEnv: "development" | "production" | "test";
 
   // Supabase
   supabase: {
@@ -45,7 +47,7 @@ export interface AppEnv {
   };
 
   // Runtime
-  runtime?: 'nodejs' | 'edge';
+  runtime?: "nodejs" | "edge";
 
   // Vercel (optional)
   vercel?: boolean;
@@ -62,7 +64,7 @@ export function validateEnv(requiredVars: string[]): EnvValidationResult {
   for (const key of requiredVars) {
     const value = process.env[key];
 
-    if (!value || value.trim() === '') {
+    if (!value || value.trim() === "") {
       missing.push(key);
       errors.push({
         key,
@@ -82,10 +84,19 @@ export function validateEnv(requiredVars: string[]): EnvValidationResult {
  * Validate Supabase environment variables
  */
 export function validateSupabaseEnv(): EnvValidationResult {
-  return validateEnv([
-    'NEXT_PUBLIC_SUPABASE_URL',
-    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-  ]);
+  const requiredGroups = [SUPABASE_URL_KEYS, SUPABASE_ANON_KEY_KEYS];
+  const missing = requiredGroups
+    .filter((group) => !group.some((key) => hasConfiguredValue(key)))
+    .map((group) => group.join(" or "));
+
+  return {
+    isValid: missing.length === 0,
+    missing,
+    errors: missing.map((key) => ({
+      key,
+      message: `Environment variable ${key} is required but not set`,
+    })),
+  };
 }
 
 /**
@@ -98,17 +109,14 @@ export function getSupabaseEnv(): {
   serviceRoleKey?: string;
 } {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
-  const anonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 
   if (!url || !anonKey) {
     const missing: string[] = [];
-    if (!url) missing.push('NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL');
-    if (!anonKey) missing.push('NEXT_PUBLIC_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY');
+    if (!url) missing.push("NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL");
+    if (!anonKey) missing.push("NEXT_PUBLIC_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY");
 
-    throw new Error(
-      `Missing required Supabase environment variables: ${missing.join(', ')}`
-    );
+    throw new Error(`Missing required Supabase environment variables: ${missing.join(", ")}`);
   }
 
   return {
@@ -124,13 +132,11 @@ export function getSupabaseEnv(): {
  */
 export function getDatabaseUrl(): string {
   const url =
-    process.env.DATABASE_URL ||
-    process.env.SUPABASE_DATABASE_URL ||
-    process.env.DIRECT_URL;
+    process.env.DATABASE_URL || process.env.SUPABASE_DATABASE_URL || process.env.DIRECT_URL;
 
   if (!url) {
     throw new Error(
-      'Missing database URL. Set one of: DATABASE_URL, SUPABASE_DATABASE_URL, or DIRECT_URL'
+      "Missing database URL. Set one of: DATABASE_URL, SUPABASE_DATABASE_URL, or DIRECT_URL"
     );
   }
 
@@ -145,17 +151,17 @@ export function getEnv(): AppEnv {
   const supabase = getSupabaseEnv();
 
   return {
-    nodeEnv: (process.env.NODE_ENV as 'development' | 'production' | 'test') || 'development',
+    nodeEnv: (process.env.NODE_ENV as "development" | "production" | "test") || "development",
     supabase,
     database: {
       url: getDatabaseUrl(),
       directUrl: process.env.DIRECT_URL,
     },
     public: {
-      appUrl: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
-      aiasStudioUrl: process.env.NEXT_PUBLIC_AIAS_STUDIO_URL || 'https://aias.studio',
+      appUrl: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
+      aiasStudioUrl: process.env.NEXT_PUBLIC_AIAS_STUDIO_URL || "https://aias.studio",
     },
-    runtime: process.env.NEXT_RUNTIME as 'nodejs' | 'edge' | undefined,
+    runtime: process.env.NEXT_RUNTIME as "nodejs" | "edge" | undefined,
     vercel: !!process.env.VERCEL,
   };
 }
@@ -164,10 +170,7 @@ export function getEnv(): AppEnv {
  * Get environment variable with typed fallback
  * Use for optional vars that should have a default
  */
-export function getEnvVar<T extends string>(
-  key: string,
-  fallback: T
-): string {
+export function getEnvVar<T extends string>(key: string, fallback: T): string {
   return process.env[key] || fallback;
 }
 
@@ -177,7 +180,7 @@ export function getEnvVar<T extends string>(
  */
 export function requireEnvVar(key: string): string {
   const value = process.env[key];
-  if (!value || value.trim() === '') {
+  if (!value || value.trim() === "") {
     throw new Error(`Required environment variable ${key} is not set`);
   }
   return value;
@@ -187,6 +190,7 @@ export function requireEnvVar(key: string): string {
  * Check if we're in a build context (where env vars might not be available)
  */
 export function isBuildContext(): boolean {
-  return process.env.NODE_ENV === 'production' &&
-         (typeof window === 'undefined' && !process.env.VERCEL);
+  return (
+    process.env.NODE_ENV === "production" && typeof window === "undefined" && !process.env.VERCEL
+  );
 }


### PR DESCRIPTION
### Motivation
- Remove duplicated env-group logic and naming drift across the web package to provide one canonical source of truth for build vs runtime env handling. 
- Tighten build-time assertions to avoid leaking server secrets to the client and to ensure builds only proceed when minimal public bootstrap + DB connection info is present. 
- Make runtime vs build-time expectations explicit so CI/operator workflows can deterministically provision required keys.

### Description
- Add a shared env key module `packages/web/src/lib/env/keys.ts` that centralizes Supabase aliases, build-required groups, runtime-required server keys, and a `hasConfiguredValue` helper. 
- Refactor env helpers to use the shared key groups, replacing ad-hoc checks with `BUILD_REQUIRED_ENV_GROUPS`, `RUNTIME_REQUIRED_SERVER_KEYS`, and `hasConfiguredValue` in `env-build-helper.ts`, `env.ts`, `runtime-access.ts`, and `validator.ts`. 
- Harden the production build gate `packages/web/scripts/assert-build-env.mjs` to require the public client bootstrap keys and a DB-connection group and to fail the build if secret-like keys are present with a `NEXT_PUBLIC_` prefix. 
- Add a short operator note to `docs/setup/env-matrix.md` pointing to this file as the canonical env truth and calling out the canonical production build path `pnpm --filter @settler/web run build`.

### Testing
- Unit tests: `pnpm --filter @settler/web exec jest src/__tests__/env/runtime-access.test.ts --runInBand` passed (2 tests). 
- Static checks: `pnpm --filter @settler/web run lint` ran and completed with only warnings (no failures). 
- Typecheck: `pnpm --filter @settler/web run typecheck` passed. 
- Build gate: `pnpm --filter @settler/web run build` correctly failed in this container due to missing build env groups (expected in CI/local without secrets); the gate now reports the exact missing groups. 

Final canonical env matrix (Red)
- Build-time required (Red): `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and one of `DATABASE_URL` | `SUPABASE_DATABASE_URL` | `DIRECT_URL` (required for production build). 
- Runtime-only required (Red): `SUPABASE_SERVICE_ROLE_KEY`, `JWT_SECRET`, `ENCRYPTION_KEY` (required at runtime, optional during build). 
- Client-secret leakage rule (Red): fail build if any secret-like keys are present as `NEXT_PUBLIC_*` (examples: `SUPABASE_SERVICE_ROLE_KEY`, `DATABASE_URL`, `DIRECT_URL`, `JWT_SECRET`, `JWT_REFRESH_SECRET`, `ENCRYPTION_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `RESEND_API_KEY`, `OPENAI_API_KEY`). 

Exact build-time required vars
- `NEXT_PUBLIC_SUPABASE_URL` 
- `NEXT_PUBLIC_SUPABASE_ANON_KEY` 
- one of `DATABASE_URL` / `SUPABASE_DATABASE_URL` / `DIRECT_URL`

Exact runtime-only vars
- `SUPABASE_SERVICE_ROLE_KEY` 
- `JWT_SECRET` 
- `ENCRYPTION_KEY`

Remaining manual dashboard dependencies
- Operators must still provision build-time vars in the deployment platform (Vercel/CI) via the project dashboard for `NEXT_PUBLIC_*` and DB connection strings (the build gate enforces presence but provisioning remains manual). 
- CI/deploy secrets such as `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_REF`, and DB migration credentials remain manual to set in the deployment control plane.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b37c588f3883289369c7835e34e4f4)