### PR TITLE
Harden console run semantics and polling

### DIFF
--- a/docs/reconciliation/README.md
+++ b/docs/reconciliation/README.md
@@ -4,16 +4,28 @@ Settler reconciliation surfaces are designed to make mismatch triage explainable
 
 ## Core entities
 
-- Execution
-- Reconciliation
-- ProofReceipt
-- PolicyRule
-- AuditEvent
-- SystemHealth
+- **Run** — the tenant-scoped execution lifecycle (`pending` → `running` → terminal) for a reconciliation job.
+- **Run Result** — the persisted outcome snapshot attached to a run, including canonical counters, row-level rationale, and provenance.
+- **Exception** — an operator workflow item derived from unresolved or escalated reconciliation outcomes.
+- **ProofReceipt** — evidence artifact linking a decision to inputs, rules, and timestamps.
+- **PolicyRule** — deterministic matching, tolerance, and validation logic.
+- **AuditEvent** — append-only operator or system action trace.
+- **SystemHealth** — runtime readiness signals for the operator shell.
+
+## Canonical operator semantics
+
+Settler’s operator-facing reconciliation pages now use one shared summary model:
+
+- `matched` and `matchedWithTolerance` represent successful row-level decisions.
+- `unmatched` is the combined count of unresolved source-side and target-side gaps.
+- `exceptioned` represents rows promoted into the exception workflow.
+- `unresolved` represents work that still requires operator review.
+- Run detail, run list, reconciliation detail, and exception list all derive these values from the same canonical contract in `packages/web/src/lib/reconciliation/canonical-run-result.ts`.
 
 ## UI surfaces
 
 - Public: `/reconciliation`
+- Operator console: `/console/runs`, `/console/reconciliations`, `/console/exceptions`
 - Control plane: `/app/reconciliation` and `/app/reconciliation/[id]`
 
 ## Validation

--- a/packages/web/src/__tests__/api/status-no-self-hop.test.ts
+++ b/packages/web/src/__tests__/api/status-no-self-hop.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("status route internal hop guardrail", () => {
+  it("does not call its own health endpoint over HTTP", () => {
+    const source = readFileSync(resolve(process.cwd(), "src/app/api/status/route.ts"), "utf-8");
+
+    expect(source).toContain("checkApplicationRuntimeHealth");
+    expect(source).not.toContain("/api/status/health");
+    expect(source).not.toContain("NEXT_PUBLIC_SITE_URL");
+  });
+});

--- a/packages/web/src/__tests__/app/console-layout-nav-role-fetch.test.ts
+++ b/packages/web/src/__tests__/app/console-layout-nav-role-fetch.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("console layout role hydration", () => {
+  it("passes super admin scope from the server layout instead of a client-side role fetch", () => {
+    const layoutSource = readFileSync(
+      resolve(process.cwd(), "src/app/console/layout.tsx"),
+      "utf-8"
+    );
+    const clientShellSource = readFileSync(
+      resolve(process.cwd(), "src/components/console/ConsoleLayout.tsx"),
+      "utf-8"
+    );
+
+    expect(layoutSource).toContain("const hasSuperAdminScope = await isSuperAdmin()");
+    expect(layoutSource).toContain("<ConsoleLayout isSuperAdmin={hasSuperAdminScope}>");
+    expect(clientShellSource).not.toContain('fetch("/api/console/user-role")');
+  });
+});

--- a/packages/web/src/__tests__/app/console-runs-canonical-semantics.test.ts
+++ b/packages/web/src/__tests__/app/console-runs-canonical-semantics.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("console runs page canonical semantics", () => {
+  it("renders canonical summary fields instead of legacy mismatch placeholders", () => {
+    const source = readFileSync(resolve(process.cwd(), "src/app/console/runs/page.tsx"), "utf-8");
+
+    expect(source).toContain("run.summary.matched");
+    expect(source).toContain("run.summary.unmatched");
+    expect(source).toContain("run.summarySemantics.exceptioned");
+    expect(source).toContain("run.summarySemantics.unresolved");
+    expect(source).not.toContain("run.summary.totalItems");
+    expect(source).not.toContain("run.summary.mismatched");
+    expect(source).not.toContain("run.summary.missing");
+  });
+});

--- a/packages/web/src/__tests__/lib/console-polling.test.ts
+++ b/packages/web/src/__tests__/lib/console-polling.test.ts
@@ -1,0 +1,49 @@
+import {
+  hasActiveRuns,
+  hasOpenExceptions,
+  shouldPollExceptions,
+  shouldPollRuns,
+} from "@/lib/console/polling";
+
+describe("console polling heuristics", () => {
+  it("keeps run polling active while visible runs are non-terminal", () => {
+    expect(
+      shouldPollRuns({
+        autoRefresh: true,
+        runs: [
+          { status: "completed", isTerminal: true },
+          { status: "running", isTerminal: false },
+        ],
+        loadingInitialState: false,
+      })
+    ).toBe(true);
+    expect(hasActiveRuns([{ status: "pending" }, { status: "completed", isTerminal: true }])).toBe(
+      true
+    );
+  });
+
+  it("pauses run polling once all visible runs are terminal", () => {
+    expect(
+      shouldPollRuns({
+        autoRefresh: true,
+        runs: [
+          { status: "completed", isTerminal: true },
+          { status: "failed", isTerminal: true },
+        ],
+        loadingInitialState: false,
+      })
+    ).toBe(false);
+  });
+
+  it("avoids exception polling for resolved-only views", () => {
+    expect(
+      shouldPollExceptions({
+        autoRefresh: true,
+        exceptions: [{ status: "resolved" }, { status: "ignored" }],
+        loadingInitialState: false,
+        statusFilter: "resolved",
+      })
+    ).toBe(false);
+    expect(hasOpenExceptions([{ status: "resolved" }, { status: "investigating" }])).toBe(true);
+  });
+});

--- a/packages/web/src/app/api/status/route.ts
+++ b/packages/web/src/app/api/status/route.ts
@@ -1,88 +1,89 @@
 import { NextRequest, NextResponse } from "next/server";
 import { addCorsHeaders, handleCors } from "@/lib/api/cors";
-import { publicRoute } from '@/middleware/billing-gate-universal';
-import { appLogger } from '@/lib/utils/logger';
-import { withSecurity } from '@/lib/middleware/api-security';
+import { publicRoute } from "@/middleware/billing-gate-universal";
+import { appLogger } from "@/lib/utils/logger";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { validateSupabaseEnv } from "@/lib/env/validator";
 
 // Cache status for 30 seconds to reduce load while keeping it fresh
 export const revalidate = 30;
