### PR TITLE
Fix Vercel static/dynamic misclassification and replace generic brand icons

### DIFF
--- a/packages/web/public/brand/settler/favicon-192x192.svg
+++ b/packages/web/public/brand/settler/favicon-192x192.svg
@@ -1,5 +1,10 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="64" height="64" rx="12" fill="#2563EB"/>
-<path d="M32 16L16 32L32 48" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M48 16L32 32L48 48" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Settler favicon: geometric layered S mark on dark navy circle -->
+  <circle cx="96" cy="96" r="96" fill="#0B1E3D"/>
+  <!-- Top C-shape (teal) — upper arc of S, opens right -->
+  <path d="M132 57C120 42 99 36 78 42C57 51 45 69 45 90" stroke="#2DA8A8" stroke-width="18" stroke-linecap="round" fill="none"/>
+  <path d="M120 66C111 54 93 51 78 55.5C60 63 54 78 54 90" stroke="#1ECFCF" stroke-width="9" stroke-linecap="round" fill="none" opacity="0.55"/>
+  <!-- Bottom C-shape (white) — lower arc of S, opens left -->
+  <path d="M60 135C72 150 93 156 114 150C135 141 147 123 147 102" stroke="#E2EBF0" stroke-width="18" stroke-linecap="round" fill="none"/>
+  <path d="M72 126C81 138 99 141 114 136.5C132 129 138 114 138 102" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" fill="none" opacity="0.6"/>
 </svg>

--- a/packages/web/public/brand/settler/favicon-512x512.svg
+++ b/packages/web/public/brand/settler/favicon-512x512.svg
@@ -1,5 +1,10 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="64" height="64" rx="12" fill="#2563EB"/>
-<path d="M32 16L16 32L32 48" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M48 16L32 32L48 48" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Settler favicon 512: geometric layered S mark on dark navy circle -->
+  <circle cx="256" cy="256" r="256" fill="#0B1E3D"/>
+  <!-- Top C-shape (teal) — upper arc of S, opens right -->
+  <path d="M352 152C320 112 264 96 208 112C152 136 120 184 120 240" stroke="#2DA8A8" stroke-width="48" stroke-linecap="round" fill="none"/>
+  <path d="M320 176C296 144 248 136 208 148C160 168 144 208 144 240" stroke="#1ECFCF" stroke-width="24" stroke-linecap="round" fill="none" opacity="0.55"/>
+  <!-- Bottom C-shape (white) — lower arc of S, opens left -->
+  <path d="M160 360C192 400 248 416 304 400C360 376 392 328 392 272" stroke="#E2EBF0" stroke-width="48" stroke-linecap="round" fill="none"/>
+  <path d="M192 336C216 368 264 376 304 364C352 344 368 304 368 272" stroke="#FFFFFF" stroke-width="24" stroke-linecap="round" fill="none" opacity="0.6"/>
 </svg>

--- a/packages/web/public/brand/settler/logo-icon.svg
+++ b/packages/web/public/brand/settler/logo-icon.svg
@@ -1,5 +1,10 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="64" height="64" rx="12" fill="#2563EB"/>
-<path d="M32 16L16 32L32 48" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M48 16L32 32L48 48" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Settler icon mark: geometric layered S on dark navy circle -->
+  <circle cx="32" cy="32" r="32" fill="#0B1E3D"/>
+  <!-- Top C-shape (teal) — upper arc of S, opens right -->
+  <path d="M44 19C40 14 33 12 26 14C19 17 15 23 15 30" stroke="#2DA8A8" stroke-width="6" stroke-linecap="round" fill="none"/>
+  <path d="M40 22C37 18 31 17 26 18.5C20 21 18 26 18 30" stroke="#1ECFCF" stroke-width="3" stroke-linecap="round" fill="none" opacity="0.55"/>
+  <!-- Bottom C-shape (white) — lower arc of S, opens left -->
+  <path d="M20 45C24 50 31 52 38 50C45 47 49 41 49 34" stroke="#E2EBF0" stroke-width="6" stroke-linecap="round" fill="none"/>
+  <path d="M24 42C27 46 33 47 38 45.5C44 43 46 38 46 34" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" fill="none" opacity="0.6"/>
 </svg>

