### PR TITLE
web: align Settler brand surfaces and truthful navigation polish

### DIFF
--- a/packages/web/public/manifest.json
+++ b/packages/web/public/manifest.json
@@ -1,11 +1,11 @@
 {
-  "name": "Settler - Financial Infrastructure",
+  "name": "Settler.dev \u2014 Deterministic Reconciliation",
   "short_name": "Settler",
-  "description": "The API Infrastructure for Financial Evidence, Deterministic Computation, and Developer Flags.",
+  "description": "Settler is a deterministic reconciliation system for auditable run evidence, policy-aware controls, and operator diagnostics.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#2563eb",
+  "background_color": "#061a2f",
+  "theme_color": "#0b6b7a",
   "orientation": "portrait-primary",
   "icons": [
     {

--- a/packages/web/src/app/app/page.tsx
+++ b/packages/web/src/app/app/page.tsx
@@ -79,14 +79,14 @@ const quickLinks = [
 export default function AppPage() {
   return (
     <div className="space-y-8">
-      <section className="rounded-xl border border-slate-200 bg-white p-6">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+      <section className="rounded-xl border border-border bg-card p-6">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           Settler Control Plane
         </p>
-        <h1 className="mt-2 text-3xl font-semibold text-slate-900">
+        <h1 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
           Deterministic Reconciliation Infrastructure
         </h1>
-        <p className="mt-3 max-w-3xl text-sm text-slate-600">
+        <p className="mt-3 max-w-3xl text-sm text-muted-foreground">
           This workspace is organized for operator-grade execution: deterministic replay, evidence
           lineage, policy-aware simulation, and live triage surfaces. Use the workflows below to
           move from incident detection to replayable root-cause analysis.
@@ -94,18 +94,15 @@ export default function AppPage() {
       </section>
 
       <section>
-        <h2 className="text-xl font-semibold text-slate-900">Differentiated operator workflows</h2>
+        <h2 className="text-xl font-semibold text-foreground">Differentiated operator workflows</h2>
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           {workflows.map((workflow) => (
-            <article
-              key={workflow.name}
-              className="rounded-xl border border-slate-200 bg-white p-5"
-            >
-              <h3 className="text-lg font-semibold text-slate-900">{workflow.name}</h3>
-              <p className="mt-2 text-sm text-slate-600">{workflow.description}</p>
+            <article key={workflow.name} className="rounded-xl border border-border bg-card p-5">
+              <h3 className="text-lg font-semibold text-foreground">{workflow.name}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">{workflow.description}</p>
               <Link
                 href={workflow.href}
-                className="mt-4 inline-flex text-sm font-medium text-blue-600"
+                className="mt-4 inline-flex text-sm font-medium text-primary"
               >
                 {workflow.cta} →
               </Link>
@@ -115,16 +112,16 @@ export default function AppPage() {
       </section>
 
       <section>
-        <h2 className="text-xl font-semibold text-slate-900">Trust and control surfaces</h2>
+        <h2 className="text-xl font-semibold text-foreground">Trust and control surfaces</h2>
         <div className="mt-4 grid gap-3 md:grid-cols-2">
           {quickLinks.map((link) => (
             <Link
               key={link.href}
               href={link.href}
-              className="rounded-lg border border-slate-200 bg-white p-4 transition hover:border-slate-300"
+              className="rounded-lg border border-border bg-card p-4 transition hover:border-primary/50"
             >
-              <p className="font-medium text-slate-900">{link.label}</p>
-              <p className="mt-1 text-sm text-slate-600">{link.detail}</p>
+              <p className="font-medium text-foreground">{link.label}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{link.detail}</p>
             </Link>
           ))}
         </div>

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -17,7 +17,7 @@ import { GlobalClientShell } from "@/components/GlobalClientShell";
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || "https://settler.dev"),
   title: {
-    default: "Settler - Open Source Reconciliation Engine",
+    default: "Settler.dev — Deterministic Reconciliation",
     template: "%s | Settler",
   },
   description:
@@ -77,8 +77,8 @@ export const metadata: Metadata = {
     type: "website",
     locale: "en_US",
     url: "https://settler.dev",
-    siteName: "Settler",
-    title: "Settler - Open Source Reconciliation Engine",
+    siteName: "Settler.dev",
+    title: "Settler.dev — Deterministic Reconciliation",
     description:
       "Settler is an open source reconciliation engine that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
     images: [
@@ -92,7 +92,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Settler - Open Source Reconciliation Engine",
+    title: "Settler.dev — Deterministic Reconciliation",
     description:
       "Settler is an open source reconciliation engine that runs deterministic workflows, explains mismatches, and exports verifiable evidence.",
     images: [getImageUrl("twitterCard")],
@@ -121,7 +121,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 5,
   userScalable: true,
-  themeColor: "#2563eb",
+  themeColor: "#0b6b7a",
   viewportFit: "cover",
 };
 

--- a/packages/web/src/components/Footer.tsx
+++ b/packages/web/src/components/Footer.tsx
@@ -6,7 +6,7 @@ const footerSections = [
   {
     heading: "Product",
     links: [
-      { href: "/platform", label: "Platform" },
+      { href: "/platform", label: "Product Surface" },
       { href: "/capabilities", label: "Capabilities" },
       { href: "/product", label: "Product" },
       { href: "/architecture", label: "Architecture" },
@@ -31,8 +31,8 @@ const footerSections = [
       { href: "/open-source", label: "Open Source" },
       { href: "/enterprise", label: "Enterprise" },
       { href: "https://github.com/Hardonian/Settler", label: "GitHub", external: true },
-      { href: "/terms", label: "Terms" },
-      { href: "/privacy", label: "Privacy" },
+      { href: "/legal/terms", label: "Terms" },
+      { href: "/legal/privacy", label: "Privacy" },
     ],
   },
 ] as const;
@@ -50,8 +50,8 @@ export function Footer() {
               <SettlerLogo variant="horizontal" className="h-10 w-auto" priority />
             </UiLink>
             <p className="text-sm text-muted-foreground">
-              Open-source reconciliation engine for deterministic, inspectable financial data
-              matching.
+              Settler is a deterministic reconciliation system with auditable evidence, operational
+              diagnostics, and policy-aware controls.
             </p>
           </div>
 

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -32,9 +32,9 @@ const featureNavigationItems = [
 
 // Secondary navigation items (in "More" dropdown on desktop, accordion on mobile)
 const secondaryNavigationItems = [
+  { href: "/support", label: "Support" },
   { href: "/faq", label: "FAQ" },
   { href: "/contact", label: "Contact" },
-  { href: "/changelog", label: "Changelog" },
   { href: "/privacy", label: "Privacy" },
   { href: "/terms", label: "Terms" },
 ];
@@ -146,23 +146,12 @@ export function Navigation() {
               href="/"
               className={cn(
                 "flex items-center flex-shrink-0",
-                "transition-transform hover:scale-105",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                "rounded relative group"
+                "rounded"
               )}
               aria-label="Settler homepage"
             >
-              <div className="relative overflow-hidden rounded">
-                <SettlerLogo
-                  variant="stacked"
-                  className="h-10 w-auto relative z-10 transition-all duration-300 group-hover:brightness-110 group-hover:drop-shadow-lg"
-                  priority
-                />
-                {/* Shine effect overlay */}
-                <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none">
-                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent -skew-x-12 animate-shine" />
-                </div>
-              </div>
+              <SettlerLogo variant="horizontal" className="h-8 w-auto" priority alt="Settler" />
             </Link>
 
             {/* Desktop Navigation */}
@@ -325,7 +314,7 @@ export function Navigation() {
                   href="/login"
                   className="text-sm text-muted-foreground hover:text-primary-600 dark:hover:text-primary-400"
                 >
-                  Login
+                  Sign in
                 </Link>
                 <Button asChild variant="default" size="default" className="whitespace-nowrap">
                   <Link href="/signup" aria-label="Get started with Settler">
@@ -365,7 +354,7 @@ export function Navigation() {
                   href="/login"
                   className="text-sm text-muted-foreground hover:text-primary-600 dark:hover:text-primary-400"
                 >
-                  Login
+                  Sign in
                 </Link>
                 <Button asChild variant="default" size="sm" className="whitespace-nowrap">
                   <Link href="/signup">Get Started</Link>

--- a/packages/web/src/components/brand/SettlerLogo.tsx
+++ b/packages/web/src/components/brand/SettlerLogo.tsx
@@ -25,10 +25,10 @@ const LOGO_CONFIG = {
     height: 32,
   },
   wordmark: {
-    light: "/brand/settler/logo-horizontal.svg",
-    dark: "/brand/settler/logo-horizontal.svg",
-    width: 520,
-    height: 160,
+    light: "/brand/settler/logo-wordmark.svg",
+    dark: "/brand/settler/logo-wordmark.svg",
+    width: 152,
+    height: 32,
   },
   stacked: {
     light: "/brand/settler/logo-stacked.svg",


### PR DESCRIPTION
### Motivation
- Remove brand drift and inconsistent logo treatments in the header/footer and make the app shell feel cohesive and truthful to Settler’s identity. 
- Replace one-off visual styling in the control-plane landing with token-driven classes for consistent dark/light behavior. 
- Fix small IA and copy issues that created noisy or non-canonical navigation/legal targets.

### Description
- Canonicalized logo handling by updating the `wordmark` mapping and dimensions in `src/components/brand/SettlerLogo.tsx` and using the horizontal variant in the global header (`src/components/Navigation.tsx`).
- Removed decorative header shine/overlays and simplified the header markup, normalized auth wording to `Sign in`, and cleaned the secondary nav (added `/support`, removed duplicate links) in `src/components/Navigation.tsx`.
- Updated footer IA and legal links to canonical paths and tightened the product copy in `src/components/Footer.tsx`.
- Tokenized and aligned the `/app` control-plane landing visuals to design tokens by switching ad-hoc slate/blue classes to `border-border`, `bg-card`, `text-foreground`, and related classes in `src/app/app/page.tsx`.
- Aligned metadata and PWA manifest identity and theme palette to the Settler.dev trust tone in `src/app/layout.tsx` and `public/manifest.json`.

### Testing
- Ran `pnpm --filter @settler/web lint` and it completed successfully. ✅
- Ran `pnpm --filter @settler/web typecheck` (`tsc --noEmit`) and it completed successfully. ✅
- Attempted `pnpm --filter @settler/web build`, which failed due to missing build-time environment variables (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and a database URL) in this environment. ⚠️
- Executed the route verification script `pnpm exec tsx scripts/verify-routes.ts`, which reported missing pages (the script appears to expect a different route layout and produced false negatives in this run). ⚠️
- Launched a local dev server with temporary env vars and captured a visual smoke screenshot to validate the header/footer/logo rendering in-context (dev server started and screenshot produced). ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ff92afac8328beafe4304ce8fc92)