### PR TITLE
Add preview Supabase schema reality audit + guarded reconciliation workflow

### DIFF
--- a/.github/workflows/preview-db-reconciliation.yml
+++ b/.github/workflows/preview-db-reconciliation.yml
@@ -1,0 +1,70 @@
+name: Preview DB Reconciliation
+
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - 'supabase/migrations/**'
+      - 'scripts/supabase-schema-reality-audit.ts'
+      - 'scripts/run-preview-reconciliation.sh'
+      - '.github/workflows/preview-db-reconciliation.yml'
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply reconciliation SQL (false = dry-run only)'
+        required: false
+        default: 'false'
+
+jobs:
+  audit-and-reconcile:
+    runs-on: ubuntu-latest
+    environment: preview
+    env:
+      DATABASE_URL: ${{ secrets.PREVIEW_DATABASE_URL }}
+      DIRECT_URL: ${{ secrets.PREVIEW_DIRECT_URL }}
+      SUPABASE_DB_URL: ${{ secrets.PREVIEW_SUPABASE_DB_URL }}
+      ALLOW_PRODUCTION_RECONCILIATION: 'false'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Install psql
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Precheck target connection
+        run: psql "${DATABASE_URL:-${DIRECT_URL:-$SUPABASE_DB_URL}}" -v ON_ERROR_STOP=1 -c "select current_database(), current_user, inet_server_addr(), inet_server_port();"
+
+      - name: Reality audit (expected vs live)
+        run: npx tsx scripts/supabase-schema-reality-audit.ts
+
+      - name: Reconciliation SQL dry-run
+        run: bash scripts/run-preview-reconciliation.sh dry-run
+
+      - name: Apply reconciliation SQL
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.apply == 'true'
+        run: bash scripts/run-preview-reconciliation.sh apply
+
+      - name: Re-audit after apply
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.apply == 'true'
+        run: npx tsx scripts/supabase-schema-reality-audit.ts
+
+      - name: Upload audit artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-db-reconciliation-audit
+          path: |
+            reports/supabase-schema-reality-report.json
+            reports/supabase-schema-reality-report.md

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "validate:env": "tsx scripts/check-env.ts production",
     "validate:env:build": "npx tsx scripts/validate-env-build.ts --build",
     "validate:env:runtime": "npx tsx scripts/validate-env-build.ts --runtime",
-    "validate:eslint-config": "test -f scripts/validate-eslint-config.ts && npx tsx scripts/validate-eslint-config.ts || (echo '⚠️  ESLint config validation script not found (expected in Vercel builds), skipping...' && exit 0)",
+    "validate:eslint-config": "test -f scripts/validate-eslint-config.ts && npx tsx scripts/validate-eslint-config.ts || (echo '\u26a0\ufe0f  ESLint config validation script not found (expected in Vercel builds), skipping...' && exit 0)",
     "validate:build-safety": "npx tsx scripts/validate-build-safety.ts",
     "validate:nextjs": "npx tsx scripts/validate-nextjs-build.ts",
     "validate:lint-config": "npx tsx scripts/validate-lint-config.ts",
@@ -136,7 +136,7 @@
     "preinstall": "export SENTRY_SKIP_AUTO_INSTALL=1 || set SENTRY_SKIP_AUTO_INSTALL=1 || true",
     "postinstall": "test -f scripts/vercel-prisma-postinstall.js && node scripts/vercel-prisma-postinstall.js || echo 'Skipping postinstall: script not found (expected in Vercel builds)'",
     "verify:build": "node scripts/verify-release.mjs --profile=build",
-    "setup:turbo": "test -f scripts/setup-vercel-turbo-cache.sh && bash scripts/setup-vercel-turbo-cache.sh || echo '⚠️  Turbo setup script not available'",
+    "setup:turbo": "test -f scripts/setup-vercel-turbo-cache.sh && bash scripts/setup-vercel-turbo-cache.sh || echo '\u26a0\ufe0f  Turbo setup script not available'",
     "demo:setup": "tsx scripts/generate-demo-data.ts",
     "demo:reset": "tsx scripts/generate-demo-data.ts",
     "demo:start": "pnpm run demo:setup && turbo run dev --filter @settler/web",
