### PR TITLE
web: harden route verification and dedupe sitemap entries

### DIFF
--- a/packages/web/scripts/verify-routes.ts
+++ b/packages/web/scripts/verify-routes.ts
@@ -18,29 +18,32 @@ interface RouteInfo {
 }
 
 const ROUTES_TO_VERIFY = [
-  // Marketing
+  // Public marketing/docs/help routes that must remain reachable.
   "/",
+  "/platform",
+  "/capabilities",
+  "/product",
   "/pricing",
   "/enterprise",
-  "/how-it-works",
-  "/why-settler",
-  "/vision",
-  "/security",
+  "/open-source",
+  "/architecture",
+  "/security-and-audit",
   "/status",
-  "/community",
   "/support",
-  "/cookbooks",
+  "/faq",
+  "/contact",
   "/docs",
   "/docs/quickstart",
   "/docs/sdk",
   "/docs/api",
-  "/docs/cli",
-  "/docs/examples",
+  "/blog",
+  "/changelog",
   "/receipts",
   "/feature-flags",
-  "/console/playground",
+  "/about",
+  "/community",
 
-  // Legal
+  // Legal/public compliance routes
   "/legal",
   "/legal/terms",
   "/legal/privacy",
@@ -48,7 +51,11 @@ const ROUTES_TO_VERIFY = [
   "/legal/subprocessors",
   "/legal/license",
 
-  // Console
+  // Auth/public entry points
+  "/login",
+  "/signup",
+
+  // App shells that should resolve to graceful states (not hard crash)
   "/console",
   "/console/receipts",
   "/console/usage",
@@ -65,7 +72,12 @@ function routeToFilePath(route: string): string[] {
     return ["src/app/page.tsx"];
   }
 
-  const parts = route.split("/").filter(Boolean);
+  const parts = route
+    .split("/")
+    .filter(Boolean)
+    // route groups do not appear in URL segments
+    .map((segment) => (segment.startsWith("(") && segment.endsWith(")") ? "" : segment))
+    .filter(Boolean);
   const filePath = join("src/app", ...parts, "page.tsx");
   const layoutPath = join("src/app", ...parts, "layout.tsx");
 
@@ -106,7 +118,7 @@ function checkRouteExists(route: string, appDir: string): RouteInfo {
 }
 
 async function main() {
-  const appDir = join(process.cwd(), "packages/web");
+  const appDir = process.cwd();
 
   console.log("🔍 Verifying routes...\n");
 

--- a/packages/web/src/lib/seo/sitemap-generator.ts
+++ b/packages/web/src/lib/seo/sitemap-generator.ts
@@ -51,7 +51,10 @@ export function generateSitemap(): MetadataRoute.Sitemap {
     ...getStaticPaths(),
     ...modePaths.map((path) => ({ path, priority: 0.7, changeFrequency: "monthly" as const })),
   ];
-  return entries.map((route) => ({
+
+  const uniqueEntries = Array.from(new Map(entries.map((entry) => [entry.path, entry])).values());
+
+  return uniqueEntries.map((route) => ({
     url: `${baseUrl}${route.path}`,
     lastModified: new Date(),
     changeFrequency: route.changeFrequency,


### PR DESCRIPTION
### Motivation
- The route verifier was producing false negatives and testing stale paths, reducing trust in route-integrity checks and masking regressions. 
- Sitemap generation could emit duplicate URLs when mode-specific paths overlap static entries, risking confusing crawler/canonical signals.

### Description
- Replaced the verifier's route list with the actual public/marketing, legal, auth, and key app-shell routes to reflect the real surfaced pages and graceful app shells (`packages/web/scripts/verify-routes.ts`).
- Fixed verifier resolution to run from the package working dir (`process.cwd()`), and added normalization to ignore route-group-style segments so URL-to-file checks don't false-fail on grouped routes.
- Added deduplication for sitemap entries by path in `packages/web/src/lib/seo/sitemap-generator.ts` using a `Map` to ensure unique URLs are returned to the sitemap generator.
- Small robustness and comment improvements to make the scripts deterministic and trustworthy for CI/local checks.

### Testing
- Ran `pnpm -C packages/web lint` — passed (precommit linted staged files as part of commit hooks).
- Ran `pnpm -C packages/web typecheck` — passed (`tsc --noEmit`).
- Ran `cd packages/web && pnpm tsx scripts/check-public-route-boundary.ts` — passed and reported boundary linter success.
- Ran `cd packages/web && pnpm tsx scripts/verify-routes.ts` — passed and verified all expected routes (40/40).
- Ran `pnpm -C packages/web build` — failed in this environment due to missing required build-time environment variables: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and one of `DATABASE_URL|SUPABASE_DATABASE_URL|DIRECT_URL` (environment blocker, not code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b602e624608328a81c1479685860a2)