### PR TITLE
Expand authenticated operational route truth and enforce disclosure in core layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Use `pnpm demo:settler` to run a deterministic end-to-end demo pipeline.
 - Security and privacy: `docs/security/`
 - API and references: `docs/reference/`, `docs/api/`
 - Console route maturity/source of truth: `packages/web/src/lib/console/route-maturity.ts` (validated by `pnpm verify:console-route-maturity`)
+- Authenticated route operational truth/source of truth: `packages/web/src/lib/routes/operational-truth.ts` (validated by `pnpm verify:operational-route-truth`)
 - Governance + inventory artifacts: `docs/_meta/`
 - Historical docs archive: `docs/archive/`
 

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "lint:boundaries": "node scripts/boundary-linter.mjs",
     "verify:claims": "node scripts/validate-site-claims.mjs",
     "verify:boundaries": "node scripts/enforce-site-boundaries.mjs && node scripts/no-stubs-scan.mjs",
-    "verify:routes": "node scripts/verify-routes.mjs && pnpm run verify:console-route-maturity",
+    "verify:routes": "node scripts/verify-routes.mjs && pnpm run verify:console-route-maturity && pnpm run verify:operational-route-truth",
     "verify:oss": "node scripts/run-with-env.mjs --set SITE_MODE=oss --set NEXT_PUBLIC_SITE_MODE=oss --unset ENTERPRISE_SITE_URL --unset NEXT_PUBLIC_ENTERPRISE_SITE_URL --unset STRIPE_SECRET_KEY -- pnpm run verify",
     "verify:enterprise": "node scripts/run-with-env.mjs --set SITE_MODE=enterprise --set NEXT_PUBLIC_SITE_MODE=enterprise -- pnpm verify",
     "verify:links": "pnpm qa:links",
@@ -296,7 +296,8 @@
     "requiem:replay": "pnpm exec tsx packages/cli/src/index.ts replay",
     "verify:all": "pnpm run validate:all",
     "verify:repo": "pnpm run repo-integrity",
