### PR TITLE
Harden connector OAuth state validation and API mutation enforcement

### DIFF
--- a/packages/web/src/__tests__/security/oauth-state.test.ts
+++ b/packages/web/src/__tests__/security/oauth-state.test.ts
@@ -1,0 +1,72 @@
+/** @jest-environment node */
+
+import { createOAuthState, verifyOAuthState } from "@/lib/security/oauth-state";
+
+describe("oauth state security", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      OAUTH_STATE_SIGNING_KEY: "x".repeat(64),
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("accepts valid signed state bound to user and provider", () => {
+    const state = createOAuthState({
+      connectorId: "connector-1",
+      tenantId: "tenant-1",
+      providerId: "stripe",
+      userId: "user-1",
+    });
+
+    const verified = verifyOAuthState(state, {
+      providerId: "stripe",
+      userId: "user-1",
+    });
+
+    expect(verified).not.toBeNull();
+    expect(verified?.connectorId).toBe("connector-1");
+    expect(verified?.tenantId).toBe("tenant-1");
+  });
+
+  it("rejects state when actor binding mismatches", () => {
+    const state = createOAuthState({
+      connectorId: "connector-1",
+      tenantId: "tenant-1",
+      providerId: "stripe",
+      userId: "user-1",
+    });
+
+    const verified = verifyOAuthState(state, {
+      providerId: "stripe",
+      userId: "user-2",
+    });
+
+    expect(verified).toBeNull();
+  });
+
+  it("rejects tampered state", () => {
+    const state = createOAuthState({
+      connectorId: "connector-1",
+      tenantId: "tenant-1",
+      providerId: "stripe",
+      userId: "user-1",
+    });
+
+    const [payload, signature] = state.split(".");
+    const tampered = `${payload}A.${signature}`;
+
+    expect(
+      verifyOAuthState(tampered, {
+        providerId: "stripe",
+        userId: "user-1",
+      })
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/security/with-security-enforcement.test.ts
+++ b/packages/web/src/__tests__/security/with-security-enforcement.test.ts
@@ -1,0 +1,74 @@
+/** @jest-environment node */
+
+import { NextResponse } from "next/server";
+import { withSecurity } from "@/lib/middleware/api-security";
+
+const authenticateRequestMock = jest.fn();
+
+jest.mock("@/lib/api/unified-auth", () => ({
+  authenticateRequest: (...args: unknown[]) => authenticateRequestMock(...args),
+}));
+
+jest.mock("@/lib/api/rate-limit", () => ({
+  withRateLimit: (handler: unknown) => handler,
+}));
+
+describe("withSecurity enforcement", () => {
+  beforeEach(() => {
+    authenticateRequestMock.mockReset();
+  });
+
+  function createRequest(
+    url: string,
+    init?: { method?: string; headers?: Record<string, string> }
+  ) {
+    return {
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers ?? {}),
+      nextUrl: new URL(url),
+    } as any;
+  }
+
+  it("returns 401 when requireAuth is enabled and auth is missing", async () => {
+    authenticateRequestMock.mockResolvedValue(null);
+
+    const handler = withSecurity(async () => NextResponse.json({ ok: true }), {
+      requireAuth: true,
+    });
+
+    const response = await handler(createRequest("https://app.settler.test/api/secure"));
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects cross-origin browser mutation requests", async () => {
+    const handler = withSecurity(async () => NextResponse.json({ ok: true }));
+
+    const response = await handler(
+      createRequest("https://app.settler.test/api/secure", {
+        method: "POST",
+        headers: {
+          origin: "https://evil.example",
+        },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    const payload = await response.json();
+    expect(payload.code).toBe("INVALID_ORIGIN");
+  });
+
+  it("allows API key mutation requests without browser origin headers", async () => {
+    const handler = withSecurity(async () => NextResponse.json({ ok: true }));
+
+    const response = await handler(
+      createRequest("https://app.settler.test/api/secure", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer rk_test_key",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/packages/web/src/app/api/connectors/callback/[providerId]/route.ts
+++ b/packages/web/src/app/api/connectors/callback/[providerId]/route.ts
@@ -8,6 +8,7 @@ import { prisma } from "@/shared/db/prismaClient";
 import { appLogger } from "@/lib/utils/logger";
 import { encrypt } from "@/lib/security/encryption";
 import { sanitizeString } from "@/lib/security/input-sanitization";
+import { verifyOAuthState } from "@/lib/security/oauth-state";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -39,6 +40,10 @@ export const GET = withUniversalBillingGate(
       const state = searchParams.get("state");
       const error = searchParams.get("error");
 
+      if (!state) {
+        return NextResponse.json({ error: "Missing OAuth state" }, { status: 400 });
+      }
+
       if (error) {
         // Sanitize error message to prevent XSS
         const sanitizedError = sanitizeString(error);
@@ -56,19 +61,31 @@ export const GET = withUniversalBillingGate(
 
       const typedSupabase = asExtendedClient(supabase);
 
-      // Get connector config
-      const { data: connectors } = await typedSupabase
-        .from("connectors")
-        .select("id, tenant_id, config")
-        .eq("provider_id", providerId)
-        .eq("status", "connecting")
-        .limit(1);
+      const validatedState = verifyOAuthState(state, {
+        providerId,
+        userId: user.id,
+      });
 
-      if (!connectors || connectors.length === 0) {
-        return NextResponse.json({ error: "Connector not found" }, { status: 404 });
+      if (!validatedState) {
+        return NextResponse.json({ error: "Invalid or expired OAuth state" }, { status: 400 });
       }
 
-      const connector = connectors[0];
+      // Get connector config from state binding
+      const { data: connectors } = await typedSupabase
+        .from("connectors")
+        .select("id, tenant_id, status, config")
+        .eq("provider_id", providerId)
+        .eq("tenant_id", validatedState.tenantId)
+        .limit(20);
+
+      const connector = Array.isArray(connectors)
+        ? connectors.find((candidate: Record<string, unknown>) => {
+            const candidateId =
+              typeof candidate.id === "string" ? candidate.id : String(candidate.id);
+            return candidateId === validatedState.connectorId && candidate.status === "connecting";
+          })
+        : null;
+
       if (!connector) {
         return NextResponse.json({ error: "Connector not found" }, { status: 404 });
       }
@@ -92,7 +109,7 @@ export const GET = withUniversalBillingGate(
       if (!tenantId) {
         return NextResponse.json({ error: "Invalid connector tenant_id" }, { status: 400 });
       }
-      const authResult = await driver.handleCallback(code, state || "", {
+      const authResult = await driver.handleCallback(code, state, {
         tenantId,
         redirectUri,
       });
@@ -188,8 +205,7 @@ export const GET = withUniversalBillingGate(
       return NextResponse.redirect(
         new URL("/dashboard/integrations?success=provider_connected", request.url)
       );
-     
-      } catch (error) {
+    } catch (error) {
       appLogger.error("Error in callback route", error);
       // Sanitize error message before redirecting
       const errorMessage =

--- a/packages/web/src/app/api/connectors/connect/[providerId]/route.ts
+++ b/packages/web/src/app/api/connectors/connect/[providerId]/route.ts
@@ -1,132 +1,141 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
-import { asExtendedClient } from '@/lib/supabase/types';
-import { getConnectorDriver } from '@settler/adapters';
-import { withUniversalBillingGate } from '@/middleware/billing-gate-universal';
-import { appLogger } from '@/lib/utils/logger';
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { asExtendedClient } from "@/lib/supabase/types";
+import { getConnectorDriver } from "@settler/adapters";
+import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
+import { appLogger } from "@/lib/utils/logger";
+import { createOAuthState } from "@/lib/security/oauth-state";
 
-export const dynamic = 'force-dynamic';
-export const runtime = 'nodejs';
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
-export const POST = withUniversalBillingGate(async function POST(
-  request: NextRequest,
-  { params }: { params: { providerId: string } }
-) {
-  try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+export const POST = withUniversalBillingGate(
+  async function POST(request: NextRequest, { params }: { params: { providerId: string } }) {
+    try {
+      const supabase = await createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
 
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+      if (!user) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
 
-    const providerId = params.providerId;
-    const driver = getConnectorDriver(providerId);
+      const providerId = params.providerId;
+      const driver = getConnectorDriver(providerId);
 
-    if (!driver) {
-      return NextResponse.json(
-        { error: `Connector ${providerId} not found` },
-        { status: 404 }
-      );
-    }
+      if (!driver) {
+        return NextResponse.json({ error: `Connector ${providerId} not found` }, { status: 404 });
+      }
 
-    const body = await request.json();
-    const { tenantId, redirectUri, config } = body;
+      const body = await request.json();
+      const { tenantId, redirectUri, config } = body;
 
-    if (!tenantId) {
-      return NextResponse.json({ error: 'tenantId is required' }, { status: 400 });
-    }
+      if (!tenantId) {
+        return NextResponse.json({ error: "tenantId is required" }, { status: 400 });
+      }
 
-    const typedSupabase = asExtendedClient(supabase);
+      const typedSupabase = asExtendedClient(supabase);
 
-    // Verify tenant access
-    const { data: membership } = await typedSupabase
-      .from('app_private.memberships')
-      .select('tenant_id')
-      .eq('user_id', user.id)
-      .eq('tenant_id', tenantId)
-      .eq('status', 'active')
-      .single();
-
-    if (!membership) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
-
-    // Get auth URL if OAuth2
-    if (driver.metadata.authType === 'oauth2' && driver.getAuthUrl) {
-      const authUrl = await driver.getAuthUrl({
-        tenantId,
-        redirectUri: redirectUri || `${request.nextUrl.origin}/api/connectors/callback/${providerId}`,
-        state: crypto.randomUUID(),
-        scopes: config?.scopes,
-      });
-
-      // Store state in session/database for verification
-      const { data: connector } = await typedSupabase
-        .from('connectors')
-        .select('id')
-        .eq('tenant_id', tenantId)
-        .eq('provider_id', providerId)
+      // Verify tenant access
+      const { data: membership } = await typedSupabase
+        .from("app_private.memberships")
+        .select("tenant_id")
+        .eq("user_id", user.id)
+        .eq("tenant_id", tenantId)
+        .eq("status", "active")
         .single();
 
-      if (!connector) {
-        // Create connector record
-        const { data: newConnector } = await typedSupabase
-          .from('connectors')
-          .insert({
-            tenant_id: tenantId,
-            provider_id: providerId,
-            display_name: driver.metadata.displayName,
-            status: 'connecting',
-            auth_type: driver.metadata.authType,
-            config: config || {},
-            created_by: user.id,
-          })
-          .select('id')
+      if (!membership) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+
+      // Get auth URL if OAuth2
+      if (driver.metadata.authType === "oauth2" && driver.getAuthUrl) {
+        let connectorId: string;
+
+        const { data: connector } = await typedSupabase
+          .from("connectors")
+          .select("id, created_by")
+          .eq("tenant_id", tenantId)
+          .eq("provider_id", providerId)
           .single();
 
-        if (!newConnector) {
-          return NextResponse.json(
-      {
-        success: false,
-        error: 'Failed to create connector',
-        message: 'Please try again later or contact support if the issue persists',
-      },
-      { status: 200 }
-    );
+        if (!connector) {
+          const { data: newConnector } = await typedSupabase
+            .from("connectors")
+            .insert({
+              tenant_id: tenantId,
+              provider_id: providerId,
+              display_name: driver.metadata.displayName,
+              status: "connecting",
+              auth_type: driver.metadata.authType,
+              config: config || {},
+              created_by: user.id,
+            })
+            .select("id")
+            .single();
+
+          if (!newConnector) {
+            return NextResponse.json(
+              {
+                success: false,
+                error: "Failed to create connector",
+                message: "Please try again later or contact support if the issue persists",
+              },
+              { status: 200 }
+            );
+          }
+
+          connectorId = String(newConnector.id);
+        } else {
+          connectorId = String(connector.id);
         }
+
+        const state = createOAuthState({
+          connectorId,
+          tenantId,
+          providerId,
+          userId: user.id,
+        });
+
+        const authUrl = await driver.getAuthUrl({
+          tenantId,
+          redirectUri:
+            redirectUri || `${request.nextUrl.origin}/api/connectors/callback/${providerId}`,
+          state,
+          scopes: config?.scopes,
+        });
 
         return NextResponse.json({
           authUrl,
-          connectorId: newConnector.id,
+          connectorId,
         });
       }
 
+      // For API key auth, return success (credentials will be stored separately)
       return NextResponse.json({
-        authUrl,
-        connectorId: connector.id,
+        success: true,
+        message: "Please provide API credentials",
       });
+    } catch (error) {
+      appLogger.error("Error in connect route", error);
+      // Never return 500 - return graceful error response
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Failed to connect integration",
+          message: "Please try again later or contact support if the issue persists",
+          details:
+            process.env.NODE_ENV === "development"
+              ? error instanceof Error
+                ? error.message
+                : String(error)
+              : undefined,
+        },
+        { status: 200 }
+      );
     }
-
-    // For API key auth, return success (credentials will be stored separately)
-    return NextResponse.json({
-      success: true,
-      message: 'Please provide API credentials',
-    });
-   
-      } catch (error) {
-    appLogger.error('Error in connect route', error);
-    // Never return 500 - return graceful error response
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Failed to connect integration',
-        message: 'Please try again later or contact support if the issue persists',
-        details: process.env.NODE_ENV === 'development' ? (error instanceof Error ? error.message : String(error)) : undefined,
-      },
-      { status: 200 }
-    );
-  }
-}, { feature: 'POST API' });
+  },
+  { feature: "POST API" }
+);

--- a/packages/web/src/lib/middleware/api-security.ts
+++ b/packages/web/src/lib/middleware/api-security.ts
@@ -1,14 +1,15 @@
 /**
  * API Security Middleware
- * 
- * Comprehensive security middleware for all API routes.
- * Includes rate limiting, input validation, CSRF protection.
+ *
+ * Comprehensive security middleware for API routes.
+ * Includes rate limiting, authenticated mutation protections, and privileged mutation controls.
  */
 
-import { NextRequest, NextResponse } from 'next/server';
-import { createHash } from 'node:crypto';
-import { withRateLimit } from '@/lib/api/rate-limit';
-import { appLogger } from '@/lib/utils/logger';
+import { NextRequest, NextResponse } from "next/server";
+import { createHash } from "node:crypto";
+import { withRateLimit } from "@/lib/api/rate-limit";
+import { appLogger } from "@/lib/utils/logger";
+import { authenticateRequest } from "@/lib/api/unified-auth";
 
 export interface SecurityOptions {
   rateLimit?: {
@@ -24,39 +25,109 @@ export interface SecurityOptions {
 
 function isPrivilegedMutation(request: NextRequest): boolean {
   const method = request.method.toUpperCase();
-  const isMutation = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
-  return isMutation && request.nextUrl.pathname.startsWith('/api/admin');
+  const isMutation =
+    method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE";
+  return isMutation && request.nextUrl.pathname.startsWith("/api/admin");
+}
+
+function isMutationMethod(request: NextRequest): boolean {
+  const method = request.method.toUpperCase();
+  return method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE";
+}
+
+function isSameOrigin(originOrReferer: string, requestOrigin: string): boolean {
+  try {
+    const origin = new URL(originOrReferer).origin;
+    return origin === requestOrigin;
+  } catch {
+    return false;
+  }
+}
+
+function validateMutationOrigin(request: NextRequest): NextResponse | null {
+  if (!isMutationMethod(request)) {
+    return null;
+  }
+
+  // API-key based callers are not browser-cookie authenticated and do not require origin checks.
+  if (
+    request.headers.get("x-api-key") ||
+    request.headers.get("authorization")?.startsWith("Bearer rk_")
+  ) {
+    return null;
+  }
+
+  const requestOrigin = request.nextUrl.origin;
+  const origin = request.headers.get("origin");
+  const referer = request.headers.get("referer");
+
+  if (origin && !isSameOrigin(origin, requestOrigin)) {
+    return NextResponse.json(
+      {
+        code: "INVALID_ORIGIN",
+        message: "Cross-origin mutation rejected.",
+      },
+      { status: 403 }
+    );
+  }
+
+  if (!origin && referer && !isSameOrigin(referer, requestOrigin)) {
+    return NextResponse.json(
+      {
+        code: "INVALID_REFERER",
+        message: "Cross-origin mutation rejected.",
+      },
+      { status: 403 }
+    );
+  }
+
+  return null;
 }
 
 /**
  * Security middleware wrapper for API routes
  * Supports both handlers with and without params (Next.js 15+ pattern)
  */
-export function withSecurity<T extends (request: NextRequest, ...args: any[]) => Promise<NextResponse>>(
-  handler: T,
-  options: SecurityOptions = {}
-): T {
+export function withSecurity<
+  T extends (request: NextRequest, ...args: any[]) => Promise<NextResponse>,
+>(handler: T, options: SecurityOptions = {}): T {
   const {
     rateLimit = { maxRequests: 60, windowMs: 60 * 1000 },
     requirePrivilegedApproval,
+    requireAuth = false,
   } = options;
 
-  // Apply rate limiting
   const securedHandler = withRateLimit(
     async (request: NextRequest, ...args: any[]) => {
+      const originViolation = validateMutationOrigin(request);
+      if (originViolation) {
+        return originViolation;
+      }
+
+      if (requireAuth) {
+        const auth = await authenticateRequest(request);
+        if (!auth) {
+          return NextResponse.json(
+            {
+              code: "UNAUTHORIZED",
+              message: "Authentication required.",
+            },
+            { status: 401 }
+          );
+        }
+      }
+
       const privilegedApprovalRequired = requirePrivilegedApproval ?? isPrivilegedMutation(request);
       if (privilegedApprovalRequired) {
-        const method = request.method.toUpperCase();
-        const operatorId = request.headers.get('x-operator-id');
-        const breakGlassTicket = request.headers.get('x-breakglass-ticket');
+        const operatorId = request.headers.get("x-operator-id");
+        const breakGlassTicket = request.headers.get("x-breakglass-ticket");
         const traceId = `priv-${Date.now()}`;
 
         if (!operatorId || !breakGlassTicket) {
           return NextResponse.json(
             {
-              code: 'PRIVILEGED_APPROVAL_REQUIRED',
-              message:
-                'Privileged mutations require x-operator-id and x-breakglass-ticket headers.',
+              code: "PRIVILEGED_APPROVAL_REQUIRED",
+              message: "Privileged mutations require operator approval headers.",
               traceId,
               retryable: false,
             },
@@ -64,40 +135,32 @@ export function withSecurity<T extends (request: NextRequest, ...args: any[]) =>
           );
         }
 
-        const sessionRecordId = createHash('sha256')
+        const sessionRecordId = createHash("sha256")
           .update(`${operatorId}|${breakGlassTicket}|${request.nextUrl.pathname}|${Date.now()}`)
-          .digest('hex');
+          .digest("hex");
 
-        appLogger.info('Privileged mutation approved', {
+        appLogger.info("Privileged mutation approved", {
           operatorId,
           breakGlassTicket,
           path: request.nextUrl.pathname,
-          method,
+          method: request.method.toUpperCase(),
           sessionRecordId,
           traceId,
         });
 
         const response = await handler(request, ...args);
-        response.headers.set('X-Privileged-Session-Record-Id', sessionRecordId);
-        response.headers.set('X-Privileged-Operator-Id', operatorId);
-        response.headers.set('X-Privileged-Breakglass-Ticket', breakGlassTicket);
-        response.headers.set('X-Privileged-Trace-Id', traceId);
-        response.headers.set('X-Content-Type-Options', 'nosniff');
-        response.headers.set('X-Frame-Options', 'DENY');
-        response.headers.set('X-XSS-Protection', '1; mode=block');
-        response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        response.headers.set("X-Privileged-Trace-Id", traceId);
+        response.headers.set("X-Privileged-Session-Record-Id", sessionRecordId);
+        response.headers.set("X-Content-Type-Options", "nosniff");
+        response.headers.set("X-Frame-Options", "DENY");
+        response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
         return response;
       }
 
-      // Add security headers
       const response = await handler(request, ...args);
-      
-      // Add security headers to all responses
-      response.headers.set('X-Content-Type-Options', 'nosniff');
-      response.headers.set('X-Frame-Options', 'DENY');
-      response.headers.set('X-XSS-Protection', '1; mode=block');
-      response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-      
+      response.headers.set("X-Content-Type-Options", "nosniff");
+      response.headers.set("X-Frame-Options", "DENY");
+      response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
       return response;
     },
     {

--- a/packages/web/src/lib/security/oauth-state.ts
+++ b/packages/web/src/lib/security/oauth-state.ts
@@ -1,0 +1,107 @@
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+export interface OAuthStatePayload {
+  connectorId: string;
+  tenantId: string;
+  providerId: string;
+  userId: string;
+  nonce: string;
+  issuedAt: number;
+}
+
+function encodeBase64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function decodeBase64Url(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function resolveStateSigningKey(): string {
+  const key =
+    process.env.OAUTH_STATE_SIGNING_KEY ||
+    process.env.JWT_SECRET ||
+    process.env.ENCRYPTION_KEY ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!key || key.length < 32) {
+    throw new Error("OAuth state signing key missing or too short");
+  }
+
+  return key;
+}
+
+function createSignature(payload: string, signingKey: string): string {
+  return createHmac("sha256", signingKey).update(payload).digest("base64url");
+}
+
+export function createOAuthState(input: Omit<OAuthStatePayload, "nonce" | "issuedAt">): string {
+  const payload: OAuthStatePayload = {
+    ...input,
+    nonce: randomUUID(),
+    issuedAt: Date.now(),
+  };
+
+  const encodedPayload = encodeBase64Url(JSON.stringify(payload));
+  const signature = createSignature(encodedPayload, resolveStateSigningKey());
+
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifyOAuthState(
+  state: string,
+  expected: Pick<OAuthStatePayload, "providerId" | "userId">,
+  ttlMs: number = OAUTH_STATE_TTL_MS
+): OAuthStatePayload | null {
+  const [encodedPayload, providedSignature] = state.split(".");
+  if (!encodedPayload || !providedSignature) {
+    return null;
+  }
+
+  const signingKey = resolveStateSigningKey();
+  const expectedSignature = createSignature(encodedPayload, signingKey);
+
+  const providedBuffer = Buffer.from(providedSignature);
+  const expectedBuffer = Buffer.from(expectedSignature);
+  if (providedBuffer.length !== expectedBuffer.length) {
+    return null;
+  }
+
+  if (!timingSafeEqual(providedBuffer, expectedBuffer)) {
+    return null;
+  }
+
+  let parsedPayload: OAuthStatePayload;
+
+  try {
+    parsedPayload = JSON.parse(decodeBase64Url(encodedPayload)) as OAuthStatePayload;
+  } catch {
+    return null;
+  }
+
+  if (
+    !parsedPayload.connectorId ||
+    !parsedPayload.tenantId ||
+    !parsedPayload.providerId ||
+    !parsedPayload.userId ||
+    !parsedPayload.nonce ||
+    typeof parsedPayload.issuedAt !== "number"
+  ) {
+    return null;
+  }
+
+  if (
+    parsedPayload.providerId !== expected.providerId ||
+    parsedPayload.userId !== expected.userId
+  ) {
+    return null;
+  }
+
+  if (Date.now() - parsedPayload.issuedAt > ttlMs) {
+    return null;
+  }
+
+  return parsedPayload;
+}


### PR DESCRIPTION
### Motivation
- Close a trust-boundary gap where connector OAuth state was unbound and replayable, and where browser-originated mutations relied on implied protections. 
- Ensure server-side `requireAuth` and privileged-mutation checks are real and centralized rather than implied by client-side or wrapper-only assumptions. 
- Reduce attacker leverage from tampered OAuth state, cross-origin mutation requests, and echoed privileged headers.

### Description
- Add a signed, TTL-bound OAuth state primitive that encodes `{connectorId, tenantId, providerId, userId, nonce, issuedAt}` with HMAC-SHA256 signing and timing-safe verification in `packages/web/src/lib/security/oauth-state.ts`. 
- Issue the signed state during connector initiation and bind it to the connector/tenant/user context in `packages/web/src/app/api/connectors/connect/[providerId]/route.ts`. 
- Validate the signed state in the OAuth callback flow and resolve the connector from the validated state before performing token exchange and credential storage in `packages/web/src/app/api/connectors/callback/[providerId]/route.ts`. 
- Harden API mutation protections in `packages/web/src/lib/middleware/api-security.ts` by enforcing optional server-side `requireAuth` via `authenticateRequest`, rejecting cross-origin browser mutations using `Origin`/`Referer` checks (while allowing API-key callers), and avoiding echoing sensitive operator/ticket headers in responses. 
- Add focused unit tests: `packages/web/src/__tests__/security/oauth-state.test.ts` (state signing/verification, tamper, actor binding) and `packages/web/src/__tests__/security/with-security-enforcement.test.ts` (`requireAuth` enforcement and cross-origin mutation rejection). 

### Testing
- Ran the new unit tests with `pnpm --filter @settler/web exec jest src/__tests__/security/oauth-state.test.ts src/__tests__/security/with-security-enforcement.test.ts --runInBand` and both suites passed. 
- Ran linting with `pnpm lint` and fixed staged files; lint completed successfully across the repository (only pre-existing warnings remain). 
- Ran type checking with `pnpm typecheck` and the repository typecheck completed successfully. 
- Attempted `pnpm build` but the web build failed in this environment due to missing required build-time environment variables (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and a server DB URL), which is an environment limitation and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f952fb1c83289d7d34236e43c5c3)