--- a/packages/web/src/app/app/layout.tsx
+++ b/packages/web/src/app/app/layout.tsx
@@ -5,6 +5,11 @@ import { createClient } from "@/lib/supabase/server";
 import { AppSidebar, MobileNav } from "@/components/app/AppNav";
 import { OperationalRouteNotice } from "@/components/shared/OperationalRouteNotice";
 
+// All /app/* routes require authenticated session state via cookies.
+// Force dynamic rendering to prevent Next.js from attempting static prerender
+// during build, which causes "[Supabase] Failed to get cookies" errors.
+export const dynamic = "force-dynamic";
+
 function SignedOutScreen() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-6">

--- a/packages/web/src/app/investor/reality/page.tsx
+++ b/packages/web/src/app/investor/reality/page.tsx
@@ -1,27 +1,30 @@
 /**
  * Board/Investor KPI Dashboard
- * 
+ *
  * Executive-level view showing key metrics suitable for investor presentations.
  * Read-only, privileged access. High signal, low noise.
  */
 
-import { Suspense } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import {
-  DollarSign,
-  Users,
-  TrendingUp,
-  AlertTriangle,
-  CheckCircle,
-  Loader2
-} from 'lucide-react';
-import { getInvestorRealityData } from '@/lib/investor/reality-data';
+import { Suspense } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { DollarSign, Users, TrendingUp, AlertTriangle, CheckCircle, Loader2 } from "lucide-react";
+import { getInvestorRealityData } from "@/lib/investor/reality-data";
 