-    "verify:console-route-maturity": "pnpm --filter @settler/web exec tsx scripts/verify-console-route-maturity.ts"
+    "verify:console-route-maturity": "pnpm --filter @settler/web exec tsx scripts/verify-console-route-maturity.ts",
+    "verify:operational-route-truth": "pnpm --filter @settler/web exec tsx scripts/verify-operational-route-truth.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/web/scripts/verify-operational-route-truth.ts
+++ b/packages/web/scripts/verify-operational-route-truth.ts
@@ -1,0 +1,122 @@
+import { readdirSync, statSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { OPERATIONAL_ROUTE_REGISTRY } from "../src/lib/routes/operational-truth";
+
+const WEB_APP_ROOT = join(process.cwd(), "src", "app");
+
+const significantRoutePrefixes = [
+  "/console",
+  "/app",
+  "/dashboard",
+  "/admin",
+  "/operator/incidents",
+];
+
+function walkPageRoutes(dir: string, base = ""): string[] {
+  const entries = readdirSync(dir);
+  const routes: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.startsWith("(") || entry.startsWith("_")) continue;
+    const abs = join(dir, entry);
+    const rel = `${base}/${entry}`.replace(/\/+/g, "/");
+    const st = statSync(abs);
+    if (st.isDirectory()) {
+      routes.push(...walkPageRoutes(abs, rel));
+      continue;
+    }
+    if (entry === "page.tsx") {
+      const routePath = base || "/";
+      routes.push(routePath);
+    }
+  }
+
+  return routes;
+}
+
+function validate() {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const seenPrefixes = new Set<string>();
+  for (const entry of OPERATIONAL_ROUTE_REGISTRY) {
+    if (seenPrefixes.has(entry.routePrefix)) {
+      errors.push(`duplicate routePrefix in operational route registry: ${entry.routePrefix}`);
+    }
+    seenPrefixes.add(entry.routePrefix);
+
+    if (entry.maturity === "thin" && entry.operationalClass !== "synthetic") {
+      errors.push(`thin routePrefix must be synthetic operationalClass: ${entry.routePrefix}`);
+    }
+
+    if (entry.roleRestriction === "super-admin" && entry.navTreatment !== "restricted") {
+      errors.push(`super-admin routePrefix must be restricted nav treatment: ${entry.routePrefix}`);
+    }
+
+    if (entry.tenantScopeRequired && entry.scopeSignal !== "tenant") {
+      errors.push(`tenant-scoped routePrefix must use tenant scope signal: ${entry.routePrefix}`);
+    }
+
+    if (entry.dataMode === "synthetic" && !entry.syntheticDataAllowed) {
+      errors.push(`synthetic data mode must explicitly allow synthetic data: ${entry.routePrefix}`);
+    }
+  }
+
+  const allPages = walkPageRoutes(WEB_APP_ROOT);
+  const significantPages = allPages.filter((route) =>
+    significantRoutePrefixes.some((prefix) => route === prefix || route.startsWith(`${prefix}/`))
+  );
+
+  for (const prefix of significantRoutePrefixes) {
+    const hasCoverage = OPERATIONAL_ROUTE_REGISTRY.some(
+      (entry) => prefix === entry.routePrefix || prefix.startsWith(`${entry.routePrefix}/`)
+    );
+    if (!hasCoverage) {
+      errors.push(`missing operational truth registry coverage for significant prefix: ${prefix}`);
+    }
+  }
+
+  for (const route of significantPages) {
+    const covered = OPERATIONAL_ROUTE_REGISTRY.some(
+      (entry) => route === entry.routePrefix || route.startsWith(`${entry.routePrefix}/`)
+    );
+    if (!covered) {
+      warnings.push(`significant route not explicitly covered by registry prefix: ${route}`);
+    }
+  }
+
+  const disclosureHosts = [
+    "src/components/console/ConsoleLayout.tsx",
+    "src/app/app/layout.tsx",
+    "src/app/dashboard/layout.tsx",
+    "src/app/admin/layout.tsx",
+  ];
+  for (const host of disclosureHosts) {
+    const abs = join(process.cwd(), host);
+    if (!existsSync(abs)) {
+      errors.push(`missing disclosure host file: ${host}`);
+      continue;
+    }
+    const content = readFileSync(abs, "utf8");
+    if (!content.includes("OperationalRouteNotice")) {
+      errors.push(`required disclosure primitive missing from layout: ${host}`);
+    }
+  }
+
+  if (warnings.length > 0) {
+    console.warn("⚠️ Operational route truth warnings:");
+    warnings.forEach((warning) => console.warn(`  - ${warning}`));
+  }
+
+  if (errors.length > 0) {
+    console.error("❌ Operational route truth verification failed:");
+    errors.forEach((error) => console.error(`  - ${error}`));
+    process.exit(1);
+  }
+
+  console.log(
+    `✅ Operational route truth verification passed (${OPERATIONAL_ROUTE_REGISTRY.length} registry entries, ${significantPages.length} significant routes scanned)`
+  );
+}
+
+validate();

--- a/packages/web/src/app/admin/layout.tsx
+++ b/packages/web/src/app/admin/layout.tsx
@@ -27,6 +27,7 @@ import { redirect } from "next/navigation";
 import { AdminErrorBoundary } from "@/components/admin/error-boundary";
 import { MobileMenu } from "@/components/admin/mobile-menu";
 import { SkipLinks } from "@/components/admin/accessibility-skip-links";