-export const dynamic = 'force-dynamic';
-export const runtime = 'nodejs'; // Ensure Node.js runtime for Prisma and Supabase
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs"; // Ensure Node.js runtime for Prisma and Supabase
 export const maxDuration = 10; // 10 seconds max for health checks
 
 export const GET = withSecurity(
   publicRoute(async function GET(request: NextRequest): Promise<NextResponse> {
-  // Handle CORS preflight
-  const corsResponse = handleCors(request);
-  if (corsResponse) return corsResponse;
+    // Handle CORS preflight
+    const corsResponse = handleCors(request);
+    if (corsResponse) return corsResponse;
 
-  try {
-    // Check actual system health
-    const healthChecks = await Promise.allSettled([
-      // Check database connectivity
-      checkDatabaseHealth(),
-      // Check Supabase connectivity
-      checkSupabaseHealth(),
-      // Check API endpoints
-      checkAPIHealth(),
-    ]);
+    try {
+      // Check actual system health
+      const healthChecks = await Promise.allSettled([
+        // Check database connectivity
+        checkDatabaseHealth(),
+        // Check Supabase connectivity
+        checkSupabaseHealth(),
+        // Check local runtime readiness without same-app HTTP hops
+        checkApplicationRuntimeHealth(),
+      ]);
 
-    // Uptime values are not measured historically — report only current connectivity status.
-    // Do not display fabricated uptime percentages.
-    const apiOk = healthChecks[2].status === 'fulfilled';
-    const dbOk = healthChecks[0].status === 'fulfilled';
+      // Uptime values are not measured historically — report only current connectivity status.
+      // Do not display fabricated uptime percentages.
+      const apiOk = healthChecks[2].status === "fulfilled" && healthChecks[2].value === true;
+      const dbOk = healthChecks[0].status === "fulfilled" && healthChecks[0].value === true;
 
-    const systems = [
-      {
-        name: "Reconciliation Engine",
-        status: apiOk ? ("operational" as const) : ("degraded" as const),
-      },
-      {
-        name: "Receipts Processing",
-        status: apiOk ? ("operational" as const) : ("degraded" as const),
-      },
-      {
-        name: "Convert Service",
-        status: apiOk ? ("operational" as const) : ("degraded" as const),
-      },
-      {
-        name: "Feature Flags",
-        status: apiOk ? ("operational" as const) : ("degraded" as const),
-      },
-      {
-        name: "Database",
-        status: dbOk ? ("operational" as const) : ("degraded" as const),
-      },
-    ];
+      const systems = [
+        {
+          name: "Reconciliation Engine",
+          status: apiOk ? ("operational" as const) : ("degraded" as const),
+        },
+        {
+          name: "Receipts Processing",
+          status: apiOk ? ("operational" as const) : ("degraded" as const),
+        },
+        {
+          name: "Convert Service",
+          status: apiOk ? ("operational" as const) : ("degraded" as const),
+        },
+        {
+          name: "Feature Flags",
+          status: apiOk ? ("operational" as const) : ("degraded" as const),
+        },
+        {
+          name: "Database",
+          status: dbOk ? ("operational" as const) : ("degraded" as const),
+        },
+      ];
 
-    // Determine overall status
-    const hasDegraded = systems.some(s => s.status === 'degraded');
-    const overallStatus = hasDegraded ? "degraded" : "operational";
+      // Determine overall status
+      const hasDegraded = systems.some((s) => s.status === "degraded");
+      const overallStatus = hasDegraded ? "degraded" : "operational";
 
-    const response = NextResponse.json({ systems, overallStatus });
-    
-    // Add caching headers for better performance
-    response.headers.set('Cache-Control', 'public, s-maxage=30, stale-while-revalidate=60');
-    
-    // Add CORS headers
-    return addCorsHeaders(response, request);
-  } catch (error) {
-    appLogger.error("Error in status GET", error);
-    // Never return 500 - return degraded status with graceful error message
-    const errorResponse = NextResponse.json(
-      { 
-        systems: [],
-        overallStatus: "degraded",
-        error: "Unable to fetch system status",
-        message: "Please try again later"
-      },
-      { status: 200 }
-    );
-    // Don't cache errors
-    errorResponse.headers.set('Cache-Control', 'no-store');
-    return addCorsHeaders(errorResponse, request);
-  }
-}),
+      const response = NextResponse.json({ systems, overallStatus });
+
+      // Add caching headers for better performance
+      response.headers.set("Cache-Control", "public, s-maxage=30, stale-while-revalidate=60");
+
+      // Add CORS headers
+      return addCorsHeaders(response, request);
+    } catch (error) {
+      appLogger.error("Error in status GET", error);
+      // Never return 500 - return degraded status with graceful error message
+      const errorResponse = NextResponse.json(
+        {
+          systems: [],
+          overallStatus: "degraded",
+          error: "Unable to fetch system status",
+          message: "Please try again later",
+        },
+        { status: 200 }
+      );
+      // Don't cache errors
+      errorResponse.headers.set("Cache-Control", "no-store");
+      return addCorsHeaders(errorResponse, request);
+    }
+  }),
   { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: false }
 );
 