@@ -281,7 +281,9 @@
     "simulate:settler": "node scripts/surface-command-runner.mjs simulate:settler",
     "tenant:create": "node scripts/surface-command-runner.mjs tenant:create",
     "chaos:test": "node scripts/surface-command-runner.mjs chaos:test",
-    "kernel:health": "tsx scripts/kernel-health.ts"
+    "kernel:health": "tsx scripts/kernel-health.ts",
+    "db:reality:audit": "tsx scripts/supabase-schema-reality-audit.ts",
+    "db:reconcile:preview": "bash scripts/run-preview-reconciliation.sh dry-run"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/reports/schema-reality-forensics.md
+++ b/reports/schema-reality-forensics.md
@@ -1,0 +1,48 @@
+# Supabase Schema Reality Forensics (Local Execution)
+
+## Canonical migration source
+
+- **Canonical source used:** `supabase/migrations/*.sql`.
+- **Why:** Supabase-oriented GitHub workflows (`supabase-migrate.yml`, `migrations-safe.yml`, `auto-migrate-on-main.yml`) apply SQL from this directory directly, while Prisma migrations coexist mainly for app-side tooling and are not the primary Supabase deployment path.
+
+## Environment and DB connection attempt
+
+- Attempted runtime connection using `DATABASE_URL || DIRECT_URL || SUPABASE_DB_URL`.
+- Result: no live DB connection string was available in the current shell session.
+
+Commands and outcomes:
+
+```bash
+env | rg "DATABASE_URL|DIRECT_URL|SUPABASE|POSTGRES"
+# => no configured DB env vars
+
+npx tsx scripts/supabase-schema-reality-audit.ts
+# => Missing DATABASE_URL, DIRECT_URL, or SUPABASE_DB_URL
+
+bash scripts/run-preview-reconciliation.sh dry-run
+# => Missing DATABASE_URL, DIRECT_URL, or SUPABASE_DB_URL
+```
+
+## What was still produced
+
+1. Deterministic reality-audit script:
+   - Parses repo migrations into expected object inventory.
+   - Connects to live DB (when env is present).
+   - Produces machine-readable and markdown reports with missing objects.
+
+2. Final reconciliation SQL artifact for controlled preview execution:
+   - `supabase/migrations/20260313000000_final_reconciliation_preview.sql`
+   - Additive and guarded; no drops.
+
+3. Preview GitHub Action path:
+   - `.github/workflows/preview-db-reconciliation.yml`
+   - Uses preview environment secrets, runs audit, performs dry-run always, and applies only on explicit `workflow_dispatch` with `apply=true`.
+
+4. DB target guardrail runner:
+   - `scripts/run-preview-reconciliation.sh`
+   - Refuses production-like targets unless explicitly overridden.
+
+## Residual risk
+
+- Live-schema vs expected-schema drift **cannot be proven locally** until preview DB secrets are present in environment or the new workflow is run in GitHub Actions `preview` environment.
+- Consolidated SQL currently captures high-confidence additive intent from committed migration history; any additional drift discovered by audit should be appended based on generated report evidence.

--- a/scripts/run-preview-reconciliation.sh
+++ b/scripts/run-preview-reconciliation.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-dry-run}"
+DB_URL="${DATABASE_URL:-${DIRECT_URL:-${SUPABASE_DB_URL:-}}}"
+PATCH_FILE="supabase/migrations/20260313000000_final_reconciliation_preview.sql"
+
+if [[ -z "$DB_URL" ]]; then
+  echo "❌ Missing DATABASE_URL, DIRECT_URL, or SUPABASE_DB_URL"
+  exit 1
+fi
+
+if [[ ! -f "$PATCH_FILE" ]]; then
+  echo "❌ Missing patch file: $PATCH_FILE"
+  exit 1
+fi
+
+echo "🔎 Verifying target identity"
+TARGET_INFO=$(psql "$DB_URL" -v ON_ERROR_STOP=1 -X -A -t -c "select current_database() || '|' || current_user || '|' || coalesce(inet_server_addr()::text,'local') || ':' || coalesce(inet_server_port()::text,'0');")
+echo "Target: $TARGET_INFO"
+
+if [[ "${ALLOW_PRODUCTION_RECONCILIATION:-false}" != "true" ]]; then
+  if [[ "$DB_URL" =~ production|prod ]] || [[ "$TARGET_INFO" =~ production|prod ]]; then
+    echo "❌ Production-looking target detected. Set ALLOW_PRODUCTION_RECONCILIATION=true to override deliberately."
+    exit 1
+  fi
+fi
+
+if [[ "$MODE" == "apply" ]]; then
+  echo "🚀 Applying reconciliation SQL"
+  psql "$DB_URL" -v ON_ERROR_STOP=1 -f "$PATCH_FILE"
+  echo "✅ Reconciliation patch applied"
+else
+  echo "🧪 Dry-run transaction (ROLLBACK)"
+  TMP_SQL=$(mktemp)
+  {
+    echo 'BEGIN;'
+    cat "$PATCH_FILE"
+    echo 'ROLLBACK;'
+  } > "$TMP_SQL"
+  psql "$DB_URL" -v ON_ERROR_STOP=1 -f "$TMP_SQL"
+  rm -f "$TMP_SQL"
+  echo "✅ Dry-run completed with rollback"
+fi

