### PR TITLE
Harden console diagnostics truth states and add authenticated route evidence map

### DIFF
--- a/docs/ops/authenticated-route-evidence-map.md
+++ b/docs/ops/authenticated-route-evidence-map.md
@@ -1,0 +1,39 @@
+# Authenticated Route Evidence Map (Local Runtime Truth)
+
+Last updated: 2026-03-15
+
+This map documents what can be **proven from repository behavior** in local runtime without inventing production-only signals.
+
+## Auth validation strategy used
+
+- Primary gate for app shell routes: `middleware.ts` + `isAppAuthRequiredRoute` for `/app/**`.
+- Runtime identity checks on console routes: server components call `supabase.auth.getUser()` and handle signed-out state with explicit redirect or route-state UI.
+- Safety model: no dev auth bypass was introduced; no production auth path was weakened.
+
+## Major authenticated surface inventory
+
+| Route group     | Auth required                                                | Tenant context required                                          | Supabase required              | Backend/data required             | Stripe required                     | Current truth state                                                                          |
+| --------------- | ------------------------------------------------------------ | ---------------------------------------------------------------- | ------------------------------ | --------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------- |
+| `/app/**`       | Yes (middleware + layout user check)                         | Optional per page, header renders tenant metadata when available | Yes for real session hydration | Mixed                             | No                                  | Healthy when Supabase/session exists; explicit signed-out and missing-env states are present |
+| `/console/**`   | Mixed (route-level checks, not globally middleware-enforced) | Mixed                                                            | Usually yes                    | Yes for most diagnostics/ops data | Optional for billing-adjacent views | Degraded-but-truthful: per-page auth checks and explicit warnings for missing dependencies   |
+| `/dashboard/**` | Mixed (legacy surfaces)                                      | Mixed                                                            | Mixed                          | Mixed                             | Mixed                               | Thin surface; behavior depends on individual route implementation                            |
+| `/billing/**`   | Yes for meaningful actions                                   | Tenant/account required for real plan state                      | Often                          | Yes                               | Yes                                 | Conditional: should be treated as disabled/degraded when Stripe env is absent                |
+
+## Route-level evidence updated in this pass
+
+### `/console/diagnostics`
+
+- Signed out users are redirected to `/login?next=/console/diagnostics`.
+- Diagnostics now distinguish:
+  - Supabase not configured (configuration warning, not fake “healthy” state)
+  - Supabase query failure (health error)
+  - Database connectivity failure (health error)
+  - Stripe keys missing (configuration warning; billing actions should be treated as disabled)
+  - No webhook/no run history (data warning; not auth failure)
+- Each diagnostic card now includes a **category** (`health`, `configuration`, `integration`, `data`) and explicit detail text to reduce ambiguous “warning mush”.
+
+## Residual conditionality
+
+- Full tenant-membership and RLS-denial UX still depends on seeded auth + tenant fixtures in the local environment.
+- Console routes still rely on per-page auth checks; there is no single middleware hard gate for all `/console/**` paths.
+- Billing truth remains environment-conditional on Stripe keys and webhook pipeline availability.

--- a/package.json
+++ b/package.json
@@ -293,7 +293,9 @@
     "audit:migrations": "node scripts/generate-migration-audit.mjs",
     "requiem:prove": "pnpm exec tsx packages/cli/src/index.ts prove",
     "requiem:verify": "pnpm exec tsx packages/cli/src/index.ts verify proofpacks/latest/proofpack.json",
