### PR TITLE
Harden env resolution visibility for local setup verification

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -25,8 +25,17 @@ Use these minimum variables before running migrations or API/server workflows:
 
 Recommended local placement:
 
-- `packages/web/.env.local` for local development secrets (gitignored)
-- root `.env` only when a shared workspace script explicitly requires it
+- root `.env.local` for canonical values used by root verification and stack scripts
+- `packages/web/.env.local` and `packages/api/.env.local` only for package-specific overrides
+
+For Doppler-managed local development, launch commands through Doppler so secrets are injected into the process:
+
+```bash
+doppler run -- pnpm run verify:setup
+doppler run -- pnpm run doctor -- --skip-pipeline --first-run
+```
+
+Vercel dashboard env does not populate local shell processes.
 
 ## Environment entrypoint
 

--- a/docs/getting-started/env-files.md
+++ b/docs/getting-started/env-files.md
@@ -4,9 +4,19 @@ This project uses a small set of env-file locations with different trust boundar
 
 ## Canonical local development files
 
-- Root `.env.local`: shared values needed by root-level scripts.
-- `packages/web/.env.local`: web-only local secrets and client-exposed keys.
-- `packages/api/.env.local` (if used): API-only local runtime values.
+- Root `.env.local`: canonical source for root scripts (`pnpm run verify:setup`, `pnpm run doctor`, `pnpm run dev:stack`).
+- `packages/web/.env.local`: optional package-local overrides for web runtime.
+- `packages/api/.env.local`: optional package-local overrides for API runtime.
+
+Load order for root verification scripts is:
+
+1. `.env`
+2. `.env.local`
+3. `.env.production`
+4. `packages/web/.env.local`
+5. `packages/api/.env.local`
+
+Earlier files win (`override: false`), so keep canonical values in root `.env.local` to avoid ambiguity.
 
 ## Source templates
 
@@ -30,12 +40,31 @@ cp .env.local.example .env.local
 - Treat `SUPABASE_SERVICE_ROLE_KEY` as privileged and server-only.
 - Prefer least-privilege API keys for connectors and integrations.
 
+## Doppler and local shell truth
+
+Vercel dashboard env is **not** visible to local commands by default.
+Doppler secrets are visible only when a command is launched through Doppler.
+
+Canonical Doppler run pattern:
+
+```bash
+doppler run -- pnpm run verify:setup
+doppler run -- pnpm run doctor -- --skip-pipeline --first-run
+```
+
+If you prefer file-based local execution, materialize `.env.local` first (example):
+
+```bash
+doppler secrets download --no-file --format env > .env.local
+```
+
 ## Verification
 
 Use:
 
 ```bash
-pnpm doctor -- --skip-pipeline --first-run
+pnpm run verify:setup
+pnpm run doctor -- --skip-pipeline --first-run
 ```
 
-This surfaces missing variables and common setup drift before running demos or migrations.
+These commands surface missing variables, show which env files were loaded, and provide remediation guidance before demos or migrations.

--- a/docs/setup/env-matrix.md
+++ b/docs/setup/env-matrix.md
@@ -85,6 +85,13 @@ This matrix is the single source of truth for runtime environment variables and 
 | `PRODUCTION_URL`        | Post-deploy verification      | Deployment           | Target URL for smoke checks                   | Optional unless post-deploy checks enabled  | internal       |
 | `GITHUB_TOKEN`          | Release automation            | CI automation        | GitHub token for release automation tasks     | Required in GitHub Actions contexts         | secret         |
 
+## Local vs CI vs Vercel env resolution
+
+- **Local root scripts** (`verify:setup`, `doctor`, `dev:stack`) read process env plus local files (`.env`, `.env.local`, `.env.production`, `packages/web/.env.local`, `packages/api/.env.local`).
+- **Doppler** values are only visible when commands are executed through Doppler (`doppler run -- <command>`) or exported into `.env.local`.
+- **Vercel dashboard env** is available only to Vercel build/runtime processes, not your local shell.
+- **GitHub Actions** receives env only through workflow `env:` entries and `secrets.*` mappings.
+
 ## Operator verification commands
 
 Use these commands after populating required env keys:
@@ -93,3 +100,8 @@ Use these commands after populating required env keys:
 - `pnpm run doctor -- --first-run`
 - `pnpm run settler:doctor -- --first-run` (alias of `doctor`)
 - `pnpm run kernel:health`
+
+For Doppler-managed local runs:
+
+- `doppler run -- pnpm run verify:setup`
+- `doppler run -- pnpm run doctor -- --first-run`

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -23,12 +23,29 @@ function addCheck(subsystem, status, message, remediation = "None") {
 }
 
 function loadEnv() {
-  [".env", ".env.local", ".env.production"].forEach((file) => {
+  const loaded = [];
+  [
+    ".env",
+    ".env.local",
+    ".env.production",
+    path.join("packages", "web", ".env.local"),
+    path.join("packages", "api", ".env.local"),
+  ].forEach((file) => {
     const filePath = path.join(rootDir, file);
     if (fs.existsSync(filePath)) {
       dotenv.config({ path: filePath, override: false });
+      loaded.push(file);
     }
   });
+
+  addCheck(
+    "env.sources",
+    loaded.length > 0 ? "PASS" : "DEGRADED",
+    loaded.length > 0
+      ? `Loaded env files: ${loaded.join(", ")}`
+      : "No local env files found; only shell-exported variables are available",
+    "Create .env.local from .env.local.example or run commands with doppler run -- <command>."
+  );
 }
 
 function hasEnv(key) {
@@ -73,7 +90,7 @@ function checkLocalEnvBootstrap() {
       "env.bootstrap",
       "DEGRADED",
       ".env.local not found; first-run env bootstrap has not been completed",
-      "Run: cp .env.local.example .env.local, then update Supabase + database values."
+      "Run: cp .env.local.example .env.local (root) or use doppler run -- <command> to inject secrets."
     );
   }
 }
@@ -91,7 +108,7 @@ function checkEnvPresence() {
       `env.${name}`,
       hasEnv(name) ? "PASS" : "FAIL",
       hasEnv(name) ? `${name} is configured` : `${name} is missing`,
-      `Set ${name} in environment or .env.local (tip: cp .env.local.example .env.local).`
+      `Set ${name} in shell/.env.local (root or package) or run via doppler run -- <command>.`
     );
   }
 

