### PR TITLE
docs: record final env-seeded launch evidence pass

### DIFF
--- a/docs/launch-evidence/final-env-seeded-pass.md
+++ b/docs/launch-evidence/final-env-seeded-pass.md
@@ -1,0 +1,61 @@
+# Final Env-Seeded Launch Evidence Pass
+
+## Scope
+
+- Repository: `/workspace/Settler`
+- Branch: current working branch
+- Mode: `FINAL ENV-SEEDED LAUNCH EVIDENCE PASS / NO THEATRE`
+
+## Phase 0 — Precheck
+
+- Node.js version: `v22.21.1`
+- pnpm version: `10.13.1`
+- Workspace was already dirty before this pass (`pnpm-lock.yaml` modified, `packages/sdk-go/go.sum` untracked).
+
+## Required launch environment verification
+
+The canonical setup verifier was executed first (`pnpm run verify:setup`). It failed immediately on missing required launch env.
+
+Missing required keys reported by the verifier:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- database DSN not present in any accepted key:
+  - `DATABASE_URL` or
+  - `SUPABASE_DATABASE_URL` or
+  - `DIRECT_URL`
+
+Non-blocking warnings reported:
+
+- Billing not enabled (Stripe env not set)
+- Enterprise integrations not enabled
+- Kernel not enabled (TS fallback path)
+
+## Canonical spine execution status
+
+Because required launch env was missing at step 1, the spine cannot be truthfully completed in launch-like conditions.
+
+1. `pnpm run verify:setup` → **FAIL** (missing required launch env)
+2. `pnpm run settler:doctor -- --first-run` → **NOT RUN** (gated by step 1 failure)
+3. `pnpm run repo-integrity` → **NOT RUN**
+4. `pnpm lint` → **NOT RUN**
+5. `pnpm typecheck` → **NOT RUN**
+6. `pnpm build` → **NOT RUN**
+7. `pnpm test` → **NOT RUN**
+8. `pnpm run check:production` → **NOT RUN**
+
+## Truthful launch verdict
+
+`A+ READY FOR GO-LIVE` cannot be claimed yet because launch-critical environment variables are missing and the launch-readiness spine could not be executed in an env-seeded context.
+
+Current truthful verdict after this evidence pass:
+
+- **B NOT YET READY DUE TO SPECIFIC BLOCKERS**
+
+Minimum actions to unblock A+ evidence pass:
+
+1. Provide the required Supabase browser and server env keys listed above.
+2. Provide a valid DB DSN in one accepted variable (`DATABASE_URL`, `SUPABASE_DATABASE_URL`, or `DIRECT_URL`).
+3. Re-run the full canonical spine and require all launch-critical commands to pass.


### PR DESCRIPTION
### Motivation
- Provide an auditable, deterministic record of the final env-seeded launch-readiness verification pass and its blockers so operators have clear, reproducible evidence of why the canonical spine could not be completed.

### Description
- Add `docs/launch-evidence/final-env-seeded-pass.md` which documents the precheck, missing required env keys, canonical spine execution status, and the truthful launch verdict; no code-path or behavioral changes were made.

### Testing
- Executed `pnpm run verify:setup` which failed due to missing required env (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and no DB DSN in `DATABASE_URL`/`SUPABASE_DATABASE_URL`/`DIRECT_URL`), and commit-time checks including `verify:conflict-markers` and `lint-staged` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4408dd2c08328a6fbeb90094910b8)