+import { OperationalRouteNotice } from "@/components/shared/OperationalRouteNotice";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -117,7 +118,10 @@ export default async function AdminLayout({ children }: { children: React.ReactN
         {/* Sidebar - Desktop Only */}
         <aside className="hidden lg:flex w-64 border-r border-border bg-card dark:bg-card flex-col fixed h-full z-10">
           <div className="p-5 border-b border-border">
-            <Link href="/admin" className="flex items-center gap-2.5 font-bold text-lg text-foreground">
+            <Link
+              href="/admin"
+              className="flex items-center gap-2.5 font-bold text-lg text-foreground"
+            >
               <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center text-primary-foreground text-sm font-bold">
                 S
               </div>
@@ -140,6 +144,9 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
         {/* Main Content */}
         <main className="flex-1 lg:ml-64 overflow-auto" role="main" id="main-content">
+          <div className="p-4">
+            <OperationalRouteNotice />
+          </div>
           {children}
         </main>
       </div>

--- a/packages/web/src/app/app/layout.tsx
+++ b/packages/web/src/app/app/layout.tsx
@@ -3,6 +3,7 @@ import { EnvErrorPanel } from "@/components/env/EnvErrorPanel";
 import { getAppEnvStatus } from "@/lib/env/runtime-access";
 import { createClient } from "@/lib/supabase/server";
 import { AppSidebar, MobileNav } from "@/components/app/AppNav";
+import { OperationalRouteNotice } from "@/components/shared/OperationalRouteNotice";
 
 function SignedOutScreen() {
   return (
@@ -43,7 +44,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   if (!user) return <SignedOutScreen />;
 
   const tenantId = user.user_metadata?.tenant_id ?? "—";
-  const envLabel = process.env.NODE_ENV === "production" ? "prod" : process.env.NODE_ENV ?? "dev";
+  const envLabel = process.env.NODE_ENV === "production" ? "prod" : (process.env.NODE_ENV ?? "dev");
 
   return (
     <div className="flex h-screen bg-background">
@@ -53,8 +54,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
           <div className="flex items-center gap-3">
             <MobileNav />
             <span className="text-sm text-muted-foreground">
-              Tenant:{" "}
-              <span className="font-medium text-foreground">{tenantId}</span>
+              Tenant: <span className="font-medium text-foreground">{tenantId}</span>
             </span>
           </div>
           <span className="rounded bg-muted/40 px-2 py-1 font-mono text-xs text-muted-foreground">
@@ -62,6 +62,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
           </span>
         </header>
         <main className="min-h-0 flex-1 overflow-auto p-4 md:p-6" id="main-content">
+          <OperationalRouteNotice />
           {children}
         </main>
       </div>

--- a/packages/web/src/app/dashboard/layout.tsx
+++ b/packages/web/src/app/dashboard/layout.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from "@/components/shared/error-boundary";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
 import type { Metadata } from "next";
+import { OperationalRouteNotice } from "@/components/shared/OperationalRouteNotice";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -22,6 +23,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     <ErrorBoundary context="Dashboard Layout">
       <Navigation />
       <main id="main-content" className="min-h-screen">
+        <div className="mx-auto max-w-7xl px-4 py-4">
+          <OperationalRouteNotice />
+        </div>
         {children}
       </main>
       <Footer />

--- a/packages/web/src/components/console/ConsoleLayout.tsx
+++ b/packages/web/src/components/console/ConsoleLayout.tsx
@@ -34,6 +34,7 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { BackendHealthBadge } from "./BackendHealthBadge";
 import { CONSOLE_ROUTE_REGISTRY, type ConsoleRouteEntry } from "@/lib/console/route-maturity";
+import { OperationalRouteNotice } from "@/components/shared/OperationalRouteNotice";
 
 const navSectionOrder = [
   "Operations",
@@ -193,7 +194,10 @@ export function ConsoleLayout({ children }: ConsoleLayoutProps) {
         </aside>
 
         <main className="flex-1 md:ml-[var(--sidebar-width)] pt-16" id="main-content">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">{children}</div>
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            <OperationalRouteNotice />
+            {children}
+          </div>
         </main>
       </div>
     </div>

--- a/packages/web/src/components/shared/OperationalRouteNotice.tsx
+++ b/packages/web/src/components/shared/OperationalRouteNotice.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { getOperationalRouteMeta } from "@/lib/routes/operational-truth";
+
+export function OperationalRouteNotice() {
+  const pathname = usePathname();
+  const meta = pathname ? getOperationalRouteMeta(pathname) : null;
+
+  if (!meta?.disclosureRequired) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-label="Operational route disclosure"
+      className="mb-4 rounded-lg border border-amber-300/70 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-semibold">Operational disclosure</span>
+        <Badge variant="outline" className="border-amber-500 text-amber-800">
+          {meta.maturity}
+        </Badge>
+        <Badge variant="outline" className="border-amber-500 text-amber-800">
+          {meta.scopeSignal === "tenant" ? "Tenant scope" : "Global scope"}
+        </Badge>
+        {meta.operationalClass === "synthetic" ? (
+          <Badge variant="outline" className="border-amber-500 text-amber-800">
+            Synthetic surface
+          </Badge>
+        ) : null}
+      </div>
+      <p className="mt-2 leading-relaxed">{meta.degradedBehavior}</p>
+    </section>
+  );
+}

--- a/packages/web/src/lib/routes/operational-truth.ts
+++ b/packages/web/src/lib/routes/operational-truth.ts
@@ -1,0 +1,233 @@
+export type RouteFamily = "console" | "app" | "dashboard" | "admin" | "operator";
+
+export type RouteMaturityClass =
+  | "runtime-operational"
+  | "runtime-degraded-without-env"
+  | "runtime-degraded-without-tenant"
+  | "runtime-degraded-without-provider"
+  | "informational"
+  | "thin"
+  | "admin-only";
+
+export type RuntimeDependencyClass = "none" | "supabase" | "stripe" | "providers" | "hybrid";
+
+export interface OperationalRouteEntry {
+  family: RouteFamily;
+  routePrefix: string;
+  routeGroupLabel: string;
+  domain:
+    | "control-plane"
+    | "reconciliation"
+    | "evidence"
+    | "governance"
+    | "integrations"
+    | "billing"
+    | "operations"
+    | "admin";
+  maturity: RouteMaturityClass;
+  runtimeDependency: RuntimeDependencyClass;
+  authRequired: boolean;
+  tenantScopeRequired: boolean;
+  roleRestriction: "none" | "super-admin";
+  providerRequirement: "none" | "optional" | "required";
+  billingRequirement: "none" | "optional" | "required";
+  databaseRequired: boolean;
+  supabaseRequired: boolean;
+  stripeRequired: boolean;
+  operationalClass: "operational" | "informational" | "synthetic" | "partial" | "restricted";
+  degradedBehavior: string;
+  disclosureRequired: boolean;
+  navTreatment: "primary" | "secondary" | "restricted";
+  ctaRestrictions: "none" | "read-only" | "disabled";
+  dataMode: "operational" | "informational" | "synthetic" | "restricted";
+  syntheticDataAllowed: boolean;
+  scopeSignal: "tenant" | "global";
+}
+
+export const OPERATIONAL_ROUTE_REGISTRY: readonly OperationalRouteEntry[] = [
+  {
+    family: "console",
+    routePrefix: "/console",
+    routeGroupLabel: "Console control plane",
+    domain: "control-plane",
+    maturity: "runtime-degraded-without-env",
+    runtimeDependency: "hybrid",
+    authRequired: true,
+    tenantScopeRequired: true,
+    roleRestriction: "none",
+    providerRequirement: "optional",
+    billingRequirement: "optional",
+    databaseRequired: true,
+    supabaseRequired: true,
+    stripeRequired: false,
+    operationalClass: "partial",
+    degradedBehavior:
+      "Routes stay reachable but disclose when tenant, provider, or env dependencies are missing.",
+    disclosureRequired: true,
+    navTreatment: "primary",
+    ctaRestrictions: "read-only",
+    dataMode: "operational",
+    syntheticDataAllowed: false,
+    scopeSignal: "tenant",
+  },
+  {
+    family: "console",
+    routePrefix: "/console/replay",
+    routeGroupLabel: "Console replay surfaces",
+    domain: "reconciliation",
+    maturity: "thin",
+    runtimeDependency: "providers",
+    authRequired: true,
+    tenantScopeRequired: true,
+    roleRestriction: "none",
+    providerRequirement: "required",
+    billingRequirement: "none",
+    databaseRequired: true,
+    supabaseRequired: true,
+    stripeRequired: false,
+    operationalClass: "synthetic",
+    degradedBehavior:
+      "Replay views are explicitly labeled synthetic when providers or history are missing.",
+    disclosureRequired: true,
+    navTreatment: "secondary",
+    ctaRestrictions: "disabled",
+    dataMode: "synthetic",
+    syntheticDataAllowed: true,
+    scopeSignal: "tenant",
+  },
+  {
+    family: "app",
+    routePrefix: "/app",
+    routeGroupLabel: "Authenticated app shell",
+    domain: "operations",
+    maturity: "runtime-degraded-without-tenant",
+    runtimeDependency: "supabase",
+    authRequired: true,
+    tenantScopeRequired: true,
+    roleRestriction: "none",
+    providerRequirement: "optional",
+    billingRequirement: "none",
+    databaseRequired: true,
+    supabaseRequired: true,
+    stripeRequired: false,
+    operationalClass: "partial",
+    degradedBehavior:
+      "Shell renders with explicit tenant-scope messaging when tenant metadata is absent.",
+    disclosureRequired: true,
+    navTreatment: "primary",
+    ctaRestrictions: "read-only",
+    dataMode: "operational",
+    syntheticDataAllowed: false,
+    scopeSignal: "tenant",
+  },
+  {
+    family: "app",
+    routePrefix: "/app/replay",
+    routeGroupLabel: "Authenticated replay lab",
+    domain: "reconciliation",
+    maturity: "thin",
+    runtimeDependency: "providers",
+    authRequired: true,
+    tenantScopeRequired: true,
+    roleRestriction: "none",
+    providerRequirement: "required",
+    billingRequirement: "none",
+    databaseRequired: true,
+    supabaseRequired: true,
+    stripeRequired: false,
+    operationalClass: "synthetic",
+    degradedBehavior: "Replay lab remains available but makes synthetic constraints explicit.",
+    disclosureRequired: true,
+    navTreatment: "secondary",
+    ctaRestrictions: "disabled",
+    dataMode: "synthetic",
+    syntheticDataAllowed: true,
+    scopeSignal: "tenant",
+  },
+  {
+    family: "dashboard",
+    routePrefix: "/dashboard",
+    routeGroupLabel: "Customer dashboard",
+    domain: "billing",
+    maturity: "runtime-degraded-without-provider",
+    runtimeDependency: "hybrid",
+    authRequired: true,
+    tenantScopeRequired: true,
+    roleRestriction: "none",
+    providerRequirement: "optional",
+    billingRequirement: "optional",
+    databaseRequired: true,
+    supabaseRequired: true,
+    stripeRequired: true,
+    operationalClass: "partial",
+    degradedBehavior:
+      "Dashboard links remain stable and disclose unavailable billing/provider telemetry.",
+    disclosureRequired: true,
+    navTreatment: "secondary",
+    ctaRestrictions: "read-only",
+    dataMode: "operational",
+    syntheticDataAllowed: false,
+    scopeSignal: "tenant",
+  },
+  {
+    family: "admin",
+    routePrefix: "/admin",
+    routeGroupLabel: "Super admin control surfaces",
+    domain: "admin",
+    maturity: "admin-only",
+    runtimeDependency: "hybrid",
+    authRequired: true,
+    tenantScopeRequired: false,
+    roleRestriction: "super-admin",
+    providerRequirement: "optional",
+    billingRequirement: "none",
+    databaseRequired: true,
+    supabaseRequired: true,
+    stripeRequired: false,
+    operationalClass: "restricted",
+    degradedBehavior:
+      "Access is denied for non-super-admin sessions with explicit scope messaging.",
+    disclosureRequired: true,
+    navTreatment: "restricted",
+    ctaRestrictions: "disabled",
+    dataMode: "restricted",
+    syntheticDataAllowed: false,
+    scopeSignal: "global",
+  },
+  {
+    family: "operator",
+    routePrefix: "/operator/incidents",
+    routeGroupLabel: "Operator incidents",
+    domain: "operations",
+    maturity: "runtime-degraded-without-env",
+    runtimeDependency: "hybrid",
+    authRequired: true,
+    tenantScopeRequired: false,
+    roleRestriction: "super-admin",
+    providerRequirement: "optional",
+    billingRequirement: "none",
+    databaseRequired: true,
+    supabaseRequired: true,
+    stripeRequired: false,
+    operationalClass: "restricted",
+    degradedBehavior:
+      "Incident management is visible only to operators and declares backend dependency gaps.",
+    disclosureRequired: true,
+    navTreatment: "restricted",
+    ctaRestrictions: "read-only",
+    dataMode: "restricted",
+    syntheticDataAllowed: false,
+    scopeSignal: "global",
+  },
+] as const;
+
+const byPrefixLengthDesc = [...OPERATIONAL_ROUTE_REGISTRY].sort(
+  (a, b) => b.routePrefix.length - a.routePrefix.length
+);
+
+export function getOperationalRouteMeta(pathname: string): OperationalRouteEntry | null {
+  const match = byPrefixLengthDesc.find(
+    (entry) => pathname === entry.routePrefix || pathname.startsWith(`${entry.routePrefix}/`)
+  );
+  return match ?? null;
+}

--- a/scripts/verify-console-route-maturity.ts
+++ b/scripts/verify-console-route-maturity.ts
@@ -1,0 +1,1 @@
+import "../packages/web/scripts/verify-console-route-maturity";

--- a/scripts/verify-operational-route-truth.ts
+++ b/scripts/verify-operational-route-truth.ts
@@ -1,0 +1,1 @@
+import "../packages/web/scripts/verify-operational-route-truth";


### PR DESCRIPTION
### Motivation
- Provide a single, code-first operational truth source that extends route maturity beyond the console to the broader authenticated surface (app, dashboard, admin, operator). 
- Ensure disclosure is not just a component somewhere but enforced consistently at layout-level host points for tenant/auth/provider/billing realities. 
- Add lightweight automated guardrails to detect drift, missing coverage, and disclosure-usage regressions.

### Description
- Added a canonical registry `OPERATIONAL_ROUTE_REGISTRY` and resolver in `packages/web/src/lib/routes/operational-truth.ts` that encodes family, prefix, maturity, dependency/auth/tenant/provider/billing flags, disclosure, nav/CTA treatment, and synthetic-data policy, and matches by longest prefix via `getOperationalRouteMeta`.
- Implemented a shared disclosure primitive `OperationalRouteNotice` in `packages/web/src/components/shared/OperationalRouteNotice.tsx` that renders maturity, scope, synthetic badge and the route's degraded-behavior text from the registry.
- Mounted `OperationalRouteNotice` into the major authenticated shells so disclosure is enforced: `console` (console layout), `app` (app layout), `dashboard` (dashboard layout) and `admin` (admin layout) components/files.
- Added a verifier `packages/web/scripts/verify-operational-route-truth.ts` that enforces registry invariants, significant-route coverage, and presence of the disclosure primitive in expected layout hosts, and exposed root wrapper scripts (`scripts/verify-operational-route-truth.ts` and `scripts/verify-console-route-maturity.ts`) so repo-integrity checks resolve them.
- Wired the check into root scripts by updating `package.json` to run `verify:operational-route-truth` as part of `verify:routes` and documented the new truth source in `README.md`.

### Testing
- Ran `pnpm --filter @settler/web exec tsx scripts/verify-operational-route-truth.ts` — verification passed: "✅ Operational route truth verification passed (7 registry entries, 140 significant routes scanned)".
- Ran `pnpm run verify:console-route-maturity` — verifier passed: "✅ Console route maturity verification passed (19 routes)".
- Ran `pnpm run verify:routes` (which runs route checks + console maturity + operational truth) — completed; Next startup logged missing env vars (expected in this environment) but route verification finished without hard 500s and the new operational-truth verification passed.
- Ran `pnpm run verify:repo` and repository integrity checks passed after adding root wrapper scripts; ran `pnpm lint` (completed with unrelated warnings but no blocking errors); `pnpm run doctor` failed as expected in this environment due to missing Supabase/DATABASE env vars; attempted Playwright screenshot of the notice timed out in this environment (no artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b694d2df708328ab873f8e389ff373)