### PR TITLE
Polish console disclosure UX and tenant-scoped page framing

### DIFF
--- a/packages/web/src/app/console/billing/page.tsx
+++ b/packages/web/src/app/console/billing/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { ConsoleLayout } from "@/components/console/ConsoleLayout";
+import { ConsolePageHeader } from "@/components/console/ConsolePageHeader";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Loader2, CreditCard, AlertCircle, CheckCircle2 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { RouteStateCard, routeStateFromVariant } from "@/components/shared/route-state";
 
 interface BillingData {
   billingAccount: {
@@ -106,26 +107,23 @@ export default function BillingPage() {
 
   if (isLoading) {
     return (
-      <ConsoleLayout>
-        <div className="flex items-center justify-center min-h-[400px]">
-          <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
-        </div>
-      </ConsoleLayout>
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
     );
   }
 
   if (error || !data) {
     return (
-      <ConsoleLayout>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center gap-2 text-red-600">
-              <AlertCircle className="h-5 w-5" />
-              <p>{error || "Failed to load billing data"}</p>
-            </div>
-          </CardContent>
-        </Card>
-      </ConsoleLayout>
+      <RouteStateCard
+        {...routeStateFromVariant("backend-unreachable", {
+          title: "Billing data unavailable",
+          description: error || "Failed to load billing data.",
+          detail:
+            "Billing remains intentionally unreachable until dependencies recover. No billing state was inferred from partial responses.",
+          actions: [{ label: "Retry", href: "/console/billing", variant: "outline" }],
+        })}
+      />
     );
   }
 
@@ -165,15 +163,14 @@ export default function BillingPage() {
   ];
 
   return (
-    <ConsoleLayout>
+    <div className="space-y-6">
+      <ConsolePageHeader
+        title="Billing & Plan"
+        description="Review tenant-scoped plan status, usage thresholds, and billing controls."
+      />
+
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold">Billing & Plan</h1>
-            <p className="text-slate-600 dark:text-slate-400 mt-1">
-              Manage your subscription and view usage
-            </p>
-          </div>
+        <div className="flex items-center justify-end">
           {data.subscription && data.stripeConfigured && (
             <Button onClick={handleManageBilling} disabled={isCreatingPortal} variant="outline">
               {isCreatingPortal ? (
@@ -232,11 +229,11 @@ export default function BillingPage() {
             {data.subscription && (
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
-                  <span className="text-slate-600 dark:text-slate-400">Plan:</span>
+                  <span className="text-muted-foreground">Plan:</span>
                   <span className="font-medium">{data.subscription.planName}</span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-slate-600 dark:text-slate-400">Period:</span>
+                  <span className="text-muted-foreground">Period:</span>
                   <span className="font-medium">
                     {new Date(data.subscription.currentPeriodStart).toLocaleDateString()} -{" "}
                     {new Date(data.subscription.currentPeriodEnd).toLocaleDateString()}
@@ -264,11 +261,11 @@ export default function BillingPage() {
               <div key={bar.service} className="space-y-2">
                 <div className="flex justify-between text-sm">
                   <span className="font-medium">{bar.service}</span>
-                  <span className="text-slate-600 dark:text-slate-400">
+                  <span className="text-muted-foreground">
                     {bar.current.toLocaleString()} / {bar.limit.toLocaleString()} {bar.unit}
                   </span>
                 </div>
-                <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2">
+                <div className="h-2 w-full rounded-full bg-muted">
                   <div
                     className={`h-2 rounded-full transition-all ${
                       bar.percentage >= 90
@@ -322,7 +319,7 @@ export default function BillingPage() {
                     </Badge>
                   )}
                 </div>
-                <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">$0/month</p>
+                <p className="mb-4 text-sm text-muted-foreground">$0/month</p>
                 <ul className="text-sm space-y-1 mb-4">
                   <li>• 10,000 reconciliations/month</li>
                   <li>• 1% exception rate included</li>
@@ -355,7 +352,7 @@ export default function BillingPage() {
                     </Badge>
                   )}
                 </div>
-                <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">$900/month</p>
+                <p className="mb-4 text-sm text-muted-foreground">$900/month</p>
                 <ul className="text-sm space-y-1 mb-4">
                   <li>• 100,000 reconciliations/month</li>
                   <li>• 1% exception rate included</li>
@@ -402,7 +399,7 @@ export default function BillingPage() {
                     </Badge>
                   )}
                 </div>
-                <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">$9,900/month</p>
+                <p className="mb-4 text-sm text-muted-foreground">$9,900/month</p>
                 <ul className="text-sm space-y-1 mb-4">
                   <li>• 1,000,000 reconciliations/month</li>
                   <li>• 1% exception rate included</li>
@@ -449,7 +446,7 @@ export default function BillingPage() {
                     </Badge>
                   )}
                 </div>
-                <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">Custom</p>
+                <p className="mb-4 text-sm text-muted-foreground">Custom</p>
                 <ul className="text-sm space-y-1 mb-4">
                   <li>• Custom volume</li>
                   <li>• Custom exception thresholds</li>
@@ -471,6 +468,6 @@ export default function BillingPage() {
           </CardContent>
         </Card>
       </div>
-    </ConsoleLayout>
+    </div>
   );
 }

--- a/packages/web/src/app/console/reconciliations/page.tsx
+++ b/packages/web/src/app/console/reconciliations/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { ConsolePageHeader } from "@/components/console/ConsolePageHeader";
 
 const surfaces = [
   {
@@ -23,12 +24,10 @@ const surfaces = [
 export default function ReconciliationsPage() {
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Reconciliations</h1>
-        <p className="text-slate-600 dark:text-slate-400 mt-2">
-          Enterprise reconciliation operations surfaced from kernel and API capabilities.
-        </p>
-      </div>
+      <ConsolePageHeader
+        title="Reconciliations"
+        description="Run tenant-scoped reconciliation workflows, inspect variance, and export evidence without leaving the control plane."
+      />
 
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         {surfaces.map((item) => (

--- a/packages/web/src/app/console/settings/page.tsx
+++ b/packages/web/src/app/console/settings/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Key, Settings2, Webhook, Shield, Bell, CreditCard } from "lucide-react";
+import { ConsolePageHeader } from "@/components/console/ConsolePageHeader";
 
 const settingsCards = [
   {
@@ -51,21 +52,18 @@ const settingsCards = [
 export default function SettingsPage() {
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Settings</h1>
-        <p className="text-slate-600 dark:text-slate-400 mt-2">
-          Configure platform-level settings, API access, governance controls, and tenant
-          preferences.
-        </p>
-      </div>
+      <ConsolePageHeader
+        title="Settings"
+        description="Manage tenant-scoped configuration, API access, governance controls, and billing behavior for this workspace."
+      />
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {settingsCards.map((card) => (
           <Card key={card.href}>
             <CardHeader>
               <div className="flex items-start gap-3">
-                <div className="rounded-lg bg-slate-100 dark:bg-slate-800 p-2">
-                  <card.icon className="h-5 w-5 text-slate-600 dark:text-slate-400" />
+                <div className="rounded-lg bg-muted p-2">
+                  <card.icon className="h-5 w-5 text-muted-foreground" />
                 </div>
                 <div className="flex-1 min-w-0">
                   <CardTitle className="text-base">{card.title}</CardTitle>

--- a/packages/web/src/components/console/ConsolePageHeader.tsx
+++ b/packages/web/src/components/console/ConsolePageHeader.tsx
@@ -1,0 +1,28 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface ConsolePageHeaderProps {
+  title: string;
+  description: string;
+  scope?: "tenant" | "global";
+  className?: string;
+}
+
+export function ConsolePageHeader({
+  title,
+  description,
+  scope = "tenant",
+  className,
+}: ConsolePageHeaderProps) {
+  return (
+    <header className={cn("space-y-3", className)}>
+      <div className="flex flex-wrap items-center gap-2">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">{title}</h1>
+        <Badge variant="outline" className="text-xs font-medium">
+          {scope === "tenant" ? "Tenant scope" : "Global scope"}
+        </Badge>
+      </div>
+      <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">{description}</p>
+    </header>
+  );
+}

--- a/packages/web/src/components/shared/OperationalRouteNotice.tsx
+++ b/packages/web/src/components/shared/OperationalRouteNotice.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { AlertTriangle, Database, Landmark, Shield } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { getOperationalRouteMeta } from "@/lib/routes/operational-truth";
 
@@ -15,23 +16,53 @@ export function OperationalRouteNotice() {
   return (
     <section
       aria-label="Operational route disclosure"
-      className="mb-4 rounded-lg border border-amber-300/70 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+      className="mb-6 rounded-xl border border-amber-300/70 bg-amber-50/80 px-4 py-4 text-sm text-amber-950 shadow-sm dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100"
     >
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="font-semibold">Operational disclosure</span>
-        <Badge variant="outline" className="border-amber-500 text-amber-800">
-          {meta.maturity}
-        </Badge>
-        <Badge variant="outline" className="border-amber-500 text-amber-800">
-          {meta.scopeSignal === "tenant" ? "Tenant scope" : "Global scope"}
-        </Badge>
-        {meta.operationalClass === "synthetic" ? (
-          <Badge variant="outline" className="border-amber-500 text-amber-800">
-            Synthetic surface
-          </Badge>
-        ) : null}
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700 dark:text-amber-300" />
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-semibold">Operational disclosure</span>
+            <Badge
+              variant="outline"
+              className="border-amber-500/80 text-amber-800 dark:text-amber-100"
+            >
+              {meta.maturity}
+            </Badge>
+            <Badge
+              variant="outline"
+              className="inline-flex items-center gap-1 border-amber-500/80 text-amber-800 dark:text-amber-100"
+            >
+              {meta.scopeSignal === "tenant" ? (
+                <Landmark className="h-3 w-3" aria-hidden="true" />
+              ) : (
+                <Shield className="h-3 w-3" aria-hidden="true" />
+              )}
+              {meta.scopeSignal === "tenant" ? "Tenant scope" : "Global scope"}
+            </Badge>
+            {meta.runtimeDependency !== "none" ? (
+              <Badge
+                variant="outline"
+                className="inline-flex items-center gap-1 border-amber-500/80 text-amber-800 dark:text-amber-100"
+              >
+                <Database className="h-3 w-3" aria-hidden="true" />
+                {meta.runtimeDependency} dependency
+              </Badge>
+            ) : null}
+            {meta.operationalClass === "synthetic" ? (
+              <Badge
+                variant="outline"
+                className="border-amber-500/80 text-amber-800 dark:text-amber-100"
+              >
+                Synthetic surface
+              </Badge>
+            ) : null}
+          </div>
+          <p className="leading-relaxed text-amber-900/90 dark:text-amber-100/90">
+            {meta.degradedBehavior}
+          </p>
+        </div>
       </div>
-      <p className="mt-2 leading-relaxed">{meta.degradedBehavior}</p>
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Make the operational-truth disclosures feel productized and calm instead of ad-hoc warnings. 
- Make tenant-scope signals and page headers immediately legible and consistent across console routes. 
- Improve billing/control-plane presentation so degraded dependency states are explicit and operator-legible. 

### Description
- Add a new shared `ConsolePageHeader` component to standardize page-level hierarchy and surface an explicit `Tenant scope` / `Global scope` badge. (`packages/web/src/components/console/ConsolePageHeader.tsx`).
- Rework the operational disclosure to improve spacing, iconography, badge semantics, and calm contrast while preserving truthful `degradedBehavior` copy and synthetic labeling (`packages/web/src/components/shared/OperationalRouteNotice.tsx`).
- Apply the new header and calmer token usage to console surfaces to normalize route framing on `Reconciliations` and `Settings` (`packages/web/src/app/console/reconciliations/page.tsx`, `packages/web/src/app/console/settings/page.tsx`).
- Harden the `Billing` route UX by replacing ad-hoc loading/error wrappers with the shared `RouteStateCard` for backend/dependency failures, add header framing, and tighten muted typography for financial readability (`packages/web/src/app/console/billing/page.tsx`).
- Minor token and accessibility-focused tweaks (icon containers, muted palette usage, badge composition) to align components with shared UI primitives and improve density and hierarchy.

### Testing
- Ran `pnpm lint`; task completed successfully (monorepo linted; pre-existing warnings remain but are unrelated to these edits). 
- Ran `pnpm typecheck`; typecheck completed successfully across packages. 
- Ran `pnpm build`; build failed for `@settler/web` because required build-time environment keys were not provided in this environment: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and a server DB URL (`DATABASE_URL` / `SUPABASE_DATABASE_URL` / `DIRECT_URL`).
- Performed a local dev run with ephemeral env (provided `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `DATABASE_URL`) to visually verify pages and captured a screenshot for review; visual verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f195c61c832892b1ed7d1daeb699)