-export const revalidate = 300;
+// ISR (revalidate) is incompatible with this route: getInvestorRealityData()
+// calls createClient() which reads cookies(). Cookies are request-bound and
+// unavailable during background ISR regeneration, causing build-time errors.
+// Force dynamic to always serve fresh live data for the board dashboard.
+export const dynamic = "force-dynamic";
 
 type InvestorRealityPayload = {
-  revenue: { mrr: number; mrr_growth: number | null; active_subscriptions: number; churn: number | null; status: string };
+  revenue: {
+    mrr: number;
+    mrr_growth: number | null;
+    active_subscriptions: number;
+    churn: number | null;
+    status: string;
+  };
   usage: { dau: number; wau: number; active_tenants: number; status: string };
   reliability: { uptime_proxy: number | null; failure_events: number };
   risk_index: number;
@@ -31,8 +34,8 @@ type InvestorRealityPayload = {
 };
 
 const FALLBACK_DASHBOARD_DATA: InvestorRealityPayload = {
-  revenue: { mrr: 0, mrr_growth: null, active_subscriptions: 0, churn: null, status: 'assumed' },
-  usage: { dau: 0, wau: 0, active_tenants: 0, status: 'assumed' },
+  revenue: { mrr: 0, mrr_growth: null, active_subscriptions: 0, churn: null, status: "assumed" },
+  usage: { dau: 0, wau: 0, active_tenants: 0, status: "assumed" },
   reliability: { uptime_proxy: null, failure_events: 0 },
   risk_index: 0,
   evidence_index: 0,
@@ -57,27 +60,32 @@ export async function InvestorDashboardContent() {
   }
 
   const formatCurrency = (value: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
     }).format(value);
   };
 
   const formatPercent = (value: number | string | null) => {
-    if (value === null || value === undefined) return 'N/A';
-    const num = typeof value === 'string' ? parseFloat(value) : value;
-    return `${num >= 0 ? '+' : ''}${num.toFixed(1)}%`;
+    if (value === null || value === undefined) return "N/A";
+    const num = typeof value === "string" ? parseFloat(value) : value;
+    return `${num >= 0 ? "+" : ""}${num.toFixed(1)}%`;
   };
 
   const getStatusBadge = (status: string) => {
     switch (status) {
-      case 'proven':
-        return <Badge className="bg-green-500"><CheckCircle className="w-3 h-3 mr-1" />PROVEN</Badge>;
-      case 'assumed':
+      case "proven":
+        return (
+          <Badge className="bg-green-500">
+            <CheckCircle className="w-3 h-3 mr-1" />
+            PROVEN
+          </Badge>
+        );
+      case "assumed":
         return <Badge className="bg-yellow-500">ASSUMED</Badge>;
-      case 'broken':
+      case "broken":
         return <Badge variant="destructive">BROKEN</Badge>;
       default:
         return <Badge>{status}</Badge>;
@@ -89,7 +97,8 @@ export async function InvestorDashboardContent() {
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2">Board KPI Dashboard</h1>
         <p className="text-muted-foreground">
-          Key performance indicators powered by the Reality System. Evidence-based metrics for investor review.
+          Key performance indicators powered by the Reality System. Evidence-based metrics for
+          investor review.
         </p>
       </div>
 
@@ -98,7 +107,8 @@ export async function InvestorDashboardContent() {
           <CardHeader>
             <CardTitle>Live metrics unavailable</CardTitle>
             <CardDescription>
-              Rendering fallback values because optional runtime services are unavailable in this environment.
+              Rendering fallback values because optional runtime services are unavailable in this
+              environment.
             </CardDescription>
           </CardHeader>
         </Card>
@@ -132,7 +142,9 @@ export async function InvestorDashboardContent() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold">{data.revenue.active_subscriptions.toLocaleString()}</div>
+            <div className="text-3xl font-bold">
+              {data.revenue.active_subscriptions.toLocaleString()}
+            </div>
             <div className="text-sm text-muted-foreground mt-1">
               Churn: {formatPercent(data.revenue.churn)}
             </div>
@@ -247,7 +259,7 @@ export async function InvestorDashboardContent() {
             <div>
               <div className="text-sm text-muted-foreground mb-1">Uptime Proxy</div>
               <div className="text-2xl font-bold">
-                {data.reliability.uptime_proxy ? `${data.reliability.uptime_proxy}%` : 'N/A'}
+                {data.reliability.uptime_proxy ? `${data.reliability.uptime_proxy}%` : "N/A"}
               </div>
             </div>
             <div>
@@ -269,8 +281,8 @@ export async function InvestorDashboardContent() {
             <div className="text-4xl font-bold">{data.evidence_index}%</div>
             <div className="flex-1">
               <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-4">
-                <div 
-                  className="bg-green-600 h-4 rounded-full transition-all" 
+                <div
+                  className="bg-green-600 h-4 rounded-full transition-all"
                   style={{ width: `${data.evidence_index}%` }}
                 ></div>
               </div>
@@ -293,11 +305,13 @@ export async function InvestorDashboardContent() {
 
 export default function InvestorRealityPage() {
   return (
-    <Suspense fallback={
-      <div className="container mx-auto p-8 flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin" />
-      </div>
-    }>
+    <Suspense
+      fallback={
+        <div className="container mx-auto p-8 flex items-center justify-center">
+          <Loader2 className="w-8 h-8 animate-spin" />
+        </div>
+      }
+    >
       <InvestorDashboardContent />
     </Suspense>
   );


### PR DESCRIPTION
Route classification fixes (resolves Vercel build errors):
- app/app/layout.tsx: add `export const dynamic = "force-dynamic"` — the
  layout calls createClient() which reads cookies(), making every /app/*
  route request-bound. Without this directive Next.js attempts static
  prerender at build time, which fails with "[Supabase] Failed to get
  cookies" and "Dynamic server usage" errors for /app/settings, /app/alerts,
  and all other /app/* routes.
- investor/reality/page.tsx: replace `export const revalidate = 300` with
  `export const dynamic = "force-dynamic"` — ISR background regeneration has
  no request context, so the cookies() call inside getInvestorRealityData()
  fails silently; force-dynamic ensures fresh live data on every request.

Brand asset fixes:
- favicon-192x192.svg, favicon-512x512.svg, logo-icon.svg: replace identical
  generic blue-square-with-chevrons placeholders with a Settler brand-
  appropriate geometric S mark (teal upper arc + white lower arc on dark navy
  circle), matching the visual identity shown in the official brand assets.

https://claude.ai/code/session_01Ux4N9QpM2ChSWvVz9mTw3k