--- a/scripts/supabase-schema-reality-audit.ts
+++ b/scripts/supabase-schema-reality-audit.ts
@@ -1,0 +1,206 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Client } from 'pg';
+
+type ObjectKind = 'table' | 'type' | 'function' | 'trigger' | 'policy' | 'index' | 'view';
+
+type ExpectedObject = {
+  kind: ObjectKind;
+  schema: string;
+  name: string;
+  source: string;
+};
+
+type Finding = ExpectedObject & {
+  status: 'present' | 'missing';
+};
+
+const MIGRATIONS_DIR = path.join(process.cwd(), 'supabase', 'migrations');
+const REPORT_JSON = path.join(process.cwd(), 'reports', 'supabase-schema-reality-report.json');
+const REPORT_MD = path.join(process.cwd(), 'reports', 'supabase-schema-reality-report.md');
+
+function parseExpectedObjects(filePath: string, sql: string): ExpectedObject[] {
+  const source = path.relative(process.cwd(), filePath);
+  const out: ExpectedObject[] = [];
+
+  const pushMatches = (regex: RegExp, kind: ObjectKind, schemaDefault = 'public') => {
+    for (const m of sql.matchAll(regex)) {
+      const qname = (m[1] || '').replace(/"/g, '');
+      if (!qname) continue;
+      const [schema, name] = qname.includes('.') ? qname.split('.') : [schemaDefault, qname];
+      out.push({ kind, schema, name, source });
+    }
+  };
+
+  pushMatches(/create\s+table\s+if\s+not\s+exists\s+([a-zA-Z0-9_."]+)/gim, 'table');
+  pushMatches(/create\s+table\s+([a-zA-Z0-9_."]+)/gim, 'table');
+  pushMatches(/create\s+type\s+([a-zA-Z0-9_."]+)\s+as\s+enum/gim, 'type');
+  pushMatches(/create\s+or\s+replace\s+function\s+([a-zA-Z0-9_."]+)\s*\(/gim, 'function');
+  pushMatches(/create\s+function\s+([a-zA-Z0-9_."]+)\s*\(/gim, 'function');
+  pushMatches(/create\s+(?:unique\s+)?index\s+if\s+not\s+exists\s+([a-zA-Z0-9_."]+)/gim, 'index');
+  pushMatches(/create\s+(?:unique\s+)?index\s+([a-zA-Z0-9_."]+)/gim, 'index');
+  pushMatches(/create\s+trigger\s+([a-zA-Z0-9_."]+)/gim, 'trigger');
+  pushMatches(/create\s+policy\s+"?([^"\n]+)"?\s+on\s+([a-zA-Z0-9_."]+)/gim, 'policy');
+  pushMatches(/create\s+or\s+replace\s+view\s+([a-zA-Z0-9_."]+)/gim, 'view');
+
+  return out
+    .filter((o) => !o.name.startsWith('pg_') && o.name !== 'schema_migrations')
+    .map((o) => ({ ...o, name: o.name.trim() }));
+}
+
+async function exists(client: Client, obj: ExpectedObject): Promise<boolean> {
+  switch (obj.kind) {
+    case 'table': {
+      const r = await client.query(`select 1 from information_schema.tables where table_schema = $1 and table_name = $2`, [obj.schema, obj.name]);
+      return r.rowCount > 0;
+    }
+    case 'type': {
+      const r = await client.query(
+        `select 1 from pg_type t join pg_namespace n on n.oid = t.typnamespace where n.nspname = $1 and t.typname = $2`,
+        [obj.schema, obj.name],
+      );
+      return r.rowCount > 0;
+    }
+    case 'function': {
+      const r = await client.query(
+        `select 1 from pg_proc p join pg_namespace n on n.oid = p.pronamespace where n.nspname = $1 and p.proname = $2`,
+        [obj.schema, obj.name],
+      );
+      return r.rowCount > 0;
+    }
+    case 'index': {
+      const r = await client.query(`select 1 from pg_indexes where schemaname = $1 and indexname = $2`, [obj.schema, obj.name]);
+      return r.rowCount > 0;
+    }
+    case 'trigger': {
+      const r = await client.query(`select 1 from pg_trigger where tgname = $1 and not tgisinternal`, [obj.name]);
+      return r.rowCount > 0;
+    }
+    case 'view': {
+      const r = await client.query(`select 1 from information_schema.views where table_schema = $1 and table_name = $2`, [obj.schema, obj.name]);
+      return r.rowCount > 0;
+    }
+    case 'policy': {
+      const r = await client.query(`select 1 from pg_policies where policyname = $1`, [obj.name]);
+      return r.rowCount > 0;
+    }
+    default:
+      return false;
+  }
+}
+
+async function main() {
+  const dbUrl = process.env.DATABASE_URL || process.env.DIRECT_URL || process.env.SUPABASE_DB_URL;
+  if (!dbUrl) {
+    throw new Error('Missing DATABASE_URL, DIRECT_URL, or SUPABASE_DB_URL');
+  }
+
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql') && !['INTROSPECTION.sql', 'GAPS_REPORT.sql', 'PATCH.sql', 'VERIFY.sql', 'ROLLBACK.sql'].includes(f))
+    .sort()
+    .map((f) => path.join(MIGRATIONS_DIR, f));
+
+  const expected: ExpectedObject[] = [];
+  for (const file of files) {
+    expected.push(...parseExpectedObjects(file, fs.readFileSync(file, 'utf8')));
+  }
+
+  const dedup = new Map<string, ExpectedObject>();
+  for (const item of expected) {
+    dedup.set(`${item.kind}:${item.schema}:${item.name}`, item);
+  }
+  const expectedUnique = [...dedup.values()];
+
+  const client = new Client({ connectionString: dbUrl, ssl: dbUrl.includes('supabase.co') ? { rejectUnauthorized: false } : undefined });
+  await client.connect();
+
+  const id = await client.query(`select current_database() as database, current_user as user, inet_server_addr()::text as server_addr, inet_server_port() as server_port, version()`);
+  const migrationsTable = await client.query(`
+    select exists (
+      select 1 from information_schema.tables where table_schema = 'supabase_migrations' and table_name = 'schema_migrations'
+    ) as exists
+  `);
+
+  let appliedVersions: string[] = [];
+  if (migrationsTable.rows[0]?.exists) {
+    const versions = await client.query(`select version from supabase_migrations.schema_migrations order by version`);
+    appliedVersions = versions.rows.map((r) => String(r.version));
+  }
+
+  const findings: Finding[] = [];
+  for (const obj of expectedUnique) {
+    const present = await exists(client, obj);
+    findings.push({ ...obj, status: present ? 'present' : 'missing' });
+  }
+
+  await client.end();
+
+  const missing = findings.filter((f) => f.status === 'missing');
+
+  fs.mkdirSync(path.dirname(REPORT_JSON), { recursive: true });
+  fs.writeFileSync(
+    REPORT_JSON,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        databaseIdentity: id.rows[0],
+        migrationFiles: files.map((f) => path.relative(process.cwd(), f)),
+        appliedMigrationVersions: appliedVersions,
+        summary: {
+          expectedObjectCount: findings.length,
+          missingObjectCount: missing.length,
+        },
+        missing,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const byFile = new Map<string, Finding[]>();
+  for (const item of missing) {
+    byFile.set(item.source, [...(byFile.get(item.source) || []), item]);
+  }
+
+  const lines: string[] = [];
+  lines.push('# Supabase Schema Reality Report');
+  lines.push('');
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push('');
+  lines.push('## Connected Database');
+  lines.push(`- Database: ${id.rows[0].database}`);
+  lines.push(`- User: ${id.rows[0].user}`);
+  lines.push(`- Server: ${id.rows[0].server_addr ?? 'unknown'}:${id.rows[0].server_port ?? 'unknown'}`);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push(`- Expected objects parsed from repo migrations: ${findings.length}`);
+  lines.push(`- Missing objects in live DB: ${missing.length}`);
+  lines.push(`- Supabase migration ledger entries: ${appliedVersions.length}`);
+  lines.push('');
+
+  lines.push('## Missing Objects by Migration');
+  if (missing.length === 0) {
+    lines.push('- None.');
+  } else {
+    for (const [source, items] of [...byFile.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+      lines.push(`- ${source}`);
+      for (const item of items.sort((a, b) => `${a.kind}:${a.name}`.localeCompare(`${b.kind}:${b.name}`))) {
+        lines.push(`  - ${item.kind}: ${item.schema}.${item.name}`);
+      }
+    }
+  }
+  lines.push('');
+
+  fs.writeFileSync(REPORT_MD, lines.join('\n'));
+
+  console.log(`Wrote ${path.relative(process.cwd(), REPORT_JSON)}`);
+  console.log(`Wrote ${path.relative(process.cwd(), REPORT_MD)}`);
+  console.log(`Missing objects: ${missing.length}`);
+}
+
+main().catch((error) => {
+  console.error('supabase-schema-reality-audit failed');
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/supabase/migrations/20260313000000_final_reconciliation_preview.sql
+++ b/supabase/migrations/20260313000000_final_reconciliation_preview.sql
@@ -1,0 +1,129 @@
+-- Final consolidated reconciliation patch for preview/staging environments.
+-- Scope: only additive, guarded changes derived from committed Supabase migration intent.
+-- Safe to run multiple times.
+
+-- Ensure required extension for UUID defaults in this patch.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ============================================================================
+-- 20260218000000_red_team_security_controls.sql intent
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.audit_notarization_checkpoints (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  checkpoint_at timestamptz NOT NULL DEFAULT now(),
+  audit_row_count bigint NOT NULL,
+  checkpoint_hash text NOT NULL,
+  source_window text NOT NULL DEFAULT 'latest_5000',
+  created_by text NOT NULL DEFAULT current_user
+);
+
+CREATE OR REPLACE FUNCTION public.compute_audit_notarization_hash(max_rows integer DEFAULT 5000)
+RETURNS text
+LANGUAGE plpgsql
+STABLE
+AS $fn$
+DECLARE
+  computed_hash text;
+BEGIN
+  IF max_rows < 1 THEN
+    max_rows := 1;
+  END IF;
+
+  IF to_regclass('public.audit_logs') IS NULL THEN
+    RETURN md5('');
+  END IF;
+
+  SELECT md5(COALESCE(string_agg(to_jsonb(a)::text, '|' ORDER BY a.id::text), ''))
+  INTO computed_hash
+  FROM (
+    SELECT *
+    FROM public.audit_logs
+    ORDER BY id DESC
+    LIMIT max_rows
+  ) a;
+
+  RETURN computed_hash;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.write_audit_notarization_checkpoint(max_rows integer DEFAULT 5000)
+RETURNS public.audit_notarization_checkpoints
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_catalog'
+AS $fn$
+DECLARE
+  inserted_row public.audit_notarization_checkpoints;
+  audit_count bigint;
+  hash_value text;
+BEGIN
+  IF to_regclass('public.audit_logs') IS NULL THEN
+    RAISE EXCEPTION 'public.audit_logs is required for notarization checkpoints';
+  END IF;
+
+  SELECT COUNT(*) INTO audit_count FROM public.audit_logs;
+  hash_value := public.compute_audit_notarization_hash(max_rows);
+
+  INSERT INTO public.audit_notarization_checkpoints (
+    audit_row_count,
+    checkpoint_hash,
+    source_window
+  ) VALUES (
+    audit_count,
+    hash_value,
+    format('latest_%s', max_rows)
+  )
+  RETURNING * INTO inserted_row;
+
+  RETURN inserted_row;
+END;
+$fn$;
+
+DO $$
+BEGIN
+  IF to_regclass('public.audit_logs') IS NOT NULL THEN
+    CREATE OR REPLACE FUNCTION public.block_audit_log_mutation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $fn$
+    BEGIN
+      RAISE EXCEPTION 'audit_logs is append-only and cannot be %', TG_OP
+        USING ERRCODE = '42501';
+    END;
+    $fn$;
+
+    DROP TRIGGER IF EXISTS trg_block_audit_log_updates ON public.audit_logs;
+    CREATE TRIGGER trg_block_audit_log_updates
+      BEFORE UPDATE OR DELETE ON public.audit_logs
+      FOR EACH ROW
+      EXECUTE FUNCTION public.block_audit_log_mutation();
+
+    REVOKE UPDATE, DELETE ON public.audit_logs FROM authenticated, anon;
+  END IF;
+END $$;
+
+-- ============================================================================
+-- 20260310000000_system_incidents.sql intent
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.system_incidents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  incident_type TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  tenant_id UUID,
+  run_id UUID,
+  status TEXT NOT NULL DEFAULT 'open',
+  summary TEXT NOT NULL,
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  acknowledged_at TIMESTAMPTZ,
+  acknowledged_by TEXT,
+  linked_run_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_system_incidents_created_at ON public.system_incidents(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_system_incidents_status ON public.system_incidents(status);
+CREATE INDEX IF NOT EXISTS idx_system_incidents_tenant ON public.system_incidents(tenant_id);
+


### PR DESCRIPTION
### Motivation

- Provide a deterministic, auditable way to compare the repo-intended Supabase schema (from `supabase/migrations`) to a live database and produce evidence of drift. 
- Create a conservative, preview-only path to apply only additive, guarded reconciliation SQL so operators can safely bring preview/staging DBs in line with committed migration intent. 
- Add guardrails (target identity checks, production protections, dry-run) so reconciliation can be reviewed and executed audibly in CI rather than run ad-hoc. 

### Description

- Added a repo-parsing reality-audit script `scripts/supabase-schema-reality-audit.ts` that parses `supabase/migrations/*.sql`, builds an expected-object inventory (tables/types/functions/indexes/triggers/views/policies), connects to a live DB via `DATABASE_URL|DIRECT_URL|SUPABASE_DB_URL`, and emits JSON + Markdown reports to `reports/`. 
- Added a guarded runner `scripts/run-preview-reconciliation.sh` which performs a target identity precheck, refuses production-looking targets by default, supports a transactional dry-run (BEGIN/ROLLBACK) and an explicit `apply` mode. 
- Added a preview-only GitHub Actions workflow `.github/workflows/preview-db-reconciliation.yml` which uses preview environment secrets, runs the audit, executes a dry-run automatically on push, and only applies the reconciliation SQL on an explicit `workflow_dispatch` with `apply=true`; artifacts are uploaded for audit. 
- Created a conservative, additive consolidated SQL artifact `supabase/migrations/20260313000000_final_reconciliation_preview.sql` that encodes guarded intent derived from recent migrations (e.g., red-team audit notarization functions/triggers and `system_incidents` table + indexes) and uses `IF NOT EXISTS`/`CREATE OR REPLACE` patterns. 
- Added `reports/schema-reality-forensics.md` documenting canonical source choice, local connection attempts, and residual risk, and added package scripts `db:reality:audit` and `db:reconcile:preview` to `package.json` for convenience. 

### Testing

- Attempted to run the reality audit with `npx tsx scripts/supabase-schema-reality-audit.ts`; this run failed as expected because no `DATABASE_URL`, `DIRECT_URL`, or `SUPABASE_DB_URL` was available in the local environment (failure reason recorded). 
- Attempted a dry-run with `bash scripts/run-preview-reconciliation.sh dry-run`; this also failed as expected with the same missing-credentials error. 
- Repository migration verification checks ran during pre-commit and flagged filename/wrapper warnings for existing unversioned files (these verification results were observed and the new migration file was renamed to a timestamped name to comply with the repository policy). 

Notes: Live-schema introspection and an actual apply could not be completed in this environment because no live DB credentials were exposed; the workflow is intentionally designed to run the full audit + dry-run (and controlled apply) in the repository's `preview` environment where secrets are provided by CI. The produced artifacts (`reports/*.json`, `reports/*.md`, and the reconciliation SQL) are ready for that run and will supply exact missing-object evidence for any required follow-up patches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b37c6d39048328b3c60346eab45b15)