--- a/scripts/verify-setup.ts
+++ b/scripts/verify-setup.ts
@@ -14,13 +14,25 @@ type Finding = {
   action?: string;
 };
 
-function loadEnvFiles(): void {
-  for (const file of [".env", ".env.local", ".env.production"]) {
+function loadEnvFiles(): string[] {
+  const loaded: string[] = [];
+  const candidates = [
+    ".env",
+    ".env.local",
+    ".env.production",
+    path.join("packages", "web", ".env.local"),
+    path.join("packages", "api", ".env.local"),
+  ];
+
+  for (const file of candidates) {
     const full = path.join(process.cwd(), file);
     if (fs.existsSync(full)) {
       dotenv.config({ path: full, override: false });
+      loaded.push(file);
     }
   }
+
+  return loaded;
 }
 
 function isEnabled(value: string | undefined): boolean {
@@ -313,7 +325,7 @@ function validateEnterprise(findings: Finding[]): void {
   }
 }
 
-function printFindings(findings: Finding[]): void {
+function printFindings(findings: Finding[], loadedEnvFiles: string[]): void {
   const grouped = new Map<string, Finding[]>();
   for (const finding of findings) {
     if (!grouped.has(finding.area)) grouped.set(finding.area, []);
@@ -321,8 +333,10 @@ function printFindings(findings: Finding[]): void {
   }
 
   console.log("🩺 Settler setup verification");
+  const loadedSummary = loadedEnvFiles.length > 0 ? loadedEnvFiles.join(", ") : "none";
+  console.log(`Loaded env files: ${loadedSummary}`);
   console.log(
-    "Tip: for first-run local bootstrap, copy .env.local.example to .env.local and replace placeholder values."
+    "Tip: local runs only see env exported in this shell, loaded from local .env files, or injected by doppler run."
   );
   for (const [area, items] of grouped.entries()) {
     console.log(`\n[${area}]`);
@@ -337,14 +351,14 @@ function printFindings(findings: Finding[]): void {
 }
 
 async function main(): Promise<void> {
-  loadEnvFiles();
+  const loadedEnvFiles = loadEnvFiles();
 
   const findings: Finding[] = [];
   validateCore(findings);
   validateBilling(findings);
   validateEnterprise(findings);
   await validateKernel(findings);
-  printFindings(findings);
+  printFindings(findings, loadedEnvFiles);
 
   const hasErrors = findings.some((finding) => finding.severity === "error");
   if (hasErrors) {


### PR DESCRIPTION
### Motivation
- Local verification scripts (`verify:setup`, `doctor`) were reporting missing Supabase/DB env even when secrets existed in Doppler/Vercel because the scripts only read process env and a limited set of local files, creating operator confusion. 
- Make the verification truth explicit so operators can see exactly what the running process consumed and provide actionable remediation (Doppler vs file materialization vs Vercel). 

### Description
- Extended verification env loading to read a deterministic local chain: `.env`, `.env.local`, `.env.production`, `packages/web/.env.local`, and `packages/api/.env.local`, and return a list of which files were loaded. (changed `scripts/verify-setup.ts` and `scripts/doctor.mjs`).
- Surface loaded env-file information and tighten remediation text to explicitly call out Doppler injection (`doppler run -- <command>`) and the canonical `cp .env.local.example .env.local` bootstrap path. (changed `scripts/verify-setup.ts` and `scripts/doctor.mjs`).
- Clarified documentation for local vs Doppler vs Vercel env resolution, canonical local load order, and recommended local run patterns (including Doppler materialization). (changed `docs/getting-started/env-files.md`, `docs/getting-started/README.md`, and `docs/setup/env-matrix.md`).
- No runtime env key renames or secret propagation magic were introduced; this is a diagnostics/docs/hardening change only. (files modified: `scripts/verify-setup.ts`, `scripts/doctor.mjs`, `docs/getting-started/env-files.md`, `docs/getting-started/README.md`, `docs/setup/env-matrix.md`).

### Testing
- Ran `pnpm run verify:setup` with no local env files and observed expected failure and the new output line showing `Loaded env files: none` (negative path: failure, expected). 
- Ran `NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=... SUPABASE_URL=... SUPABASE_ANON_KEY=... DATABASE_URL=... pnpm run verify:setup` and observed verification pass with no critical blockers (positive path: passed).
- Ran `pnpm run doctor -- --skip-pipeline --first-run` to validate env-source diagnostics and remediation text; it correctly reports loaded env files (DEGRADED when no `.env.local` and OK/DEGRADED when values injected). (behavior: diagnostics shown as expected).
- Executed `pnpm run lint` which completed successfully with warnings only, and executed the workspace `pnpm run typecheck` which completed (long-running workspace typecheck) without fatal errors in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44726b17c83289cf3992987cc1403)