-    "requiem:replay": "pnpm exec tsx packages/cli/src/index.ts replay"
+    "requiem:replay": "pnpm exec tsx packages/cli/src/index.ts replay",
+    "verify:all": "pnpm run validate:all",
+    "verify:repo": "pnpm run repo-integrity"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/web/src/app/console/diagnostics/page.tsx
+++ b/packages/web/src/app/console/diagnostics/page.tsx
@@ -14,38 +14,65 @@ import { redirect } from "next/navigation";
 interface DiagnosticItem {
   name: string;
   status: "ok" | "warning" | "error";
+  category: "health" | "configuration" | "auth" | "data" | "integration";
   message: string;
+  detail: string;
   value?: string | number;
 }
 
 async function getDiagnostics(): Promise<DiagnosticItem[]> {
   const diagnostics: DiagnosticItem[] = [];
+  const hasSupabaseEnv = Boolean(
+    process.env.SUPABASE_URL ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    process.env.SUPABASE_ANON_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  );
 
   // Check Supabase connection
-  try {
-    const supabase = await createClient();
-    const { error } = await supabase.from("tenants").select("id").limit(1);
-    if (error) {
-      // Log error but don't throw - graceful degradation
+  if (!hasSupabaseEnv) {
+    diagnostics.push({
+      name: "Supabase Connection",
+      status: "warning",
+      category: "configuration",
+      message: "Supabase environment variables are not configured",
+      detail:
+        "Console data backed by Supabase is intentionally unavailable in this runtime until SUPABASE_URL and SUPABASE_ANON_KEY are provided.",
+    });
+  } else {
+    try {
+      const supabase = await createClient();
+      const { error } = await supabase.from("tenants").select("id").limit(1);
+      if (error) {
+        // Log error but don't throw - graceful degradation
+        diagnostics.push({
+          name: "Supabase Connection",
+          status: "error",
+          category: "health",
+          message: error.message || "Connection failed",
+          detail:
+            "Authenticated route hydration and tenant-backed data reads are currently degraded because Supabase rejected the probe query.",
+        });
+        // Continue to next check instead of throwing
+      } else {
+        diagnostics.push({
+          name: "Supabase Connection",
+          status: "ok",
+          category: "health",
+          message: "Connected successfully",
+          detail: "Supabase is reachable for tenant and authenticated console queries.",
+        });
+      }
+    } catch (err) {
       diagnostics.push({
         name: "Supabase Connection",
         status: "error",
-        message: error.message || "Connection failed",
-      });
-      // Continue to next check instead of throwing
-    } else {
-      diagnostics.push({
-        name: "Supabase Connection",
-        status: "ok",
-        message: "Connected successfully",
+        category: "health",
+        message: err instanceof Error ? err.message : "Connection failed",
+        detail:
+          "Runtime could not initialize the Supabase client. Authenticated routes may still render but should be treated as degraded.",
       });
     }
-  } catch (err) {
-    diagnostics.push({
-      name: "Supabase Connection",
-      status: "error",
-      message: err instanceof Error ? err.message : "Connection failed",
-    });
   }
 
   // Check Prisma connection
@@ -54,13 +81,17 @@ async function getDiagnostics(): Promise<DiagnosticItem[]> {
     diagnostics.push({
       name: "Database Connection",
       status: "ok",
+      category: "health",
       message: "Connected successfully",
+      detail: "Prisma can execute queries against the configured primary database.",
     });
   } catch (err) {
     diagnostics.push({
       name: "Database Connection",
       status: "error",
+      category: "health",
       message: err instanceof Error ? err.message : "Connection failed",
+      detail: "Database-backed operator surfaces are unavailable until connectivity is restored.",
     });
   }
 
@@ -71,13 +102,18 @@ async function getDiagnostics(): Promise<DiagnosticItem[]> {
     diagnostics.push({
       name: "Stripe Configuration",
       status: "ok",
+      category: "integration",
       message: "Stripe keys configured",
+      detail: "Checkout and billing portal routes are allowed to call Stripe.",
     });
   } else {
     diagnostics.push({
       name: "Stripe Configuration",
       status: "warning",
+      category: "configuration",
       message: "Stripe keys not configured",
+      detail:
+        "Billing pages can render, but upgrade, checkout, and portal actions should be treated as disabled in this environment.",
     });
   }
 
@@ -91,21 +127,29 @@ async function getDiagnostics(): Promise<DiagnosticItem[]> {
       diagnostics.push({
         name: "Last Stripe Webhook",
         status: lastWebhook.status === "processed" ? "ok" : "warning",
+        category: "integration",
         message: `${lastWebhook.type} - ${lastWebhook.status}`,
+        detail:
+          "This reflects persisted webhook processing state and may lag if background workers are not running.",
         value: lastWebhook.receivedAt.toISOString(),
       });
     } else {
       diagnostics.push({
         name: "Last Stripe Webhook",
         status: "warning",
+        category: "data",
         message: "No webhooks received yet",
+        detail:
+          "No webhook events have been persisted in this environment yet; this is not an auth failure by itself.",
       });
     }
   } catch {
     diagnostics.push({
       name: "Last Stripe Webhook",
       status: "error",
+      category: "integration",
       message: "Failed to query webhooks",
+      detail: "Webhook health could not be verified because the stripe_events query failed.",
     });
   }
 
@@ -120,21 +164,29 @@ async function getDiagnostics(): Promise<DiagnosticItem[]> {
         name: "Last Reconciliation Run",
         status:
           lastRun.status === "completed" ? "ok" : lastRun.status === "failed" ? "error" : "warning",
+        category: "data",
         message: `Status: ${lastRun.status}, Matched: ${lastRun.matchedCount || 0}`,
+        detail:
+          "This value comes from persisted reconciliation runs. Pending status means execution did not fully complete yet.",
         value: lastRun.startedAt.toISOString(),
       });
     } else {
       diagnostics.push({
         name: "Last Reconciliation Run",
         status: "warning",
+        category: "data",
         message: "No reconciliation runs yet",
+        detail:
+          "No run data exists yet for this tenant context. Create a run to validate this pipeline end-to-end.",
       });
     }
   } catch {
     diagnostics.push({
       name: "Last Reconciliation Run",
       status: "error",
+      category: "data",
       message: "Failed to query reconciliation runs",
+      detail: "Reconciliation history could not be read due to a database or authorization error.",
     });
   }
 