@@ -91,7 +92,7 @@ export const GET = withSecurity(
  */
 async function checkDatabaseHealth(): Promise<boolean> {
   try {
-    const { prisma } = await import('@/shared/db/prismaClient');
+    const { prisma } = await import("@/shared/db/prismaClient");
     await prisma.$queryRaw`SELECT 1`;
     return true;
   } catch {
@@ -104,9 +105,9 @@ async function checkDatabaseHealth(): Promise<boolean> {
  */
 async function checkSupabaseHealth(): Promise<boolean> {
   try {
-    const { createClient } = await import('@/lib/supabase/server');
+    const { createClient } = await import("@/lib/supabase/server");
     const supabase = await createClient();
-    const { error } = await supabase.from('users').select('id').limit(1);
+    const { error } = await supabase.from("users").select("id").limit(1);
     return !error;
   } catch {
     return false;
@@ -116,16 +117,11 @@ async function checkSupabaseHealth(): Promise<boolean> {
 /**
  * Check API health
  */
-async function checkAPIHealth(): Promise<boolean> {
+async function checkApplicationRuntimeHealth(): Promise<boolean> {
   try {
-    // Check if we can reach our own health endpoint
-    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://settler.dev';
-    const response = await fetch(`${baseUrl}/api/status/health`, {
-      signal: AbortSignal.timeout(5000),
-    });
-    return response.ok;
+    const envValidation = validateSupabaseEnv();
+    return envValidation.isValid;
   } catch {
-    // If we can't check ourselves, assume operational
-    return true;
+    return false;
   }
 }

--- a/packages/web/src/app/console/exceptions/page.tsx
+++ b/packages/web/src/app/console/exceptions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,8 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ConsolePageHeader } from "@/components/console/ConsolePageHeader";
+import { shouldPollExceptions } from "@/lib/console/polling";
 import { safeFetch } from "@/lib/safe-fetch";
 import { RefreshCw, ArrowLeft } from "lucide-react";
 import Link from "next/link";
@@ -36,6 +38,8 @@ interface ExceptionFilters {
   search?: string;
 }
 
+const POLL_INTERVAL_MS = 15_000;
+
 export default function ExceptionsPage() {
   const searchParams = useSearchParams();
   const runId = searchParams.get("runId");
@@ -52,19 +56,17 @@ export default function ExceptionsPage() {
     if (typeFilter && !filters.type) {
       setFilters((prev) => ({ ...prev, type: typeFilter }));
     }
-  }, [typeFilter]);
+  }, [filters.type, typeFilter]);
 
-  useEffect(() => {
-    loadExceptions();
+  const pollingEnabled = shouldPollExceptions({
+    autoRefresh,
+    exceptions,
+    loadingInitialState: loading && exceptions.length === 0,
+    statusFilter: filters.status,
+    runScoped: Boolean(runId),
+  });
 
-    if (autoRefresh) {
-      const interval = setInterval(loadExceptions, 30000); // Poll every 30 seconds
-      return () => clearInterval(interval);
-    }
-    return undefined;
-  }, [autoRefresh, filters]);
-
-  const loadExceptions = async () => {
+  const loadExceptions = useCallback(async () => {
     setLoading(true);
     const queryParams = new URLSearchParams();
 
@@ -95,7 +97,22 @@ export default function ExceptionsPage() {
       setExceptions([]);
     }
     setLoading(false);
-  };
+  }, [filters, runId]);
+
+  useEffect(() => {
+    void loadExceptions();
+  }, [loadExceptions]);
+
+  useEffect(() => {
+    if (!pollingEnabled) {
+      return undefined;
+    }
+
+    const interval = setInterval(() => {
+      void loadExceptions();
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [loadExceptions, pollingEnabled]);
 
   const handleRefresh = async () => {
     await loadExceptions();
@@ -129,7 +146,7 @@ export default function ExceptionsPage() {
 
   if (loading && exceptions.length === 0) {
     return (
-      <div className="p-6 space-y-6">
+      <div className="space-y-6">
         <Skeleton className="h-12 w-64" />
         <Skeleton className="h-64" />
       </div>
@@ -138,7 +155,7 @@ export default function ExceptionsPage() {
 
   if (error && exceptions.length === 0) {
     return (
-      <div className="p-6">
+      <div>
         <ErrorState title="Failed to load exceptions" message={error} onRetry={handleRefresh} />
       </div>
     );
@@ -146,7 +163,7 @@ export default function ExceptionsPage() {
 
   if (exceptions.length === 0) {
     return (
-      <div className="p-6">
+      <div>
         <EmptyState
           title="No exceptions found"
           description={
@@ -166,7 +183,7 @@ export default function ExceptionsPage() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="space-y-6">
       {/* Back navigation when coming from run detail */}
       {runId && (
         <div className="mb-4">
@@ -179,15 +196,15 @@ export default function ExceptionsPage() {
         </div>
       )}
 
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Exceptions</h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-1">
-            {runId
-              ? "Exceptions from this reconciliation run"
-              : "Action queue for reconciliation outcomes that require operator decisions"}
-          </p>
-        </div>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <ConsolePageHeader
+          title="Exceptions"
+          description={
+            runId
+              ? "Exceptions recorded for this run, with status, severity, and rationale tags carried from the canonical workflow model."
+              : "Operator decision queue for unresolved reconciliation outcomes, grouped by workflow status instead of legacy mismatch projections."
+          }
+        />
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
             <input
@@ -201,6 +218,9 @@ export default function ExceptionsPage() {
               Auto-refresh
             </label>
           </div>
+          <Badge variant="outline">
+            {pollingEnabled ? `Polling every ${POLL_INTERVAL_MS / 1000}s` : "Polling paused"}
+          </Badge>
           <Button variant="outline" size="sm" onClick={handleRefresh}>
             <RefreshCw className={`w-4 h-4 mr-2 ${loading ? "animate-spin" : ""}`} />
             Refresh

--- a/packages/web/src/app/console/layout.tsx
+++ b/packages/web/src/app/console/layout.tsx
@@ -14,6 +14,7 @@ import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
 import { LocalDevBanner } from "@/components/env/LocalDevBanner";
 import { getConsoleAccessStatus } from "@/lib/auth/console-gate";
+import { isSuperAdmin } from "@/lib/auth/super-admin";
 import { validateSupabaseEnv } from "@/lib/env/validator";
 import { EnvErrorPanel } from "@/components/env/EnvErrorPanel";
 import { appLogger } from "@/lib/utils/logger";
@@ -60,6 +61,7 @@ export default async function ConsoleRootLayout({ children }: { children: React.
     // Check console access status (doesn't redirect, just returns status)
     // This allows unauthenticated users to see the free view
     const accessStatus = await getConsoleAccessStatus();
+    const hasSuperAdminScope = await isSuperAdmin();
 
     // Log access status for monitoring
     if (!accessStatus.allowed) {
@@ -77,7 +79,7 @@ export default async function ConsoleRootLayout({ children }: { children: React.
       <ErrorBoundary context="Console Layout">
         <Navigation />
         {process.env.NODE_ENV === "development" && <LocalDevBanner />}
-        <ConsoleLayout>{children}</ConsoleLayout>
+        <ConsoleLayout isSuperAdmin={hasSuperAdminScope}>{children}</ConsoleLayout>
         <Footer />
       </ErrorBoundary>
     );
@@ -101,7 +103,7 @@ export default async function ConsoleRootLayout({ children }: { children: React.
     return (
       <>
         <Navigation />
-        <ConsoleLayout>
+        <ConsoleLayout isSuperAdmin={false}>
           <RouteStateCard
             {...routeStateFromVariant("backend-unreachable", {
               icon: TriangleAlert,

--- a/packages/web/src/app/console/runs/page.tsx
+++ b/packages/web/src/app/console/runs/page.tsx
@@ -1,189 +1,253 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  RefreshCw,
+  Search,
+  TimerReset,
+  XCircle,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
-import { safeFetch } from "@/lib/safe-fetch";
-import { useGovernanceState } from "@/hooks/use-governance-state";
+import { ConsolePageHeader } from "@/components/console/ConsolePageHeader";
 import { FreezeErrorAlert } from "@/components/shared/FreezeErrorAlert";
-import { RefreshCw, CheckCircle2, XCircle, Clock, AlertCircle } from "lucide-react";
-import Link from "next/link";
-
-import { Run, RunSummary } from "@settler/types";
+import { useGovernanceState } from "@/hooks/use-governance-state";
+import { shouldPollRuns } from "@/lib/console/polling";
+import { safeFetch } from "@/lib/safe-fetch";
 
 interface RunFilters {
   status?: string;
   search?: string;
 }
 
+interface RunListItem {
+  id: string;
+  name: string;
+  status: "pending" | "running" | "completed" | "failed" | "unknown";
+  statusLabel?: string;
+  startedAt: string;
+  completedAt: string | null;
+  progress: number;
+  progressState?: "not_started" | "in_progress" | "completed" | "failed" | "unknown";
+  isTerminal: boolean;
+  summary: {
+    total: number;
+    sourceCount: number;
+    targetCount: number;
+    matched: number;
+    unmatched: number;
+    unmatchedSourceCount: number;
+    unmatchedTargetCount: number;
+    conflicts: number;
+  };
+  summarySemantics: {
+    processed: number;
+    matchedWithTolerance: number;
+    exceptioned: number;
+    unresolved: number;
+    ignored: number;
+    resolved: number;
+  };
+  summaryState: "success" | "review_needed" | "in_progress" | "failed" | "empty" | "unknown";
+  configDrift?: {
+    status?: "none" | "detected" | "indeterminate";
+  };
+}
+
+const POLL_INTERVAL_MS = 15_000;
+
+function getStatusIcon(status: RunListItem["status"]) {
+  switch (status) {
+    case "completed":
+      return CheckCircle2;
+    case "failed":
+      return XCircle;
+    case "running":
+      return RefreshCw;
+    case "pending":
+      return Clock;
+    default:
+      return AlertCircle;
+  }
+}
+
+function getStatusColor(status: RunListItem["status"]) {
+  switch (status) {
+    case "completed":
+      return "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300";
+    case "failed":
+      return "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300";
+    case "running":
+      return "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300";
+    case "pending":
+      return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300";
+    default:
+      return "bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300";
+  }
+}
+
+function getSummaryStateTone(state: RunListItem["summaryState"]) {
+  switch (state) {
+    case "success":
+      return "text-green-700 dark:text-green-300";
+    case "review_needed":
+      return "text-amber-700 dark:text-amber-300";
+    case "failed":
+      return "text-red-700 dark:text-red-300";
+    case "in_progress":
+      return "text-blue-700 dark:text-blue-300";
+    default:
+      return "text-slate-600 dark:text-slate-400";
+  }
+}
+
+function formatDuration(startedAt: string, completedAt: string | null) {
+  const start = new Date(startedAt).getTime();
+  const end = completedAt ? new Date(completedAt).getTime() : Date.now();
+  const durationMs = end - start;
+
+  if (durationMs < 1000) return "< 1s";
+  if (durationMs < 60_000) return `${Math.floor(durationMs / 1000)}s`;
+  if (durationMs < 3_600_000) {
+    return `${Math.floor(durationMs / 60_000)}m ${Math.floor((durationMs % 60_000) / 1000)}s`;
+  }
+  return `${Math.floor(durationMs / 3_600_000)}h ${Math.floor((durationMs % 3_600_000) / 60_000)}m`;
+}
+
+function formatCount(value: number) {
+  return value.toLocaleString();
+}
+
 export default function RunsPage() {
-  const [runs, setRuns] = useState<Run[]>([]);
+  const [runs, setRuns] = useState<RunListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filters, setFilters] = useState<RunFilters>({});
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { isFrozen, governanceState } = useGovernanceState();
 
-  useEffect(() => {
-    loadRuns();
-
-    if (autoRefresh) {
-      const interval = setInterval(loadRuns, 30000); // Poll every 30 seconds
-      return () => clearInterval(interval);
-    }
-    return undefined;
-  }, [autoRefresh, filters]);
-
-  const loadRuns = async () => {
+  const loadRuns = useCallback(async () => {
     setLoading(true);
-    const queryParams = new URLSearchParams();
-    Object.entries(filters).forEach(([key, value]) => {
-      if (value) {
-        queryParams.append(key, value as string);
-      }
-    });
 
-    const result = await safeFetch<Run[]>(`/api/runs?${queryParams.toString()}`);
+    const queryParams = new URLSearchParams();
+    if (filters.status) {
+      queryParams.set("status", filters.status);
+    }
+    if (filters.search) {
+      queryParams.set("search", filters.search);
+    }
+
+    const query = queryParams.toString();
+    const result = await safeFetch<RunListItem[]>(query ? `/api/runs?${query}` : "/api/runs");
 
     if (result.success && result.data) {
       setRuns(result.data);
       setError(null);
     } else {
-      setError(result.error?.message || "Failed to load runs");
       setRuns([]);
+      setError(result.error?.message || "Failed to load runs");
     }
+
     setLoading(false);
-  };
+  }, [filters.search, filters.status]);
 
-  const handleRefresh = async () => {
+  useEffect(() => {
+    void loadRuns();
+  }, [loadRuns]);
+
+  const pollingEnabled = shouldPollRuns({
+    autoRefresh,
+    runs,
+    loadingInitialState: loading && runs.length === 0,
+    statusFilter: filters.status,
+  });
+
+  useEffect(() => {
+    if (!pollingEnabled) {
+      return undefined;
+    }
+
+    const interval = setInterval(() => {
+      void loadRuns();
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [loadRuns, pollingEnabled]);
+
+  const totals = useMemo(
+    () =>
+      runs.reduce(
+        (acc, run) => {
+          acc.totalRuns += 1;
+          acc.matched += run.summary.matched;
+          acc.reviewRequired += run.summarySemantics.unresolved;
+          acc.exceptions += run.summarySemantics.exceptioned;
+          if (!run.isTerminal) {
+            acc.activeRuns += 1;
+          }
+          return acc;
+        },
+        {
+          totalRuns: 0,
+          activeRuns: 0,
+          matched: 0,
+          reviewRequired: 0,
+          exceptions: 0,
+        }
+      ),
+    [runs]
+  );
+
+  const handleRefresh = useCallback(async () => {
     await loadRuns();
-  };
+  }, [loadRuns]);
 
-  const getStatusIcon = (status: Run["status"]) => {
-    switch (status) {
-      case "completed":
-        return CheckCircle2;
-      case "failed":
-        return XCircle;
-      case "running":
-        return RefreshCw;
-      case "pending":
-        return Clock;
-      default:
-        return AlertCircle;
-    }
-  };
-
-  const getStatusColor = (status: Run["status"]) => {
-    switch (status) {
-      case "completed":
-        return "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300";
-      case "failed":
-        return "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300";
-      case "running":
-        return "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300";
-      case "pending":
-        return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300";
-      default:
-        return "bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300";
-    }
-  };
-
-  const formatDuration = (startedAt: string, completedAt: string | null) => {
-    const start = new Date(startedAt).getTime();
-    const end = completedAt ? new Date(completedAt).getTime() : Date.now();
-    const durationMs = end - start;
-
-    if (durationMs < 1000) return "< 1s";
-    if (durationMs < 60000) return `${Math.floor(durationMs / 1000)}s`;
-    if (durationMs < 3600000)
-      return `${Math.floor(durationMs / 60000)}m ${Math.floor((durationMs % 60000) / 1000)}s`;
-    return `${Math.floor(durationMs / 3600000)}h ${Math.floor((durationMs % 3600000) / 60000)}m`;
-  };
+  const showFreezeBanner = isFrozen && governanceState;
 
   if (loading && runs.length === 0) {
     return (
-      <div className="p-6 space-y-6">
-        <Skeleton className="h-12 w-64" />
-        <Skeleton className="h-64" />
+      <div className="space-y-6">
+        <Skeleton className="h-12 w-72" />
+        <div className="grid gap-4 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-28 w-full" />
+          ))}
+        </div>
+        <Skeleton className="h-96 w-full" />
       </div>
     );
   }
 
   if (error && runs.length === 0) {
     return (
-      <div className="p-6">
+      <div className="space-y-6">
+        {showFreezeBanner ? (
+          <FreezeErrorAlert
+            reason={governanceState.freeze_reason}
+            scope={governanceState.frozen_by || "tenant"}
+            frozenAt={governanceState.frozen_at || undefined}
+            recoveryAction={{
+              label: "View Governance Settings",
+              href: "/console/settings?tab=governance",
+            }}
+          />
+        ) : null}
         <ErrorState title="Failed to load runs" message={error} onRetry={handleRefresh} />
       </div>
     );
   }
 
-  if (runs.length === 0 && !filters.status && !filters.search) {
-    return (
-      <div className="p-6 space-y-6">
-        {/* Governance Freeze Banner */}
-        {isFrozen && governanceState && (
-          <FreezeErrorAlert
-            reason={governanceState.freeze_reason}
-            scope={governanceState.frozen_by || "tenant"}
-            frozenAt={governanceState.frozen_at || undefined}
-            recoveryAction={{
-              label: "View Governance Settings",
-              href: "/console/settings?tab=governance",
-            }}
-          />
-        )}
-        <EmptyState
-          title="No reconciliation runs yet"
-          description="Reconciliation runs will appear here once jobs are executed. Create a job and run it to see execution history."
-          action={{
-            label: "Open Reconciliations",
-            onClick: () => {
-              window.location.href = "/console/reconciliations";
-            },
-          }}
-        />
-      </div>
-    );
-  }
-
-  if (runs.length === 0) {
-    return (
-      <div className="p-6 space-y-6">
-        {/* Governance Freeze Banner */}
-        {isFrozen && governanceState && (
-          <FreezeErrorAlert
-            reason={governanceState.freeze_reason}
-            scope={governanceState.frozen_by || "tenant"}
-            frozenAt={governanceState.frozen_at || undefined}
-            recoveryAction={{
-              label: "View Governance Settings",
-              href: "/console/settings?tab=governance",
-            }}
-          />
-        )}
-        <EmptyState
-          title="No runs match your filters"
-          description="Try adjusting your search criteria or clearing filters to see all runs"
-          action={{
-            label: "Clear Filters",
-            onClick: () => {
-              setFilters({});
-            },
-          }}
-        />
-      </div>
-    );
-  }
-
   return (
-    <div className="p-6 space-y-6">
-      {/* Governance Freeze Banner */}
-      {isFrozen && governanceState && (
+    <div className="space-y-6">
+      {showFreezeBanner ? (
         <FreezeErrorAlert
           reason={governanceState.freeze_reason}
           scope={governanceState.frozen_by || "tenant"}
@@ -193,187 +257,341 @@ export default function RunsPage() {
             href: "/console/settings?tab=governance",
           }}
         />
-      )}
+      ) : null}
 
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Runs</h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-1">
-            Execution history for tenant-scoped reconciliations and their review outcomes
-          </p>
-        </div>
-        <div className="flex items-center gap-4">
-          <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400 cursor-pointer">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <ConsolePageHeader
+          title="Runs"
+          description="Track canonical reconciliation execution state, compare persisted outcomes, and open the exact run that produced the current exception queue."
+        />
+
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
             <input
               type="checkbox"
               id="auto-refresh-checkbox"
               checked={autoRefresh}
-              onChange={(e) => setAutoRefresh(e.target.checked)}
-              className="rounded"
+              onChange={(event) => setAutoRefresh(event.target.checked)}
+              className="rounded border-border"
             />
-            Auto-refresh
+            Auto-refresh active work
           </label>
           <Button variant="outline" size="sm" onClick={handleRefresh}>
-            <RefreshCw className={`w-4 h-4 mr-2 ${loading ? "animate-spin" : ""}`} />
-            Refresh
+            <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            Refresh now
           </Button>
         </div>
       </div>
 
-      {/* Filters */}
-      <Card className="mb-6">
+      <Card>
+        <CardContent className="flex flex-col gap-3 py-5 text-sm text-muted-foreground lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-1">
+            <p className="font-medium text-foreground">One canonical run model</p>
+            <p>
+              Matched, unmatched, conflict, exception, and review counts come from the same
+              canonical summary contract used by run detail and reconciliation detail.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">
+              {pollingEnabled ? `Polling every ${POLL_INTERVAL_MS / 1000}s` : "Polling paused"}
+            </Badge>
+            <Badge variant="outline">
+              {totals.activeRuns > 0
+                ? `${totals.activeRuns} run${totals.activeRuns === 1 ? "" : "s"} active`
+                : "All visible runs terminal"}
+            </Badge>
+          </div>
+        </CardContent>
+      </Card>
+
+      {runs.length > 0 ? (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Visible runs</CardDescription>
+              <CardTitle className="text-3xl">{formatCount(totals.totalRuns)}</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Current tenant-scoped run history after filters.
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Matched rows</CardDescription>
+              <CardTitle className="text-3xl text-green-600 dark:text-green-400">
+                {formatCount(totals.matched)}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Rows that reconciled under exact or tolerance-supported logic.
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Review required</CardDescription>
+              <CardTitle className="text-3xl text-amber-600 dark:text-amber-400">
+                {formatCount(totals.reviewRequired)}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Unresolved outcomes still awaiting operator action.
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Exceptioned rows</CardDescription>
+              <CardTitle className="text-3xl text-red-600 dark:text-red-400">
+                {formatCount(totals.exceptions)}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Rows promoted into the exception workflow.
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+
+      <Card>
         <CardHeader>
           <CardTitle>Filters</CardTitle>
+          <CardDescription>
+            Filter the canonical run history by lifecycle state or run name / identifier.
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div>
+          <div className="grid gap-4 md:grid-cols-[220px_minmax(0,1fr)_auto]">
+            <div className="space-y-2">
               <label
                 htmlFor="status-filter"
-                className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+                className="block text-sm font-medium text-slate-700 dark:text-slate-300"
               >
                 Status
               </label>
               <select
                 id="status-filter"
                 value={filters.status || ""}
-                onChange={(e) =>
-                  setFilters((prev) => ({ ...prev, status: e.target.value || undefined }))
+                onChange={(event) =>
+                  setFilters((current) => ({
+                    ...current,
+                    status: event.target.value || undefined,
+                  }))
                 }
-                className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full rounded-md border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-600"
               >
-                <option value="">All Statuses</option>
+                <option value="">All statuses</option>
                 <option value="pending">Pending</option>
                 <option value="running">Running</option>
                 <option value="completed">Completed</option>
                 <option value="failed">Failed</option>
               </select>
             </div>
-            <div>
+            <div className="space-y-2">
               <label
                 htmlFor="search-filter"
-                className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+                className="block text-sm font-medium text-slate-700 dark:text-slate-300"
               >
                 Search
               </label>
-              <input
-                id="search-filter"
-                type="text"
-                placeholder="Search runs..."
-                value={filters.search || ""}
-                onChange={(e) =>
-                  setFilters((prev) => ({ ...prev, search: e.target.value || undefined }))
-                }
-                className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  id="search-filter"
+                  type="text"
+                  placeholder="Search run name or UUID..."
+                  value={filters.search || ""}
+                  onChange={(event) =>
+                    setFilters((current) => ({
+                      ...current,
+                      search: event.target.value || undefined,
+                    }))
+                  }
+                  className="w-full rounded-md border border-slate-300 py-2 pl-9 pr-3 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-600"
+                />
+              </div>
+            </div>
+            <div className="flex items-end">
+              <Button
+                variant="ghost"
+                onClick={() => setFilters({})}
+                disabled={!filters.search && !filters.status}
+              >
+                <TimerReset className="mr-2 h-4 w-4" />
+                Clear filters
+              </Button>
             </div>
           </div>
         </CardContent>
       </Card>
 
-      {/* Runs Table */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Runs List</CardTitle>
-          <CardDescription>{runs.length} runs found</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-slate-200 dark:border-slate-700">
-                  <th className="text-left py-3 px-4 text-sm font-medium text-slate-600 dark:text-slate-400">
-                    Run ID
-                  </th>
-                  <th className="text-left py-3 px-4 text-sm font-medium text-slate-600 dark:text-slate-400">
-                    Name
-                  </th>
-                  <th className="text-left py-3 px-4 text-sm font-medium text-slate-600 dark:text-slate-400">
-                    Status
-                  </th>
-                  <th className="text-left py-3 px-4 text-sm font-medium text-slate-600 dark:text-slate-400">
-                    Start Time
-                  </th>
-                  <th className="text-left py-3 px-4 text-sm font-medium text-slate-600 dark:text-slate-400">
-                    End Time
-                  </th>
-                  <th className="text-left py-3 px-4 text-sm font-medium text-slate-600 dark:text-slate-400">
-                    Duration
-                  </th>
-                  <th className="text-left py-3 px-4 text-sm font-medium text-slate-600 dark:text-slate-400">
-                    Source / Target
-                  </th>
-                  <th className="text-left py-3 px-4 text-sm font-medium text-slate-600 dark:text-slate-400">
-                    Needs Review
-                  </th>
-                  <th className="text-left py-3 px-4 text-sm font-medium text-slate-600 dark:text-slate-400">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {runs.map((run) => {
-                  const StatusIcon = getStatusIcon(run.status);
-                  return (
-                    <tr
-                      key={run.id}
-                      className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50"
-                    >
-                      <td className="py-3 px-4">
-                        <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">
-                          {run.id.slice(0, 8)}...
-                        </code>
-                      </td>
-                      <td className="py-3 px-4 text-sm text-slate-900 dark:text-white">
-                        {run.name}
-                      </td>
-                      <td className="py-3 px-4">
+      {runs.length === 0 ? (
+        <EmptyState
+          title={
+            filters.status || filters.search
+              ? "No runs match your filters"
+              : "No reconciliation runs yet"
+          }
+          description={
+            filters.status || filters.search
+              ? "Try widening the lifecycle filter or clearing your search to review the full tenant run history."
+              : "Runs appear here after a tenant-scoped reconciliation starts. Open Reconciliations to launch or inspect the next workflow."
+          }
+          action={{
+            label: filters.status || filters.search ? "Clear Filters" : "Open Reconciliations",
+            onClick: () => {
+              if (filters.status || filters.search) {
+                setFilters({});
+                return;
+              }
+
+              window.location.href = "/console/reconciliations";
+            },
+          }}
+        />
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>Run history</CardTitle>
+            <CardDescription>
+              Every row uses the same lifecycle and summary semantics surfaced on run detail.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {runs.map((run) => {
+              const StatusIcon = getStatusIcon(run.status);
+              return (
+                <div
+                  key={run.id}
+                  className="rounded-xl border border-slate-200 p-4 shadow-sm dark:border-slate-800"
+                >
+                  <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                    <div className="min-w-0 flex-1 space-y-3">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="truncate text-lg font-semibold text-foreground">
+                          {run.name}
+                        </h2>
                         <Badge className={getStatusColor(run.status)}>
-                          <StatusIcon className="w-3 h-3 mr-1" />
+                          <StatusIcon
+                            className={`mr-1 h-3.5 w-3.5 ${run.status === "running" ? "animate-spin" : ""}`}
+                          />
                           {run.statusLabel || run.status}
                         </Badge>
-                      </td>
-                      <td className="py-3 px-4 text-sm text-slate-600 dark:text-slate-400">
-                        {run.startedAt ? new Date(run.startedAt).toLocaleString() : "-"}
-                      </td>
-                      <td className="py-3 px-4 text-sm text-slate-600 dark:text-slate-400">
-                        {run.completedAt ? new Date(run.completedAt).toLocaleString() : "-"}
-                      </td>
-                      <td className="py-3 px-4 text-sm text-slate-600 dark:text-slate-400">
-                        {run.startedAt ? formatDuration(run.startedAt, run.completedAt) : "-"}
-                      </td>
-                      <td className="py-3 px-4 text-sm text-slate-600 dark:text-slate-400">
-                        {run.summary ? `${run.summary.totalItems.toLocaleString()}` : "-"}
-                      </td>
-                      <td className="py-3 px-4">
-                        {run.summary && run.summary.mismatched + run.summary.missing > 0 ? (
-                          <span className="text-red-600 dark:text-red-400 font-medium">
-                            {(run.summary.mismatched + run.summary.missing).toLocaleString()}
-                          </span>
-                        ) : (
-                          <span className="text-slate-600 dark:text-slate-400">
-                            {run.summary
-                              ? (run.summary.mismatched + run.summary.missing).toLocaleString()
-                              : "-"}
-                          </span>
-                        )}
-                      </td>
-                      <td className="py-3 px-4">
-                        <Link
-                          href={`/console/runs/${run.id}`}
-                          className="text-blue-600 dark:text-blue-400 hover:underline text-sm"
-                        >
-                          View Details
+                        {run.configDrift?.status === "detected" ? (
+                          <Badge variant="outline" className="text-amber-700 dark:text-amber-300">
+                            Config drift detected
+                          </Badge>
+                        ) : null}
+                      </div>
+
+                      <div className="grid gap-3 text-sm text-muted-foreground md:grid-cols-2 xl:grid-cols-4">
+                        <div>
+                          <div className="font-medium text-foreground">Run ID</div>
+                          <code className="text-xs">{run.id}</code>
+                        </div>
+                        <div>
+                          <div className="font-medium text-foreground">Started</div>
+                          <div>{new Date(run.startedAt).toLocaleString()}</div>
+                        </div>
+                        <div>
+                          <div className="font-medium text-foreground">Completed</div>
+                          <div>
+                            {run.completedAt
+                              ? new Date(run.completedAt).toLocaleString()
+                              : "Still running"}
+                          </div>
+                        </div>
+                        <div>
+                          <div className="font-medium text-foreground">Duration</div>
+                          <div>{formatDuration(run.startedAt, run.completedAt)}</div>
+                        </div>
+                      </div>
+
+                      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
+                        <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-800">
+                          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                            Matched
+                          </div>
+                          <div className="mt-1 text-xl font-semibold text-green-600 dark:text-green-400">
+                            {formatCount(run.summary.matched)}
+                          </div>
+                        </div>
+                        <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-800">
+                          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                            Unmatched
+                          </div>
+                          <div className="mt-1 text-xl font-semibold text-amber-600 dark:text-amber-400">
+                            {formatCount(run.summary.unmatched)}
+                          </div>
+                        </div>
+                        <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-800">
+                          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                            Conflicts
+                          </div>
+                          <div className="mt-1 text-xl font-semibold text-red-600 dark:text-red-400">
+                            {formatCount(run.summary.conflicts)}
+                          </div>
+                        </div>
+                        <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-800">
+                          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                            Exceptions
+                          </div>
+                          <div className="mt-1 text-xl font-semibold">
+                            {formatCount(run.summarySemantics.exceptioned)}
+                          </div>
+                        </div>
+                        <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-800">
+                          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                            Review required
+                          </div>
+                          <div className="mt-1 text-xl font-semibold">
+                            {formatCount(run.summarySemantics.unresolved)}
+                          </div>
+                        </div>
+                        <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-800">
+                          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                            Tolerance matches
+                          </div>
+                          <div className="mt-1 text-xl font-semibold">
+                            {formatCount(run.summarySemantics.matchedWithTolerance)}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap items-center gap-3 text-sm">
+                        <span className={getSummaryStateTone(run.summaryState)}>
+                          Summary state: {run.summaryState.replaceAll("_", " ")}
+                        </span>
+                        <span className="text-muted-foreground">
+                          Processed {formatCount(run.summarySemantics.processed)} of{" "}
+                          {formatCount(run.summary.total)} records
+                        </span>
+                        <span className="text-muted-foreground">
+                          Source {formatCount(run.summary.sourceCount)} / Target{" "}
+                          {formatCount(run.summary.targetCount)}
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className="flex flex-wrap gap-3 xl:w-56 xl:flex-col">
+                      <Button asChild>
+                        <Link href={`/console/runs/${run.id}`}>Open run detail</Link>
+                      </Button>
+                      <Button asChild variant="outline">
+                        <Link href={`/console/reconciliations?runId=${run.id}`}>
+                          Inspect reconciliation
                         </Link>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
+                      </Button>
+                      <Button asChild variant="ghost">
+                        <Link href={`/console/exceptions?runId=${run.id}`}>Open exceptions</Link>
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/console/ConsoleLayout.tsx
+++ b/packages/web/src/components/console/ConsoleLayout.tsx
@@ -8,7 +8,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import {
   LayoutDashboard,
@@ -86,23 +86,16 @@ function maturityBadge(entry: ConsoleRouteEntry) {
 
 interface ConsoleLayoutProps {
   children: React.ReactNode;
+  isSuperAdmin?: boolean;
 }
 
-export function ConsoleLayout({ children }: ConsoleLayoutProps) {
+export function ConsoleLayout({
+  children,
+  isSuperAdmin: initialIsSuperAdmin = false,
+}: ConsoleLayoutProps) {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
-  const [isSuperAdmin, setIsSuperAdmin] = useState(false);
-
-  useEffect(() => {
-    fetch("/api/console/user-role")
-      .then((res) => res.json())
-      .then((data) => {
-        setIsSuperAdmin(data.role === "SUPER_ADMIN" || data.isSuperAdmin === true);
-      })
-      .catch(() => {
-        setIsSuperAdmin(false);
-      });
-  }, []);
+  const isSuperAdmin = initialIsSuperAdmin;
 
   const navSections = navSectionOrder
     .map((section) => {

--- a/packages/web/src/lib/console/polling.ts
+++ b/packages/web/src/lib/console/polling.ts
@@ -1,0 +1,79 @@
+export type PollableRunLike = {
+  status?: string | null;
+  isTerminal?: boolean | null;
+};
+
+export type PollableExceptionLike = {
+  status?: "pending" | "investigating" | "resolved" | "ignored" | string | null;
+};
+
+export function hasActiveRuns(runs: PollableRunLike[]): boolean {
+  return runs.some((run) => {
+    if (typeof run.isTerminal === "boolean") {
+      return !run.isTerminal;
+    }
+
+    const status = run.status?.toLowerCase();
+    return status === "pending" || status === "running";
+  });
+}
+
+export function shouldPollRuns(input: {
+  autoRefresh: boolean;
+  runs: PollableRunLike[];
+  loadingInitialState: boolean;
+  statusFilter?: string;
+}): boolean {
+  if (!input.autoRefresh) {
+    return false;
+  }
+
+  if (input.loadingInitialState) {
+    return true;
+  }
+
+  const normalizedStatus = input.statusFilter?.toLowerCase();
+  if (normalizedStatus === "pending" || normalizedStatus === "running") {
+    return true;
+  }
+
+  return hasActiveRuns(input.runs);
+}
+
+export function hasOpenExceptions(exceptions: PollableExceptionLike[]): boolean {
+  return exceptions.some((exception) => {
+    const status = exception.status?.toLowerCase();
+    return status === "pending" || status === "investigating";
+  });
+}
+
+export function shouldPollExceptions(input: {
+  autoRefresh: boolean;
+  exceptions: PollableExceptionLike[];
+  loadingInitialState: boolean;
+  statusFilter?: string;
+  runScoped?: boolean;
+}): boolean {
+  if (!input.autoRefresh) {
+    return false;
+  }
+
+  if (input.loadingInitialState) {
+    return true;
+  }
+
+  const normalizedStatus = input.statusFilter?.toLowerCase();
+  if (normalizedStatus === "resolved" || normalizedStatus === "ignored") {
+    return false;
+  }
+
+  if (normalizedStatus === "pending" || normalizedStatus === "investigating") {
+    return true;
+  }
+
+  if (hasOpenExceptions(input.exceptions)) {
+    return true;
+  }
+
+  return Boolean(input.runScoped);
+}


### PR DESCRIPTION
### Motivation

- The `/console/runs` surface was still presenting legacy/mismatched summary fields and weak polling, causing split semantics between run-list and run-detail and creating unnecessary refresh churn.  
- Console navigation relied on a client-side role fetch to decide admin-only nav visibility, introducing an unnecessary internal hop and race.  
- The public status endpoint used a same-app HTTP self-call for health checks which wastes runtime and can misrepresent local readiness.

### Description

- Rebuilt the `/console/runs` operator surface to consume the canonical run/result contract and surface operator-grade counters (matched, matchedWithTolerance, unmatched, conflicts, exceptioned, unresolved) and richer states, filters, and actions (`packages/web/src/app/console/runs/page.tsx`).  
- Added shared polling heuristics (`packages/web/src/lib/console/polling.ts`) and wired them into runs and exceptions pages so polling pauses when visible work is terminal and continues only for active/run-scoped work (`packages/web/src/app/console/exceptions/page.tsx`, `packages/web/src/app/console/runs/page.tsx`).  
- Removed the client-side console role lookup and instead pass server-derived super-admin scope into the client shell to decide restricted nav items (`packages/web/src/app/console/layout.tsx`, `packages/web/src/components/console/ConsoleLayout.tsx`).  
- Replaced the status-route self-HTTP hop with a local runtime readiness check and tightened the degraded/operational calculation to rely on concrete check results (`packages/web/src/app/api/status/route.ts`).  
- Added guardrail tests and documentation: polling heuristics unit tests, run semantics and server-role hydration guards, and a status-route no-self-hop test, plus reconciliation docs updated to document canonical operator semantics (`packages/web/src/__tests__/**`, `docs/reconciliation/README.md`).

### Testing

- Ran formatting and static checks with `prettier --check <files>` against the modified files and they passed.  
- Executed runtime assertions that validate the new polling heuristics and source-guardrail expectations with small Node assertion scripts (`node --experimental-strip-types` and `node` scripts that assert heuristics and source checks), and those assertions passed locally.  
- Attempted workspace verification (ESLint, Jest, full `tsc` typecheck and install) but these were blocked by the environment: `pnpm install --frozen-lockfile` failed due to lockfile mismatch and required Node engine `>=24 <25`, and `pnpm install --no-frozen-lockfile` could not complete because registry fetches returned `403 Forbidden`; as a result `eslint`, `jest`, and `tsc --noEmit` runs could not be executed in this session.  

Commands run (results):  
- `prettier --check packages/web/src/app/console/runs/page.tsx packages/web/src/app/console/exceptions/page.tsx packages/web/src/app/console/layout.tsx packages/web/src/components/console/ConsoleLayout.tsx packages/web/src/lib/console/polling.ts packages/web/src/app/api/status/route.ts packages/web/src/__tests__/** docs/reconciliation/README.md` — passed.  
- `node --experimental-strip-types` (polling heuristics assertions) — passed.  
- `node` (source guardrail assertions reading modified sources) — passed.  
- `pnpm --filter @settler/web exec eslint ...` — blocked (workspace deps missing / environment Node v22 vs repo Node >=24).  
- `pnpm --filter @settler/web exec jest ...` — blocked (workspace deps missing).  
- `tsc --noEmit -p packages/web/tsconfig.json` — blocked (missing installed type packages / environment mismatch).  

If CI or a reviewer runs the full verification in a Node 24 environment with working npm registry access, the added tests and lint/typecheck should be executed to confirm full workspace health.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb722c383c8328860be12c67b6c76e)