### PR TITLE
Harden API mutation auth defaults and browser-origin validation

### DIFF
--- a/packages/web/src/__tests__/security/with-security-enforcement.test.ts
+++ b/packages/web/src/__tests__/security/with-security-enforcement.test.ts
@@ -57,7 +57,58 @@ describe("withSecurity enforcement", () => {
     expect(payload.code).toBe("INVALID_ORIGIN");
   });
 
+  it("rejects browser mutations that omit both origin and referer", async () => {
+    const handler = withSecurity(async () => NextResponse.json({ ok: true }));
+
+    const response = await handler(
+      createRequest("https://app.settler.test/api/secure", {
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(403);
+    const payload = await response.json();
+    expect(payload.code).toBe("MISSING_ORIGIN_CONTEXT");
+  });
+
+  it("rejects cross-site browser mutations via sec-fetch-site", async () => {
+    const handler = withSecurity(async () => NextResponse.json({ ok: true }));
+
+    const response = await handler(
+      createRequest("https://app.settler.test/api/secure", {
+        method: "POST",
+        headers: {
+          "sec-fetch-site": "cross-site",
+          origin: "https://app.settler.test",
+        },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    const payload = await response.json();
+    expect(payload.code).toBe("INVALID_FETCH_SITE");
+  });
+
+  it("requires auth by default for mutation routes", async () => {
+    authenticateRequestMock.mockResolvedValue(null);
+
+    const handler = withSecurity(async () => NextResponse.json({ ok: true }));
+
+    const response = await handler(
+      createRequest("https://app.settler.test/api/secure", {
+        method: "POST",
+        headers: {
+          origin: "https://app.settler.test",
+        },
+      })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
   it("allows API key mutation requests without browser origin headers", async () => {
+    authenticateRequestMock.mockResolvedValue({ tenantId: "tenant-1", actorId: "user-1" });
+
     const handler = withSecurity(async () => NextResponse.json({ ok: true }));
 
     const response = await handler(

--- a/packages/web/src/lib/middleware/api-security.ts
+++ b/packages/web/src/lib/middleware/api-security.ts
@@ -60,6 +60,27 @@ function validateMutationOrigin(request: NextRequest): NextResponse | null {
   const requestOrigin = request.nextUrl.origin;
   const origin = request.headers.get("origin");
   const referer = request.headers.get("referer");
+  const secFetchSite = request.headers.get("sec-fetch-site");
+
+  if (secFetchSite && !["same-origin", "same-site", "none"].includes(secFetchSite)) {
+    return NextResponse.json(
+      {
+        code: "INVALID_FETCH_SITE",
+        message: "Cross-site mutation rejected.",
+      },
+      { status: 403 }
+    );
+  }
+
+  if (!origin && !referer) {
+    return NextResponse.json(
+      {
+        code: "MISSING_ORIGIN_CONTEXT",
+        message: "Mutation requests must include an origin or referer header.",
+      },
+      { status: 403 }
+    );
+  }
 
   if (origin && !isSameOrigin(origin, requestOrigin)) {
     return NextResponse.json(
@@ -94,7 +115,7 @@ export function withSecurity<
   const {
     rateLimit = { maxRequests: 60, windowMs: 60 * 1000 },
     requirePrivilegedApproval,
-    requireAuth = false,
+    requireAuth,
   } = options;
 
   const securedHandler = withRateLimit(
@@ -104,7 +125,9 @@ export function withSecurity<
         return originViolation;
       }
 
-      if (requireAuth) {
+      const authRequired = requireAuth ?? isMutationMethod(request);
+
+      if (authRequired) {
         const auth = await authenticateRequest(request);
         if (!auth) {
           return NextResponse.json(


### PR DESCRIPTION
### Motivation
- Prevent false-confidence where mutation handlers wrapped with `withSecurity` could be unintentionally left unauthenticated by making auth required for mutation methods by default.
- Reduce browser-origin mutation attack surface (CSRF-style and cross-site requests) by validating `Sec-Fetch-Site`, `Origin`, and `Referer` semantics server-side.
- Preserve non-browser programmatic callers (API keys / internal callers) while making browser-driven mutation requirements explicit and enforceable.

### Description
- Changed `withSecurity` to treat mutation methods (`POST`/`PUT`/`PATCH`/`DELETE`) as authenticated by default by evaluating `requireAuth ?? isMutationMethod(request)` instead of defaulting to `false`, so routes must explicitly opt out to allow unauthenticated mutations (file: `packages/web/src/lib/middleware/api-security.ts`).
- Tightened origin/fetch-site validation in `validateMutationOrigin` to reject unsafe `sec-fetch-site` values, require at least one of `Origin` or `Referer` for browser-like mutation requests, and keep strict same-origin checks when those headers are present while continuing to bypass these checks for API-key/internal callers (file: `packages/web/src/lib/middleware/api-security.ts`).
- Added unit tests that assert the new denial/allow paths: missing origin/referer leads to `MISSING_ORIGIN_CONTEXT`, `sec-fetch-site: cross-site` leads to `INVALID_FETCH_SITE`, default auth requirement for mutations returns `401` when unauthenticated, and API-key callers still succeed (file: `packages/web/src/__tests__/security/with-security-enforcement.test.ts`).

### Testing
- Ran the focused unit tests: `pnpm --filter @settler/web exec jest src/__tests__/security/with-security-enforcement.test.ts --runInBand` and the test suite for those cases passed (6/6 tests passed).
- Initiated repository-level checks: `pnpm lint` was started but the workspace-wide Turborepo lint run did not complete in-session (observed partial output and fan-out; no deterministic completion signal).
- Initiated `pnpm typecheck` and `pnpm build`; both progressed across workspace packages but did not complete within the execution window, so full workspace build/typecheck completion is pending in CI or a longer-running environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6fffc7aac8328b5d806a0d9f8c8da)