@@ -152,13 +204,18 @@ async function getDiagnostics(): Promise<DiagnosticItem[]> {
     diagnostics.push({
       name: "Environment Variables",
       status: "ok",
+      category: "configuration",
       message: "All required env vars present",
+      detail: "Core runtime environment contracts are satisfied for authenticated route execution.",
     });
   } else {
     diagnostics.push({
       name: "Environment Variables",
       status: "warning",
+      category: "configuration",
       message: `Missing: ${missingEnvVars.join(", ")}`,
+      detail:
+        "The console remains reachable, but missing variables will degrade auth/session hydration and dependent API actions.",
     });
   }
 
@@ -173,7 +230,7 @@ export default async function DiagnosticsPage() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/auth/login");
+    redirect("/login?next=/console/diagnostics");
   }
 
   const diagnostics = await getDiagnostics();
@@ -230,10 +287,14 @@ export default async function DiagnosticsPage() {
                 {getStatusIcon(item.status)}
               </div>
               <CardDescription>{item.message}</CardDescription>
+              <p className="text-xs text-muted-foreground">{item.detail}</p>
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between">
                 {getStatusBadge(item.status)}
+                <Badge variant="outline" className="uppercase">
+                  {item.category}
+                </Badge>
                 {item.value && (
                   <span className="text-sm text-slate-500 font-mono">{item.value}</span>
                 )}


### PR DESCRIPTION
### Motivation

- Make the console diagnostics page explicit and truthful about dependency failures so operators can distinguish missing configuration, auth/session degradation, data gaps, and integration health instead of seeing ambiguous "warning" states. 
- Ensure the diagnostics route behaves deterministically for signed-out users and documents what can be proven locally about authenticated surfaces and their residual conditionality. 

### Description

- Updated the console diagnostics page to surface structured diagnostics: added `category` and `detail` fields per diagnostic and rendered category badges and detail copy in each card; added explicit messages for Supabase, DB, Stripe, webhook, reconciliation run, and env contract checks (`packages/web/src/app/console/diagnostics/page.tsx`).
- Added a pre-check for Supabase environment variables so the route reports a clear configuration-warning when public Supabase keys are not present (avoids probing/giving a false healthy impression). 
- Fixed signed-out redirect behavior for the diagnostics route to include a proper return path: `redirect('/login?next=/console/diagnostics')`.
- Added an ops document that inventories the authenticated route surface, the local auth-validation strategy used for proof, and remaining conditionality (`docs/ops/authenticated-route-evidence-map.md`).
- Exposed two verification script aliases at the repo root: `verify:all` and `verify:repo` to align the top-level verification command surface with expected workflows (`package.json`).

### Testing

- Ran `pnpm lint` which completed successfully (repository has existing lint warnings, no new errors introduced). 
- Ran `pnpm typecheck` which completed successfully across packages. 
- Ran `pnpm build` which failed in this environment due to missing required runtime/build env vars (`SUPABASE_*`, `DATABASE_URL`), as expected for local runtime without secrets. 
- Ran `pnpm verify:routes` which exercised the Next.js app startup and route rendering and completed without hard-500s while reporting startup validation warnings for missing env variables. 
- Ran `pnpm run doctor` which failed (expected) because local environment variables and DB/Stripe secrets are not configured. 
- Ran `pnpm run verify:all` which failed due to an existing `validate-nextjs` tsconfig parsing error surfaced by the repo validator (pre-existing issue). 
- Ran `pnpm run verify:repo` which failed due to existing repo-integrity issues referencing missing `src/index.ts` script targets (pre-existing issue). 

Evidence artifacts: Playwright screenshot captured for `/console/diagnostics` in the degraded local runtime (artifact path: `browser:/tmp/codex_browser_invocations/0b87aa3f98b1da55/artifacts/artifacts/console-diagnostics-unauth.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b60ae784b48328bf90ae5a44d5127d)