### PR TITLE
Surface connector durability truth in integration logs and operator runbook

### DIFF
--- a/docs/integrations/connectors-overview.md
+++ b/docs/integrations/connectors-overview.md
@@ -106,6 +106,7 @@ interface ConnectorDriver {
 
 - `sync_runs.persistence_status` expresses durability truth: `durable_atomic`, `durable_non_atomic`, or `failed_partial`.
 - `sync_runs.recovery_required=true` marks partial-write incidents that require operator or automated repair before trustable completion.
+- Dashboard integration logs surface this durability state directly so operators can distinguish atomic success, degraded fallback success, and recovery-required incidents at a glance.
 - Fallback failures emit `sync_recovery_required` evidence in `raw_events` with stage-by-stage completion details.
 - `sync_input_snapshot` stores the connector sync input payload with `schema_version` metadata and row counts.
 - When atomic RPC persistence is unavailable, runtime emits `sync_atomic_fallback` so degraded durability is machine-visible.

--- a/docs/runbook/operator-failure-triage.md
+++ b/docs/runbook/operator-failure-triage.md
@@ -41,3 +41,24 @@ If GitHub/Slack/Stripe/private connectors are unavailable:
 - mark capability as `unavailable` or `unsupported_oss`
 - do not claim automated routing or billing sync is active
 - keep manual triage path explicit in issue notes
+
+## 6) Connector durability and recovery triage
+
+When triaging connector incidents, classify each `sync_runs` record by durability truth before declaring the run healthy.
+
+- `persistence_status=durable_atomic`: all normalized writes completed atomically.
+- `persistence_status=durable_non_atomic`: fallback writes succeeded; inspect `raw_events.event_type=sync_atomic_fallback` for incident evidence.
+- `persistence_status=failed_partial` or `recovery_required=true`: partial write occurred; run is not trustable until recovery completes.
+
+Suggested query (scoped by tenant and connector):
+
+```sql
+select id, status, persistence_status, recovery_required, started_at, finished_at
+from sync_runs
+where tenant_id = :tenant_id
+  and connector_id = :connector_id
+order by started_at desc
+limit 50;
+```
+
+Recovery-required incidents should include corresponding `raw_events.event_type=sync_recovery_required` entries with stage completion metadata. Use these entries to determine whether to replay from source cursor or perform targeted cleanup/re-sync.

--- a/packages/web/src/app/dashboard/integrations/[integrationId]/logs/page.tsx
+++ b/packages/web/src/app/dashboard/integrations/[integrationId]/logs/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Loader2, ArrowLeft, RefreshCw } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import { asExtendedClient } from "@/lib/supabase/types";
+import { getSyncDurabilityPresentation } from "@/lib/integrations/sync-run-persistence";
 
 interface SyncRun {
   id: string;
@@ -18,6 +19,8 @@ interface SyncRun {
   errors_count: number;
   warnings_count: number;
   error_message: string | null;
+  persistence_status: string | null;
+  recovery_required: boolean;
 }
 
 export default function IntegrationLogsPage() {
@@ -36,16 +39,18 @@ export default function IntegrationLogsPage() {
     try {
       setIsLoading(true);
       const supabase = createClient();
-      
-      const { data: { user } } = await supabase.auth.getUser();
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) return;
 
       const typedSupabase = asExtendedClient(supabase);
       const { data: memberships } = await typedSupabase
-        .from('app_private.memberships')
-        .select('tenant_id')
-        .eq('user_id', user.id)
-        .eq('status', 'active')
+        .from("app_private.memberships")
+        .select("tenant_id")
+        .eq("user_id", user.id)
+        .eq("status", "active")
         .limit(1);
 
       const tenantId = memberships?.[0]?.tenant_id;
@@ -53,49 +58,74 @@ export default function IntegrationLogsPage() {
 
       // Get connector
       const { data: connector } = await typedSupabase
-        .from('connectors')
-        .select('id')
-        .eq('tenant_id', tenantId)
-        .eq('provider_id', integrationId)
+        .from("connectors")
+        .select("id")
+        .eq("tenant_id", tenantId)
+        .eq("provider_id", integrationId)
         .single();
 
       if (!connector) return;
 
-      // Get sync runs - using regular supabase client for sync_runs table
-      // (not in our typed client yet, but this table may not exist)
-      const { data: runs } = await (supabase as unknown as {
-        from(table: 'sync_runs'): {
-          select(columns: string): {
-            eq(column: string, value: unknown): {
-              order(column: string, options: { ascending: boolean }): {
-                limit(count: number): Promise<{ data: SyncRun[] | null; error: unknown }>;
+      const { data: runs } = await (
+        supabase as unknown as {
+          from(table: "sync_runs"): {
+            select(columns: string): {
+              eq(
+                column: string,
+                value: unknown
+              ): {
+                order(
+                  column: string,
+                  options: { ascending: boolean }
+                ): {
+                  limit(count: number): Promise<{ data: SyncRun[] | null; error: unknown }>;
+                };
               };
             };
           };
-        };
-      }).from('sync_runs')
-        .select('*')
-        .eq('connector_id', connector.id)
-        .order('started_at', { ascending: false })
+        }
+      )
+        .from("sync_runs")
+        .select("*")
+        .eq("connector_id", connector.id)
+        .order("started_at", { ascending: false })
         .limit(50);
 
       setSyncRuns((runs || []) as SyncRun[]);
     } catch (error) {
-      console.error('Failed to fetch sync runs:', error);
+      console.error("Failed to fetch sync runs:", error);
     } finally {
       setIsLoading(false);
     }
   };
 
+  const getDurabilityBadge = (run: SyncRun) => {
+    const durability = getSyncDurabilityPresentation(run.persistence_status, run.recovery_required);
+
+    if (durability.tone === "success") {
+      return <Badge className="bg-emerald-600">{durability.label}</Badge>;
+    }
+
+    if (durability.tone === "warning") {
+      return <Badge className="bg-amber-500 text-black">{durability.label}</Badge>;
+    }
+
+    if (durability.tone === "danger") {
+      return <Badge variant="destructive">{durability.label}</Badge>;
+    }
+
+    return <Badge variant="outline">{durability.label}</Badge>;
+  };
+
   const getStatusBadge = (status: string) => {
     switch (status) {
-      case 'completed':
+      case "completed":
         return <Badge className="bg-green-500">Completed</Badge>;
-      case 'failed':
+      case "failed":
         return <Badge variant="destructive">Failed</Badge>;
-      case 'running':
+      case "running":
         return <Badge className="bg-blue-500">Running</Badge>;
-      case 'pending':
+      case "pending":
         return <Badge variant="outline">Pending</Badge>;
       default:
         return <Badge variant="secondary">{status}</Badge>;
@@ -121,9 +151,7 @@ export default function IntegrationLogsPage() {
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
             Sync Logs - {integrationId}
           </h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-1">
-            View sync history and errors
-          </p>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">View sync history and errors</p>
         </div>
         <Button onClick={fetchSyncRuns} variant="outline" className="ml-auto">
           <RefreshCw className="mr-2 h-4 w-4" />
@@ -144,39 +172,47 @@ export default function IntegrationLogsPage() {
               </p>
             ) : (
               syncRuns.map((run) => (
-                <div
-                  key={run.id}
-                  className="border rounded-lg p-4 space-y-2"
-                >
+                <div key={run.id} className="border rounded-lg p-4 space-y-2">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       {getStatusBadge(run.status)}
+                      {getDurabilityBadge(run)}
                       <span className="text-sm text-gray-600 dark:text-gray-400">
                         {new Date(run.started_at).toLocaleString()}
                       </span>
                     </div>
                     {run.finished_at && (
                       <span className="text-xs text-gray-500">
-                        Duration: {Math.round(
-                          (new Date(run.finished_at).getTime() - new Date(run.started_at).getTime()) / 1000
-                        )}s
+                        Duration:{" "}
+                        {Math.round(
+                          (new Date(run.finished_at).getTime() -
+                            new Date(run.started_at).getTime()) /
+                            1000
+                        )}
+                        s
                       </span>
                     )}
                   </div>
                   <div className="grid grid-cols-3 gap-4 text-sm">
                     <div>
-                      <span className="text-gray-600 dark:text-gray-400">Transactions:</span>{' '}
+                      <span className="text-gray-600 dark:text-gray-400">Transactions:</span>{" "}
                       <span className="font-medium">{run.transactions_synced || 0}</span>
                     </div>
                     <div>
-                      <span className="text-gray-600 dark:text-gray-400">Errors:</span>{' '}
+                      <span className="text-gray-600 dark:text-gray-400">Errors:</span>{" "}
                       <span className="font-medium text-red-600">{run.errors_count || 0}</span>
                     </div>
                     <div>
-                      <span className="text-gray-600 dark:text-gray-400">Warnings:</span>{' '}
+                      <span className="text-gray-600 dark:text-gray-400">Warnings:</span>{" "}
                       <span className="font-medium text-yellow-600">{run.warnings_count || 0}</span>
                     </div>
                   </div>
+                  <p className="text-xs text-gray-600 dark:text-gray-400">
+                    {
+                      getSyncDurabilityPresentation(run.persistence_status, run.recovery_required)
+                        .description
+                    }
+                  </p>
                   {run.error_message && (
                     <div className="mt-2 p-2 bg-red-50 dark:bg-red-900/20 rounded text-sm text-red-800 dark:text-red-200">
                       {run.error_message}

--- a/packages/web/src/lib/integrations/__tests__/sync-run-persistence.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/sync-run-persistence.test.ts
@@ -1,0 +1,36 @@
+import { getSyncDurabilityPresentation } from "@/lib/integrations/sync-run-persistence";
+
+describe("getSyncDurabilityPresentation", () => {
+  it("returns recovery-required when explicit recovery flag is true", () => {
+    expect(getSyncDurabilityPresentation("durable_atomic", true)).toEqual({
+      label: "Recovery required",
+      tone: "danger",
+      description:
+        "Partial write detected. Review sync_recovery_required evidence before trusting this run.",
+    });
+  });
+
+  it("returns atomic durable when status is durable_atomic", () => {
+    expect(getSyncDurabilityPresentation("durable_atomic", false)).toEqual({
+      label: "Atomic durable",
+      tone: "success",
+      description: "Persistence completed atomically.",
+    });
+  });
+
+  it("returns degraded durable when status is durable_non_atomic", () => {
+    expect(getSyncDurabilityPresentation("durable_non_atomic", false)).toEqual({
+      label: "Degraded durable",
+      tone: "warning",
+      description: "Write completed through fallback path. Verify sync_atomic_fallback evidence.",
+    });
+  });
+
+  it("returns unknown for legacy runs without durability metadata", () => {
+    expect(getSyncDurabilityPresentation(null, false)).toEqual({
+      label: "Durability unknown",
+      tone: "neutral",
+      description: "Run predated durability truth fields or status was not captured.",
+    });
+  });
+});

--- a/packages/web/src/lib/integrations/sync-run-persistence.ts
+++ b/packages/web/src/lib/integrations/sync-run-persistence.ts
@@ -1,0 +1,43 @@
+export type SyncRunPersistenceStatus = "durable_atomic" | "durable_non_atomic" | "failed_partial";
+
+export type SyncDurabilityPresentation = {
+  label: string;
+  tone: "success" | "warning" | "danger" | "neutral";
+  description: string;
+};
+
+export function getSyncDurabilityPresentation(
+  persistenceStatus: string | null | undefined,
+  recoveryRequired: boolean | null | undefined
+): SyncDurabilityPresentation {
+  if (recoveryRequired === true || persistenceStatus === "failed_partial") {
+    return {
+      label: "Recovery required",
+      tone: "danger",
+      description:
+        "Partial write detected. Review sync_recovery_required evidence before trusting this run.",
+    };
+  }
+
+  if (persistenceStatus === "durable_atomic") {
+    return {
+      label: "Atomic durable",
+      tone: "success",
+      description: "Persistence completed atomically.",
+    };
+  }
+
+  if (persistenceStatus === "durable_non_atomic") {
+    return {
+      label: "Degraded durable",
+      tone: "warning",
+      description: "Write completed through fallback path. Verify sync_atomic_fallback evidence.",
+    };
+  }
+
+  return {
+    label: "Durability unknown",
+    tone: "neutral",
+    description: "Run predated durability truth fields or status was not captured.",
+  };
+}


### PR DESCRIPTION
### Motivation
- Operators lacked visibility into persistence truth for connector syncs, so a run could appear "completed" without showing whether writes were atomic, degraded, or partial requiring recovery.
- The platform schema and runtime already emit `persistence_status` and `recovery_required`; this change aligns UI and runbook with that machine-readable truth to reduce operator risk and improve triage.

### Description
- Added a shared mapping helper `getSyncDurabilityPresentation` at `packages/web/src/lib/integrations/sync-run-persistence.ts` that maps `persistence_status` + `recovery_required` to a stable label, tone, and guidance string for UI and operator surfaces.
- Updated the integration logs view at `packages/web/src/app/dashboard/integrations/[integrationId]/logs/page.tsx` to fetch and render durability badges and per-run explanatory copy alongside run status and timestamps.
- Added unit tests at `packages/web/src/lib/integrations/__tests__/sync-run-persistence.test.ts` to lock in mapping behavior and recovery precedence.
- Updated docs: `docs/integrations/connectors-overview.md` to note that the dashboard surfaces durability truth, and `docs/runbook/operator-failure-triage.md` to add a connector durability triage section with a suggested SQL query for affected runs.

### Testing
- Ran the focused unit test suite with `pnpm --filter @settler/web exec jest src/lib/integrations/__tests__/sync-run-persistence.test.ts --runInBand` and all tests passed.
- Ran lint for touched files with `pnpm --filter @settler/web exec eslint` on the new and updated files; linter completed with no blocking errors for the changed scope.
- Ran type checking with `pnpm --filter @settler/web run typecheck` and the package typecheck completed without errors for the touched package.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b41e679dd0832882180a13331e7a91)