### PR TITLE
Add guarded style verification and normalize operational route disclosure

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,7 +297,8 @@
     "verify:all": "pnpm run validate:all",
     "verify:repo": "pnpm run repo-integrity",
     "verify:console-route-maturity": "pnpm --filter @settler/web exec tsx scripts/verify-console-route-maturity.ts",
-    "verify:operational-route-truth": "pnpm --filter @settler/web exec tsx scripts/verify-operational-route-truth.ts"
+    "verify:operational-route-truth": "pnpm --filter @settler/web exec tsx scripts/verify-operational-route-truth.ts",
+    "verify:styles": "node scripts/verify-styles.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/web/src/components/shared/OperationalRouteNotice.tsx
+++ b/packages/web/src/components/shared/OperationalRouteNotice.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 import { AlertTriangle, Database, Landmark, Shield } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { getOperationalRouteMeta } from "@/lib/routes/operational-truth";
 
 export function OperationalRouteNotice() {
@@ -14,55 +15,46 @@ export function OperationalRouteNotice() {
   }
 
   return (
-    <section
+    <Alert
+      variant="warning"
       aria-label="Operational route disclosure"
-      className="mb-6 rounded-xl border border-amber-300/70 bg-amber-50/80 px-4 py-4 text-sm text-amber-950 shadow-sm dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100"
+      className="mb-6 rounded-xl border-amber-300/70 bg-amber-50/80 shadow-sm dark:border-amber-800 dark:bg-amber-950/40"
     >
-      <div className="flex items-start gap-3">
-        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700 dark:text-amber-300" />
-        <div className="space-y-2">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="font-semibold">Operational disclosure</span>
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <AlertTitle className="mb-0">Operational disclosure</AlertTitle>
+          <Badge variant="outline" className="border-amber-500/80 text-current">
+            {meta.maturity}
+          </Badge>
+          <Badge
+            variant="outline"
+            className="inline-flex items-center gap-1 border-amber-500/80 text-current"
+          >
+            {meta.scopeSignal === "tenant" ? (
+              <Landmark className="h-3 w-3" aria-hidden="true" />
+            ) : (
+              <Shield className="h-3 w-3" aria-hidden="true" />
+            )}
+            {meta.scopeSignal === "tenant" ? "Tenant scope" : "Global scope"}
+          </Badge>
+          {meta.runtimeDependency !== "none" ? (
             <Badge
               variant="outline"
-              className="border-amber-500/80 text-amber-800 dark:text-amber-100"
+              className="inline-flex items-center gap-1 border-amber-500/80 text-current"
             >
-              {meta.maturity}
+              <Database className="h-3 w-3" aria-hidden="true" />
+              {meta.runtimeDependency} dependency
             </Badge>
-            <Badge
-              variant="outline"
-              className="inline-flex items-center gap-1 border-amber-500/80 text-amber-800 dark:text-amber-100"
-            >
-              {meta.scopeSignal === "tenant" ? (
-                <Landmark className="h-3 w-3" aria-hidden="true" />
-              ) : (
-                <Shield className="h-3 w-3" aria-hidden="true" />
-              )}
-              {meta.scopeSignal === "tenant" ? "Tenant scope" : "Global scope"}
+          ) : null}
+          {meta.operationalClass === "synthetic" ? (
+            <Badge variant="outline" className="border-amber-500/80 text-current">
+              Synthetic surface
             </Badge>
-            {meta.runtimeDependency !== "none" ? (
-              <Badge
-                variant="outline"
-                className="inline-flex items-center gap-1 border-amber-500/80 text-amber-800 dark:text-amber-100"
-              >
-                <Database className="h-3 w-3" aria-hidden="true" />
-                {meta.runtimeDependency} dependency
-              </Badge>
-            ) : null}
-            {meta.operationalClass === "synthetic" ? (
-              <Badge
-                variant="outline"
-                className="border-amber-500/80 text-amber-800 dark:text-amber-100"
-              >
-                Synthetic surface
-              </Badge>
-            ) : null}
-          </div>
-          <p className="leading-relaxed text-amber-900/90 dark:text-amber-100/90">
-            {meta.degradedBehavior}
-          </p>
+          ) : null}
         </div>
+        <AlertDescription className="leading-relaxed">{meta.degradedBehavior}</AlertDescription>
       </div>
-    </section>
+    </Alert>
   );
 }

--- a/scripts/verify-styles.mjs
+++ b/scripts/verify-styles.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const guardedFiles = [
+  "packages/web/src/components/shared/OperationalRouteNotice.tsx",
+  "packages/web/src/components/shared/route-state.tsx",
+  "packages/web/src/components/console/ConsoleLayout.tsx",
+  "packages/web/src/app/console/error.tsx",
+  "packages/web/src/app/dashboard/not-found.tsx",
+  "packages/web/src/app/console/not-found.tsx",
+];
+
+const bannedPattern = /\b(?:text|bg|border|ring)-(?:slate|gray)-[\w/[\].:-]+/g;
+const violations = [];
+
+for (const file of guardedFiles) {
+  const source = readFileSync(file, "utf8");
+  const lines = source.split(/\r?\n/);
+
+  lines.forEach((line, index) => {
+    const matches = line.match(bannedPattern);
+    if (!matches) return;
+    for (const match of matches) {
+      violations.push(`${file}:${index + 1} uses banned utility '${match}'`);
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error("❌ Style verification failed for guarded route-truth surfaces.");
+  for (const violation of violations) {
+    console.error(`  - ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log(`✅ Style verification passed (${guardedFiles.length} guarded files checked)`);


### PR DESCRIPTION
### Motivation
- Prevent style-token drift on critical route-truth and disclosure surfaces by banning ad-hoc `slate/gray` utilities on guarded files.
- Make the operational-disclosure UI consistent and maintainable by using shared alert primitives and semantic token-aligned classes.

### Description
- Add a focused guardrail script `scripts/verify-styles.mjs` and wire it to a new root script `verify:styles` to fail if guarded files contain banned `text-*/bg-*/border-*/ring-*` utilities for `slate`/`gray` palettes.
- Refactor `packages/web/src/components/shared/OperationalRouteNotice.tsx` to use shared `Alert`, `AlertTitle`, and `AlertDescription` primitives, normalize badge styling and replace one-off hardcoded color utilities with semantic usages (e.g. `text-current`).
- Restrict the style verification scope to a small set of high-leverage files (route-state, console layout, and the main disclosure hosts) to avoid broad churn while protecting operator-facing truth surfaces.

### Testing
- `pnpm run verify:styles` — passed.
- `pnpm run verify:routes` (includes `verify:console-route-maturity` and `verify:operational-route-truth`) — passed.
- `pnpm lint`, `pnpm run verify:all`, and `pnpm run verify:repo` — passed (lint produced warnings only in unrelated packages).
- `pnpm run doctor` — failed as expected in this environment due to missing Supabase / DATABASE env vars (environmental limitation, not a code regression).
- `pnpm typecheck` and `pnpm build` were initiated but not fully completed in-session due to long-running workloads in this container; these should be green in CI/normal developer environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7366143088328b65166fbc734f8e7)