### PR TITLE
feat(frontend): premium polish pass — light mode tokens, DataTable system, slate token migration

### DIFF
--- a/design-system/css-tokens.css
+++ b/design-system/css-tokens.css
@@ -205,6 +205,75 @@
   --z-toast: 500;
 }
 
+/* ============================================
+   LIGHT MODE — Semantic Overrides
+   ============================================
+   Applied when the <html> element does NOT have
+   the `dark` class. These override the dark-first
+   semantic tokens above so both themes are first-class.
+   ============================================ */
+
+:root:not(.dark) {
+  /* Background layers */
+  --bg: #f8fafc;
+  --bg-muted: #f1f5f9;
+  --bg-subtle: #e2e8f0;
+
+  --surface: #ffffff;
+  --surface-muted: #f8fafc;
+  --surface-elevated: #ffffff;
+
+  /* Text */
+  --text: #0f172a;
+  --text-muted: #475569;
+  --text-subtle: #94a3b8;
+  --text-inverse: #ffffff;
+
+  /* Brand/Action — keep teal, same hues */
+  --primary: var(--color-teal-600);
+  --primary-hover: var(--color-teal-700);
+  --primary-light: rgba(13, 148, 136, 0.08);
+  --primary-foreground: #ffffff;
+
+  /* Highlight */
+  --highlight: var(--color-blue-600);
+  --highlight-hover: var(--color-blue-500);
+
+  /* Border — visible on light surfaces */
+  --border: rgba(15, 23, 42, 0.10);
+  --border-muted: rgba(15, 23, 42, 0.06);
+  --border-focus: var(--color-teal-600);
+
+  /* Focus ring */
+  --focus-ring: 0 0 0 3px rgba(13, 148, 136, 0.25);
+  --focus-ring-offset: #ffffff;
+
+  /* Shadows — stronger on light */
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.08), 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-md: 0 4px 16px rgba(15, 23, 42, 0.10), 0 2px 4px rgba(15, 23, 42, 0.06);
+  --shadow-lg: 0 8px 32px rgba(15, 23, 42, 0.14), 0 4px 8px rgba(15, 23, 42, 0.08);
+
+  /* Sidebar */
+  --sidebar-bg: #ffffff;
+  --sidebar-border: rgba(15, 23, 42, 0.10);
+  --sidebar-active-bg: rgba(13, 148, 136, 0.08);
+  --sidebar-active-text: var(--color-teal-700);
+
+  /* HSL aliases for shadcn/ui compatibility — light overrides */
+  --background: 210 40% 98%;
+  --foreground: 222 47% 11%;
+  --card: 0 0% 100%;
+  --card-foreground: 222 47% 11%;
+  --muted: 210 40% 96%;
+  --muted-foreground: 215 16% 47%;
+  --accent: 171 77% 36%;
+  --accent-foreground: 0 0% 100%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 0% 100%;
+  --ring: 171 77% 36%;
+  --input: 214 32% 91%;
+}
+
 /* Backward compatibility aliases */
 :root {
   --color-primary-500: var(--color-teal-500);

--- a/packages/web/src/app/(marketing)/home/page.tsx
+++ b/packages/web/src/app/(marketing)/home/page.tsx
@@ -149,7 +149,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
     <ErrorBoundary context="Home Page">
       <main
         id="main-content"
-        className="min-h-screen bg-slate-50 pb-[env(safe-area-inset-bottom)] dark:bg-slate-950 antialiased"
+        className="min-h-screen bg-background pb-[env(safe-area-inset-bottom)]  antialiased"
         aria-label="Settler homepage"
       >
         <Navigation />
@@ -173,7 +173,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
               <HeroAnimationWrapper>
                 <div className="text-left max-w-2xl">
                   <div className="mb-5 flex justify-start">
-                    <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-3.5 py-1.5 text-xs font-semibold text-slate-700 dark:text-slate-300 shadow-sm">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-border dark:border-border bg-card dark:bg-background px-3.5 py-1.5 text-xs font-semibold text-foreground dark:text-muted-foreground shadow-sm">
                       <Github className="w-3.5 h-3.5" aria-hidden="true" />
                       Open-source · Apache 2.0
                     </span>
@@ -184,7 +184,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                       as="h1"
                       id="hero-heading"
                       text="Reconcile Financial Data. Find Every Mismatch. Prove the Results."
-                      className="text-3xl sm:text-4xl md:text-5xl lg:text-[3.25rem] font-bold mb-4 sm:mb-6 text-slate-900 dark:text-white tracking-tight leading-[1.1]"
+                      className="text-3xl sm:text-4xl md:text-5xl lg:text-[3.25rem] font-bold mb-4 sm:mb-6 text-foreground dark:text-foreground tracking-tight leading-[1.1]"
                       delay={0}
                       staggerDelay={0.02}
                       splitBy="words"
@@ -192,7 +192,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                   </div>
 
                   <div className="mb-10 sm:mb-12">
-                    <p className="text-lg sm:text-xl text-slate-600 dark:text-slate-400 leading-relaxed">
+                    <p className="text-lg sm:text-xl text-muted-foreground dark:text-muted-foreground leading-relaxed">
                       Settler matches records across Stripe, banks, ERPs, and ledgers — then
                       surfaces every mismatch with full context. Every run produces verifiable
                       evidence. Every run can be replayed.
@@ -203,7 +203,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                     <Button
                       size="lg"
                       asChild
-                      className="w-full sm:w-auto bg-slate-900 hover:bg-slate-800 text-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100 px-8 py-6 text-lg font-semibold shadow-xl transition-all duration-200"
+                      className="w-full sm:w-auto bg-foreground hover:bg-foreground/90 text-background px-8 py-6 text-lg font-semibold shadow-xl transition-all duration-200"
                     >
                       <Link
                         href="/docs/quickstart"
@@ -218,7 +218,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                       size="lg"
                       variant="outline"
                       asChild
-                      className="w-full sm:w-auto px-8 py-6 text-lg border-2 border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 hover:bg-slate-50 dark:hover:bg-slate-800 transition-all duration-200"
+                      className="w-full sm:w-auto px-8 py-6 text-lg border-2 border-border dark:border-border bg-card dark:bg-background hover:bg-background dark:hover:bg-card transition-all duration-200"
                     >
                       <Link href={repoUrl} className="flex items-center justify-center gap-3">
                         <span>View on GitHub</span>
@@ -228,39 +228,39 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
                   {/* Trust signals */}
                   <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mb-12 sm:mb-16">
-                    <span className="flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-500">
+                    <span className="flex items-center gap-1.5 text-sm text-muted-foreground dark:text-muted-foreground">
                       <CheckCircle2
-                        className="w-3.5 h-3.5 text-slate-400 dark:text-slate-600"
+                        className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground"
                         aria-hidden="true"
                       />
                       Apache 2.0
                     </span>
-                    <span className="text-slate-300 dark:text-slate-700" aria-hidden="true">
+                    <span className="text-muted-foreground dark:text-foreground" aria-hidden="true">
                       ·
                     </span>
-                    <span className="flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-500">
+                    <span className="flex items-center gap-1.5 text-sm text-muted-foreground dark:text-muted-foreground">
                       <CheckCircle2
-                        className="w-3.5 h-3.5 text-slate-400 dark:text-slate-600"
+                        className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground"
                         aria-hidden="true"
                       />
                       Self-hostable
                     </span>
-                    <span className="text-slate-300 dark:text-slate-700" aria-hidden="true">
+                    <span className="text-muted-foreground dark:text-foreground" aria-hidden="true">
                       ·
                     </span>
-                    <span className="flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-500">
+                    <span className="flex items-center gap-1.5 text-sm text-muted-foreground dark:text-muted-foreground">
                       <CheckCircle2
-                        className="w-3.5 h-3.5 text-slate-400 dark:text-slate-600"
+                        className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground"
                         aria-hidden="true"
                       />
                       TypeScript &amp; Python SDKs
                     </span>
-                    <span className="text-slate-300 dark:text-slate-700" aria-hidden="true">
+                    <span className="text-muted-foreground dark:text-foreground" aria-hidden="true">
                       ·
                     </span>
-                    <span className="flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-500">
+                    <span className="flex items-center gap-1.5 text-sm text-muted-foreground dark:text-muted-foreground">
                       <CheckCircle2
-                        className="w-3.5 h-3.5 text-slate-400 dark:text-slate-600"
+                        className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground"
                         aria-hidden="true"
                       />
                       SHA-256 audit trail
@@ -289,18 +289,18 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
         {/* Core Capabilities */}
         <section
-          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900"
+          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-card dark:bg-background"
           aria-label="Core capabilities"
         >
           <div className="max-w-7xl mx-auto">
             <div className="text-center mb-12 sm:mb-16">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
+              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground dark:text-muted-foreground mb-3">
                 Core Capabilities
               </p>
-              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-slate-900 dark:text-white tracking-tight">
+              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-foreground dark:text-foreground tracking-tight">
                 Verifiable Execution for Operational Systems
               </h2>
-              <p className="text-lg text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
+              <p className="text-lg text-muted-foreground dark:text-muted-foreground max-w-3xl mx-auto leading-relaxed">
                 No black boxes. Deterministic runs, replay verification, and traceable
                 policy-governed execution at every step.
               </p>
@@ -314,16 +314,16 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                     key={index}
                     className="p-6 sm:p-8 h-full transition-all duration-300 hover:shadow-xl"
                   >
-                    <div className="w-12 h-12 rounded-xl bg-slate-100 dark:bg-slate-800 flex items-center justify-center mb-4">
+                    <div className="w-12 h-12 rounded-xl bg-muted/40 dark:bg-card flex items-center justify-center mb-4">
                       <Icon
-                        className="w-6 h-6 text-slate-700 dark:text-slate-300"
+                        className="w-6 h-6 text-foreground dark:text-muted-foreground"
                         aria-hidden="true"
                       />
                     </div>
-                    <h3 className="text-lg sm:text-xl font-semibold mb-2 text-slate-900 dark:text-white">
+                    <h3 className="text-lg sm:text-xl font-semibold mb-2 text-foreground dark:text-foreground">
                       {capability.title}
                     </h3>
-                    <p className="text-sm sm:text-base text-slate-600 dark:text-slate-400 leading-relaxed">
+                    <p className="text-sm sm:text-base text-muted-foreground dark:text-muted-foreground leading-relaxed">
                       {capability.description}
                     </p>
                   </SpotlightCard>
@@ -335,18 +335,18 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
         {/* Developer Workflow */}
         <section
-          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-slate-50 dark:bg-slate-950"
+          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-background "
           aria-label="Developer workflow"
         >
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12 sm:mb-16">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
+              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground dark:text-muted-foreground mb-3">
                 Developer Experience
               </p>
-              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-slate-900 dark:text-white tracking-tight">
+              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-foreground dark:text-foreground tracking-tight">
                 Four Steps to Audit-Ready Reconciliation
               </h2>
-              <p className="text-lg text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
+              <p className="text-lg text-muted-foreground dark:text-muted-foreground max-w-3xl mx-auto leading-relaxed">
                 Install the SDK, define your rules, run reconciliation, review evidence. No complex
                 setup required.
               </p>
@@ -358,9 +358,9 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                 return (
                   <div
                     key={index}
-                    className="relative p-6 pt-10 bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 flex flex-col items-center text-center overflow-visible"
+                    className="relative p-6 pt-10 bg-card dark:bg-background rounded-2xl border border-border dark:border-border flex flex-col items-center text-center overflow-visible"
                   >
-                    <div className="absolute top-4 left-4 w-8 h-8 rounded-full bg-slate-900 dark:bg-white text-white dark:text-slate-900 flex items-center justify-center text-sm font-bold shadow-sm ring-2 ring-white dark:ring-slate-900">
+                    <div className="absolute top-4 left-4 w-8 h-8 rounded-full bg-foreground text-background flex items-center justify-center text-sm font-bold shadow-sm ring-2 ring-border">
                       {step.number}
                     </div>
 
@@ -374,18 +374,18 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                     </div>
 
                     <div className="pt-2 w-full min-w-0">
-                      <h3 className="text-lg font-semibold mb-2 text-slate-900 dark:text-white flex items-center justify-center gap-2">
+                      <h3 className="text-lg font-semibold mb-2 text-foreground dark:text-foreground flex items-center justify-center gap-2">
                         <Icon
-                          className="w-5 h-5 text-slate-700 dark:text-slate-300"
+                          className="w-5 h-5 text-foreground dark:text-muted-foreground"
                           aria-hidden="true"
                         />
                         {step.title}
                       </h3>
-                      <p className="text-sm text-slate-600 dark:text-slate-400 mb-4 leading-relaxed">
+                      <p className="text-sm text-muted-foreground dark:text-muted-foreground mb-4 leading-relaxed">
                         {step.description}
                       </p>
                       <code
-                        className="block text-xs bg-slate-100 dark:bg-slate-800 px-3 py-2 rounded text-slate-700 dark:text-slate-300 font-mono overflow-hidden text-ellipsis whitespace-nowrap max-w-full"
+                        className="block text-xs bg-muted/40 dark:bg-card px-3 py-2 rounded text-foreground dark:text-muted-foreground font-mono overflow-hidden text-ellipsis whitespace-nowrap max-w-full"
                         title={step.code}
                       >
                         {step.code}
@@ -400,29 +400,29 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
         {/* Code Example */}
         <section
-          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-slate-900 text-white"
+          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-background"
           aria-label="Code example"
         >
           <div className="max-w-5xl mx-auto">
             <div className="text-center mb-10 sm:mb-12">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 mb-3">
+              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
                 TypeScript SDK
               </p>
               <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 tracking-tight">
                 Inspectable, Testable, Version Controlled
               </h2>
-              <p className="text-lg text-slate-400 max-w-3xl mx-auto leading-relaxed">
+              <p className="text-lg text-muted-foreground max-w-3xl mx-auto leading-relaxed">
                 Your reconciliation rules are code. Review them in PRs, test them in CI, deploy them
                 with confidence.
               </p>
             </div>
 
-            <div className="rounded-2xl overflow-hidden bg-slate-950 border border-slate-800 shadow-2xl">
-              <div className="flex items-center gap-2 px-4 py-3 bg-slate-900 border-b border-slate-800">
+            <div className="rounded-2xl overflow-hidden bg-card border border-border shadow-2xl">
+              <div className="flex items-center gap-2 px-4 py-3 bg-background border-b border-border">
                 <div className="w-3 h-3 rounded-full bg-red-500" aria-hidden="true" />
                 <div className="w-3 h-3 rounded-full bg-yellow-500" aria-hidden="true" />
                 <div className="w-3 h-3 rounded-full bg-green-500" aria-hidden="true" />
-                <span className="ml-4 text-sm text-slate-400 font-mono">reconciliation.ts</span>
+                <span className="ml-4 text-sm text-muted-foreground font-mono">reconciliation.ts</span>
               </div>
               <div className="p-4 sm:p-6 overflow-x-auto">
                 <AnimatedCodeBlock
@@ -455,12 +455,12 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                 const Icon = feature.icon;
                 return (
                   <div key={idx} className="flex items-start gap-3">
-                    <div className="w-10 h-10 rounded-lg bg-slate-800 flex items-center justify-center flex-shrink-0">
-                      <Icon className="w-5 h-5 text-slate-300" aria-hidden="true" />
+                    <div className="w-10 h-10 rounded-lg bg-card flex items-center justify-center flex-shrink-0">
+                      <Icon className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
                     </div>
                     <div>
-                      <h4 className="font-semibold text-white mb-1">{feature.title}</h4>
-                      <p className="text-sm text-slate-400">{feature.desc}</p>
+                      <h4 className="font-semibold text-foreground mb-1">{feature.title}</h4>
+                      <p className="text-sm text-muted-foreground">{feature.desc}</p>
                     </div>
                   </div>
                 );
@@ -471,18 +471,18 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
         {/* Enterprise Inevitability Narrative */}
         <section
-          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900"
+          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-card dark:bg-background"
           aria-label="Why this matters"
         >
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12 sm:mb-16">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
+              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground dark:text-muted-foreground mb-3">
                 Why Settler
               </p>
-              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-slate-900 dark:text-white tracking-tight">
+              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-foreground dark:text-foreground tracking-tight">
                 Why Teams Move Beyond Spreadsheets
               </h2>
-              <p className="text-lg text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
+              <p className="text-lg text-muted-foreground dark:text-muted-foreground max-w-3xl mx-auto leading-relaxed">
                 Manual reconciliation breaks at scale. Repeatable, API-driven reconciliation is what
                 teams build toward.
               </p>
@@ -513,18 +513,18 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                 return (
                   <div
                     key={idx}
-                    className="p-6 md:p-8 bg-slate-50 dark:bg-slate-800/50 rounded-2xl border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-md transition-all duration-200"
+                    className="p-6 md:p-8 bg-background dark:bg-card/50 rounded-2xl border border-border dark:border-border hover:border-border dark:hover:border-border hover:shadow-md transition-all duration-200"
                   >
-                    <div className="w-11 h-11 rounded-xl bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 flex items-center justify-center mb-5 shadow-sm">
+                    <div className="w-11 h-11 rounded-xl bg-card dark:bg-card border border-border dark:border-border flex items-center justify-center mb-5 shadow-sm">
                       <Icon
-                        className="w-5 h-5 text-slate-700 dark:text-slate-300"
+                        className="w-5 h-5 text-foreground dark:text-muted-foreground"
                         aria-hidden="true"
                       />
                     </div>
-                    <h3 className="text-lg font-semibold mb-2.5 text-slate-900 dark:text-white tracking-tight">
+                    <h3 className="text-lg font-semibold mb-2.5 text-foreground dark:text-foreground tracking-tight">
                       {item.title}
                     </h3>
-                    <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
+                    <p className="text-sm text-foreground dark:text-muted-foreground leading-relaxed">
                       {item.description}
                     </p>
                   </div>
@@ -535,18 +535,18 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
         </section>
 
         <section
-          className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900"
+          className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 bg-card dark:bg-background"
           aria-label="Platform architecture preview"
         >
           <div className="max-w-6xl mx-auto space-y-4">
             <div className="max-w-3xl">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
+              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground dark:text-muted-foreground mb-3">
                 Visual proof
               </p>
-              <h2 className="text-2xl sm:text-3xl font-bold text-slate-900 dark:text-white tracking-tight">
+              <h2 className="text-2xl sm:text-3xl font-bold text-foreground dark:text-foreground tracking-tight">
                 See the actual system shape, not just feature claims
               </h2>
-              <p className="mt-3 text-slate-600 dark:text-slate-400">
+              <p className="mt-3 text-muted-foreground dark:text-muted-foreground">
                 This architecture preview maps shipped surfaces, control-plane modules, and runtime
                 boundaries. Continue to the dedicated architecture page for deeper detail.
               </p>
@@ -557,18 +557,18 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
         {/* Feature Pages */}
         <section
-          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-slate-50 dark:bg-slate-950"
+          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-background "
           aria-label="Key features"
         >
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
+              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground dark:text-muted-foreground mb-3">
                 Explore
               </p>
-              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-slate-900 dark:text-white tracking-tight">
+              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-foreground dark:text-foreground tracking-tight">
                 Go Deeper on Each Capability
               </h2>
-              <p className="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto leading-relaxed">
+              <p className="text-lg text-muted-foreground dark:text-muted-foreground max-w-2xl mx-auto leading-relaxed">
                 Each feature has its own dedicated page with detailed mechanics, interactive demos,
                 and documentation.
               </p>
@@ -606,21 +606,21 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                   <Link
                     key={feature.href}
                     href={feature.href}
-                    className="group p-6 bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-slate-300 dark:hover:border-slate-700 hover:shadow-lg transition-all duration-200 flex flex-col"
+                    className="group p-6 bg-card dark:bg-background rounded-2xl border border-border dark:border-border hover:border-border dark:hover:border-border hover:shadow-lg transition-all duration-200 flex flex-col"
                   >
-                    <div className="w-11 h-11 rounded-xl bg-slate-100 dark:bg-slate-800 flex items-center justify-center mb-4 flex-shrink-0">
+                    <div className="w-11 h-11 rounded-xl bg-muted/40 dark:bg-card flex items-center justify-center mb-4 flex-shrink-0">
                       <Icon
-                        className="w-5 h-5 text-slate-700 dark:text-slate-300"
+                        className="w-5 h-5 text-foreground dark:text-muted-foreground"
                         aria-hidden="true"
                       />
                     </div>
-                    <h3 className="text-base font-semibold text-slate-900 dark:text-white mb-2 tracking-tight">
+                    <h3 className="text-base font-semibold text-foreground dark:text-foreground mb-2 tracking-tight">
                       {feature.label}
                     </h3>
-                    <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed flex-1 mb-4">
+                    <p className="text-sm text-muted-foreground dark:text-muted-foreground leading-relaxed flex-1 mb-4">
                       {feature.description}
                     </p>
-                    <span className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
+                    <span className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground dark:text-muted-foreground group-hover:text-foreground dark:group-hover:text-primary-foreground transition-colors">
                       {feature.cta}
                       <ArrowRight
                         className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5"
@@ -636,33 +636,33 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
         {/* GitHub / Quickstart CTA */}
         <section
-          className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 bg-slate-900 dark:bg-slate-950"
+          className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 bg-background "
           aria-label="Get started"
         >
           <div className="max-w-3xl mx-auto text-center">
             <div className="mb-5 flex justify-center">
-              <span className="inline-flex items-center gap-2 rounded-full border border-slate-700 bg-slate-800 px-3.5 py-1.5 text-xs font-semibold text-slate-300">
+              <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3.5 py-1.5 text-xs font-semibold text-muted-foreground">
                 <Github className="w-3.5 h-3.5" aria-hidden="true" />
                 Apache 2.0 · Open Source
               </span>
             </div>
-            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white tracking-tight mb-4">
+            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-foreground tracking-tight mb-4">
               Start in Minutes
             </h2>
-            <p className="text-lg text-slate-400 max-w-xl mx-auto leading-relaxed mb-10">
+            <p className="text-lg text-muted-foreground max-w-xl mx-auto leading-relaxed mb-10">
               One SDK install. Define your rules. Run reconciliation. Review the evidence.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link
                 href="/docs/quickstart"
-                className="inline-flex items-center justify-center gap-2 rounded-xl bg-white text-slate-900 hover:bg-slate-100 px-8 py-3.5 text-base font-semibold shadow-lg transition-all duration-200"
+                className="inline-flex items-center justify-center gap-2 rounded-xl bg-card text-foreground hover:bg-muted/40 px-8 py-3.5 text-base font-semibold shadow-lg transition-all duration-200"
               >
                 <BookOpen className="w-4 h-4" aria-hidden="true" />
                 Read the Quickstart
               </Link>
               <Link
                 href={repoUrl}
-                className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-700 bg-slate-800 text-slate-200 hover:bg-slate-700 hover:border-slate-600 px-8 py-3.5 text-base font-medium transition-all duration-200"
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-border bg-card text-foreground hover:bg-muted hover:border-border px-8 py-3.5 text-base font-medium transition-all duration-200"
               >
                 <Github className="w-4 h-4" aria-hidden="true" />
                 View on GitHub
@@ -673,27 +673,27 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
         {/* FAQ */}
         <section
-          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-slate-50 dark:bg-slate-950"
+          className="py-16 sm:py-20 lg:py-24 px-4 sm:px-6 lg:px-8 bg-background "
           aria-label="Common questions"
         >
           <div className="max-w-3xl mx-auto">
             <div className="text-center mb-10 sm:mb-12">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-500 mb-3">
+              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground dark:text-muted-foreground mb-3">
                 FAQ
               </p>
-              <h2 className="text-2xl sm:text-3xl font-bold mb-2 text-slate-900 dark:text-white tracking-tight">
+              <h2 className="text-2xl sm:text-3xl font-bold mb-2 text-foreground dark:text-foreground tracking-tight">
                 Common Questions
               </h2>
             </div>
             <Accordion type="single" collapsible className="w-full space-y-4">
               <AccordionItem
                 value="what-is"
-                className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 px-6"
+                className="bg-card dark:bg-background rounded-xl border border-border dark:border-border px-6"
               >
                 <AccordionTrigger className="text-base sm:text-lg font-semibold py-4 hover:no-underline">
                   What is Settler?
                 </AccordionTrigger>
-                <AccordionContent className="text-sm sm:text-base text-slate-700 dark:text-slate-300 pb-4 leading-relaxed">
+                <AccordionContent className="text-sm sm:text-base text-foreground dark:text-muted-foreground pb-4 leading-relaxed">
                   Settler is an open-source reconciliation engine that matches financial records
                   across Stripe, banks, ERPs, and ledgers. It surfaces every mismatch with full
                   context, generates verifiable evidence for each run, and lets you replay any run
@@ -703,12 +703,12 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
               <AccordionItem
                 value="deterministic"
-                className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 px-6"
+                className="bg-card dark:bg-background rounded-xl border border-border dark:border-border px-6"
               >
                 <AccordionTrigger className="text-base sm:text-lg font-semibold py-4 hover:no-underline">
                   What does deterministic mean?
                 </AccordionTrigger>
-                <AccordionContent className="text-sm sm:text-base text-slate-700 dark:text-slate-300 pb-4 leading-relaxed">
+                <AccordionContent className="text-sm sm:text-base text-foreground dark:text-muted-foreground pb-4 leading-relaxed">
                   Deterministic means the same inputs always produce the same outputs. Given
                   identical data sources and matching rules, Settler will always identify the same
                   variances. This makes debugging, testing, and auditing tractable.
@@ -717,12 +717,12 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
               <AccordionItem
                 value="self-host"
-                className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 px-6"
+                className="bg-card dark:bg-background rounded-xl border border-border dark:border-border px-6"
               >
                 <AccordionTrigger className="text-base sm:text-lg font-semibold py-4 hover:no-underline">
                   Can I self-host Settler?
                 </AccordionTrigger>
-                <AccordionContent className="text-sm sm:text-base text-slate-700 dark:text-slate-300 pb-4 leading-relaxed">
+                <AccordionContent className="text-sm sm:text-base text-foreground dark:text-muted-foreground pb-4 leading-relaxed">
                   Yes. Self-hosting is a first-class deployment model. Settler is open source under
                   Apache 2.0. Your data stays in your infrastructure unless you choose to use the
                   managed cloud service.
@@ -731,12 +731,12 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
               <AccordionItem
                 value="not"
-                className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 px-6"
+                className="bg-card dark:bg-background rounded-xl border border-border dark:border-border px-6"
               >
                 <AccordionTrigger className="text-base sm:text-lg font-semibold py-4 hover:no-underline">
                   What is Settler NOT?
                 </AccordionTrigger>
-                <AccordionContent className="text-sm sm:text-base text-slate-700 dark:text-slate-300 pb-4 leading-relaxed">
+                <AccordionContent className="text-sm sm:text-base text-foreground dark:text-muted-foreground pb-4 leading-relaxed">
                   Settler is not accounting software, an audit tool, or compliance certification. It
                   does not make decisions or automate judgment. It surfaces mismatches and evidence
                   for human review. You decide how to act on the results.

--- a/packages/web/src/app/admin/monitoring/page.tsx
+++ b/packages/web/src/app/admin/monitoring/page.tsx
@@ -220,10 +220,10 @@ export default function MonitoringDashboard() {
   return (
     <div className="p-8 space-y-6">
       <div>
-        <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-2">
+        <h1 className="text-3xl font-bold text-foreground mb-2">
           Monitoring Dashboard
         </h1>
-        <p className="text-slate-600 dark:text-slate-400">
+        <p className="text-muted-foreground">
           Real-time system health and business metrics
         </p>
       </div>
@@ -232,7 +232,7 @@ export default function MonitoringDashboard() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 flex items-center gap-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               <Activity className="w-4 h-4" />
               System Status
             </CardTitle>
@@ -256,14 +256,14 @@ export default function MonitoringDashboard() {
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 flex items-center gap-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               <Users className="w-4 h-4" />
               Active Customers
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{health?.metrics.active_customers || 0}</div>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               {health?.metrics.active_subscriptions || 0} active subscriptions
             </p>
           </CardContent>
@@ -271,7 +271,7 @@ export default function MonitoringDashboard() {
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 flex items-center gap-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               <Shield className="w-4 h-4" />
               SLA Compliance
             </CardTitle>
@@ -280,7 +280,7 @@ export default function MonitoringDashboard() {
             <div className="text-2xl font-bold">
               {overallSlaPercentage.toFixed(1)}%
             </div>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               {sla?.violations.current || 0} current violations
             </p>
           </CardContent>
@@ -288,14 +288,14 @@ export default function MonitoringDashboard() {
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 flex items-center gap-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               <Clock className="w-4 h-4" />
               Open Tickets
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{health?.metrics.open_support_tickets || 0}</div>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               {health?.metrics.sla_violations || 0} SLA violations
             </p>
           </CardContent>
@@ -306,7 +306,7 @@ export default function MonitoringDashboard() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 flex items-center gap-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               <DollarSign className="w-4 h-4" />
               Monthly Recurring Revenue
             </CardTitle>
@@ -315,7 +315,7 @@ export default function MonitoringDashboard() {
             <div className="text-2xl font-bold">
               ${(unitEconomics?.mrr || 0).toLocaleString()}
             </div>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               ARPU: ${((unitEconomics?.calculated_metrics?.arpu) || 0).toFixed(2)}
             </p>
           </CardContent>
@@ -323,7 +323,7 @@ export default function MonitoringDashboard() {
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 flex items-center gap-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               <TrendingUp className="w-4 h-4" />
               Churn Rate
             </CardTitle>
@@ -332,7 +332,7 @@ export default function MonitoringDashboard() {
             <div className="text-2xl font-bold">
               {(business?.customers.churn_rate || 0).toFixed(2)}%
             </div>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               {business?.customers.churned_30d || 0} churned (30d)
             </p>
           </CardContent>
@@ -340,7 +340,7 @@ export default function MonitoringDashboard() {
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 flex items-center gap-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               <Database className="w-4 h-4" />
               Usage (30d)
             </CardTitle>
@@ -349,13 +349,13 @@ export default function MonitoringDashboard() {
             <div className="text-2xl font-bold">
               {((unitEconomics?.usage?.total_reconciliations_30d) || 0).toLocaleString()}
             </div>
-            <p className="text-xs text-slate-500 mt-1">Reconciliations</p>
+            <p className="text-xs text-muted-foreground mt-1">Reconciliations</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
               Plan Distribution
             </CardTitle>
           </CardHeader>
@@ -384,19 +384,19 @@ export default function MonitoringDashboard() {
           <CardContent>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               <div>
-                <div className="text-sm text-slate-500">Total Tickets</div>
+                <div className="text-sm text-muted-foreground">Total Tickets</div>
                 <div className="text-2xl font-bold">{operational.support.total}</div>
               </div>
               <div>
-                <div className="text-sm text-slate-500">Open</div>
+                <div className="text-sm text-muted-foreground">Open</div>
                 <div className="text-2xl font-bold text-amber-600">{operational.support.open}</div>
               </div>
               <div>
-                <div className="text-sm text-slate-500">SLA Met</div>
+                <div className="text-sm text-muted-foreground">SLA Met</div>
                 <div className="text-2xl font-bold text-green-600">{operational.support.sla_met}</div>
               </div>
               <div>
-                <div className="text-sm text-slate-500">SLA Missed</div>
+                <div className="text-sm text-muted-foreground">SLA Missed</div>
                 <div className="text-2xl font-bold text-red-600">{operational.support.sla_missed}</div>
               </div>
             </div>
@@ -404,19 +404,19 @@ export default function MonitoringDashboard() {
               <div className="text-sm font-semibold mb-2">By Priority</div>
               <div className="grid grid-cols-4 gap-4">
                 <div>
-                  <div className="text-xs text-slate-500">Critical</div>
+                  <div className="text-xs text-muted-foreground">Critical</div>
                   <div className="text-lg font-bold text-red-600">{operational.support.by_priority.critical}</div>
                 </div>
                 <div>
-                  <div className="text-xs text-slate-500">High</div>
+                  <div className="text-xs text-muted-foreground">High</div>
                   <div className="text-lg font-bold text-orange-600">{operational.support.by_priority.high}</div>
                 </div>
                 <div>
-                  <div className="text-xs text-slate-500">Medium</div>
+                  <div className="text-xs text-muted-foreground">Medium</div>
                   <div className="text-lg font-bold text-yellow-600">{operational.support.by_priority.medium}</div>
                 </div>
                 <div>
-                  <div className="text-xs text-slate-500">Low</div>
+                  <div className="text-xs text-muted-foreground">Low</div>
                   <div className="text-lg font-bold text-blue-600">{operational.support.by_priority.low}</div>
                 </div>
               </div>
@@ -441,7 +441,7 @@ export default function MonitoringDashboard() {
                   <div className="flex justify-between items-start mb-2">
                     <div>
                       <div className="font-semibold">{account.tier}</div>
-                      <div className="text-sm text-slate-500">
+                      <div className="text-sm text-muted-foreground">
                         {account.total_tickets} tickets
                       </div>
                     </div>
@@ -451,15 +451,15 @@ export default function MonitoringDashboard() {
                   </div>
                   <div className="grid grid-cols-3 gap-4 mt-2 text-sm">
                     <div>
-                      <div className="text-slate-500">SLA Met</div>
+                      <div className="text-muted-foreground">SLA Met</div>
                       <div className="font-semibold text-green-600">{account.sla_met}</div>
                     </div>
                     <div>
-                      <div className="text-slate-500">SLA Missed</div>
+                      <div className="text-muted-foreground">SLA Missed</div>
                       <div className="font-semibold text-red-600">{account.sla_missed}</div>
                     </div>
                     <div>
-                      <div className="text-slate-500">Avg Response</div>
+                      <div className="text-muted-foreground">Avg Response</div>
                       <div className="font-semibold">{(account.avg_response_time_hours || 0).toFixed(1)}h</div>
                     </div>
                   </div>
@@ -498,30 +498,30 @@ export default function MonitoringDashboard() {
                           </div>
                           <div className="grid grid-cols-4 gap-4 text-sm">
                             <div>
-                              <div className="text-slate-500">Total</div>
+                              <div className="text-muted-foreground">Total</div>
                               <div className="font-semibold">{stats.totalRequests.toLocaleString()}</div>
                             </div>
                             <div>
-                              <div className="text-slate-500">Failures</div>
+                              <div className="text-muted-foreground">Failures</div>
                               <div className="font-semibold text-red-600">{stats.failureCount}</div>
                             </div>
                             <div>
-                              <div className="text-slate-500">Avg Duration</div>
+                              <div className="text-muted-foreground">Avg Duration</div>
                               <div className="font-semibold">{stats.avgDurationMs.toFixed(0)}ms</div>
                             </div>
                             <div>
-                              <div className="text-slate-500">P95 Duration</div>
+                              <div className="text-muted-foreground">P95 Duration</div>
                               <div className="font-semibold">{stats.p95DurationMs.toFixed(0)}ms</div>
                             </div>
                           </div>
                           {(stats.retryCount > 0 || stats.deadLetterCount > 0) && (
                             <div className="mt-2 pt-2 border-t grid grid-cols-2 gap-4 text-sm">
                               <div>
-                                <div className="text-slate-500">Retries</div>
+                                <div className="text-muted-foreground">Retries</div>
                                 <div className="font-semibold text-yellow-600">{stats.retryCount}</div>
                               </div>
                               <div>
-                                <div className="text-slate-500">Dead Letters</div>
+                                <div className="text-muted-foreground">Dead Letters</div>
                                 <div className="font-semibold text-red-600">{stats.deadLetterCount}</div>
                               </div>
                             </div>
@@ -545,7 +545,7 @@ export default function MonitoringDashboard() {
                             >
                               {(adapter.errorRate * 100).toFixed(1)}%
                             </Badge>
-                            <span className="text-xs text-slate-500">
+                            <span className="text-xs text-muted-foreground">
                               {adapter.totalRequests} requests
                             </span>
                           </div>
@@ -567,7 +567,7 @@ export default function MonitoringDashboard() {
                       <div className="text-2xl font-bold text-red-600">
                         {health.reliability.deadLetterCount}
                       </div>
-                      <p className="text-xs text-slate-500 mt-1">
+                      <p className="text-xs text-muted-foreground mt-1">
                         Jobs requiring manual intervention
                       </p>
                     </CardContent>
@@ -586,8 +586,8 @@ export default function MonitoringDashboard() {
                           {health.reliability.latestFailures.slice(0, 5).map((failure, idx) => (
                             <div key={idx} className="text-sm border-l-2 border-red-500 pl-2">
                               <div className="font-medium">{failure.operation}</div>
-                              <div className="text-xs text-slate-500 truncate">{failure.error}</div>
-                              <div className="text-xs text-slate-400">
+                              <div className="text-xs text-muted-foreground truncate">{failure.error}</div>
+                              <div className="text-xs text-muted-foreground">
                                 {new Date(failure.timestamp).toLocaleString()}
                               </div>
                             </div>
@@ -604,7 +604,7 @@ export default function MonitoringDashboard() {
       )}
 
       {/* Last Updated */}
-      <div className="text-xs text-slate-500 text-center">
+      <div className="text-xs text-muted-foreground text-center">
         Last updated: {health?.metrics.timestamp ? new Date(health.metrics.timestamp).toLocaleString() : 'Never'}
         {' • '}
         Auto-refresh: 30s

--- a/packages/web/src/app/admin/ops/page.tsx
+++ b/packages/web/src/app/admin/ops/page.tsx
@@ -167,13 +167,13 @@ export default function AdminOpsConsole() {
   };
 
   return (
-    <div className="flex flex-col lg:flex-row h-[calc(100vh-4rem)] bg-slate-50 dark:bg-slate-900" id="main-content">
+    <div className="flex flex-col lg:flex-row h-[calc(100vh-4rem)] bg-muted/20 dark:bg-background" id="main-content">
       {/* Left Panel: Exception List */}
-      <div className="w-full lg:w-1/2 border-r border-slate-200 dark:border-slate-800 flex flex-col">
+      <div className="w-full lg:w-1/2 border-r border-border dark:border-border flex flex-col">
         {/* Header */}
-        <div className="p-4 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950">
+        <div className="p-4 border-b border-border dark:border-border bg-card bg-muted">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+            <h2 className="text-lg font-semibold text-foreground dark:text-white">
               Exception Queue
             </h2>
             <div className="flex items-center gap-2">
@@ -181,7 +181,7 @@ export default function AdminOpsConsole() {
                 connectionState === 'connected' ? 'bg-green-500' :
                 connectionState === 'reconnecting' ? 'bg-yellow-500' : 'bg-red-500'
               }`} />
-              <span className="text-xs text-slate-500 dark:text-slate-400">
+              <span className="text-xs text-muted-foreground dark:text-muted-foreground">
                 {connectionState}
               </span>
             </div>
@@ -189,7 +189,7 @@ export default function AdminOpsConsole() {
 
           {/* Search */}
           <div className="relative mb-3">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
             <Input
               placeholder="Search exceptions..."
               value={searchQuery}
@@ -203,7 +203,7 @@ export default function AdminOpsConsole() {
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="text-sm border border-slate-200 dark:border-slate-700 rounded px-2 py-1 bg-white dark:bg-slate-900 text-slate-900 dark:text-white"
+              className="text-sm border border-border dark:border-border rounded px-2 py-1 bg-card dark:bg-background text-foreground dark:text-white"
             >
               <option value="all">All Status</option>
               <option value="new">New</option>
@@ -213,7 +213,7 @@ export default function AdminOpsConsole() {
             <select
               value={severityFilter}
               onChange={(e) => setSeverityFilter(e.target.value)}
-              className="text-sm border border-slate-200 dark:border-slate-700 rounded px-2 py-1 bg-white dark:bg-slate-900 text-slate-900 dark:text-white"
+              className="text-sm border border-border dark:border-border rounded px-2 py-1 bg-card dark:bg-background text-foreground dark:text-white"
             >
               <option value="all">All Severity</option>
               <option value="critical">Critical</option>
@@ -226,11 +226,11 @@ export default function AdminOpsConsole() {
         {/* List */}
         <div className="flex-1 overflow-y-auto">
           {isLoading ? (
-            <div className="p-4 text-center text-slate-500 dark:text-slate-400">
+            <div className="p-4 text-center text-muted-foreground dark:text-muted-foreground">
               Loading exceptions...
             </div>
           ) : filteredExceptions.length === 0 ? (
-            <div className="p-4 text-center text-slate-500 dark:text-slate-400">
+            <div className="p-4 text-center text-muted-foreground dark:text-muted-foreground">
               No exceptions found
             </div>
           ) : (
@@ -242,8 +242,8 @@ export default function AdminOpsConsole() {
                     setSelectedException(ex.id);
                     selectedIndexRef.current = index;
                   }}
-                  className={`w-full p-4 text-left hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
-                    selectedException === ex.id ? 'bg-slate-100 dark:bg-slate-800 ring-2 ring-blue-500' : ''
+                  className={`w-full p-4 text-left hover:bg-muted/40 dark:hover:bg-card transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                    selectedException === ex.id ? 'bg-muted/40 dark:bg-card ring-2 ring-blue-500' : ''
                   }`}
                   aria-selected={selectedException === ex.id}
                   role="option"
@@ -260,11 +260,11 @@ export default function AdminOpsConsole() {
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-1">
                         {getStatusIcon(ex.status)}
-                        <span className="text-sm font-medium text-slate-900 dark:text-white">
+                        <span className="text-sm font-medium text-foreground dark:text-white">
                           {ex.reason}
                         </span>
                       </div>
-                      <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground dark:text-muted-foreground">
                         <span>{ex.source}</span>
                         <span>•</span>
                         <span>{new Date(ex.createdAt).toLocaleString()}</span>
@@ -286,7 +286,7 @@ export default function AdminOpsConsole() {
         {selectedExceptionData ? (
           <ExceptionDetail exception={selectedExceptionData} />
         ) : (
-          <div className="flex-1 flex items-center justify-center text-slate-500 dark:text-slate-400">
+          <div className="flex-1 flex items-center justify-center text-muted-foreground dark:text-muted-foreground">
             Select an exception to view details
           </div>
         )}
@@ -355,28 +355,28 @@ function ExceptionDetail({ exception }: { exception: ExceptionItem }) {
         </CardHeader>
         <CardContent className="space-y-4">
           <div>
-            <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+            <h3 className="text-sm font-medium text-foreground dark:text-muted-foreground mb-2">
               Details
             </h3>
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
-                <span className="text-slate-500 dark:text-slate-400">Source:</span>
-                <span className="text-slate-900 dark:text-white">{exception.source}</span>
+                <span className="text-muted-foreground dark:text-muted-foreground">Source:</span>
+                <span className="text-foreground dark:text-white">{exception.source}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-slate-500 dark:text-slate-400">Status:</span>
-                <span className="text-slate-900 dark:text-white">{exception.status}</span>
+                <span className="text-muted-foreground dark:text-muted-foreground">Status:</span>
+                <span className="text-foreground dark:text-white">{exception.status}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-slate-500 dark:text-slate-400">Created:</span>
-                <span className="text-slate-900 dark:text-white">
+                <span className="text-muted-foreground dark:text-muted-foreground">Created:</span>
+                <span className="text-foreground dark:text-white">
                   {new Date(exception.createdAt).toLocaleString()}
                 </span>
               </div>
               {exception.ruleId && (
                 <div className="flex justify-between">
-                  <span className="text-slate-500 dark:text-slate-400">Rule ID:</span>
-                  <span className="text-slate-900 dark:text-white font-mono text-xs">
+                  <span className="text-muted-foreground dark:text-muted-foreground">Rule ID:</span>
+                  <span className="text-foreground dark:text-white font-mono text-xs">
                     {exception.ruleId}
                   </span>
                 </div>
@@ -386,16 +386,16 @@ function ExceptionDetail({ exception }: { exception: ExceptionItem }) {
 
           {exception.evidence && (
             <div>
-              <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              <h3 className="text-sm font-medium text-foreground dark:text-muted-foreground mb-2">
                 Evidence
               </h3>
-              <pre className="text-xs bg-slate-100 dark:bg-slate-800 p-3 rounded overflow-auto">
+              <pre className="text-xs bg-muted/40 dark:bg-card p-3 rounded overflow-auto">
                 {JSON.stringify(exception.evidence, null, 2)}
               </pre>
             </div>
           )}
 
-          <div className="flex gap-2 pt-4 border-t border-slate-200 dark:border-slate-800">
+          <div className="flex gap-2 pt-4 border-t border-border dark:border-border">
             <Button 
               variant="default" 
               size="sm"

--- a/packages/web/src/app/admin/runs/[runId]/page.tsx
+++ b/packages/web/src/app/admin/runs/[runId]/page.tsx
@@ -23,7 +23,7 @@ export default function AdminRunDetailPage({ params }: { params: { runId: string
     return (
       <div className="p-8">
         <div className="text-center py-12">
-          <p className="text-slate-500 dark:text-slate-400">Run not found</p>
+          <p className="text-muted-foreground dark:text-muted-foreground">Run not found</p>
           <Link href="/admin/runs">
             <Button variant="outline" className="mt-4">
               <ArrowLeft className="w-4 h-4 mr-2" />
@@ -44,7 +44,7 @@ export default function AdminRunDetailPage({ params }: { params: { runId: string
       case "running":
         return <Clock className="w-5 h-5 text-blue-600 animate-spin" />;
       default:
-        return <Clock className="w-5 h-5 text-slate-400" />;
+        return <Clock className="w-5 h-5 text-muted-foreground" />;
     }
   };
 
@@ -57,7 +57,7 @@ export default function AdminRunDetailPage({ params }: { params: { runId: string
       case "running":
         return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
       default:
-        return "bg-slate-100 text-slate-800 dark:bg-slate-900/30 dark:text-slate-300";
+        return "bg-muted/40 text-foreground dark:bg-background/30 dark:text-muted-foreground";
     }
   };
 
@@ -72,7 +72,7 @@ export default function AdminRunDetailPage({ params }: { params: { runId: string
       : null;
 
   return (
-    <div className="p-8 space-y-6 bg-slate-50 dark:bg-slate-900 min-h-screen">
+    <div className="p-8 space-y-6 bg-muted/20 dark:bg-background min-h-screen">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
@@ -83,10 +83,10 @@ export default function AdminRunDetailPage({ params }: { params: { runId: string
             </Button>
           </Link>
           <div>
-            <h1 className="text-3xl font-bold text-slate-900 dark:text-white">
+            <h1 className="text-3xl font-bold text-foreground dark:text-white">
               {run.name || `Run ${run.id.slice(0, 8)}`}
             </h1>
-            <p className="text-slate-500 dark:text-slate-400 mt-1">
+            <p className="text-muted-foreground dark:text-muted-foreground mt-1">
               Reconciliation run details and drilldown
             </p>
           </div>
@@ -101,48 +101,48 @@ export default function AdminRunDetailPage({ params }: { params: { runId: string
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 dark:text-slate-400">
+            <CardTitle className="text-sm font-medium text-muted-foreground dark:text-muted-foreground">
               Matched
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-slate-900 dark:text-white">
+            <div className="text-2xl font-bold text-foreground dark:text-white">
               {run.matchedCount} ({matchedPercent.toFixed(1)}%)
             </div>
           </CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 dark:text-slate-400">
+            <CardTitle className="text-sm font-medium text-muted-foreground dark:text-muted-foreground">
               Unmatched Source
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-slate-900 dark:text-white">
+            <div className="text-2xl font-bold text-foreground dark:text-white">
               {run.unmatchedSourceCount || 0}
             </div>
           </CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 dark:text-slate-400">
+            <CardTitle className="text-sm font-medium text-muted-foreground dark:text-muted-foreground">
               Unmatched Target
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-slate-900 dark:text-white">
+            <div className="text-2xl font-bold text-foreground dark:text-white">
               {run.unmatchedTargetCount || 0}
             </div>
           </CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 dark:text-slate-400">
+            <CardTitle className="text-sm font-medium text-muted-foreground dark:text-muted-foreground">
               Confidence
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-slate-900 dark:text-white">
+            <div className="text-2xl font-bold text-foreground dark:text-white">
               {run.confidenceAvg ? (Number(run.confidenceAvg) * 100).toFixed(1) + "%" : "N/A"}
             </div>
           </CardContent>
@@ -157,43 +157,43 @@ export default function AdminRunDetailPage({ params }: { params: { runId: string
         <CardContent>
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
-              <span className="text-slate-500 dark:text-slate-400">Run ID:</span>
-              <span className="ml-2 font-mono text-xs text-slate-900 dark:text-white">
+              <span className="text-muted-foreground dark:text-muted-foreground">Run ID:</span>
+              <span className="ml-2 font-mono text-xs text-foreground dark:text-white">
                 {run.id}
               </span>
             </div>
             <div>
-              <span className="text-slate-500 dark:text-slate-400">Tenant ID:</span>
-              <span className="ml-2 font-mono text-xs text-slate-900 dark:text-white">
+              <span className="text-muted-foreground dark:text-muted-foreground">Tenant ID:</span>
+              <span className="ml-2 font-mono text-xs text-foreground dark:text-white">
                 {run.tenantId.slice(0, 8)}
               </span>
             </div>
             <div>
-              <span className="text-slate-500 dark:text-slate-400">Started:</span>
-              <span className="ml-2 text-slate-900 dark:text-white">
+              <span className="text-muted-foreground dark:text-muted-foreground">Started:</span>
+              <span className="ml-2 text-foreground dark:text-white">
                 {new Date(run.startedAt).toLocaleString()}
               </span>
             </div>
             {run.completedAt && (
               <div>
-                <span className="text-slate-500 dark:text-slate-400">Completed:</span>
-                <span className="ml-2 text-slate-900 dark:text-white">
+                <span className="text-muted-foreground dark:text-muted-foreground">Completed:</span>
+                <span className="ml-2 text-foreground dark:text-white">
                   {new Date(run.completedAt).toLocaleString()}
                 </span>
               </div>
             )}
             {duration && (
               <div>
-                <span className="text-slate-500 dark:text-slate-400">Duration:</span>
-                <span className="ml-2 text-slate-900 dark:text-white">
+                <span className="text-muted-foreground dark:text-muted-foreground">Duration:</span>
+                <span className="ml-2 text-foreground dark:text-white">
                   {formatDuration(duration)}
                 </span>
               </div>
             )}
             {run.traceId && (
               <div>
-                <span className="text-slate-500 dark:text-slate-400">Trace ID:</span>
-                <span className="ml-2 font-mono text-xs text-slate-900 dark:text-white">
+                <span className="text-muted-foreground dark:text-muted-foreground">Trace ID:</span>
+                <span className="ml-2 font-mono text-xs text-foreground dark:text-white">
                   {run.traceId}
                 </span>
               </div>
@@ -209,10 +209,10 @@ export default function AdminRunDetailPage({ params }: { params: { runId: string
           )}
           {run.metadata && Object.keys(run.metadata).length > 0 && (
             <details className="mt-4">
-              <summary className="text-sm text-slate-600 dark:text-slate-400 cursor-pointer mb-2">
+              <summary className="text-sm text-muted-foreground dark:text-muted-foreground cursor-pointer mb-2">
                 View Metadata
               </summary>
-              <pre className="text-xs bg-slate-100 dark:bg-slate-800 p-3 rounded overflow-auto">
+              <pre className="text-xs bg-muted/40 dark:bg-card p-3 rounded overflow-auto">
                 {JSON.stringify(run.metadata, null, 2)}
               </pre>
             </details>

--- a/packages/web/src/app/app/capability-status/page.tsx
+++ b/packages/web/src/app/app/capability-status/page.tsx
@@ -59,7 +59,7 @@ function systemStatusIcon(status?: string) {
   if (s === 'down' || s === 'error' || s === 'critical') {
     return <XCircle className="h-4 w-4 text-red-500 shrink-0" aria-hidden="true" />;
   }
-  return <Clock className="h-4 w-4 text-slate-400 shrink-0" aria-hidden="true" />;
+  return <Clock className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />;
 }
 
 function formatTimestamp(ts?: string): string {
@@ -86,27 +86,27 @@ export default async function CapabilityStatusPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-xl border border-slate-200 bg-white p-6">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+      <section className="rounded-xl border border-border bg-card p-6">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           Capability Status
         </p>
-        <h1 className="mt-2 text-2xl font-semibold text-slate-900">
+        <h1 className="mt-2 text-2xl font-semibold text-foreground">
           Availability and operational posture
         </h1>
-        <p className="mt-2 text-sm text-slate-600">
+        <p className="mt-2 text-sm text-muted-foreground">
           Combines runtime status endpoints with the surfaced capability registry.
         </p>
       </section>
 
       <section className="grid gap-4 md:grid-cols-2">
         {/* System status */}
-        <article className="rounded-lg border border-slate-200 bg-white p-4">
-          <h2 className="font-semibold text-slate-900">System Status</h2>
+        <article className="rounded-lg border border-border bg-card p-4">
+          <h2 className="font-semibold text-foreground">System Status</h2>
           {status ? (
             <>
               <div className="mt-3 flex items-center gap-2">
                 {systemStatusIcon(status.overallStatus)}
-                <span className="text-sm font-medium capitalize text-slate-800">
+                <span className="text-sm font-medium capitalize text-foreground">
                   {status.overallStatus ?? 'Unknown'}
                 </span>
               </div>
@@ -114,10 +114,10 @@ export default async function CapabilityStatusPage() {
                 <ul className="mt-3 space-y-2" aria-label="System component statuses">
                   {status.systems.slice(0, 6).map((s) => (
                     <li key={s.name} className="flex items-center justify-between text-sm">
-                      <span className="text-slate-600">{s.name}</span>
+                      <span className="text-muted-foreground">{s.name}</span>
                       <span className="flex items-center gap-1.5">
                         {systemStatusIcon(s.status)}
-                        <span className="capitalize text-slate-700">{s.status ?? 'unknown'}</span>
+                        <span className="capitalize text-foreground">{s.status ?? 'unknown'}</span>
                       </span>
                     </li>
                   ))}
@@ -130,18 +130,18 @@ export default async function CapabilityStatusPage() {
               )}
             </>
           ) : (
-            <p className="mt-2 text-sm text-slate-500">Status endpoint unavailable.</p>
+            <p className="mt-2 text-sm text-muted-foreground">Status endpoint unavailable.</p>
           )}
         </article>
 
         {/* Health check */}
-        <article className="rounded-lg border border-slate-200 bg-white p-4">
-          <h2 className="font-semibold text-slate-900">Health Check</h2>
+        <article className="rounded-lg border border-border bg-card p-4">
+          <h2 className="font-semibold text-foreground">Health Check</h2>
           {health ? (
             <>
               <div className="mt-3 flex items-center gap-2">
                 {systemStatusIcon(healthStatus)}
-                <span className="text-sm font-medium capitalize text-slate-800">{healthStatus}</span>
+                <span className="text-sm font-medium capitalize text-foreground">{healthStatus}</span>
               </div>
               <div className="mt-3 flex items-center gap-2">
                 {allServicesNominal ? (
@@ -149,39 +149,39 @@ export default async function CapabilityStatusPage() {
                 ) : (
                   <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0" aria-hidden="true" />
                 )}
-                <span className="text-sm text-slate-600">
+                <span className="text-sm text-muted-foreground">
                   {allServicesNominal ? 'All services nominal' : 'One or more services degraded'}
                 </span>
               </div>
-              <p className="mt-3 text-xs text-slate-400">
+              <p className="mt-3 text-xs text-muted-foreground">
                 Last checked: {formatTimestamp(health.timestamp)}
               </p>
             </>
           ) : (
-            <p className="mt-2 text-sm text-slate-500">Health endpoint unavailable.</p>
+            <p className="mt-2 text-sm text-muted-foreground">Health endpoint unavailable.</p>
           )}
         </article>
       </section>
 
       {capabilities.length > 0 && (
-        <section className="rounded-lg border border-slate-200 bg-white p-4">
-          <h2 className="font-semibold text-slate-900">Surfaced Capabilities</h2>
+        <section className="rounded-lg border border-border bg-card p-4">
+          <h2 className="font-semibold text-foreground">Surfaced Capabilities</h2>
           <div className="mt-3 grid gap-3 md:grid-cols-2">
             {capabilities.map((cap) => (
-              <article key={cap.name} className="rounded border border-slate-200 p-3 text-sm">
-                <p className="font-medium text-slate-900">{cap.name}</p>
+              <article key={cap.name} className="rounded border border-border p-3 text-sm">
+                <p className="font-medium text-foreground">{cap.name}</p>
                 <dl className="mt-1 space-y-0.5">
                   <div className="flex gap-2">
-                    <dt className="text-slate-400 w-16 shrink-0">Maturity</dt>
-                    <dd className="text-slate-700 capitalize">{cap.maturity}</dd>
+                    <dt className="text-muted-foreground w-16 shrink-0">Maturity</dt>
+                    <dd className="text-foreground capitalize">{cap.maturity}</dd>
                   </div>
                   <div className="flex gap-2">
-                    <dt className="text-slate-400 w-16 shrink-0">Visibility</dt>
-                    <dd className="text-slate-700 capitalize">{cap.visibility}</dd>
+                    <dt className="text-muted-foreground w-16 shrink-0">Visibility</dt>
+                    <dd className="text-foreground capitalize">{cap.visibility}</dd>
                   </div>
                 </dl>
                 {cap.gating && (
-                  <p className="mt-2 text-xs text-slate-400">{cap.gating}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">{cap.gating}</p>
                 )}
               </article>
             ))}

--- a/packages/web/src/app/app/onboarding/page.tsx
+++ b/packages/web/src/app/app/onboarding/page.tsx
@@ -13,11 +13,11 @@ import {
 
 const OnboardingPage: React.FC = () => {
   return (
-    <div className="bg-background-light dark:bg-background-dark font-display text-text-main dark:text-slate-100 antialiased selection:bg-primary selection:text-white">
+    <div className="bg-background-light dark:bg-background-dark font-display text-text-main text-muted-foreground antialiased selection:bg-primary selection:text-white">
       <div className="relative flex h-full min-h-screen w-full flex-col max-w-md mx-auto bg-background-light dark:bg-background-dark shadow-2xl overflow-hidden">
         {/* Header */}
-        <header className="flex items-center justify-between px-4 py-3 bg-background-light dark:bg-background-dark sticky top-0 z-10 border-b border-slate-200 dark:border-slate-800">
-          <button className="flex items-center justify-center w-10 h-10 -ml-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-text-main dark:text-white transition-colors">
+        <header className="flex items-center justify-between px-4 py-3 bg-background-light dark:bg-background-dark sticky top-0 z-10 border-b border-border dark:border-border">
+          <button className="flex items-center justify-center w-10 h-10 -ml-2 rounded-full hover:bg-muted/40 dark:hover:bg-card text-text-main dark:text-white transition-colors">
             <ArrowLeft className="h-6 w-6" />
           </button>
           <h1 className="text-base font-semibold text-text-main dark:text-white tracking-tight">
@@ -31,12 +31,12 @@ const OnboardingPage: React.FC = () => {
         <div className="w-full bg-background-light dark:bg-background-dark pt-6 pb-2 px-6">
           <div className="flex w-full items-center justify-center gap-3">
             <div className="h-1.5 w-8 rounded-full bg-primary"></div>
-            <div className="h-1.5 w-8 rounded-full bg-slate-200 dark:bg-slate-700"></div>
-            <div className="h-1.5 w-8 rounded-full bg-slate-200 dark:bg-slate-700"></div>
-            <div className="h-1.5 w-8 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+            <div className="h-1.5 w-8 rounded-full bg-slate-200 dark:bg-muted"></div>
+            <div className="h-1.5 w-8 rounded-full bg-slate-200 dark:bg-muted"></div>
+            <div className="h-1.5 w-8 rounded-full bg-slate-200 dark:bg-muted"></div>
           </div>
           <div className="mt-2 text-center">
-            <span className="text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+            <span className="text-xs font-medium text-text-secondary dark:text-muted-foreground uppercase tracking-wider">
               Step 1 of 4
             </span>
           </div>
@@ -47,7 +47,7 @@ const OnboardingPage: React.FC = () => {
             <h2 className="text-2xl font-bold text-text-main dark:text-white tracking-tight mb-2">
               Set up your Workspace
             </h2>
-            <p className="text-text-secondary dark:text-slate-400 text-sm leading-relaxed">
+            <p className="text-text-secondary dark:text-muted-foreground text-sm leading-relaxed">
               Let's configure your secure, audit-ready environment. First, give it an identity.
             </p>
           </div>
@@ -55,14 +55,14 @@ const OnboardingPage: React.FC = () => {
             {/* Workspace Name */}
             <div className="space-y-1.5">
               <label
-                className="block text-sm font-medium text-text-main dark:text-slate-200"
+                className="block text-sm font-medium text-text-main text-muted-foreground"
                 htmlFor="workspace-name"
               >
                 Workspace Name
               </label>
               <div className="relative">
                 <input
-                  className="form-input block w-full rounded-lg border-slate-300 dark:border-slate-700 bg-surface-light dark:bg-slate-800 text-text-main dark:text-white shadow-sm focus:border-primary focus:ring-primary h-12 px-4 transition-colors placeholder:text-slate-400"
+                  className="form-input block w-full rounded-lg border-border dark:border-border bg-surface-light dark:bg-card text-text-main dark:text-white shadow-sm focus:border-primary focus:ring-primary h-12 px-4 transition-colors placeholder:text-muted-foreground"
                   id="workspace-name"
                   placeholder="e.g. Acme Corp"
                   type="text"
@@ -76,31 +76,31 @@ const OnboardingPage: React.FC = () => {
             {/* Subdomain */}
             <div className="space-y-1.5">
               <label
-                className="block text-sm font-medium text-text-main dark:text-slate-200"
+                className="block text-sm font-medium text-text-main text-muted-foreground"
                 htmlFor="subdomain"
               >
                 Workspace URL
               </label>
               <div className="flex rounded-lg shadow-sm">
-                <span className="inline-flex items-center rounded-l-lg border border-r-0 border-slate-300 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-3 text-slate-500 dark:text-slate-400 sm:text-sm">
+                <span className="inline-flex items-center rounded-l-lg border border-r-0 border-border dark:border-border bg-muted/20 dark:bg-background px-3 text-muted-foreground dark:text-muted-foreground sm:text-sm">
                   https://
                 </span>
                 <input
-                  className="block w-full min-w-0 flex-1 rounded-none rounded-r-lg border-slate-300 dark:border-slate-700 bg-surface-light dark:bg-slate-800 text-text-main dark:text-white focus:border-primary focus:ring-primary sm:text-sm h-12 px-4"
+                  className="block w-full min-w-0 flex-1 rounded-none rounded-r-lg border-border dark:border-border bg-surface-light dark:bg-card text-text-main dark:text-white focus:border-primary focus:ring-primary sm:text-sm h-12 px-4"
                   id="subdomain"
                   placeholder="acme"
                   type="text"
                   defaultValue="acme-production"
                 />
               </div>
-              <p className="text-xs text-text-secondary dark:text-slate-500">
+              <p className="text-xs text-text-secondary dark:text-muted-foreground">
                 Your team will use this URL to access the platform.
               </p>
             </div>
             {/* Environment Type Selection */}
             <div className="space-y-3 pt-2">
               <div className="flex items-center justify-between">
-                <label className="block text-sm font-medium text-text-main dark:text-slate-200">
+                <label className="block text-sm font-medium text-text-main text-muted-foreground">
                   Tenant Mode
                 </label>
                 <button className="text-primary hover:text-primary-dark">
@@ -128,7 +128,7 @@ const OnboardingPage: React.FC = () => {
                       Shared Environment
                     </span>
                     <span
-                      className="mt-1 flex items-center text-sm text-text-secondary dark:text-slate-400"
+                      className="mt-1 flex items-center text-sm text-text-secondary dark:text-muted-foreground"
                       id="tenant-mode-0-description-0"
                     >
                       Cost-effective multi-tenant setup. Best for development and staging.
@@ -141,7 +141,7 @@ const OnboardingPage: React.FC = () => {
                 />
               </label>
               {/* Option 2: Dedicated */}
-              <label className="relative flex cursor-pointer rounded-xl border border-slate-200 dark:border-slate-700 bg-surface-light dark:bg-slate-800 p-4 shadow-sm focus:outline-none hover:border-slate-300 dark:hover:border-slate-600 transition-all">
+              <label className="relative flex cursor-pointer rounded-xl border border-border dark:border-border bg-surface-light dark:bg-card p-4 shadow-sm focus:outline-none hover:border-border dark:hover:border-slate-600 transition-all">
                 <input
                   aria-describedby="tenant-mode-1-description-0 tenant-mode-1-description-1"
                   aria-labelledby="tenant-mode-1-label"
@@ -153,64 +153,64 @@ const OnboardingPage: React.FC = () => {
                 <span className="flex flex-1">
                   <span className="flex flex-col">
                     <span
-                      className="block text-sm font-bold text-text-main dark:text-slate-200 flex items-center gap-2"
+                      className="block text-sm font-bold text-text-main text-muted-foreground flex items-center gap-2"
                       id="tenant-mode-1-label"
                     >
                       <ShieldCheck className="h-5 w-5" />
                       Isolated Environment
                     </span>
                     <span
-                      className="mt-1 flex items-center text-sm text-text-secondary dark:text-slate-400"
+                      className="mt-1 flex items-center text-sm text-text-secondary dark:text-muted-foreground"
                       id="tenant-mode-1-description-0"
                     >
                       Dedicated resources for strict compliance. Best for production.
                     </span>
                   </span>
                 </span>
-                <Circle aria-hidden="true" className="text-slate-300 dark:text-slate-600 h-6 w-6" />
+                <Circle aria-hidden="true" className="text-muted-foreground dark:text-muted-foreground h-6 w-6" />
               </label>
             </div>
             {/* Compliance Quick Toggles */}
-            <div className="pt-4 border-t border-slate-100 dark:border-slate-800">
+            <div className="pt-4 border-t border-slate-100 dark:border-border">
               <h3 className="text-sm font-medium text-text-main dark:text-white mb-4">
                 Audit-Ready Defaults
               </h3>
               <div className="flex items-center justify-between mb-4">
                 <div className="flex flex-col">
-                  <span className="text-sm font-medium text-text-main dark:text-slate-200">
+                  <span className="text-sm font-medium text-text-main text-muted-foreground">
                     SOC2 Logging Preset
                   </span>
-                  <span className="text-xs text-text-secondary dark:text-slate-500">
+                  <span className="text-xs text-text-secondary dark:text-muted-foreground">
                     Enables 90-day retention
                   </span>
                 </div>
                 <label className="relative inline-flex items-center cursor-pointer">
                   <input defaultChecked className="sr-only peer" type="checkbox" value="" />
-                  <div className="w-11 h-6 bg-slate-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer dark:bg-slate-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+                  <div className="w-11 h-6 bg-slate-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer dark:bg-muted peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-card after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
                 </label>
               </div>
               <div className="flex items-center justify-between">
                 <div className="flex flex-col">
-                  <span className="text-sm font-medium text-text-main dark:text-slate-200">
+                  <span className="text-sm font-medium text-text-main text-muted-foreground">
                     Enforce 2FA
                   </span>
-                  <span className="text-xs text-text-secondary dark:text-slate-500">
+                  <span className="text-xs text-text-secondary dark:text-muted-foreground">
                     Require for all admins
                   </span>
                 </div>
                 <label className="relative inline-flex items-center cursor-pointer">
                   <input defaultChecked className="sr-only peer" type="checkbox" value="" />
-                  <div className="w-11 h-6 bg-slate-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer dark:bg-slate-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+                  <div className="w-11 h-6 bg-slate-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer dark:bg-muted peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-card after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
                 </label>
               </div>
             </div>
           </form>
         </main>
         {/* Sticky Footer */}
-        <div className="absolute bottom-0 left-0 right-0 bg-white/90 dark:bg-slate-900/90 backdrop-blur-sm border-t border-slate-200 dark:border-slate-800 p-4 z-20">
+        <div className="absolute bottom-0 left-0 right-0 bg-card/90 dark:bg-background/90 backdrop-blur-sm border-t border-border dark:border-border p-4 z-20">
           <div className="flex gap-3">
             <button
-              className="flex-1 py-3 px-4 bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700 text-text-main dark:text-white rounded-lg font-semibold text-sm transition-colors"
+              className="flex-1 py-3 px-4 bg-muted/40 hover:bg-slate-200 dark:bg-card dark:hover:bg-muted text-text-main dark:text-white rounded-lg font-semibold text-sm transition-colors"
               type="button"
             >
               Save Draft

--- a/packages/web/src/app/app/runs/page.tsx
+++ b/packages/web/src/app/app/runs/page.tsx
@@ -236,32 +236,34 @@ export default async function AppRunsPage() {
         </CardContent>
       </Card>
 
-      <section className="bg-slate-900 rounded-3xl p-10 text-white relative overflow-hidden shadow-2xl border border-white/5">
-        <div className="absolute right-0 top-0 p-10 opacity-10">
+      <section className="rounded-2xl p-8 relative overflow-hidden border border-primary/15 bg-gradient-to-br from-primary/8 via-card to-card shadow-sm">
+        <div className="absolute right-0 top-0 p-8 opacity-[0.04] pointer-events-none">
           <ShieldCheck className="h-64 w-64 text-primary" />
         </div>
-        <div className="relative z-10 max-w-2xl space-y-6">
-          <Badge className="bg-primary/20 text-primary border-primary/40 font-black tracking-[0.2em] uppercase px-4 py-1.5 h-auto">
-            Advanced Feature
+        <div className="relative z-10 max-w-2xl space-y-5">
+          <Badge className="bg-primary/10 text-primary border-primary/30 font-semibold tracking-[0.15em] uppercase px-3 py-1 h-auto text-xs">
+            Audit Ready
           </Badge>
-          <h2 className="text-3xl md:text-4xl font-bold tracking-tight italic">
+          <h2 className="text-2xl font-bold tracking-tight text-foreground">
             Automated Evidence Generation
           </h2>
-          <p className="text-slate-400 font-medium leading-relaxed italic border-l-2 border-primary/40 pl-6">
-            Every run listed here generates a cryptographically signed output bundle. These bundles
-            can be sent directly to auditors to prove mathematical correctness without exposing raw
-            underlying sensitive data.
+          <p className="text-muted-foreground leading-relaxed border-l-2 border-primary/30 pl-5">
+            Every run generates a cryptographically signed output bundle. Send directly to auditors
+            to prove mathematical correctness without exposing raw transaction data.
           </p>
-          <div className="flex gap-4 pt-4">
-            <Button className="h-12 px-6 font-bold shadow-2xl ring-1 ring-primary/20">
+          <div className="flex flex-wrap gap-3 pt-2">
+            <Button className="font-semibold gap-2 shadow-sm">
               Configure Evidence Protocols
             </Button>
             <Button
-              variant="ghost"
-              className="h-12 px-6 font-bold text-slate-300 hover:text-white flex gap-2"
+              variant="outline"
+              className="font-semibold gap-2"
+              asChild
             >
-              Learn about Proof Graphs
-              <ExternalLink size={14} />
+              <Link href="/app/proofs">
+                Explore Proof Graph
+                <ExternalLink size={13} />
+              </Link>
             </Button>
           </div>
         </div>

--- a/packages/web/src/app/console/control-plane/page.tsx
+++ b/packages/web/src/app/console/control-plane/page.tsx
@@ -129,10 +129,10 @@ export default function ControlPlanePage() {
   return (
     <div className="p-6 space-y-6">
       <div>
-        <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Control Plane</h1>
-        <p className="text-slate-600 dark:text-slate-400 mt-1">
+        <h1 className="text-3xl font-bold text-foreground dark:text-white">Control Plane</h1>
+        <p className="text-muted-foreground dark:text-muted-foreground mt-1">
           Manage API keys, policies, and observability settings.
-          <span className="text-xs text-slate-500 ml-2">
+          <span className="text-xs text-muted-foreground ml-2">
             Workspace-scoped controls for security and performance.
           </span>
         </p>
@@ -182,15 +182,15 @@ export default function ControlPlanePage() {
                   {keys.map((key) => (
                     <div
                       key={key.id}
-                      className="flex items-center justify-between p-4 bg-slate-50 dark:bg-slate-800 rounded-lg"
+                      className="flex items-center justify-between p-4 bg-muted/20 dark:bg-card rounded-lg"
                     >
                       <div>
-                        <div className="font-medium text-slate-900 dark:text-white">{key.name}</div>
-                        <code className="text-sm text-slate-600 dark:text-slate-400">
+                        <div className="font-medium text-foreground dark:text-white">{key.name}</div>
+                        <code className="text-sm text-muted-foreground dark:text-muted-foreground">
                           {maskToken(key.keyPrefix + "****")}
                         </code>
                         {key.lastUsedAt && (
-                          <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                          <div className="text-xs text-muted-foreground dark:text-muted-foreground mt-1">
                             Last used: {new Date(key.lastUsedAt).toLocaleString()}
                           </div>
                         )}
@@ -220,11 +220,11 @@ export default function ControlPlanePage() {
                   {policies.map((policy) => (
                     <div
                       key={policy.id}
-                      className="flex items-center justify-between p-4 bg-slate-50 dark:bg-slate-800 rounded-lg"
+                      className="flex items-center justify-between p-4 bg-muted/20 dark:bg-card rounded-lg"
                     >
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-2">
-                          <h3 className="font-medium text-slate-900 dark:text-white">
+                          <h3 className="font-medium text-foreground dark:text-white">
                             {policy.type === "rate_limit" && "Rate Limiting"}
                             {policy.type === "ip_allowlist" && "IP Allowlist"}
                             {policy.type === "webhook_signing" && "Webhook Signing"}
@@ -233,7 +233,7 @@ export default function ControlPlanePage() {
                             {policy.enabled ? "Enabled" : "Disabled"}
                           </Badge>
                         </div>
-                        <p className="text-sm text-slate-600 dark:text-slate-400">
+                        <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                           {policy.type === "rate_limit" &&
                             `Limit: ${policy.config.requestsPerMinute} requests/minute`}
                           {policy.type === "ip_allowlist" &&
@@ -266,26 +266,26 @@ export default function ControlPlanePage() {
               ) : metrics ? (
                 <div className="grid md:grid-cols-3 gap-6">
                   <div>
-                    <div className="text-3xl font-bold text-slate-900 dark:text-white">
+                    <div className="text-3xl font-bold text-foreground dark:text-white">
                       {metrics.requestCount.toLocaleString()}
                     </div>
-                    <div className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+                    <div className="text-sm text-muted-foreground dark:text-muted-foreground mt-1">
                       Requests ({metrics.period})
                     </div>
                   </div>
                   <div>
-                    <div className="text-3xl font-bold text-slate-900 dark:text-white">
+                    <div className="text-3xl font-bold text-foreground dark:text-white">
                       {(metrics.errorRate * 100).toFixed(2)}%
                     </div>
-                    <div className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+                    <div className="text-sm text-muted-foreground dark:text-muted-foreground mt-1">
                       Error Rate
                     </div>
                   </div>
                   <div>
-                    <div className="text-3xl font-bold text-slate-900 dark:text-white">
+                    <div className="text-3xl font-bold text-foreground dark:text-white">
                       {metrics.p95Latency}ms
                     </div>
-                    <div className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+                    <div className="text-sm text-muted-foreground dark:text-muted-foreground mt-1">
                       P95 Latency
                     </div>
                   </div>
@@ -310,7 +310,7 @@ export default function ControlPlanePage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between">
-                <p className="text-sm text-slate-600 dark:text-slate-400">
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                   Trigger diagnostics to refresh insights and remediation recommendations.
                 </p>
                 <Button variant="outline" size="sm" onClick={runDiagnosticsTrigger}>
@@ -319,7 +319,7 @@ export default function ControlPlanePage() {
                 </Button>
               </div>
               {triggerStatus && (
-                <p className="text-xs text-slate-500 dark:text-slate-400">{triggerStatus}</p>
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground">{triggerStatus}</p>
               )}
 
               {loading ? (
@@ -335,10 +335,10 @@ export default function ControlPlanePage() {
                   {insights.map((insight) => (
                     <div
                       key={insight.id}
-                      className="rounded-lg border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900"
+                      className="rounded-lg border border-border dark:border-border p-4 bg-card dark:bg-background"
                     >
                       <div className="flex items-center justify-between gap-2">
-                        <h3 className="font-medium text-slate-900 dark:text-white">
+                        <h3 className="font-medium text-foreground dark:text-white">
                           {insight.title}
                         </h3>
                         <Badge
@@ -351,15 +351,15 @@ export default function ControlPlanePage() {
                           {insight.severity}
                         </Badge>
                       </div>
-                      <p className="text-sm text-slate-600 dark:text-slate-300 mt-2">
+                      <p className="text-sm text-muted-foreground dark:text-muted-foreground mt-2">
                         {insight.evidenceSummary}
                       </p>
-                      <p className="text-sm text-slate-700 dark:text-slate-300 mt-2">
+                      <p className="text-sm text-foreground dark:text-muted-foreground mt-2">
                         <span className="font-medium">Recommended action:</span>{" "}
                         {insight.recommendedAction}
                       </p>
                       <div className="mt-3 flex items-center justify-between">
-                        <span className="text-xs text-slate-500 dark:text-slate-400">
+                        <span className="text-xs text-muted-foreground dark:text-muted-foreground">
                           Scope: {insight.affectedScope} · Confidence{" "}
                           {(insight.confidence * 100).toFixed(0)}%
                         </span>

--- a/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
+++ b/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
@@ -159,7 +159,7 @@ export default function ExceptionDetailPage() {
       case "resolved":
         return "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300";
       case "ignored":
-        return "bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300";
+        return "bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground";
       case "investigating":
         return "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300";
       default:
@@ -222,10 +222,10 @@ export default function ExceptionDetailPage() {
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Exception Detail</h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-1">
+          <h1 className="text-3xl font-bold text-foreground dark:text-white">Exception Detail</h1>
+          <p className="text-muted-foreground dark:text-muted-foreground mt-1">
             Exception ID:{" "}
-            <code className="bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">{exception.id}</code>
+            <code className="bg-muted/40 dark:bg-card px-2 py-1 rounded">{exception.id}</code>
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -235,7 +235,7 @@ export default function ExceptionDetailPage() {
           </Button>
           <Link
             href="/console/exceptions"
-            className="text-sm text-slate-600 dark:text-slate-400 hover:underline"
+            className="text-sm text-muted-foreground dark:text-muted-foreground hover:underline"
           >
             ← Back to List
           </Link>
@@ -252,7 +252,7 @@ export default function ExceptionDetailPage() {
           {exception.severity.charAt(0).toUpperCase() + exception.severity.slice(1)}
         </Badge>
         {exception.confidenceScore !== undefined && (
-          <Badge className="bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300">
+          <Badge className="bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground">
             Confidence: {Math.round(exception.confidenceScore * 100)}%
           </Badge>
         )}
@@ -266,20 +266,20 @@ export default function ExceptionDetailPage() {
         <CardContent>
           <div className="space-y-4">
             {exception.statusDetail && (
-              <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">
+              <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm text-foreground dark:border-border dark:bg-background/60 dark:text-muted-foreground">
                 {exception.statusDetail}
               </div>
             )}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <h3 className="font-medium text-slate-900 dark:text-white">Type</h3>
-                <p className="text-slate-600 dark:text-slate-400">
+                <h3 className="font-medium text-foreground dark:text-white">Type</h3>
+                <p className="text-muted-foreground dark:text-muted-foreground">
                   {exception.type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
                 </p>
               </div>
               {exception.reasonTags && exception.reasonTags.length > 0 && (
                 <div>
-                  <h3 className="font-medium text-slate-900 dark:text-white">Decision Drivers</h3>
+                  <h3 className="font-medium text-foreground dark:text-white">Decision Drivers</h3>
                   <div className="mt-1 flex flex-wrap gap-1.5">
                     {exception.reasonTags.map((tag) => (
                       <Badge key={`${exception.id}-${tag}`} variant="outline">
@@ -290,18 +290,18 @@ export default function ExceptionDetailPage() {
                 </div>
               )}
               <div>
-                <h3 className="font-medium text-slate-900 dark:text-white">Description</h3>
-                <p className="text-slate-600 dark:text-slate-400">{exception.description}</p>
+                <h3 className="font-medium text-foreground dark:text-white">Description</h3>
+                <p className="text-muted-foreground dark:text-muted-foreground">{exception.description}</p>
               </div>
               <div>
-                <h3 className="font-medium text-slate-900 dark:text-white">Detected</h3>
-                <p className="text-slate-600 dark:text-slate-400">
+                <h3 className="font-medium text-foreground dark:text-white">Detected</h3>
+                <p className="text-muted-foreground dark:text-muted-foreground">
                   {new Date(exception.detectedAt).toLocaleString()}
                 </p>
               </div>
               {exception.runId && (
                 <div>
-                  <h3 className="font-medium text-slate-900 dark:text-white">Run</h3>
+                  <h3 className="font-medium text-foreground dark:text-white">Run</h3>
                   <Link
                     href={`/console/runs/${exception.runId}`}
                     className="text-sm text-blue-600 hover:underline dark:text-blue-400"
@@ -312,24 +312,24 @@ export default function ExceptionDetailPage() {
               )}
               {exception.fieldPath && (
                 <div>
-                  <h3 className="font-medium text-slate-900 dark:text-white">Field</h3>
-                  <p className="text-slate-600 dark:text-slate-400 font-mono">
+                  <h3 className="font-medium text-foreground dark:text-white">Field</h3>
+                  <p className="text-muted-foreground dark:text-muted-foreground font-mono">
                     {exception.fieldPath}
                   </p>
                 </div>
               )}
               {exception.amount && exception.currency && (
                 <div>
-                  <h3 className="font-medium text-slate-900 dark:text-white">Amount</h3>
-                  <p className="text-slate-600 dark:text-slate-400 font-mono">
+                  <h3 className="font-medium text-foreground dark:text-white">Amount</h3>
+                  <p className="text-muted-foreground dark:text-muted-foreground font-mono">
                     {exception.currency} {exception.amount.toLocaleString()}
                   </p>
                 </div>
               )}
               {exception.sourceTransactionId && (
                 <div>
-                  <h3 className="font-medium text-slate-900 dark:text-white">Source Transaction</h3>
-                  <p className="text-slate-600 dark:text-slate-400 font-mono">
+                  <h3 className="font-medium text-foreground dark:text-white">Source Transaction</h3>
+                  <p className="text-muted-foreground dark:text-muted-foreground font-mono">
                     {exception.sourceTransactionId}
                     <Button
                       variant="ghost"
@@ -346,8 +346,8 @@ export default function ExceptionDetailPage() {
               )}
               {exception.targetTransactionId && (
                 <div>
-                  <h3 className="font-medium text-slate-900 dark:text-white">Target Transaction</h3>
-                  <p className="text-slate-600 dark:text-slate-400 font-mono">
+                  <h3 className="font-medium text-foreground dark:text-white">Target Transaction</h3>
+                  <p className="text-muted-foreground dark:text-muted-foreground font-mono">
                     {exception.targetTransactionId}
                     <Button
                       variant="ghost"
@@ -364,14 +364,14 @@ export default function ExceptionDetailPage() {
               )}
               {exception.sourceSystem && (
                 <div>
-                  <h3 className="font-medium text-slate-900 dark:text-white">Source System</h3>
-                  <p className="text-slate-600 dark:text-slate-400">{exception.sourceSystem}</p>
+                  <h3 className="font-medium text-foreground dark:text-white">Source System</h3>
+                  <p className="text-muted-foreground dark:text-muted-foreground">{exception.sourceSystem}</p>
                 </div>
               )}
               {exception.targetSystem && (
                 <div>
-                  <h3 className="font-medium text-slate-900 dark:text-white">Target System</h3>
-                  <p className="text-slate-600 dark:text-slate-400">{exception.targetSystem}</p>
+                  <h3 className="font-medium text-foreground dark:text-white">Target System</h3>
+                  <p className="text-muted-foreground dark:text-muted-foreground">{exception.targetSystem}</p>
                 </div>
               )}
             </div>
@@ -386,19 +386,19 @@ export default function ExceptionDetailPage() {
           </CardHeader>
           <CardContent>
             <div className="grid gap-4 md:grid-cols-2">
-              <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/60">
-                <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <div className="rounded-lg border border-border bg-muted/20 p-4 dark:border-border dark:bg-background/60">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground dark:text-muted-foreground">
                   Expected
                 </p>
-                <pre className="mt-2 whitespace-pre-wrap break-words text-sm text-slate-700 dark:text-slate-300">
+                <pre className="mt-2 whitespace-pre-wrap break-words text-sm text-foreground dark:text-muted-foreground">
                   {JSON.stringify(exception.expectedValue ?? null, null, 2)}
                 </pre>
               </div>
-              <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/60">
-                <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <div className="rounded-lg border border-border bg-muted/20 p-4 dark:border-border dark:bg-background/60">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground dark:text-muted-foreground">
                   Actual
                 </p>
-                <pre className="mt-2 whitespace-pre-wrap break-words text-sm text-slate-700 dark:text-slate-300">
+                <pre className="mt-2 whitespace-pre-wrap break-words text-sm text-foreground dark:text-muted-foreground">
                   {JSON.stringify(exception.actualValue ?? null, null, 2)}
                 </pre>
               </div>
@@ -412,7 +412,7 @@ export default function ExceptionDetailPage() {
           <CardHeader>
             <CardTitle>Decision Record</CardTitle>
           </CardHeader>
-          <CardContent className="space-y-2 text-sm text-slate-600 dark:text-slate-400">
+          <CardContent className="space-y-2 text-sm text-muted-foreground dark:text-muted-foreground">
             {exception.resolution && <p>{exception.resolution}</p>}
             {exception.resolvedAt && (
               <p>Resolved at {new Date(exception.resolvedAt).toLocaleString()}</p>
@@ -433,7 +433,7 @@ export default function ExceptionDetailPage() {
             <CardTitle>Suggested Actions</CardTitle>
           </CardHeader>
           <CardContent>
-            <ul className="list-disc list-inside space-y-2 text-slate-600 dark:text-slate-400">
+            <ul className="list-disc list-inside space-y-2 text-muted-foreground dark:text-muted-foreground">
               {exception.suggestedActions.map((action, index) => (
                 <li key={index}>{action}</li>
               ))}
@@ -449,7 +449,7 @@ export default function ExceptionDetailPage() {
             <CardTitle>Applied Playbook</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-slate-600 dark:text-slate-400">{exception.playbookApplied}</p>
+            <p className="text-muted-foreground dark:text-muted-foreground">{exception.playbookApplied}</p>
           </CardContent>
         </Card>
       )}
@@ -469,7 +469,7 @@ export default function ExceptionDetailPage() {
           </FreezeBlockedButton>
           <FreezeBlockedButton
             onClick={handleIgnore}
-            className="bg-slate-600 hover:bg-slate-700"
+            className="bg-slate-600 hover:bg-muted"
             isFrozen={isFrozen}
             freezeReason={governanceState?.freeze_reason}
             frozenMessage="Ignoring exceptions is blocked by tenant freeze"
@@ -504,22 +504,22 @@ export default function ExceptionDetailPage() {
           <CardContent>
             <div className="space-y-3">
               {exception.auditTrail.map((entry, index) => (
-                <div key={index} className="border-l-2 border-slate-200 dark:border-slate-700 pl-4">
+                <div key={index} className="border-l-2 border-border dark:border-border pl-4">
                   <div className="flex items-start gap-3">
-                    <div className="flex-shrink-0 text-xs text-slate-500 dark:text-slate-400">
+                    <div className="flex-shrink-0 text-xs text-muted-foreground dark:text-muted-foreground">
                       {new Date(entry.timestamp).toLocaleTimeString()}
                     </div>
                     <div className="flex-1">
                       <div className="flex items-start gap-2">
-                        <span className="font-medium text-slate-900 dark:text-white">
+                        <span className="font-medium text-foreground dark:text-white">
                           {entry.action}
                         </span>
-                        <span className="text-xs text-slate-500 dark:text-slate-400">
+                        <span className="text-xs text-muted-foreground dark:text-muted-foreground">
                           by {entry.user}
                         </span>
                       </div>
                       {entry.details && (
-                        <p className="text-slate-600 dark:text-slate-400 mt-1">{entry.details}</p>
+                        <p className="text-muted-foreground dark:text-muted-foreground mt-1">{entry.details}</p>
                       )}
                     </div>
                   </div>

--- a/packages/web/src/app/console/runs/[runId]/page.tsx
+++ b/packages/web/src/app/console/runs/[runId]/page.tsx
@@ -161,9 +161,9 @@ export default function RunPage() {
       case "running":
         return "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300";
       case "unknown":
-        return "bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300";
+        return "bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground";
       default:
-        return "bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300";
+        return "bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground";
     }
   };
 
@@ -211,16 +211,16 @@ export default function RunPage() {
   return (
     <div className="p-6 space-y-6">
       {/* Breadcrumb navigation */}
-      <nav className="flex items-center text-sm text-slate-600 dark:text-slate-400 mb-4">
-        <Link href="/console" className="hover:text-slate-900 dark:hover:text-white">
+      <nav className="flex items-center text-sm text-muted-foreground dark:text-muted-foreground mb-4">
+        <Link href="/console" className="hover:text-foreground dark:hover:text-white">
           Console
         </Link>
         <span className="mx-2">/</span>
-        <Link href="/console/runs" className="hover:text-slate-900 dark:hover:text-white">
+        <Link href="/console/runs" className="hover:text-foreground dark:hover:text-white">
           Runs
         </Link>
         <span className="mx-2">/</span>
-        <span className="text-slate-900 dark:text-white">{run.name}</span>
+        <span className="text-foreground dark:text-white">{run.name}</span>
       </nav>
 
       <div className="flex items-center justify-between">
@@ -232,15 +232,15 @@ export default function RunPage() {
             </Button>
           </Link>
           <div>
-            <h1 className="text-3xl font-bold text-slate-900 dark:text-white">{run.name}</h1>
-            <p className="text-slate-600 dark:text-slate-400 mt-1">
+            <h1 className="text-3xl font-bold text-foreground dark:text-white">{run.name}</h1>
+            <p className="text-muted-foreground dark:text-muted-foreground mt-1">
               Run ID:{" "}
-              <code className="bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">{run.id}</code>
+              <code className="bg-muted/40 dark:bg-card px-2 py-1 rounded">{run.id}</code>
             </p>
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+          <label className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground">
             <input
               type="checkbox"
               checked={autoRefresh}
@@ -274,7 +274,7 @@ export default function RunPage() {
                 <span>Progress</span>
                 <span>{run.progress}%</span>
               </div>
-              <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2">
+              <div className="w-full bg-slate-200 dark:bg-muted rounded-full h-2">
                 <div
                   className="bg-blue-600 h-2 rounded-full transition-all"
                   style={{ width: `${run.progress}%` }}
@@ -286,21 +286,21 @@ export default function RunPage() {
                 <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-6">
                   <div>
                     <div className="text-2xl font-bold">{run.summary.sourceCount}</div>
-                    <div className="text-sm text-slate-600 dark:text-slate-400">Source Rows</div>
+                    <div className="text-sm text-muted-foreground dark:text-muted-foreground">Source Rows</div>
                   </div>
                   <div>
                     <div className="text-2xl font-bold">{run.summary.targetCount}</div>
-                    <div className="text-sm text-slate-600 dark:text-slate-400">Target Rows</div>
+                    <div className="text-sm text-muted-foreground dark:text-muted-foreground">Target Rows</div>
                   </div>
                   <div>
                     <div className="text-2xl font-bold text-green-600">{run.summary.matched}</div>
-                    <div className="text-sm text-slate-600 dark:text-slate-400">Matched</div>
+                    <div className="text-sm text-muted-foreground dark:text-muted-foreground">Matched</div>
                   </div>
                   <div>
                     <div className="text-2xl font-bold text-amber-600">
                       {run.summary.unmatchedSourceCount}
                     </div>
-                    <div className="text-sm text-slate-600 dark:text-slate-400">
+                    <div className="text-sm text-muted-foreground dark:text-muted-foreground">
                       Unmatched Source
                     </div>
                   </div>
@@ -308,17 +308,17 @@ export default function RunPage() {
                     <div className="text-2xl font-bold text-amber-600">
                       {run.summary.unmatchedTargetCount}
                     </div>
-                    <div className="text-sm text-slate-600 dark:text-slate-400">
+                    <div className="text-sm text-muted-foreground dark:text-muted-foreground">
                       Unmatched Target
                     </div>
                   </div>
                   <div>
                     <div className="text-2xl font-bold text-red-600">{run.summary.conflicts}</div>
-                    <div className="text-sm text-slate-600 dark:text-slate-400">Conflicts</div>
+                    <div className="text-sm text-muted-foreground dark:text-muted-foreground">Conflicts</div>
                   </div>
                 </div>
                 {run.summaryMath?.note ? (
-                  <p className="text-xs text-slate-500 dark:text-slate-400">{run.summaryMath.note}</p>
+                  <p className="text-xs text-muted-foreground dark:text-muted-foreground">{run.summaryMath.note}</p>
                 ) : null}
               </div>
             )}
@@ -334,17 +334,17 @@ export default function RunPage() {
               Run detail shows the latest persisted result for this run definition.
             </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-3 text-sm text-slate-600 dark:text-slate-400">
+          <CardContent className="space-y-3 text-sm text-muted-foreground dark:text-muted-foreground">
             <p>
               Persisted results:{" "}
-              <span className="font-medium text-slate-900 dark:text-white">
+              <span className="font-medium text-foreground dark:text-white">
                 {run.resultContext.persistedResultCount}
               </span>
             </p>
             {run.resultContext.latestResultId ? (
               <p>
                 Latest result ID:{" "}
-                <code className="bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded break-all">
+                <code className="bg-muted/40 dark:bg-card px-1.5 py-0.5 rounded break-all">
                   {run.resultContext.latestResultId}
                 </code>
               </p>
@@ -355,11 +355,11 @@ export default function RunPage() {
               <p>Evaluated at {new Date(run.resultContext.latestResultStartedAt).toLocaleString()}.</p>
             )}
             {run.resultContext.comparison && (
-              <div className="rounded-md border border-slate-200 dark:border-slate-700 p-3">
-                <p className="font-medium text-slate-900 dark:text-white">Compared to prior result</p>
+              <div className="rounded-md border border-border dark:border-border p-3">
+                <p className="font-medium text-foreground dark:text-white">Compared to prior result</p>
                 <p className="mt-1">
                   Previous result{" "}
-                  <code className="bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded break-all">
+                  <code className="bg-muted/40 dark:bg-card px-1.5 py-0.5 rounded break-all">
                     {run.resultContext.comparison.previousResultId}
                   </code>
                   {run.resultContext.comparison.previousResultStartedAt
@@ -372,7 +372,7 @@ export default function RunPage() {
                   {formatSignedDelta(run.resultContext.comparison.deltaUnmatched)} • Conflicts{" "}
                   {formatSignedDelta(run.resultContext.comparison.deltaConflicts)}
                 </p>
-                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                <p className="mt-1 text-xs text-muted-foreground dark:text-muted-foreground">
                   Snapshot{" "}
                   {run.resultContext.comparison.snapshotChanged ? "changed" : "unchanged"} • Input
                   hash {run.resultContext.comparison.inputHashChanged ? "changed" : "unchanged"}
@@ -394,32 +394,32 @@ export default function RunPage() {
           <CardContent className="space-y-4">
             <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-6">
               <div>
-                <p className="text-2xl font-bold text-slate-900 dark:text-white">
+                <p className="text-2xl font-bold text-foreground dark:text-white">
                   {run.exceptions.total}
                 </p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">Total</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">Total</p>
               </div>
               <div>
                 <p className="text-2xl font-bold text-amber-600">{run.exceptions.pending}</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">Pending</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">Pending</p>
               </div>
               <div>
                 <p className="text-2xl font-bold text-blue-600">{run.exceptions.investigating}</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">Investigating</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">Investigating</p>
               </div>
               <div>
                 <p className="text-2xl font-bold text-green-600">{run.exceptions.resolved}</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">Resolved</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">Resolved</p>
               </div>
               <div>
-                <p className="text-2xl font-bold text-slate-700 dark:text-slate-200">
+                <p className="text-2xl font-bold text-foreground dark:text-slate-200">
                   {run.exceptions.ignored}
                 </p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">Ignored</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">Ignored</p>
               </div>
               <div>
                 <p className="text-2xl font-bold text-red-600">{run.exceptions.reviewRequired}</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">Needs Review</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">Needs Review</p>
               </div>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -461,7 +461,7 @@ export default function RunPage() {
                     <Eye className="w-4 h-4" />
                     <span className="font-semibold">View Results</span>
                   </div>
-                  <span className="text-xs text-slate-600 dark:text-slate-400">
+                  <span className="text-xs text-muted-foreground dark:text-muted-foreground">
                     See detailed reconciliation outcomes
                   </span>
                 </Button>
@@ -479,7 +479,7 @@ export default function RunPage() {
                         {run.summary.unmatched}
                       </Badge>
                     </div>
-                    <span className="text-xs text-slate-600 dark:text-slate-400">
+                    <span className="text-xs text-muted-foreground dark:text-muted-foreground">
                       Investigate unmatched records
                     </span>
                   </Button>
@@ -498,7 +498,7 @@ export default function RunPage() {
                         {run.summary.conflicts}
                       </Badge>
                     </div>
-                    <span className="text-xs text-slate-600 dark:text-slate-400">
+                    <span className="text-xs text-muted-foreground dark:text-muted-foreground">
                       Resolve conflicting matches
                     </span>
                   </Button>
@@ -526,13 +526,13 @@ export default function RunPage() {
       )}
 
       {run.status === "pending" && (
-        <Card className="border-slate-200 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-800/10">
+        <Card className="border-border dark:border-border bg-muted/20/50 dark:bg-card/10">
           <CardContent className="pt-6">
             <div className="flex items-start gap-3">
-              <Clock className="w-5 h-5 text-slate-600 dark:text-slate-400 flex-shrink-0 mt-0.5" />
+              <Clock className="w-5 h-5 text-muted-foreground dark:text-muted-foreground flex-shrink-0 mt-0.5" />
               <div>
-                <p className="font-medium text-slate-900 dark:text-white mb-1">Run pending</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
+                <p className="font-medium text-foreground dark:text-white mb-1">Run pending</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                   This run is queued and will start shortly.
                 </p>
               </div>
@@ -577,22 +577,22 @@ export default function RunPage() {
             )}
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
               <div>
-                <p className="text-sm font-medium text-slate-900 dark:text-white">Adapters</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
+                <p className="text-sm font-medium text-foreground dark:text-white">Adapters</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                   {[run.config.sourceAdapter, run.config.targetAdapter]
                     .filter(Boolean)
                     .join(" -> ") || "Not recorded"}
                 </p>
               </div>
               <div>
-                <p className="text-sm font-medium text-slate-900 dark:text-white">Strategy</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
+                <p className="text-sm font-medium text-foreground dark:text-white">Strategy</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                   {run.config.reconStrategy || "Not recorded"}
                 </p>
               </div>
               <div>
-                <p className="text-sm font-medium text-slate-900 dark:text-white">Rules</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
+                <p className="text-sm font-medium text-foreground dark:text-white">Rules</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                   {run.config.validationRuleCount > 0
                     ? `${run.config.validationRuleCount} rule${
                         run.config.validationRuleCount === 1 ? "" : "s"
@@ -601,8 +601,8 @@ export default function RunPage() {
                 </p>
               </div>
               <div>
-                <p className="text-sm font-medium text-slate-900 dark:text-white">Rule Versions</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
+                <p className="text-sm font-medium text-foreground dark:text-white">Rule Versions</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                   {run.config.ruleVersionCount > 0
                     ? `${run.config.ruleVersionCount} locked version${
                         run.config.ruleVersionCount === 1 ? "" : "s"
@@ -611,27 +611,27 @@ export default function RunPage() {
                 </p>
               </div>
               <div>
-                <p className="text-sm font-medium text-slate-900 dark:text-white">Snapshot</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400 font-mono break-all">
+                <p className="text-sm font-medium text-foreground dark:text-white">Snapshot</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground font-mono break-all">
                   {run.config.snapshotId || "Not persisted"}
                 </p>
               </div>
               <div>
-                <p className="text-sm font-medium text-slate-900 dark:text-white">Input Hash</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400 font-mono break-all">
+                <p className="text-sm font-medium text-foreground dark:text-white">Input Hash</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground font-mono break-all">
                   {run.config.inputHash || "Not recorded"}
                 </p>
               </div>
               <div>
-                <p className="text-sm font-medium text-slate-900 dark:text-white">Template</p>
-                <p className="text-sm text-slate-600 dark:text-slate-400 font-mono break-all">
+                <p className="text-sm font-medium text-foreground dark:text-white">Template</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground font-mono break-all">
                   {run.config.templateId || "None"}
                 </p>
               </div>
             </div>
             {run.config.validationRuleLabels.length > 0 && (
               <div>
-                <p className="mb-2 text-sm font-medium text-slate-900 dark:text-white">
+                <p className="mb-2 text-sm font-medium text-foreground dark:text-white">
                   Recorded Rule Coverage
                 </p>
                 <div className="flex flex-wrap gap-2">
@@ -645,7 +645,7 @@ export default function RunPage() {
             )}
             {run.config.ruleVersionLabels.length > 0 && (
               <div>
-                <p className="mb-2 text-sm font-medium text-slate-900 dark:text-white">
+                <p className="mb-2 text-sm font-medium text-foreground dark:text-white">
                   Snapshot Rule Versions
                 </p>
                 <div className="flex flex-wrap gap-2">
@@ -657,7 +657,7 @@ export default function RunPage() {
                 </div>
               </div>
             )}
-            <p className="text-sm text-slate-500 dark:text-slate-400">{run.config.summaryBasis}</p>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground">{run.config.summaryBasis}</p>
           </CardContent>
         </Card>
       )}
@@ -674,7 +674,7 @@ export default function RunPage() {
               return (
                 <div
                   key={stage.id}
-                  className="flex items-start gap-4 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg"
+                  className="flex items-start gap-4 p-4 bg-muted/20 dark:bg-card rounded-lg"
                 >
                   <div
                     className={`w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 ${
@@ -684,7 +684,7 @@ export default function RunPage() {
                           ? "bg-blue-100 dark:bg-blue-900/30 animate-pulse"
                           : stage.status === "failed"
                             ? "bg-red-100 dark:bg-red-900/30"
-                            : "bg-slate-100 dark:bg-slate-700"
+                            : "bg-muted/40 dark:bg-muted"
                     }`}
                   >
                     <StageIcon
@@ -695,13 +695,13 @@ export default function RunPage() {
                             ? "text-blue-600 dark:text-blue-400"
                             : stage.status === "failed"
                               ? "text-red-600 dark:text-red-400"
-                              : "text-slate-400"
+                              : "text-muted-foreground"
                       } ${stage.status === "running" ? "animate-spin" : ""}`}
                     />
                   </div>
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-1">
-                      <h3 className="font-medium text-slate-900 dark:text-white">{stage.name}</h3>
+                      <h3 className="font-medium text-foreground dark:text-white">{stage.name}</h3>
                       <Badge className={getStatusColor(stage.status)}>{stage.status}</Badge>
                     </div>
                     {stage.error && (
@@ -711,7 +711,7 @@ export default function RunPage() {
                       </div>
                     )}
                     {stage.completedAt && (
-                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                      <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-1">
                         Completed {new Date(stage.completedAt).toLocaleString()}
                       </p>
                     )}

--- a/packages/web/src/app/dashboard/page.tsx
+++ b/packages/web/src/app/dashboard/page.tsx
@@ -180,7 +180,7 @@ async function DashboardMetrics() {
             <h1 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 dark:from-electric-cyan dark:via-electric-purple dark:to-electric-blue bg-clip-text text-transparent">
               Ecosystem Metrics
             </h1>
-            <p className="text-xl text-slate-700 dark:text-slate-300 mb-4">
+            <p className="text-xl text-foreground dark:text-muted-foreground mb-4">
               Live community and integration activity
             </p>
             <div className="flex justify-center">
@@ -242,34 +242,34 @@ async function DashboardMetrics() {
           {/* Additional Metrics */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
             <HoverCard>
-              <div className="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 border border-slate-200 dark:border-slate-700">
+              <div className="bg-card dark:bg-card rounded-lg shadow-lg p-6 border border-border border-border">
                 <div className="flex items-center gap-3 mb-4">
                   <MessageSquare className="w-6 h-6 text-blue-600 dark:text-electric-cyan" />
-                  <h3 className="text-xl font-semibold text-slate-900 dark:text-white">
+                  <h3 className="text-xl font-semibold text-foreground dark:text-white">
                     Total Published Posts
                   </h3>
                 </div>
-                <p className="text-4xl font-bold text-slate-900 dark:text-white mb-2">
+                <p className="text-4xl font-bold text-foreground dark:text-white mb-2">
                   <AnimatedNumber value={metrics.totalPosts} />
                 </p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                   Community content across all categories
                 </p>
               </div>
             </HoverCard>
 
             <HoverCard>
-              <div className="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 border border-slate-200 dark:border-slate-700">
+              <div className="bg-card dark:bg-card rounded-lg shadow-lg p-6 border border-border border-border">
                 <div className="flex items-center gap-3 mb-4">
                   <Users className="w-6 h-6 text-indigo-600 dark:text-electric-purple" />
-                  <h3 className="text-xl font-semibold text-slate-900 dark:text-white">
+                  <h3 className="text-xl font-semibold text-foreground dark:text-white">
                     Total Community Members
                   </h3>
                 </div>
-                <p className="text-4xl font-bold text-slate-900 dark:text-white mb-2">
+                <p className="text-4xl font-bold text-foreground dark:text-white mb-2">
                   <AnimatedNumber value={metrics.totalProfiles} />
                 </p>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                   Active profiles in the ecosystem
                 </p>
               </div>
@@ -278,12 +278,12 @@ async function DashboardMetrics() {
 
           {/* Top Post Highlight */}
           {topPost && (
-            <div className="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 border border-slate-200 dark:border-slate-700 mb-6">
-              <h3 className="text-xl font-semibold text-slate-900 dark:text-white mb-4">
+            <div className="bg-card dark:bg-card rounded-lg shadow-lg p-6 border border-border border-border mb-6">
+              <h3 className="text-xl font-semibold text-foreground dark:text-white mb-4">
                 Most Engaged Post Today
               </h3>
-              <p className="text-lg text-slate-700 dark:text-slate-300 mb-2">{topPost.title}</p>
-              <div className="flex gap-6 text-sm text-slate-600 dark:text-slate-400">
+              <p className="text-lg text-foreground dark:text-muted-foreground mb-2">{topPost.title}</p>
+              <div className="flex gap-6 text-sm text-muted-foreground dark:text-muted-foreground">
                 <span>{topPost.views || 0} views</span>
                 <span>{topPost.upvotes || 0} upvotes</span>
                 <span className="font-semibold">{metrics.topPostEngagement} total engagement</span>
@@ -293,67 +293,67 @@ async function DashboardMetrics() {
 
           {/* External API Metrics */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 border border-slate-200 dark:border-slate-700">
+            <div className="bg-card dark:bg-card rounded-lg shadow-lg p-6 border border-border border-border">
               <div className="flex items-center gap-3 mb-4">
-                <Github className="w-6 h-6 text-slate-700 dark:text-slate-300" />
-                <h3 className="text-xl font-semibold text-slate-900 dark:text-white">
+                <Github className="w-6 h-6 text-foreground dark:text-muted-foreground" />
+                <h3 className="text-xl font-semibold text-foreground dark:text-white">
                   GitHub Repository
                 </h3>
               </div>
               {externalMetrics.github.unavailable ? (
-                <p className="text-sm text-slate-500 dark:text-slate-400">
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                   GitHub data unavailable — API could not be reached.
                 </p>
               ) : (
                 <div className="space-y-2">
                   <div className="flex justify-between">
-                    <span className="text-slate-600 dark:text-slate-400">Stars</span>
-                    <span className="font-semibold text-slate-900 dark:text-white">
+                    <span className="text-muted-foreground dark:text-muted-foreground">Stars</span>
+                    <span className="font-semibold text-foreground dark:text-white">
                       {externalMetrics.github.stars.toLocaleString()}
                     </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-slate-600 dark:text-slate-400">Forks</span>
-                    <span className="font-semibold text-slate-900 dark:text-white">
+                    <span className="text-muted-foreground dark:text-muted-foreground">Forks</span>
+                    <span className="font-semibold text-foreground dark:text-white">
                       {externalMetrics.github.forks.toLocaleString()}
                     </span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-slate-600 dark:text-slate-400">Open Issues</span>
-                    <span className="font-semibold text-slate-900 dark:text-white">
+                    <span className="text-muted-foreground dark:text-muted-foreground">Open Issues</span>
+                    <span className="font-semibold text-foreground dark:text-white">
                       {externalMetrics.github.openIssues.toLocaleString()}
                     </span>
                   </div>
                 </div>
               )}
-              <p className="text-xs text-slate-500 dark:text-slate-400 mt-4">
+              <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-4">
                 Live data from GitHub API
               </p>
             </div>
 
             <HoverCard>
-              <div className="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 border border-slate-200 dark:border-slate-700">
+              <div className="bg-card dark:bg-card rounded-lg shadow-lg p-6 border border-border border-border">
                 <div className="flex items-center gap-3 mb-4">
-                  <Package className="w-6 h-6 text-slate-700 dark:text-slate-300" />
-                  <h3 className="text-xl font-semibold text-slate-900 dark:text-white">
+                  <Package className="w-6 h-6 text-foreground dark:text-muted-foreground" />
+                  <h3 className="text-xl font-semibold text-foreground dark:text-white">
                     NPM Package
                   </h3>
                 </div>
                 {externalMetrics.npm.unavailable ? (
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                  <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                     NPM data unavailable — registry could not be reached.
                   </p>
                 ) : (
                   <div className="space-y-2">
                     <div className="flex justify-between">
-                      <span className="text-slate-600 dark:text-slate-400">Version</span>
-                      <span className="font-semibold text-slate-900 dark:text-white">
+                      <span className="text-muted-foreground dark:text-muted-foreground">Version</span>
+                      <span className="font-semibold text-foreground dark:text-white">
                         {externalMetrics.npm.version}
                       </span>
                     </div>
                   </div>
                 )}
-                <p className="text-xs text-slate-500 dark:text-slate-400 mt-4">
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-4">
                   Live data from NPM Registry
                 </p>
               </div>
@@ -371,7 +371,7 @@ async function DashboardMetrics() {
         <div className="flex items-center justify-center py-24">
           <div className="text-center">
             <p className="text-red-600 dark:text-red-400 mb-4">Error loading dashboard metrics</p>
-            <p className="text-slate-600 dark:text-slate-400 text-sm">
+            <p className="text-muted-foreground dark:text-muted-foreground text-sm">
               Please try refreshing the page
             </p>
           </div>
@@ -399,29 +399,29 @@ function MetricCard({
 }) {
   return (
     <div
-      className={`bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 border-2 ${
-        passed ? "border-green-500 dark:border-green-400" : "border-slate-200 dark:border-slate-700"
+      className={`bg-card dark:bg-card rounded-lg shadow-lg p-6 border-2 ${
+        passed ? "border-green-500 dark:border-green-400" : "border-border border-border"
       }`}
     >
       <div className="flex items-center gap-3 mb-4">
         <Icon
           className={`w-6 h-6 ${
-            passed ? "text-green-600 dark:text-green-400" : "text-slate-600 dark:text-slate-400"
+            passed ? "text-green-600 dark:text-green-400" : "text-muted-foreground dark:text-muted-foreground"
           }`}
         />
-        <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h3>
+        <h3 className="text-lg font-semibold text-foreground dark:text-white">{title}</h3>
       </div>
       <p
         className={`text-4xl font-bold mb-2 ${
-          passed ? "text-green-600 dark:text-green-400" : "text-slate-900 dark:text-white"
+          passed ? "text-green-600 dark:text-green-400" : "text-foreground dark:text-white"
         }`}
       >
         {value.toLocaleString()}
       </p>
-      <p className="text-sm text-slate-600 dark:text-slate-400 mb-2">{description}</p>
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground mb-2">{description}</p>
       <div className="flex items-center gap-2">
         <div className={`w-2 h-2 rounded-full ${passed ? "bg-green-500" : "bg-yellow-500"}`} />
-        <span className="text-xs text-slate-500 dark:text-slate-400">
+        <span className="text-xs text-muted-foreground dark:text-muted-foreground">
           Target: {threshold.toLocaleString()} {passed ? "✓" : "(in progress)"}
         </span>
       </div>
@@ -438,7 +438,7 @@ export default function DashboardPage() {
           <div className="flex items-center justify-center min-h-[60vh]">
             <div className="text-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 dark:border-electric-cyan mx-auto mb-4"></div>
-              <p className="text-slate-600 dark:text-slate-400">Loading metrics…</p>
+              <p className="text-muted-foreground dark:text-muted-foreground">Loading metrics…</p>
             </div>
           </div>
           <Footer />

--- a/packages/web/src/app/enterprise/page.tsx
+++ b/packages/web/src/app/enterprise/page.tsx
@@ -78,14 +78,14 @@ const narrativeSections = [
 export default function EnterprisePage() {
   if (getSiteMode() !== "enterprise") {
     return (
-      <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+      <div className="min-h-screen bg-muted/20 bg-muted">
         <Navigation />
         <main className="mx-auto max-w-3xl px-6 py-32 text-center">
           <Badge className="mb-4">Enterprise feature unavailable</Badge>
           <h1 className="text-3xl font-semibold mb-4">
             Enterprise surface is disabled for this host.
           </h1>
-          <p className="text-slate-600 dark:text-slate-300">
+          <p className="text-muted-foreground dark:text-muted-foreground">
             Set SITE_MODE=enterprise to enable enterprise marketing content.
           </p>
         </main>
@@ -95,7 +95,7 @@ export default function EnterprisePage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+    <div className="min-h-screen bg-muted/20 bg-muted">
       <Navigation />
 
       {/* Hero */}
@@ -106,16 +106,16 @@ export default function EnterprisePage() {
         <div className="max-w-7xl mx-auto">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div>
-              <Badge className="mb-6 bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900 px-4 py-2 text-sm font-medium">
+              <Badge className="mb-6 bg-background text-white dark:bg-muted/40 dark:text-foreground px-4 py-2 text-sm font-medium">
                 Enterprise Infrastructure
               </Badge>
               <h1
                 id="enterprise-heading"
-                className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold text-slate-900 dark:text-white leading-tight mb-6 tracking-tight"
+                className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold text-foreground dark:text-white leading-tight mb-6 tracking-tight"
               >
                 What Serious Financial Infrastructure Evolves Toward
               </h1>
-              <p className="text-lg md:text-xl text-slate-600 dark:text-slate-400 mb-8 leading-relaxed">
+              <p className="text-lg md:text-xl text-muted-foreground dark:text-muted-foreground mb-8 leading-relaxed">
                 Deploy deterministic reconciliation with tenant isolation, governance boundaries,
                 and audit-ready evidence trails. Designed for teams where operational confidence is
                 not optional.
@@ -124,7 +124,7 @@ export default function EnterprisePage() {
                 <Button
                   size="lg"
                   asChild
-                  className="bg-slate-900 hover:bg-slate-800 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100 text-white px-8 py-6 text-lg font-semibold"
+                  className="bg-background hover:bg-card dark:bg-card dark:text-foreground dark:hover:bg-muted/40 text-white px-8 py-6 text-lg font-semibold"
                 >
                   <Link href="/contact" className="flex items-center justify-center gap-2">
                     Discuss Your Architecture <ArrowRight className="w-5 h-5" aria-hidden="true" />
@@ -140,7 +140,7 @@ export default function EnterprisePage() {
                 className="absolute inset-0 bg-blue-500/10 blur-3xl rounded-full"
                 aria-hidden="true"
               />
-              <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-slate-200 dark:border-slate-800">
+              <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-border border-border">
                 <Image
                   src="https://images.pexels.com/photos/25626439/pexels-photo-25626439.jpeg"
                   alt="Enterprise architecture visualization representing institutional-grade reconciliation infrastructure"
@@ -157,15 +157,15 @@ export default function EnterprisePage() {
 
       {/* Enterprise Capabilities */}
       <section
-        className="py-16 md:py-24 bg-white dark:bg-slate-900 px-4 sm:px-6 lg:px-8"
+        className="py-16 md:py-24 bg-card dark:bg-background px-4 sm:px-6 lg:px-8"
         aria-label="Enterprise capabilities"
       >
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-12 md:mb-16">
-            <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-4 text-slate-900 dark:text-white tracking-tight">
+            <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-4 text-foreground dark:text-white tracking-tight">
               Enterprise Capabilities
             </h2>
-            <p className="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto leading-relaxed">
+            <p className="text-lg text-muted-foreground dark:text-muted-foreground max-w-2xl mx-auto leading-relaxed">
               Security, compliance, and governance controls built into the infrastructure layer.
             </p>
           </div>
@@ -175,18 +175,18 @@ export default function EnterprisePage() {
               return (
                 <SpotlightCard
                   key={index}
-                  className="p-6 md:p-8 border-slate-200 dark:border-slate-800"
+                  className="p-6 md:p-8 border-border border-border"
                 >
-                  <div className="w-12 h-12 bg-slate-100 dark:bg-slate-800 rounded-xl flex items-center justify-center mb-6">
+                  <div className="w-12 h-12 bg-muted/40 dark:bg-card rounded-xl flex items-center justify-center mb-6">
                     <Icon
-                      className="w-6 h-6 text-slate-700 dark:text-slate-300"
+                      className="w-6 h-6 text-foreground dark:text-muted-foreground"
                       aria-hidden="true"
                     />
                   </div>
-                  <h3 className="text-lg md:text-xl font-semibold mb-3 text-slate-900 dark:text-white">
+                  <h3 className="text-lg md:text-xl font-semibold mb-3 text-foreground dark:text-white">
                     {feature.title}
                   </h3>
-                  <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+                  <p className="text-sm text-muted-foreground dark:text-muted-foreground leading-relaxed">
                     {feature.description}
                   </p>
                 </SpotlightCard>
@@ -202,7 +202,7 @@ export default function EnterprisePage() {
         return (
           <section
             key={index}
-            className={`py-16 md:py-24 px-4 sm:px-6 lg:px-8 ${isEven ? "bg-slate-50 dark:bg-slate-950" : "bg-white dark:bg-slate-900"}`}
+            className={`py-16 md:py-24 px-4 sm:px-6 lg:px-8 ${isEven ? "bg-muted/20 bg-muted" : "bg-card dark:bg-background"}`}
             aria-label={section.badge}
           >
             <div className="max-w-6xl mx-auto">
@@ -210,13 +210,13 @@ export default function EnterprisePage() {
                 className={`grid grid-cols-1 lg:grid-cols-2 gap-12 items-center ${isEven ? "" : "lg:[direction:rtl]"}`}
               >
                 <div className={isEven ? "" : "lg:[direction:ltr]"}>
-                  <Badge className="mb-4 bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200 px-3 py-1 text-xs font-medium uppercase tracking-wider">
+                  <Badge className="mb-4 bg-slate-200 text-slate-800 dark:bg-card text-muted-foreground px-3 py-1 text-xs font-medium uppercase tracking-wider">
                     {section.badge}
                   </Badge>
-                  <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-6 text-slate-900 dark:text-white tracking-tight leading-tight">
+                  <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-6 text-foreground dark:text-white tracking-tight leading-tight">
                     {section.title}
                   </h2>
-                  <p className="text-base md:text-lg text-slate-600 dark:text-slate-400 leading-relaxed">
+                  <p className="text-base md:text-lg text-muted-foreground dark:text-muted-foreground leading-relaxed">
                     {section.description}
                   </p>
                 </div>
@@ -244,17 +244,17 @@ export default function EnterprisePage() {
 
       {/* Operational Maturity Narrative */}
       <section
-        className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-slate-50 dark:bg-slate-950"
+        className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-muted/20 bg-muted"
         aria-label="Operational maturity"
       >
         <div className="max-w-4xl mx-auto text-center">
-          <Badge className="mb-4 bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200 px-3 py-1 text-xs font-medium uppercase tracking-wider">
+          <Badge className="mb-4 bg-slate-200 text-slate-800 dark:bg-card text-muted-foreground px-3 py-1 text-xs font-medium uppercase tracking-wider">
             The Operational Maturity Narrative
           </Badge>
-          <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-6 text-slate-900 dark:text-white tracking-tight">
+          <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-6 text-foreground dark:text-white tracking-tight">
             Manual Reconciliation Is a Phase
           </h2>
-          <p className="text-lg text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed mb-12">
+          <p className="text-lg text-muted-foreground dark:text-muted-foreground max-w-3xl mx-auto leading-relaxed mb-12">
             Deterministic, API-based reconciliation is the stable end-state that mature financial
             operations evolve toward. The question is not whether to adopt it, but when.
           </p>
@@ -284,16 +284,16 @@ export default function EnterprisePage() {
               return (
                 <div
                   key={idx}
-                  className="p-6 md:p-8 bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800"
+                  className="p-6 md:p-8 bg-card dark:bg-background rounded-2xl border border-border border-border"
                 >
                   <Icon
-                    className="w-8 h-8 text-slate-700 dark:text-slate-300 mx-auto mb-4"
+                    className="w-8 h-8 text-foreground dark:text-muted-foreground mx-auto mb-4"
                     aria-hidden="true"
                   />
-                  <h3 className="text-lg font-semibold mb-2 text-slate-900 dark:text-white">
+                  <h3 className="text-lg font-semibold mb-2 text-foreground dark:text-white">
                     {phase.title}
                   </h3>
-                  <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+                  <p className="text-sm text-muted-foreground dark:text-muted-foreground leading-relaxed">
                     {phase.description}
                   </p>
                 </div>
@@ -305,17 +305,17 @@ export default function EnterprisePage() {
 
       {/* Audit Narrative */}
       <section
-        className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900"
+        className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-card dark:bg-background"
         aria-label="Audit readiness"
       >
         <div className="max-w-4xl mx-auto text-center">
-          <Badge className="mb-4 bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200 px-3 py-1 text-xs font-medium uppercase tracking-wider">
+          <Badge className="mb-4 bg-slate-200 text-slate-800 dark:bg-card text-muted-foreground px-3 py-1 text-xs font-medium uppercase tracking-wider">
             The Audit Narrative
           </Badge>
-          <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-6 text-slate-900 dark:text-white tracking-tight">
+          <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-6 text-foreground dark:text-white tracking-tight">
             Every Decision Traceable
           </h2>
-          <p className="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto leading-relaxed mb-10">
+          <p className="text-lg text-muted-foreground dark:text-muted-foreground max-w-2xl mx-auto leading-relaxed mb-10">
             Every workflow reproducible. Every adjustment reviewable. Settler produces deterministic
             evidence that auditors can independently verify.
           </p>
@@ -328,13 +328,13 @@ export default function EnterprisePage() {
             ].map((item, idx) => (
               <div
                 key={idx}
-                className="p-6 bg-slate-50 dark:bg-slate-800/50 rounded-xl border border-slate-200 dark:border-slate-800"
+                className="p-6 bg-muted/20 dark:bg-card/50 rounded-xl border border-border border-border"
               >
                 <CheckCircle
-                  className="w-8 h-8 text-slate-700 dark:text-slate-300 mx-auto mb-4"
+                  className="w-8 h-8 text-foreground dark:text-muted-foreground mx-auto mb-4"
                   aria-hidden="true"
                 />
-                <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">{item}</p>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground leading-relaxed">{item}</p>
               </div>
             ))}
           </div>
@@ -348,17 +348,17 @@ export default function EnterprisePage() {
             ].map((badge, idx) => (
               <div key={idx} className="flex flex-col items-center gap-1">
                 <Shield
-                  className="w-10 h-10 text-slate-400 dark:text-slate-500"
+                  className="w-10 h-10 text-muted-foreground dark:text-muted-foreground"
                   aria-hidden="true"
                 />
-                <span className="text-xs font-semibold text-slate-700 dark:text-slate-300">
+                <span className="text-xs font-semibold text-foreground dark:text-muted-foreground">
                   {badge.label}
                 </span>
-                <span className="text-xs text-slate-500 dark:text-slate-500">{badge.sublabel}</span>
+                <span className="text-xs text-muted-foreground dark:text-muted-foreground">{badge.sublabel}</span>
               </div>
             ))}
           </div>
-          <p className="text-xs text-slate-400 dark:text-slate-600 mt-6 max-w-lg mx-auto">
+          <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-6 max-w-lg mx-auto">
             Architecture alignment does not constitute certification. Review your deployment configuration and consult your compliance team for your audit requirements.
           </p>
         </div>
@@ -366,14 +366,14 @@ export default function EnterprisePage() {
 
       {/* Final CTA */}
       <section
-        className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-slate-900 text-white"
+        className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-background text-white"
         aria-label="Enterprise engagement"
       >
         <div className="max-w-4xl mx-auto text-center">
           <h2 className="text-2xl md:text-3xl lg:text-5xl font-bold mb-6 tracking-tight">
             This matches how your systems should already operate.
           </h2>
-          <p className="text-lg md:text-xl text-slate-400 mb-10 leading-relaxed max-w-2xl mx-auto">
+          <p className="text-lg md:text-xl text-muted-foreground mb-10 leading-relaxed max-w-2xl mx-auto">
             Discuss your reconciliation architecture with our team. No dramatic claims. Quiet
             inevitability.
           </p>
@@ -381,7 +381,7 @@ export default function EnterprisePage() {
             <Button
               size="lg"
               asChild
-              className="w-full sm:w-auto bg-white text-slate-900 hover:bg-slate-100 px-10 py-7 text-lg font-semibold"
+              className="w-full sm:w-auto bg-card text-foreground hover:bg-muted/40 px-10 py-7 text-lg font-semibold"
             >
               <Link href="/contact" className="flex items-center justify-center gap-2">
                 Schedule an Enterprise Briefing{" "}
@@ -392,7 +392,7 @@ export default function EnterprisePage() {
               size="lg"
               variant="outline"
               asChild
-              className="w-full sm:w-auto px-10 py-7 text-lg border-2 border-slate-600 bg-transparent text-white hover:bg-slate-800"
+              className="w-full sm:w-auto px-10 py-7 text-lg border-2 border-slate-600 bg-transparent text-white hover:bg-card"
             >
               <Link href="/pricing">Explore Engagement Models</Link>
             </Button>

--- a/packages/web/src/app/feature-flags/page.tsx
+++ b/packages/web/src/app/feature-flags/page.tsx
@@ -24,7 +24,7 @@ export default function FeatureFlagsPage() {
           <h1 className="text-5xl font-bold mb-4 bg-gradient-to-r from-electric-purple to-electric-indigo bg-clip-text text-transparent">
             Feature Flags API
           </h1>
-          <p className="text-xl text-slate-600 max-w-2xl mx-auto mb-4">
+          <p className="text-xl text-muted-foreground max-w-2xl mx-auto mb-4">
             A simple, developer-friendly feature flag service. LaunchDarkly-lite, built by developers for developers.
           </p>
           <div className="inline-flex items-center gap-2 px-4 py-2 bg-green-100 text-green-800 rounded-full text-sm font-medium mb-8">
@@ -42,9 +42,9 @@ export default function FeatureFlagsPage() {
         </div>
 
         {/* Why Free */}
-        <div className="bg-slate-900 rounded-lg p-8 mb-16 text-center">
+        <div className="bg-background rounded-lg p-8 mb-16 text-center">
           <h2 className="text-2xl font-bold text-white mb-4">Why We Built This</h2>
-          <p className="text-lg text-slate-300 max-w-3xl mx-auto">
+          <p className="text-lg text-muted-foreground max-w-3xl mx-auto">
             We know what it's like to wrestle with feature flags. Most services are expensive, 
             over-engineered, or require complex setup. We built a simple API that just works. 
             It's free because we're developers too, and we want to help you ship faster.
@@ -53,25 +53,25 @@ export default function FeatureFlagsPage() {
 
         {/* Features */}
         <div className="grid md:grid-cols-3 gap-8 mb-16">
-          <div className="p-6 rounded-lg border border-slate-200 bg-white">
+          <div className="p-6 rounded-lg border border-border bg-card">
             <Code className="w-8 h-8 text-electric-purple mb-4" />
             <h3 className="text-xl font-semibold mb-2">Simple API</h3>
-            <p className="text-slate-600">
+            <p className="text-muted-foreground">
               RESTful endpoints that make sense. Create flags, set environments, evaluate values. 
               No SDK complexity.
             </p>
           </div>
-          <div className="p-6 rounded-lg border border-slate-200 bg-white">
+          <div className="p-6 rounded-lg border border-border bg-card">
             <Zap className="w-8 h-8 text-electric-cyan mb-4" />
             <h3 className="text-xl font-semibold mb-2">Fast Evaluation</h3>
-            <p className="text-slate-600">
+            <p className="text-muted-foreground">
               Sub-10ms evaluation times. Built on Settler's infrastructure with global edge caching.
             </p>
           </div>
-          <div className="p-6 rounded-lg border border-slate-200 bg-white">
+          <div className="p-6 rounded-lg border border-border bg-card">
             <ToggleLeft className="w-8 h-8 text-electric-indigo mb-4" />
             <h3 className="text-xl font-semibold mb-2">Environments & Overrides</h3>
-            <p className="text-slate-600">
+            <p className="text-muted-foreground">
               Organize flags by environment (prod, staging, dev). Override per-user or per-tenant 
               for testing.
             </p>
@@ -79,12 +79,12 @@ export default function FeatureFlagsPage() {
         </div>
 
         {/* Example */}
-        <div className="bg-slate-900 rounded-lg p-8 mb-16">
+        <div className="bg-background rounded-lg p-8 mb-16">
           <h2 className="text-2xl font-bold text-white mb-4">Example Usage</h2>
           <div className="space-y-6">
             <div>
-              <p className="text-sm text-slate-400 mb-2">Create a flag:</p>
-              <pre className="text-sm text-slate-300 overflow-x-auto">
+              <p className="text-sm text-muted-foreground mb-2">Create a flag:</p>
+              <pre className="text-sm text-muted-foreground overflow-x-auto">
 {`POST /api/v1/feature-flags
 {
   "key": "new-dashboard",
@@ -95,8 +95,8 @@ export default function FeatureFlagsPage() {
               </pre>
             </div>
             <div>
-              <p className="text-sm text-slate-400 mb-2">Evaluate in your app:</p>
-              <pre className="text-sm text-slate-300 overflow-x-auto">
+              <p className="text-sm text-muted-foreground mb-2">Evaluate in your app:</p>
+              <pre className="text-sm text-muted-foreground overflow-x-auto">
 {`POST /api/v1/feature-flags/evaluate
 {
   "flagKey": "new-dashboard",
@@ -119,27 +119,27 @@ Response:
         <div className="mb-16">
           <h2 className="text-3xl font-bold text-center mb-8">Perfect For</h2>
           <div className="grid md:grid-cols-2 gap-6">
-            <div className="p-6 rounded-lg bg-slate-50">
+            <div className="p-6 rounded-lg bg-muted/20">
               <h3 className="text-xl font-semibold mb-2">Gradual Rollouts</h3>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Enable features for specific users or percentages. Test in production safely.
               </p>
             </div>
-            <div className="p-6 rounded-lg bg-slate-50">
+            <div className="p-6 rounded-lg bg-muted/20">
               <h3 className="text-xl font-semibold mb-2">A/B Testing</h3>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Use string/number flags to test different variants and measure impact.
               </p>
             </div>
-            <div className="p-6 rounded-lg bg-slate-50">
+            <div className="p-6 rounded-lg bg-muted/20">
               <h3 className="text-xl font-semibold mb-2">Emergency Kill Switches</h3>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Quickly disable features without deploying. Critical for production stability.
               </p>
             </div>
-            <div className="p-6 rounded-lg bg-slate-50">
+            <div className="p-6 rounded-lg bg-muted/20">
               <h3 className="text-xl font-semibold mb-2">Environment Management</h3>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Different flag values for prod, staging, and dev. Keep environments in sync.
               </p>
             </div>

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -239,7 +239,9 @@
 
   /* Inline code: ensure proper contrast and sizing */
   code:not(pre code) {
-    @apply bg-neutral-100 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 px-1.5 py-0.5 rounded;
+    background: var(--bg-subtle);
+    color: var(--text);
+    @apply px-1.5 py-0.5 rounded;
     font-size: clamp(0.8125rem, 1vw + 0.25rem, 0.875rem); /* 13px - 14px */
   }
 
@@ -287,15 +289,16 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  @apply bg-neutral-100 dark:bg-neutral-800;
+  background: var(--bg-subtle);
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-neutral-300 dark:bg-neutral-600 rounded-full;
+  background: var(--border);
+  border-radius: var(--radius-full);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  @apply bg-neutral-400 dark:bg-neutral-500;
+  background: var(--text-subtle);
 }
 
 /* Performance optimizations */

--- a/packages/web/src/app/open-source/page.tsx
+++ b/packages/web/src/app/open-source/page.tsx
@@ -109,20 +109,20 @@ const quickStartSteps = [
 
 export default function OpenSourcePage() {
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+    <div className="min-h-screen bg-muted/20 bg-muted">
       <Navigation />
       <main id="main-content">
         {/* Hero */}
-        <section className="pt-24 pb-16 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+        <section className="pt-24 pb-16 px-4 sm:px-6 lg:px-8 bg-card dark:bg-background border-b border-border dark:border-border">
           <div className="max-w-5xl mx-auto">
             <div className="flex items-center gap-3 mb-5">
               <Badge variant="outline">Apache 2.0</Badge>
               <Badge variant="outline">Open Source</Badge>
             </div>
-            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-slate-900 dark:text-white mb-6 max-w-3xl">
+            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-foreground dark:text-white mb-6 max-w-3xl">
               Reconciliation Infrastructure You Can Actually Inspect
             </h1>
-            <p className="text-xl text-slate-600 dark:text-slate-400 max-w-3xl mb-8 leading-relaxed">
+            <p className="text-xl text-muted-foreground dark:text-muted-foreground max-w-3xl mb-8 leading-relaxed">
               Settler is fully open source. The matching engine, evidence model, CLI, SDK, and
               self-host stack are all Apache 2.0. No gated core, no hidden runtime logic.
             </p>
@@ -150,10 +150,10 @@ export default function OpenSourcePage() {
         {/* OSS Components */}
         <section className="py-16 px-4 sm:px-6 lg:px-8">
           <div className="max-w-5xl mx-auto">
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-3">
+            <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
               What&apos;s Open Source
             </h2>
-            <p className="text-slate-600 dark:text-slate-400 mb-10">
+            <p className="text-muted-foreground dark:text-muted-foreground mb-10">
               Every component that processes, hashes, or moves your data is open source and
               auditable.
             </p>
@@ -164,20 +164,20 @@ export default function OpenSourcePage() {
                   <Link
                     key={component.title}
                     href={component.link}
-                    className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6 hover:border-blue-400 dark:hover:border-blue-600 transition-colors group"
+                    className="rounded-2xl border border-border dark:border-border bg-card dark:bg-background p-6 hover:border-blue-400 dark:hover:border-blue-600 transition-colors group"
                   >
                     <div className="flex items-center justify-between mb-4">
                       <div className="w-10 h-10 rounded-lg bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
                         <Icon className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                       </div>
-                      <span className="text-xs font-medium text-slate-500 dark:text-slate-500 bg-slate-100 dark:bg-slate-800 rounded-full px-2.5 py-0.5">
+                      <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground bg-muted/40 dark:bg-card rounded-full px-2.5 py-0.5">
                         {component.badge}
                       </span>
                     </div>
-                    <h3 className="font-bold text-slate-900 dark:text-white mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                    <h3 className="font-bold text-foreground dark:text-white mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
                       {component.title}
                     </h3>
-                    <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+                    <p className="text-sm text-muted-foreground dark:text-muted-foreground leading-relaxed">
                       {component.description}
                     </p>
                   </Link>
@@ -188,14 +188,14 @@ export default function OpenSourcePage() {
         </section>
 
         {/* Quickstart */}
-        <section className="py-12 px-4 sm:px-6 lg:px-8 bg-white dark:bg-slate-900 border-t border-b border-slate-200 dark:border-slate-800">
+        <section className="py-12 px-4 sm:px-6 lg:px-8 bg-card dark:bg-background border-t border-b border-border dark:border-border">
           <div className="max-w-5xl mx-auto">
             <div className="grid md:grid-cols-2 gap-12 items-start">
               <div>
-                <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-3">
+                <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
                   Run it in 3 Minutes
                 </h2>
-                <p className="text-slate-600 dark:text-slate-400 mb-6">
+                <p className="text-muted-foreground dark:text-muted-foreground mb-6">
                   Clone, install, and run the demo path to see deterministic reconciliation
                   end-to-end. No database or API keys needed.
                 </p>
@@ -206,10 +206,10 @@ export default function OpenSourcePage() {
                         {step.step}
                       </span>
                       <div>
-                        <p className="text-sm font-medium text-slate-900 dark:text-white mb-1">
+                        <p className="text-sm font-medium text-foreground dark:text-white mb-1">
                           {step.title}
                         </p>
-                        <code className="block text-xs bg-slate-900 dark:bg-slate-950 text-green-400 rounded-lg p-2 font-mono">
+                        <code className="block text-xs bg-background bg-muted text-green-400 rounded-lg p-2 font-mono">
                           {step.code}
                         </code>
                       </div>
@@ -227,16 +227,16 @@ export default function OpenSourcePage() {
               </div>
 
               {/* Self-host benefits */}
-              <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/50 p-6">
+              <div className="rounded-2xl border border-border dark:border-border bg-muted/20 dark:bg-card/50 p-6">
                 <div className="flex items-center gap-2 mb-4">
-                  <Eye className="w-5 h-5 text-slate-600 dark:text-slate-400" />
-                  <h3 className="font-bold text-slate-900 dark:text-white">Why Self-Host?</h3>
+                  <Eye className="w-5 h-5 text-muted-foreground dark:text-muted-foreground" />
+                  <h3 className="font-bold text-foreground dark:text-white">Why Self-Host?</h3>
                 </div>
                 <ul className="space-y-3">
                   {selfHostBenefits.map((benefit) => (
                     <li key={benefit} className="flex items-start gap-2.5">
                       <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
-                      <span className="text-sm text-slate-700 dark:text-slate-300">{benefit}</span>
+                      <span className="text-sm text-foreground dark:text-muted-foreground">{benefit}</span>
                     </li>
                   ))}
                 </ul>
@@ -250,10 +250,10 @@ export default function OpenSourcePage() {
           <div className="max-w-5xl mx-auto">
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
               <div>
-                <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-2">
+                <h2 className="text-2xl font-bold text-foreground dark:text-white mb-2">
                   Architecture
                 </h2>
-                <p className="text-slate-600 dark:text-slate-400">
+                <p className="text-muted-foreground dark:text-muted-foreground">
                   The OSS build exposes the full system architecture.
                 </p>
               </div>
@@ -284,12 +284,12 @@ export default function OpenSourcePage() {
               ].map((block) => (
                 <div
                   key={block.title}
-                  className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-5"
+                  className="rounded-xl border border-border dark:border-border bg-card dark:bg-background p-5"
                 >
-                  <h3 className="font-bold text-slate-900 dark:text-white mb-2 text-sm">
+                  <h3 className="font-bold text-foreground dark:text-white mb-2 text-sm">
                     {block.title}
                   </h3>
-                  <p className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed">
+                  <p className="text-xs text-muted-foreground dark:text-muted-foreground leading-relaxed">
                     {block.description}
                   </p>
                 </div>
@@ -301,11 +301,11 @@ export default function OpenSourcePage() {
         {/* CTA */}
         <section className="pb-16 px-4 sm:px-6 lg:px-8">
           <div className="max-w-5xl mx-auto">
-            <div className="rounded-2xl bg-slate-900 dark:bg-slate-800 p-8 text-center">
+            <div className="rounded-2xl bg-background dark:bg-card p-8 text-center">
               <h2 className="text-2xl font-bold text-white mb-3">
                 Inspect the Source Before You Trust It
               </h2>
-              <p className="text-slate-400 mb-6 max-w-xl mx-auto">
+              <p className="text-muted-foreground mb-6 max-w-xl mx-auto">
                 Financial infrastructure should be auditable. Read the code, run the tests, verify
                 the evidence model.
               </p>
@@ -324,7 +324,7 @@ export default function OpenSourcePage() {
                 <Button
                   variant="outline"
                   asChild
-                  className="border-slate-600 text-white hover:bg-slate-700"
+                  className="border-slate-600 text-white hover:bg-muted"
                 >
                   <Link href="/security-and-audit">Security Model</Link>
                 </Button>

--- a/packages/web/src/app/realtime-dashboard/page.tsx
+++ b/packages/web/src/app/realtime-dashboard/page.tsx
@@ -33,7 +33,7 @@ export default function RealtimeDashboard({ params, searchParams }: PageProps) {
       case 'running':
         return 'text-blue-600 dark:text-blue-400';
       default:
-        return 'text-slate-600 dark:text-slate-400';
+        return 'text-muted-foreground dark:text-muted-foreground';
     }
   };
 
@@ -51,7 +51,7 @@ export default function RealtimeDashboard({ params, searchParams }: PageProps) {
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 dark:from-slate-900 dark:via-slate-800 dark:to-black">
       <Navigation />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 pt-24">
-        <h1 className="text-3xl font-bold mb-6 text-slate-900 dark:text-white">Reconciliation Dashboard</h1>
+        <h1 className="text-3xl font-bold mb-6 text-foreground dark:text-white">Reconciliation Dashboard</h1>
 
       {/* Connection Status */}
       <div className="mb-6">
@@ -61,7 +61,7 @@ export default function RealtimeDashboard({ params, searchParams }: PageProps) {
               connected ? 'bg-green-500' : 'bg-red-500'
             }`}
           />
-          <span className="text-sm text-slate-700 dark:text-slate-300">
+          <span className="text-sm text-foreground dark:text-muted-foreground">
             {connected ? 'Connected' : 'Disconnected'}
           </span>
         </div>
@@ -69,33 +69,33 @@ export default function RealtimeDashboard({ params, searchParams }: PageProps) {
 
       {/* Execution Status */}
       {execution && (
-        <div className="bg-white dark:bg-slate-800 rounded-lg shadow-lg p-6 mb-6 border border-slate-200 dark:border-slate-700">
-          <h2 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">Execution Status</h2>
+        <div className="bg-card dark:bg-card rounded-lg shadow-lg p-6 mb-6 border border-border dark:border-border">
+          <h2 className="text-xl font-semibold mb-4 text-foreground dark:text-white">Execution Status</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
-              <span className="text-slate-600 dark:text-slate-400">Status:</span>
+              <span className="text-muted-foreground dark:text-muted-foreground">Status:</span>
               <span className={`ml-2 font-semibold ${getStatusColor(execution.status)}`}>
                 {execution.status?.toUpperCase()}
               </span>
             </div>
             <div>
-              <span className="text-slate-600 dark:text-slate-400">Duration:</span>
-              <span className="ml-2 font-semibold text-slate-900 dark:text-white">
+              <span className="text-muted-foreground dark:text-muted-foreground">Duration:</span>
+              <span className="ml-2 font-semibold text-foreground dark:text-white">
                 {formatDuration(execution.startedAt, execution.completedAt)}
               </span>
             </div>
             {execution.startedAt && (
               <div>
-                <span className="text-slate-600 dark:text-slate-400">Started:</span>
-                <span className="ml-2 text-slate-900 dark:text-white">
+                <span className="text-muted-foreground dark:text-muted-foreground">Started:</span>
+                <span className="ml-2 text-foreground dark:text-white">
                   {new Date(execution.startedAt).toLocaleString()}
                 </span>
               </div>
             )}
             {execution.completedAt && (
               <div>
-                <span className="text-slate-600 dark:text-slate-400">Completed:</span>
-                <span className="ml-2 text-slate-900 dark:text-white">
+                <span className="text-muted-foreground dark:text-muted-foreground">Completed:</span>
+                <span className="ml-2 text-foreground dark:text-white">
                   {new Date(execution.completedAt).toLocaleString()}
                 </span>
               </div>
@@ -105,48 +105,48 @@ export default function RealtimeDashboard({ params, searchParams }: PageProps) {
           {/* Summary */}
           {execution.summary && (
             <div className="mt-6">
-              <h3 className="text-lg font-semibold mb-3 text-slate-900 dark:text-white">Summary</h3>
+              <h3 className="text-lg font-semibold mb-3 text-foreground dark:text-white">Summary</h3>
               <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
                 <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded border border-blue-200 dark:border-blue-800">
-                  <div className="text-sm text-slate-600 dark:text-slate-400">Source Records</div>
-                  <div className="text-2xl font-bold text-slate-900 dark:text-white">
+                  <div className="text-sm text-muted-foreground dark:text-muted-foreground">Source Records</div>
+                  <div className="text-2xl font-bold text-foreground dark:text-white">
                     {execution.summary.total_source_records || 0}
                   </div>
                 </div>
                 <div className="bg-green-50 dark:bg-green-900/20 p-4 rounded border border-green-200 dark:border-green-800">
-                  <div className="text-sm text-slate-600 dark:text-slate-400">Target Records</div>
-                  <div className="text-2xl font-bold text-slate-900 dark:text-white">
+                  <div className="text-sm text-muted-foreground dark:text-muted-foreground">Target Records</div>
+                  <div className="text-2xl font-bold text-foreground dark:text-white">
                     {execution.summary.total_target_records || 0}
                   </div>
                 </div>
                 <div className="bg-purple-50 dark:bg-purple-900/20 p-4 rounded border border-purple-200 dark:border-purple-800">
-                  <div className="text-sm text-slate-600 dark:text-slate-400">Matches</div>
-                  <div className="text-2xl font-bold text-slate-900 dark:text-white">
+                  <div className="text-sm text-muted-foreground dark:text-muted-foreground">Matches</div>
+                  <div className="text-2xl font-bold text-foreground dark:text-white">
                     {execution.summary.matched_count || 0}
                   </div>
                 </div>
                 <div className="bg-yellow-50 dark:bg-yellow-900/20 p-4 rounded border border-yellow-200 dark:border-yellow-800">
-                  <div className="text-sm text-slate-600 dark:text-slate-400">Unmatched Source</div>
-                  <div className="text-2xl font-bold text-slate-900 dark:text-white">
+                  <div className="text-sm text-muted-foreground dark:text-muted-foreground">Unmatched Source</div>
+                  <div className="text-2xl font-bold text-foreground dark:text-white">
                     {execution.summary.unmatched_source_count || 0}
                   </div>
                 </div>
                 <div className="bg-orange-50 dark:bg-orange-900/20 p-4 rounded border border-orange-200 dark:border-orange-800">
-                  <div className="text-sm text-slate-600 dark:text-slate-400">Unmatched Target</div>
-                  <div className="text-2xl font-bold text-slate-900 dark:text-white">
+                  <div className="text-sm text-muted-foreground dark:text-muted-foreground">Unmatched Target</div>
+                  <div className="text-2xl font-bold text-foreground dark:text-white">
                     {execution.summary.unmatched_target_count || 0}
                   </div>
                 </div>
                 <div className="bg-red-50 dark:bg-red-900/20 p-4 rounded border border-red-200 dark:border-red-800">
-                  <div className="text-sm text-slate-600 dark:text-slate-400">Errors</div>
-                  <div className="text-2xl font-bold text-slate-900 dark:text-white">
+                  <div className="text-sm text-muted-foreground dark:text-muted-foreground">Errors</div>
+                  <div className="text-2xl font-bold text-foreground dark:text-white">
                     {execution.summary.errors_count || 0}
                   </div>
                 </div>
               </div>
               {execution.summary.accuracy_percentage !== null && (
                 <div className="mt-4">
-                  <div className="text-sm text-slate-600 dark:text-slate-400 mb-1">Accuracy</div>
+                  <div className="text-sm text-muted-foreground dark:text-muted-foreground mb-1">Accuracy</div>
                   <div className="text-3xl font-bold text-green-600 dark:text-green-400">
                     {execution.summary.accuracy_percentage?.toFixed(2)}%
                   </div>
@@ -172,9 +172,9 @@ export default function RealtimeDashboard({ params, searchParams }: PageProps) {
       )}
 
       {/* Logs */}
-      <div className="bg-slate-50 dark:bg-slate-800 rounded-lg p-4 border border-slate-200 dark:border-slate-700">
-        <h3 className="text-lg font-semibold mb-2 text-slate-900 dark:text-white">Activity Log</h3>
-        <div className="max-h-64 overflow-y-auto font-mono text-sm text-slate-700 dark:text-slate-300">
+      <div className="bg-muted/20 dark:bg-card rounded-lg p-4 border border-border dark:border-border">
+        <h3 className="text-lg font-semibold mb-2 text-foreground dark:text-white">Activity Log</h3>
+        <div className="max-h-64 overflow-y-auto font-mono text-sm text-foreground dark:text-muted-foreground">
           {logs.map((log, idx) => (
             <div key={idx} className="mb-1">
               {log}

--- a/packages/web/src/app/support/page.tsx
+++ b/packages/web/src/app/support/page.tsx
@@ -279,11 +279,11 @@ export default function Support() {
         <div className="max-w-7xl mx-auto">
           <h2
             id="support-options-heading"
-            className="text-3xl md:text-4xl font-bold text-center mb-4 text-slate-900 dark:text-white"
+            className="text-3xl md:text-4xl font-bold text-center mb-4 text-foreground dark:text-white"
           >
             Support Channels
           </h2>
-          <p className="text-center text-slate-600 dark:text-slate-300 mb-12 max-w-2xl mx-auto">
+          <p className="text-center text-muted-foreground dark:text-muted-foreground mb-12 max-w-2xl mx-auto">
             Choose the support channel that works best for you
           </p>
           <div
@@ -294,20 +294,20 @@ export default function Support() {
             {supportOptions.map((option, index) => (
               <Card
                 key={index}
-                className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800 transition-all duration-200 hover:shadow-lg hover:scale-[1.02]"
+                className="bg-card dark:bg-background border-border border-border transition-all duration-200 hover:shadow-lg hover:scale-[1.02]"
                 role="listitem"
               >
                 <CardHeader>
                   <div className="text-4xl mb-2">{option.icon}</div>
                   <div className="flex items-center justify-between">
-                    <CardTitle className="text-lg text-slate-900 dark:text-white">
+                    <CardTitle className="text-lg text-foreground dark:text-white">
                       {option.title}
                     </CardTitle>
                     <Badge variant="outline" className="text-xs">
                       {option.tier}
                     </Badge>
                   </div>
-                  <CardDescription className="text-slate-600 dark:text-slate-300">
+                  <CardDescription className="text-muted-foreground dark:text-muted-foreground">
                     {option.description}
                   </CardDescription>
                 </CardHeader>
@@ -316,7 +316,7 @@ export default function Support() {
                     <Button
                       asChild
                       variant="outline"
-                      className="w-full border-slate-300 dark:border-slate-700"
+                      className="w-full border-border border-border"
                     >
                       <a
                         href={option.link}
@@ -331,7 +331,7 @@ export default function Support() {
                     <Button
                       asChild
                       variant="outline"
-                      className="w-full border-slate-300 dark:border-slate-700"
+                      className="w-full border-border border-border"
                     >
                       <Link href={option.link}>{option.linkText} →</Link>
                     </Button>
@@ -345,32 +345,32 @@ export default function Support() {
 
       {/* Support Tiers */}
       <section
-        className="py-20 px-4 sm:px-6 lg:px-8 bg-white/50 dark:bg-slate-800/50"
+        className="py-20 px-4 sm:px-6 lg:px-8 bg-card/50 dark:bg-card/50"
         aria-labelledby="support-tiers-heading"
       >
         <div className="max-w-7xl mx-auto">
           <h2
             id="support-tiers-heading"
-            className="text-3xl md:text-4xl font-bold text-center mb-4 text-slate-900 dark:text-white"
+            className="text-3xl md:text-4xl font-bold text-center mb-4 text-foreground dark:text-white"
           >
             Support Tiers
           </h2>
-          <p className="text-center text-slate-600 dark:text-slate-300 mb-12 max-w-2xl mx-auto">
+          <p className="text-center text-muted-foreground dark:text-muted-foreground mb-12 max-w-2xl mx-auto">
             Different support levels for different needs
           </p>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {supportTiers.map((tier, index) => (
               <Card
                 key={index}
-                className={`bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800 transition-all duration-200 hover:shadow-lg ${
+                className={`bg-card dark:bg-background border-border border-border transition-all duration-200 hover:shadow-lg ${
                   tier.tier === "Enterprise" ? "ring-2 ring-blue-500" : ""
                 }`}
               >
                 <CardHeader>
-                  <CardTitle className="text-xl text-slate-900 dark:text-white mb-2">
+                  <CardTitle className="text-xl text-foreground dark:text-white mb-2">
                     {tier.tier}
                   </CardTitle>
-                  <CardDescription className="text-slate-600 dark:text-slate-300">
+                  <CardDescription className="text-muted-foreground dark:text-muted-foreground">
                     Response Time: {tier.responseTime}
                   </CardDescription>
                 </CardHeader>
@@ -379,7 +379,7 @@ export default function Support() {
                     {tier.features.map((feature, idx) => (
                       <li
                         key={idx}
-                        className="flex items-start text-sm text-slate-600 dark:text-slate-300"
+                        className="flex items-start text-sm text-muted-foreground dark:text-muted-foreground"
                       >
                         <span className="mr-2 text-green-500">✓</span>
                         {feature}
@@ -398,29 +398,29 @@ export default function Support() {
         <div className="max-w-7xl mx-auto">
           <h2
             id="escalation-heading"
-            className="text-3xl md:text-4xl font-bold text-center mb-4 text-slate-900 dark:text-white"
+            className="text-3xl md:text-4xl font-bold text-center mb-4 text-foreground dark:text-white"
           >
             Support Escalation
           </h2>
-          <p className="text-center text-slate-600 dark:text-slate-300 mb-12 max-w-2xl mx-auto">
+          <p className="text-center text-muted-foreground dark:text-muted-foreground mb-12 max-w-2xl mx-auto">
             How we handle and escalate support requests
           </p>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
             {escalationLevels.map((level, index) => (
               <Card
                 key={index}
-                className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800"
+                className="bg-card dark:bg-background border-border border-border"
               >
                 <CardHeader>
                   <Badge variant="outline" className="w-fit mb-2">
                     {level.level}
                   </Badge>
-                  <CardTitle className="text-lg text-slate-900 dark:text-white">
+                  <CardTitle className="text-lg text-foreground dark:text-white">
                     {level.name}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <ul className="space-y-1 text-sm text-slate-600 dark:text-slate-300">
+                  <ul className="space-y-1 text-sm text-muted-foreground dark:text-muted-foreground">
                     {level.includes.map((item, idx) => (
                       <li key={idx} className="flex items-start">
                         <span className="mr-2">•</span>
@@ -437,28 +437,28 @@ export default function Support() {
 
       {/* Severity Levels */}
       <section
-        className="py-20 px-4 sm:px-6 lg:px-8 bg-white/50 dark:bg-slate-800/50"
+        className="py-20 px-4 sm:px-6 lg:px-8 bg-card/50 dark:bg-card/50"
         aria-labelledby="severity-heading"
       >
         <div className="max-w-4xl mx-auto">
           <h2
             id="severity-heading"
-            className="text-3xl md:text-4xl font-bold text-center mb-4 text-slate-900 dark:text-white"
+            className="text-3xl md:text-4xl font-bold text-center mb-4 text-foreground dark:text-white"
           >
             Issue Severity & Response Times
           </h2>
-          <p className="text-center text-slate-600 dark:text-slate-300 mb-12">
+          <p className="text-center text-muted-foreground dark:text-muted-foreground mb-12">
             We prioritize issues based on severity to ensure critical problems are resolved quickly
           </p>
           <div className="space-y-4">
             {severityLevels.map((severity, index) => (
               <Card
                 key={index}
-                className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800"
+                className="bg-card dark:bg-background border-border border-border"
               >
                 <CardHeader>
                   <div className="flex items-center justify-between">
-                    <CardTitle className="text-lg text-slate-900 dark:text-white">
+                    <CardTitle className="text-lg text-foreground dark:text-white">
                       {severity.severity}
                     </CardTitle>
                     <div className="flex gap-4 text-sm">
@@ -466,7 +466,7 @@ export default function Support() {
                       <Badge variant="outline">Resolution: {severity.resolutionTime}</Badge>
                     </div>
                   </div>
-                  <CardDescription className="text-slate-600 dark:text-slate-300">
+                  <CardDescription className="text-muted-foreground dark:text-muted-foreground">
                     {severity.description}
                   </CardDescription>
                 </CardHeader>
@@ -477,13 +477,13 @@ export default function Support() {
       </section>
 
       {/* FAQ Section */}
-      <section className="py-20 px-4 sm:px-6 lg:px-8 bg-white/50 dark:bg-slate-800/50">
+      <section className="py-20 px-4 sm:px-6 lg:px-8 bg-card/50 dark:bg-card/50">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-12">
-            <h2 className="text-3xl md:text-4xl font-bold mb-4 text-slate-900 dark:text-white">
+            <h2 className="text-3xl md:text-4xl font-bold mb-4 text-foreground dark:text-white">
               Frequently Asked Questions
             </h2>
-            <p className="text-lg text-slate-600 dark:text-slate-300">
+            <p className="text-lg text-muted-foreground dark:text-muted-foreground">
               Search our knowledge base for quick answers
             </p>
           </div>
@@ -495,7 +495,7 @@ export default function Support() {
               placeholder="Search FAQs..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full px-4 py-3 border border-slate-300 dark:border-slate-700 rounded-lg bg-white dark:bg-slate-900 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-4 py-3 border border-border border-border rounded-lg bg-card dark:bg-background text-foreground dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               aria-label="Search frequently asked questions"
             />
           </div>
@@ -506,23 +506,23 @@ export default function Support() {
               filteredFaqs.map((faq, index) => (
                 <Card
                   key={index}
-                  className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800 transition-all duration-300 hover:shadow-lg"
+                  className="bg-card dark:bg-background border-border border-border transition-all duration-300 hover:shadow-lg"
                   role="listitem"
                 >
                   <CardHeader>
-                    <CardTitle className="text-lg text-slate-900 dark:text-white">
+                    <CardTitle className="text-lg text-foreground dark:text-white">
                       {faq.question}
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <p className="text-slate-600 dark:text-slate-300">{faq.answer}</p>
+                    <p className="text-muted-foreground dark:text-muted-foreground">{faq.answer}</p>
                   </CardContent>
                 </Card>
               ))
             ) : (
-              <Card className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800">
+              <Card className="bg-card dark:bg-background border-border border-border">
                 <CardContent className="py-8 text-center">
-                  <p className="text-slate-600 dark:text-slate-300">
+                  <p className="text-muted-foreground dark:text-muted-foreground">
                     No FAQs found matching "{searchQuery}". Try a different search term.
                   </p>
                 </CardContent>

--- a/packages/web/src/app/transparency/page.tsx
+++ b/packages/web/src/app/transparency/page.tsx
@@ -13,14 +13,14 @@ import {
 
 const TransparencyDashboard: React.FC = () => {
   return (
-    <div className="bg-background-light dark:bg-background-dark font-display text-slate-900 dark:text-slate-100 overflow-x-hidden antialiased">
-      <div className="relative flex h-full min-h-screen w-full flex-col max-w-md mx-auto bg-white dark:bg-background-dark shadow-xl">
+    <div className="bg-background-light dark:bg-background-dark font-display text-foreground text-muted-foreground overflow-x-hidden antialiased">
+      <div className="relative flex h-full min-h-screen w-full flex-col max-w-md mx-auto bg-card dark:bg-background-dark shadow-xl">
         {/* Sticky Header */}
-        <div className="sticky top-0 z-50 flex items-center bg-white/90 dark:bg-background-dark/90 backdrop-blur-md border-b border-slate-100 dark:border-slate-800 p-4 pb-3 justify-between">
-          <button className="text-slate-900 dark:text-slate-100 flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">
+        <div className="sticky top-0 z-50 flex items-center bg-card/90 dark:bg-background-dark/90 backdrop-blur-md border-b border-slate-100 border-border p-4 pb-3 justify-between">
+          <button className="text-foreground text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-muted/40 dark:hover:bg-card transition-colors">
             <ArrowLeft className="h-6 w-6" />
           </button>
-          <h2 className="text-slate-900 dark:text-slate-100 text-lg font-bold leading-tight tracking-tight flex-1 text-center pr-10">
+          <h2 className="text-foreground text-muted-foreground text-lg font-bold leading-tight tracking-tight flex-1 text-center pr-10">
             Transparency
           </h2>
         </div>
@@ -31,7 +31,7 @@ const TransparencyDashboard: React.FC = () => {
             <div className="relative flex min-h-[400px] flex-col gap-6 rounded-2xl overflow-hidden p-6 items-start justify-end shadow-sm">
               <div className="absolute inset-0 bg-gradient-to-t from-primary/90 to-primary/40"></div>
               <div className="relative z-10 flex flex-col gap-2 text-left">
-                <div className="inline-flex items-center gap-1.5 rounded-full bg-white/20 backdrop-blur-md px-3 py-1 text-xs font-semibold text-white w-fit mb-2 border border-white/30">
+                <div className="inline-flex items-center gap-1.5 rounded-full bg-card/20 backdrop-blur-md px-3 py-1 text-xs font-semibold text-white w-fit mb-2 border border-white/30">
                   <BadgeCheck className="h-4 w-4" />
                   <span>Deterministic Logic</span>
                 </div>
@@ -48,27 +48,27 @@ const TransparencyDashboard: React.FC = () => {
           {/* Stats Ticker (Horizontal Scroll) */}
           <div className="w-full overflow-x-auto no-scrollbar pb-2 px-4">
             <div className="flex gap-3 min-w-max">
-              <div className="flex flex-col gap-1 rounded-xl p-4 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700 min-w-[140px]">
-                <p className="text-slate-500 dark:text-slate-400 text-xs font-semibold uppercase tracking-wider">
+              <div className="flex flex-col gap-1 rounded-xl p-4 bg-muted/20 dark:bg-card/50 border border-slate-100 border-border min-w-[140px]">
+                <p className="text-muted-foreground dark:text-muted-foreground text-xs font-semibold uppercase tracking-wider">
                   Match Rate
                 </p>
                 <p className="text-primary dark:text-primary font-bold text-2xl tracking-tight">
                   99.9%
                 </p>
               </div>
-              <div className="flex flex-col gap-1 rounded-xl p-4 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700 min-w-[140px]">
-                <p className="text-slate-500 dark:text-slate-400 text-xs font-semibold uppercase tracking-wider">
+              <div className="flex flex-col gap-1 rounded-xl p-4 bg-muted/20 dark:bg-card/50 border border-slate-100 border-border min-w-[140px]">
+                <p className="text-muted-foreground dark:text-muted-foreground text-xs font-semibold uppercase tracking-wider">
                   Latency
                 </p>
-                <p className="text-slate-900 dark:text-slate-100 font-bold text-2xl tracking-tight">
+                <p className="text-foreground text-muted-foreground font-bold text-2xl tracking-tight">
                   &lt; 2s
                 </p>
               </div>
-              <div className="flex flex-col gap-1 rounded-xl p-4 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700 min-w-[140px]">
-                <p className="text-slate-500 dark:text-slate-400 text-xs font-semibold uppercase tracking-wider">
+              <div className="flex flex-col gap-1 rounded-xl p-4 bg-muted/20 dark:bg-card/50 border border-slate-100 border-border min-w-[140px]">
+                <p className="text-muted-foreground dark:text-muted-foreground text-xs font-semibold uppercase tracking-wider">
                   Safety Score
                 </p>
-                <p className="text-slate-900 dark:text-slate-100 font-bold text-2xl tracking-tight">
+                <p className="text-foreground text-muted-foreground font-bold text-2xl tracking-tight">
                   100%
                 </p>
               </div>
@@ -76,7 +76,7 @@ const TransparencyDashboard: React.FC = () => {
           </div>
           {/* Process Flow Stepper */}
           <div className="px-4 pt-8 pb-4">
-            <h2 className="text-slate-900 dark:text-slate-100 text-xl font-bold leading-tight mb-6">
+            <h2 className="text-foreground text-muted-foreground text-xl font-bold leading-tight mb-6">
               The Settlement Process
             </h2>
             <div className="grid grid-cols-[32px_1fr] gap-x-4">
@@ -85,14 +85,14 @@ const TransparencyDashboard: React.FC = () => {
                 <div className="flex items-center justify-center size-8 rounded-full bg-primary/10 text-primary">
                   <CheckCircle className="h-5 w-5" />
                 </div>
-                <div className="w-[2px] bg-slate-200 dark:bg-slate-700 h-full min-h-[60px]"></div>
+                <div className="w-[2px] bg-slate-200 bg-muted h-full min-h-[60px]"></div>
               </div>
               <div className="pb-8 pt-1">
                 <div className="flex flex-col gap-2">
-                  <h3 className="text-slate-900 dark:text-slate-100 text-base font-bold">
+                  <h3 className="text-foreground text-muted-foreground text-base font-bold">
                     Auto-Match Engine
                   </h3>
-                  <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
+                  <p className="text-muted-foreground dark:text-muted-foreground text-sm leading-relaxed">
                     Our engine ingests transaction data and applies rigorous 14-point comparison
                     rules.
                   </p>
@@ -107,32 +107,32 @@ const TransparencyDashboard: React.FC = () => {
                 <div className="flex items-center justify-center size-8 rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400">
                   <Wrench className="h-5 w-5" />
                 </div>
-                <div className="w-[2px] bg-slate-200 dark:bg-slate-700 h-full min-h-[60px]"></div>
+                <div className="w-[2px] bg-slate-200 bg-muted h-full min-h-[60px]"></div>
               </div>
               <div className="pb-8 pt-1">
                 <div className="flex flex-col gap-2">
-                  <h3 className="text-slate-900 dark:text-slate-100 text-base font-bold">
+                  <h3 className="text-foreground text-muted-foreground text-base font-bold">
                     Human-in-the-Loop Review
                   </h3>
-                  <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
+                  <p className="text-muted-foreground dark:text-muted-foreground text-sm leading-relaxed">
                     When logic finds an anomaly, it's flagged for expert review. No guessing
                     allowed.
                   </p>
                   {/* Mini UI Card Simulation */}
-                  <div className="mt-3 p-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50">
+                  <div className="mt-3 p-3 rounded-lg border border-border border-border bg-muted/20 dark:bg-card/50">
                     <div className="flex justify-between items-center mb-2">
                       <span className="text-[10px] font-bold uppercase text-orange-600 bg-orange-100 px-1.5 py-0.5 rounded">
                         Exception
                       </span>
-                      <span className="text-[10px] text-slate-400 font-mono">ID: #8821X</span>
+                      <span className="text-[10px] text-muted-foreground font-mono">ID: #8821X</span>
                     </div>
                     <div className="flex gap-2 items-center mb-3">
                       <div className="h-1.5 flex-1 bg-slate-200 rounded-full overflow-hidden">
                         <div className="h-full w-3/4 bg-orange-400"></div>
                       </div>
-                      <span className="text-[10px] text-slate-500">75% Match</span>
+                      <span className="text-[10px] text-muted-foreground">75% Match</span>
                     </div>
-                    <button className="w-full py-1.5 rounded bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 text-xs font-medium text-slate-700 dark:text-slate-200 shadow-sm">
+                    <button className="w-full py-1.5 rounded bg-card bg-muted border border-border border-border text-xs font-medium text-foreground text-muted-foreground shadow-sm">
                       Start Manual Review
                     </button>
                   </div>
@@ -146,10 +146,10 @@ const TransparencyDashboard: React.FC = () => {
               </div>
               <div className="pb-4 pt-1">
                 <div className="flex flex-col gap-2">
-                  <h3 className="text-slate-900 dark:text-slate-100 text-base font-bold">
+                  <h3 className="text-foreground text-muted-foreground text-base font-bold">
                     Final Settlement
                   </h3>
-                  <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
+                  <p className="text-muted-foreground dark:text-muted-foreground text-sm leading-relaxed">
                     Once verified, data is written to an immutable ledger. Safe, secure, and
                     permanent.
                   </p>
@@ -159,51 +159,51 @@ const TransparencyDashboard: React.FC = () => {
           </div>
           {/* Guardrails Grid */}
           <div className="p-4 pt-2 pb-24">
-            <h2 className="text-slate-900 dark:text-slate-100 text-xl font-bold leading-tight mb-4">
+            <h2 className="text-foreground text-muted-foreground text-xl font-bold leading-tight mb-4">
               Safety Guardrails
             </h2>
             <div className="grid grid-cols-2 gap-3">
-              <div className="p-4 rounded-xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700 flex flex-col gap-2">
-                <div className="p-2 rounded-lg bg-white dark:bg-slate-700 w-fit shadow-sm text-primary">
+              <div className="p-4 rounded-xl bg-muted/20 dark:bg-card/50 border border-slate-100 border-border flex flex-col gap-2">
+                <div className="p-2 rounded-lg bg-card bg-muted w-fit shadow-sm text-primary">
                   <ScrollText className="h-6 w-6" />
                 </div>
-                <h4 className="font-semibold text-sm text-slate-900 dark:text-slate-100 mt-1">
+                <h4 className="font-semibold text-sm text-foreground text-muted-foreground mt-1">
                   Audit Trails
                 </h4>
-                <p className="text-xs text-slate-500 dark:text-slate-400">
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground">
                   Every action is logged and searchable.
                 </p>
               </div>
-              <div className="p-4 rounded-xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700 flex flex-col gap-2">
-                <div className="p-2 rounded-lg bg-white dark:bg-slate-700 w-fit shadow-sm text-primary">
+              <div className="p-4 rounded-xl bg-muted/20 dark:bg-card/50 border border-slate-100 border-border flex flex-col gap-2">
+                <div className="p-2 rounded-lg bg-card bg-muted w-fit shadow-sm text-primary">
                   <BadgeCheck className="h-6 w-6" />
                 </div>
-                <h4 className="font-semibold text-sm text-slate-900 dark:text-slate-100 mt-1">
+                <h4 className="font-semibold text-sm text-foreground text-muted-foreground mt-1">
                   RBAC
                 </h4>
-                <p className="text-xs text-slate-500 dark:text-slate-400">
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground">
                   Strict role-based access control.
                 </p>
               </div>
-              <div className="p-4 rounded-xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700 flex flex-col gap-2">
-                <div className="p-2 rounded-lg bg-white dark:bg-slate-700 w-fit shadow-sm text-primary">
+              <div className="p-4 rounded-xl bg-muted/20 dark:bg-card/50 border border-slate-100 border-border flex flex-col gap-2">
+                <div className="p-2 rounded-lg bg-card bg-muted w-fit shadow-sm text-primary">
                   <ShieldCheck className="h-6 w-6" />
                 </div>
-                <h4 className="font-semibold text-sm text-slate-900 dark:text-slate-100 mt-1">
+                <h4 className="font-semibold text-sm text-foreground text-muted-foreground mt-1">
                   Encryption
                 </h4>
-                <p className="text-xs text-slate-500 dark:text-slate-400">
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground">
                   AES-256 encryption at rest.
                 </p>
               </div>
-              <div className="p-4 rounded-xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700 flex flex-col gap-2">
-                <div className="p-2 rounded-lg bg-white dark:bg-slate-700 w-fit shadow-sm text-primary">
+              <div className="p-4 rounded-xl bg-muted/20 dark:bg-card/50 border border-slate-100 border-border flex flex-col gap-2">
+                <div className="p-2 rounded-lg bg-card bg-muted w-fit shadow-sm text-primary">
                   <Eye className="h-6 w-6" />
                 </div>
-                <h4 className="font-semibold text-sm text-slate-900 dark:text-slate-100 mt-1">
+                <h4 className="font-semibold text-sm text-foreground text-muted-foreground mt-1">
                   Read-Only
                 </h4>
-                <p className="text-xs text-slate-500 dark:text-slate-400">
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground">
                   Restricted views for external auditors.
                 </p>
               </div>
@@ -211,7 +211,7 @@ const TransparencyDashboard: React.FC = () => {
           </div>
         </div>
         {/* Sticky Bottom Action */}
-        <div className="absolute bottom-0 w-full p-4 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg border-t border-slate-100 dark:border-slate-800">
+        <div className="absolute bottom-0 w-full p-4 bg-card/80 dark:bg-background-dark/80 backdrop-blur-lg border-t border-slate-100 border-border">
           <button className="w-full flex cursor-pointer items-center justify-center rounded-lg h-12 px-5 bg-primary hover:bg-primary/90 transition-colors text-white text-base font-bold shadow-lg shadow-primary/20">
             View Documentation
           </button>

--- a/packages/web/src/components/RoleMatrix.tsx
+++ b/packages/web/src/components/RoleMatrix.tsx
@@ -6,11 +6,11 @@ import { Shield, AlertTriangle } from "lucide-react";
 const RoleMatrix: React.FC = () => {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
-      <div className="rounded-full bg-slate-100 p-4 mb-4">
-        <Shield className="h-8 w-8 text-slate-400" aria-hidden="true" />
+      <div className="rounded-full bg-muted/40 p-4 mb-4">
+        <Shield className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
       </div>
-      <h3 className="text-lg font-bold text-slate-900 mb-2">Role Management Not Yet Implemented</h3>
-      <p className="text-sm text-slate-600 max-w-md mb-4">
+      <h3 className="text-lg font-bold text-foreground mb-2">Role Management Not Yet Implemented</h3>
+      <p className="text-sm text-muted-foreground max-w-md mb-4">
         Backend role and permission management infrastructure is not yet connected. The role matrix
         will be activated once the permission system is fully wired to this interface.
       </p>

--- a/packages/web/src/components/admin/AuditLogViewer.tsx
+++ b/packages/web/src/components/admin/AuditLogViewer.tsx
@@ -78,28 +78,28 @@ export function AuditLogViewer() {
         </div>
 
         {loading ? (
-          <div className="text-center py-8 text-slate-500 dark:text-slate-400">Loading...</div>
+          <div className="text-center py-8 text-muted-foreground dark:text-muted-foreground">Loading...</div>
         ) : (
           <div className="space-y-2 max-h-96 overflow-y-auto">
             {filteredLogs.map((log) => (
               <div
                 key={log.id}
-                className="p-3 border border-slate-200 dark:border-slate-700 rounded-lg text-sm"
+                className="p-3 border border-border dark:border-border rounded-lg text-sm"
               >
                 <div className="flex items-center justify-between mb-2">
                   <div className="flex items-center gap-2">
                     <Badge variant="outline">{log.action}</Badge>
-                    <span className="text-slate-600 dark:text-slate-400">{log.resource}</span>
+                    <span className="text-muted-foreground dark:text-muted-foreground">{log.resource}</span>
                   </div>
-                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                  <span className="text-xs text-muted-foreground dark:text-muted-foreground">
                     {new Date(log.timestamp).toLocaleString()}
                   </span>
                 </div>
-                <div className="text-xs text-slate-500 dark:text-slate-400">
+                <div className="text-xs text-muted-foreground dark:text-muted-foreground">
                   User: {log.userId} • IP: {log.ipAddress}
                 </div>
                 {log.details && (
-                  <div className="mt-2 text-xs text-slate-600 dark:text-slate-400">
+                  <div className="mt-2 text-xs text-muted-foreground dark:text-muted-foreground">
                     {log.details}
                   </div>
                 )}

--- a/packages/web/src/components/admin/UserImpersonation.tsx
+++ b/packages/web/src/components/admin/UserImpersonation.tsx
@@ -71,7 +71,7 @@ export function UserImpersonation() {
         )}
 
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
             placeholder="Search users by email or ID..."
             value={searchQuery}
@@ -80,7 +80,7 @@ export function UserImpersonation() {
           />
         </div>
 
-        <div className="text-sm text-slate-500 dark:text-slate-400">
+        <div className="text-sm text-muted-foreground dark:text-muted-foreground">
           Search for a user and click &quot;Impersonate&quot; to view their dashboard as them.
         </div>
       </CardContent>

--- a/packages/web/src/components/admin/ai-assist.tsx
+++ b/packages/web/src/components/admin/ai-assist.tsx
@@ -40,15 +40,15 @@ export function AIAssistCard({
 }: AIAssistProps) {
   if (!enabled) {
     return (
-      <Card className="border-slate-200 dark:border-slate-800">
+      <Card className="border-border dark:border-border">
         <CardContent className="pt-6">
-          <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400">
+          <div className="flex items-center gap-2 text-muted-foreground dark:text-muted-foreground">
             <Info className="w-4 h-4" />
             <span className="text-sm">
               AI Assist is disabled. Using deterministic baseline only.
             </span>
           </div>
-          <div className="mt-2 p-3 bg-slate-50 dark:bg-slate-900 rounded text-sm">
+          <div className="mt-2 p-3 bg-muted/20 dark:bg-background rounded text-sm">
             <strong>Baseline:</strong> {recommendation.deterministicBaseline}
           </div>
         </CardContent>
@@ -83,12 +83,12 @@ export function AIAssistCard({
         {/* Deterministic Baseline (Always Shown) */}
         <div>
           <div className="flex items-center gap-2 mb-2">
-            <CheckCircle2 className="w-4 h-4 text-slate-600 dark:text-slate-400" />
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+            <CheckCircle2 className="w-4 h-4 text-muted-foreground dark:text-muted-foreground" />
+            <span className="text-sm font-medium text-foreground dark:text-muted-foreground">
               Deterministic Baseline
             </span>
           </div>
-          <p className="text-sm text-slate-600 dark:text-slate-400 ml-6">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground ml-6">
             {recommendation.deterministicBaseline}
           </p>
         </div>
@@ -98,11 +98,11 @@ export function AIAssistCard({
           <div>
             <div className="flex items-center gap-2 mb-2">
               <Sparkles className="w-4 h-4 text-blue-600 dark:text-blue-400" />
-              <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              <span className="text-sm font-medium text-foreground dark:text-muted-foreground">
                 AI Enhancement
               </span>
             </div>
-            <p className="text-sm text-slate-600 dark:text-slate-400 ml-6">
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground ml-6">
               {recommendation.aiEnhancement}
             </p>
           </div>
@@ -111,27 +111,27 @@ export function AIAssistCard({
         {/* Explanation */}
         <div>
           <div className="flex items-center gap-2 mb-2">
-            <Info className="w-4 h-4 text-slate-600 dark:text-slate-400" />
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+            <Info className="w-4 h-4 text-muted-foreground dark:text-muted-foreground" />
+            <span className="text-sm font-medium text-foreground dark:text-muted-foreground">
               Explanation
             </span>
           </div>
-          <p className="text-sm text-slate-600 dark:text-slate-400 ml-6">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground ml-6">
             {recommendation.explanation}
           </p>
         </div>
 
         {/* Signals (Expandable) */}
         <details>
-          <summary className="text-sm font-medium text-slate-700 dark:text-slate-300 cursor-pointer mb-2">
+          <summary className="text-sm font-medium text-foreground dark:text-muted-foreground cursor-pointer mb-2">
             View Detection Signals
           </summary>
           <div className="mt-2 space-y-2 ml-4">
             {recommendation.signals.map((signal, idx) => (
               <div key={idx} className="flex items-center justify-between text-xs">
-                <span className="text-slate-600 dark:text-slate-400">{signal.name}:</span>
+                <span className="text-muted-foreground dark:text-muted-foreground">{signal.name}:</span>
                 <div className="flex items-center gap-2">
-                  <span className="font-mono text-slate-900 dark:text-white">{signal.value}</span>
+                  <span className="font-mono text-foreground dark:text-white">{signal.value}</span>
                   <Badge variant="outline" className="text-xs">
                     {signal.weight.toFixed(2)}
                   </Badge>
@@ -142,14 +142,14 @@ export function AIAssistCard({
         </details>
 
         {/* Suggested Action */}
-        <div className="pt-4 border-t border-slate-200 dark:border-slate-800">
+        <div className="pt-4 border-t border-border dark:border-border">
           <div className="flex items-center gap-2 mb-2">
-            <AlertCircle className="w-4 h-4 text-slate-600 dark:text-slate-400" />
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+            <AlertCircle className="w-4 h-4 text-muted-foreground dark:text-muted-foreground" />
+            <span className="text-sm font-medium text-foreground dark:text-muted-foreground">
               Suggested Action
             </span>
           </div>
-          <p className="text-sm text-slate-600 dark:text-slate-400 ml-6 mb-4">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground ml-6 mb-4">
             {recommendation.suggestedAction}
           </p>
           <div className="flex gap-2">
@@ -163,8 +163,8 @@ export function AIAssistCard({
         </div>
 
         {/* Disclaimer */}
-        <div className="pt-2 border-t border-slate-200 dark:border-slate-800">
-          <p className="text-xs text-slate-500 dark:text-slate-400">
+        <div className="pt-2 border-t border-border dark:border-border">
+          <p className="text-xs text-muted-foreground dark:text-muted-foreground">
             <strong>Note:</strong> AI recommendations are suggestions only. All actions are logged
             in the audit trail. You can always fall back to the deterministic baseline.
           </p>

--- a/packages/web/src/components/admin/empty-states.tsx
+++ b/packages/web/src/components/admin/empty-states.tsx
@@ -21,13 +21,13 @@ export function NoResultsEmptyState({ searchQuery }: { searchQuery?: string }) {
     <Card>
       <CardContent className="pt-12 pb-12">
         <div className="flex flex-col items-center text-center">
-          <div className="mb-4 text-slate-400 dark:text-slate-500">
+          <div className="mb-4 text-muted-foreground dark:text-muted-foreground">
             <Search className="w-12 h-12" />
           </div>
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">
+          <h3 className="text-lg font-semibold text-foreground dark:text-white mb-2">
             No results found
           </h3>
-          <p className="text-sm text-slate-500 dark:text-slate-400 max-w-sm mb-4">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground max-w-sm mb-4">
             {searchQuery
               ? `No items match "${searchQuery}". Try adjusting your search or filters.`
               : "No items found matching your criteria."}
@@ -46,13 +46,13 @@ export function NoExceptionsEmptyState() {
     <Card>
       <CardContent className="pt-12 pb-12">
         <div className="flex flex-col items-center text-center">
-          <div className="mb-4 text-slate-400 dark:text-slate-500">
+          <div className="mb-4 text-muted-foreground dark:text-muted-foreground">
             <AlertCircle className="w-12 h-12" />
           </div>
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">
+          <h3 className="text-lg font-semibold text-foreground dark:text-white mb-2">
             No exceptions
           </h3>
-          <p className="text-sm text-slate-500 dark:text-slate-400 max-w-sm mb-4">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground max-w-sm mb-4">
             The exception queue is empty. Exceptions appear here when mismatches are flagged for
             review.
           </p>
@@ -70,11 +70,11 @@ export function NoRunsEmptyState() {
     <Card>
       <CardContent className="pt-12 pb-12">
         <div className="flex flex-col items-center text-center">
-          <div className="mb-4 text-slate-400 dark:text-slate-500">
+          <div className="mb-4 text-muted-foreground dark:text-muted-foreground">
             <FileSearch className="w-12 h-12" />
           </div>
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">No runs yet</h3>
-          <p className="text-sm text-slate-500 dark:text-slate-400 max-w-sm mb-4">
+          <h3 className="text-lg font-semibold text-foreground dark:text-white mb-2">No runs yet</h3>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground max-w-sm mb-4">
             No reconciliation runs recorded. Trigger a run via the API or CLI to get started.
           </p>
         </div>
@@ -91,13 +91,13 @@ export function NoAuditEmptyState() {
     <Card>
       <CardContent className="pt-12 pb-12">
         <div className="flex flex-col items-center text-center">
-          <div className="mb-4 text-slate-400 dark:text-slate-500">
+          <div className="mb-4 text-muted-foreground dark:text-muted-foreground">
             <Inbox className="w-12 h-12" />
           </div>
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">
+          <h3 className="text-lg font-semibold text-foreground dark:text-white mb-2">
             No audit entries
           </h3>
-          <p className="text-sm text-slate-500 dark:text-slate-400 max-w-sm mb-4">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground max-w-sm mb-4">
             No audit trail entries found for the selected filters.
           </p>
         </div>

--- a/packages/web/src/components/admin/error-boundary.tsx
+++ b/packages/web/src/components/admin/error-boundary.tsx
@@ -66,7 +66,7 @@ export class AdminErrorBoundary extends Component<Props, State> {
       }
 
       return (
-        <div className="min-h-screen flex items-center justify-center p-4 bg-slate-50 dark:bg-slate-900">
+        <div className="min-h-screen flex items-center justify-center p-4 bg-muted/20 dark:bg-background">
           <Card className="max-w-md w-full">
             <CardHeader>
               <div className="flex items-center gap-3">
@@ -75,16 +75,16 @@ export class AdminErrorBoundary extends Component<Props, State> {
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
-              <p className="text-sm text-slate-600 dark:text-slate-400">
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                 An unexpected error occurred in the admin dashboard. Our team has been notified.
               </p>
               
               {process.env.NODE_ENV === 'development' && this.state.error && (
                 <details className="text-xs">
-                  <summary className="cursor-pointer text-slate-500 dark:text-slate-400 mb-2">
+                  <summary className="cursor-pointer text-muted-foreground dark:text-muted-foreground mb-2">
                     Error Details (Development Only)
                   </summary>
-                  <pre className="bg-slate-100 dark:bg-slate-800 p-3 rounded overflow-auto">
+                  <pre className="bg-muted/40 dark:bg-card p-3 rounded overflow-auto">
                     {this.state.error.toString()}
                     {this.state.errorInfo?.componentStack}
                   </pre>

--- a/packages/web/src/components/admin/loading-overlay.tsx
+++ b/packages/web/src/components/admin/loading-overlay.tsx
@@ -18,14 +18,14 @@ export function LoadingOverlay({ message = 'Loading...', fullScreen = false }: L
     <div
       className={`${
         fullScreen ? 'fixed inset-0' : 'absolute inset-0'
-      } bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm flex items-center justify-center z-50`}
+      } bg-card/80 dark:bg-background/80 backdrop-blur-sm flex items-center justify-center z-50`}
       role="status"
       aria-live="polite"
       aria-label={message}
     >
       <div className="flex flex-col items-center gap-4">
         <LoadingSpinner size="lg" />
-        <p className="text-sm text-slate-600 dark:text-slate-400">{message}</p>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground">{message}</p>
       </div>
     </div>
   );

--- a/packages/web/src/components/admin/microinteractions.tsx
+++ b/packages/web/src/components/admin/microinteractions.tsx
@@ -31,7 +31,7 @@ export function LoadingSpinner({
   return (
     <Loader2 
       className={cn(
-        'animate-spin text-slate-400',
+        'animate-spin text-muted-foreground',
         sizeClasses[size],
         className
       )} 
@@ -223,7 +223,7 @@ export function RippleButton({
       {ripples.map(ripple => (
         <span
           key={ripple.id}
-          className="absolute rounded-full bg-white/30 animate-ripple pointer-events-none"
+          className="absolute rounded-full bg-card/30 animate-ripple pointer-events-none"
           style={{
             left: ripple.x,
             top: ripple.y,

--- a/packages/web/src/components/admin/mobile-menu.tsx
+++ b/packages/web/src/components/admin/mobile-menu.tsx
@@ -49,15 +49,15 @@ export function MobileMenu({ children, className }: MobileMenuProps) {
           <nav
             id="mobile-menu"
             className={cn(
-              'fixed top-0 left-0 h-full w-64 bg-white dark:bg-slate-950 border-r border-slate-200 dark:border-slate-800 z-50 transform transition-transform duration-200 lg:hidden',
+              'fixed top-0 left-0 h-full w-64 bg-card dark:bg-slate-950 border-r border-border dark:border-border z-50 transform transition-transform duration-200 lg:hidden',
               isOpen ? 'translate-x-0' : '-translate-x-full',
               className
             )}
             aria-label="Mobile navigation"
           >
-            <div className="p-4 border-b border-slate-200 dark:border-slate-800">
+            <div className="p-4 border-b border-border dark:border-border">
               <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2 font-bold text-xl text-slate-900 dark:text-white">
+                <div className="flex items-center gap-2 font-bold text-xl text-foreground dark:text-white">
                   <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center text-white">S</div>
                   Settler Admin
                 </div>

--- a/packages/web/src/components/admin/trust-signals.tsx
+++ b/packages/web/src/components/admin/trust-signals.tsx
@@ -71,7 +71,7 @@ export function SystemStatusCard({ status }: { status: 'operational' | 'degraded
         <div className="flex items-center gap-3">
           <Icon className={`w-5 h-5 ${config.color}`} />
           <div>
-            <div className="text-sm font-medium text-slate-900 dark:text-white">
+            <div className="text-sm font-medium text-foreground dark:text-white">
               System Status
             </div>
             <div className={`text-xs ${config.color}`}>

--- a/packages/web/src/components/admin/urgency-indicators.tsx
+++ b/packages/web/src/components/admin/urgency-indicators.tsx
@@ -39,13 +39,13 @@ export function UsageWarning({
             isCritical ? 'text-red-600 dark:text-red-400' : 'text-yellow-600 dark:text-yellow-400'
           }`} />
           <div className="flex-1">
-            <div className="font-medium text-slate-900 dark:text-white mb-1">
+            <div className="font-medium text-foreground dark:text-white mb-1">
               {isCritical ? 'Critical' : 'Warning'}: {type === 'usage' ? 'Usage' : type === 'quota' ? 'Quota' : 'Rate'} Limit
             </div>
-            <div className="text-sm text-slate-600 dark:text-slate-400 mb-3">
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground mb-3">
               You've used {current.toLocaleString()} of {limit.toLocaleString()} ({percentage.toFixed(1)}%)
             </div>
-            <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2 mb-3">
+            <div className="w-full bg-slate-200 dark:bg-muted rounded-full h-2 mb-3">
               <div
                 className={`h-2 rounded-full transition-all ${
                   isCritical ? 'bg-red-600' : 'bg-yellow-600'
@@ -85,10 +85,10 @@ export function UpgradePrompt({
         <div className="flex items-start gap-3">
           <Zap className="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5" />
           <div className="flex-1">
-            <div className="font-medium text-slate-900 dark:text-white mb-1">
+            <div className="font-medium text-foreground dark:text-white mb-1">
               Unlock {feature}
             </div>
-            <div className="text-sm text-slate-600 dark:text-slate-400 mb-3">
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground mb-3">
               Upgrade from <strong>{currentTier}</strong> to <strong>{recommendedTier}</strong> to access this feature
             </div>
             <Link href="/console/billing">

--- a/packages/web/src/components/ai/AIAnomalyDetector.tsx
+++ b/packages/web/src/components/ai/AIAnomalyDetector.tsx
@@ -58,8 +58,8 @@ export function AIAnomalyDetector({ userId }: { userId?: string }) {
       <Card>
         <CardContent className="pt-6">
           <div className="animate-pulse space-y-4">
-            <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-3/4"></div>
-            <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-1/2"></div>
+            <div className="h-4 bg-slate-200 dark:bg-muted rounded w-3/4"></div>
+            <div className="h-4 bg-slate-200 dark:bg-muted rounded w-1/2"></div>
           </div>
         </CardContent>
       </Card>
@@ -75,7 +75,7 @@ export function AIAnomalyDetector({ userId }: { userId?: string }) {
           <CardContent className="pt-6">
             <div className="text-center py-8">
               <Activity className="w-12 h-12 text-green-600 mx-auto mb-4" />
-              <p className="text-slate-600 dark:text-slate-400">
+              <p className="text-muted-foreground dark:text-muted-foreground">
                 No anomalies detected. Everything looks good! ✅
               </p>
             </div>
@@ -138,7 +138,7 @@ export function AIAnomalyDetector({ userId }: { userId?: string }) {
                     </div>
                   </CardHeader>
                   <CardContent>
-                    <div className="text-xs text-slate-500 dark:text-slate-400">
+                    <div className="text-xs text-muted-foreground dark:text-muted-foreground">
                       Detected: {anomaly.detectedAt.toLocaleString()}
                     </div>
                   </CardContent>

--- a/packages/web/src/components/ai/AIOnboardingAssistant.tsx
+++ b/packages/web/src/components/ai/AIOnboardingAssistant.tsx
@@ -100,15 +100,15 @@ export function AIOnboardingAssistant() {
                   "max-w-[80%] rounded-lg p-3",
                   message.role === "user"
                     ? "bg-blue-600 text-white"
-                    : "bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-white"
+                    : "bg-muted/40 dark:bg-card text-foreground dark:text-white"
                 )}
               >
                 <p className="text-sm">{message.content}</p>
                 <p className="text-xs mt-1 opacity-70">{message.timestamp.toLocaleTimeString()}</p>
               </div>
               {message.role === "user" && (
-                <div className="w-8 h-8 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center flex-shrink-0">
-                  <User className="w-4 h-4 text-slate-600 dark:text-slate-400" />
+                <div className="w-8 h-8 rounded-full bg-muted/40 dark:bg-card flex items-center justify-center flex-shrink-0">
+                  <User className="w-4 h-4 text-muted-foreground dark:text-muted-foreground" />
                 </div>
               )}
             </div>
@@ -118,8 +118,8 @@ export function AIOnboardingAssistant() {
               <div className="w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center flex-shrink-0">
                 <Bot className="w-4 h-4 text-blue-600 dark:text-blue-400" />
               </div>
-              <div className="bg-slate-100 dark:bg-slate-800 rounded-lg p-3">
-                <Loader2 className="w-4 h-4 animate-spin text-slate-600 dark:text-slate-400" />
+              <div className="bg-muted/40 dark:bg-card rounded-lg p-3">
+                <Loader2 className="w-4 h-4 animate-spin text-muted-foreground dark:text-muted-foreground" />
               </div>
             </div>
           )}
@@ -127,7 +127,7 @@ export function AIOnboardingAssistant() {
         </div>
 
         {/* Input */}
-        <div className="border-t border-slate-200 dark:border-slate-700 p-4">
+        <div className="border-t border-border dark:border-border p-4">
           <div className="flex items-center gap-2">
             <Input
               value={input}

--- a/packages/web/src/components/ai/AITroubleshootingWizard.tsx
+++ b/packages/web/src/components/ai/AITroubleshootingWizard.tsx
@@ -130,7 +130,7 @@ export function AITroubleshootingWizard() {
       <CardContent className="space-y-6">
         <div>
           <div className="flex items-center justify-between mb-4">
-            <span className="text-sm text-slate-600 dark:text-slate-400">
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground">
               Step {currentStep + 1} of {TROUBLESHOOTING_FLOW.length}
             </span>
             <div className="flex gap-1">
@@ -150,7 +150,7 @@ export function AITroubleshootingWizard() {
             </div>
           </div>
 
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+          <h3 className="text-lg font-semibold text-foreground dark:text-white mb-4">
             {step.question}
           </h3>
 
@@ -159,7 +159,7 @@ export function AITroubleshootingWizard() {
               {step.options.map((option) => (
                 <div
                   key={option.value}
-                  className="flex items-center space-x-2 p-3 border border-slate-200 dark:border-slate-700 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800 cursor-pointer"
+                  className="flex items-center space-x-2 p-3 border border-border dark:border-border rounded-lg hover:bg-muted/20 dark:hover:bg-card cursor-pointer"
                   onClick={() => handleAnswer(option.value, option.nextStep)}
                 >
                   <RadioGroupItem value={option.value} id={option.value} />
@@ -167,7 +167,7 @@ export function AITroubleshootingWizard() {
                     {option.label}
                   </Label>
                   {option.nextStep !== undefined && (
-                    <ChevronRight className="w-4 h-4 text-slate-400" />
+                    <ChevronRight className="w-4 h-4 text-muted-foreground" />
                   )}
                 </div>
               ))}

--- a/packages/web/src/components/ai/SupportAssistant.tsx
+++ b/packages/web/src/components/ai/SupportAssistant.tsx
@@ -85,7 +85,7 @@ export function SupportAssistant({ context }: { context?: { page?: string; actio
               setResponse(null);
               setError(null);
             }}
-            className="text-white hover:bg-white/20 h-8 w-8 p-0"
+            className="text-white hover:bg-card/20 h-8 w-8 p-0"
           >
             <X className="h-4 w-4" />
           </Button>
@@ -130,14 +130,14 @@ export function SupportAssistant({ context }: { context?: { page?: string; actio
         {response && (
           <div className="space-y-4">
             <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 border border-blue-200 dark:border-blue-800">
-              <p className="text-sm text-slate-700 dark:text-slate-300 whitespace-pre-wrap">
+              <p className="text-sm text-foreground dark:text-muted-foreground whitespace-pre-wrap">
                 {response.answer}
               </p>
             </div>
 
             {response.suggestions && response.suggestions.length > 0 && (
               <div>
-                <p className="text-xs font-semibold text-slate-600 dark:text-slate-400 mb-2">
+                <p className="text-xs font-semibold text-muted-foreground dark:text-muted-foreground mb-2">
                   Quick Actions:
                 </p>
                 <div className="space-y-2">
@@ -158,7 +158,7 @@ export function SupportAssistant({ context }: { context?: { page?: string; actio
 
             {response.related_docs && response.related_docs.length > 0 && (
               <div>
-                <p className="text-xs font-semibold text-slate-600 dark:text-slate-400 mb-2 flex items-center gap-1">
+                <p className="text-xs font-semibold text-muted-foreground dark:text-muted-foreground mb-2 flex items-center gap-1">
                   <BookOpen className="h-3 w-3" />
                   Related Documentation:
                 </p>

--- a/packages/web/src/components/jobs/JobCompletionBanner.tsx
+++ b/packages/web/src/components/jobs/JobCompletionBanner.tsx
@@ -61,7 +61,7 @@ export function JobCompletionBanner({
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-2">
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+              <h3 className="text-lg font-semibold text-foreground dark:text-white">
                 {isHighAccuracy && !hasUnmatched
                   ? 'Reconciliation Complete'
                   : hasUnmatched
@@ -69,7 +69,7 @@ export function JobCompletionBanner({
                   : 'Reconciliation Complete'}
               </h3>
             </div>
-            <p className="text-slate-700 dark:text-slate-300 mb-4">
+            <p className="text-foreground dark:text-muted-foreground mb-4">
               <strong>{jobName}</strong> finished processing at {new Date(completedAt).toLocaleTimeString()}.
               {isHighAccuracy && !hasUnmatched ? (
                 <> All {matchedCount.toLocaleString()} transactions matched successfully with {accuracy}% accuracy.</>

--- a/packages/web/src/components/public-visual-proof.tsx
+++ b/packages/web/src/components/public-visual-proof.tsx
@@ -173,31 +173,31 @@ const packaging = [
 export function PlatformOverviewDiagram() {
   return (
     <section
-      className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+      className="rounded-2xl border border-border bg-card p-6 shadow-sm dark:border-slate-800 dark:bg-background"
       aria-label="Platform overview diagram"
     >
       <div className="mb-6">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400">
           System map
         </p>
-        <h2 className="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-100">
+        <h2 className="mt-2 text-2xl font-semibold text-foreground dark:text-slate-100">
           Platform overview: surfaces, control plane, and runtime boundary
         </h2>
       </div>
       <div className="space-y-4">
         {platformLayers.map((layer) => (
           <div key={layer.heading}>
-            <h3 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-300">
+            <h3 className="mb-3 text-sm font-semibold text-foreground dark:text-muted-foreground">
               {layer.heading}
             </h3>
             <div className="grid gap-3 md:grid-cols-3">
               {layer.nodes.map((node) => (
                 <article
                   key={node.title}
-                  className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-950/50"
+                  className="rounded-xl border border-border bg-muted/20 p-4 dark:border-border dark:bg-slate-950/50"
                 >
                   <div className="flex items-center justify-between gap-3">
-                    <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                    <p className="text-sm font-semibold text-foreground dark:text-slate-100">
                       {node.title}
                     </p>
                     {node.badge ? (
@@ -206,7 +206,7 @@ export function PlatformOverviewDiagram() {
                       </span>
                     ) : null}
                   </div>
-                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{node.detail}</p>
+                  <p className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground">{node.detail}</p>
                 </article>
               ))}
             </div>
@@ -220,12 +220,12 @@ export function PlatformOverviewDiagram() {
 export function WorkflowJourneyDiagram() {
   return (
     <section
-      className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+      className="rounded-2xl border border-border bg-card p-6 shadow-sm dark:border-slate-800 dark:bg-background"
       aria-label="Workflow journey diagram"
     >
       <div className="mb-6 flex items-center gap-3">
         <MonitorSmartphone className="h-5 w-5 text-blue-600" />
-        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+        <h2 className="text-2xl font-semibold text-foreground dark:text-slate-100">
           User, operator, and developer journey lanes
         </h2>
       </div>
@@ -233,23 +233,23 @@ export function WorkflowJourneyDiagram() {
         {journey.map((row) => (
           <div
             key={row.lane}
-            className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+            className="rounded-xl border border-border p-4 dark:border-border"
           >
-            <p className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
               {row.lane}
             </p>
             <div className="grid gap-3 md:grid-cols-4">
               {row.steps.map((step, index) => (
                 <div
                   key={step}
-                  className="flex items-center gap-2 rounded-lg bg-slate-50 p-3 text-sm dark:bg-slate-950/40"
+                  className="flex items-center gap-2 rounded-lg bg-muted/20 p-3 text-sm dark:bg-slate-950/40"
                 >
-                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white dark:bg-white dark:text-slate-900">
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-background text-xs font-semibold text-white dark:bg-card dark:text-foreground">
                     {index + 1}
                   </span>
-                  <span className="text-slate-700 dark:text-slate-300">{step}</span>
+                  <span className="text-foreground dark:text-muted-foreground">{step}</span>
                   {index < row.steps.length - 1 ? (
-                    <ArrowRight className="ml-auto h-4 w-4 text-slate-400" />
+                    <ArrowRight className="ml-auto h-4 w-4 text-muted-foreground" />
                   ) : null}
                 </div>
               ))}
@@ -264,22 +264,22 @@ export function WorkflowJourneyDiagram() {
 export function CapabilityMap() {
   return (
     <section
-      className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+      className="rounded-2xl border border-border bg-card p-6 shadow-sm dark:border-slate-800 dark:bg-background"
       aria-label="Capability map"
     >
-      <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+      <h2 className="text-2xl font-semibold text-foreground dark:text-slate-100">
         Capability map grounded in shipped surfaces
       </h2>
       <div className="mt-5 grid gap-4 md:grid-cols-2">
         {capabilityClusters.map((cluster) => (
           <article
             key={cluster.title}
-            className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+            className="rounded-xl border border-border p-4 dark:border-border"
           >
-            <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+            <h3 className="text-base font-semibold text-foreground dark:text-slate-100">
               {cluster.title}
             </h3>
-            <ul className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-400">
+            <ul className="mt-3 space-y-2 text-sm text-muted-foreground dark:text-muted-foreground">
               {cluster.bullets.map((bullet) => (
                 <li key={bullet} className="flex gap-2">
                   <span aria-hidden>•</span>
@@ -297,8 +297,8 @@ export function CapabilityMap() {
 export function IntegrationAndPackagingMap() {
   return (
     <section className="grid gap-6 lg:grid-cols-2" aria-label="Integration and packaging maps">
-      <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+      <article className="rounded-2xl border border-border bg-card p-6 shadow-sm dark:border-slate-800 dark:bg-background">
+        <h2 className="text-2xl font-semibold text-foreground dark:text-slate-100">
           Integration surface map
         </h2>
         <div className="mt-5 space-y-3">
@@ -307,27 +307,27 @@ export function IntegrationAndPackagingMap() {
             return (
               <div
                 key={item.label}
-                className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+                className="rounded-xl border border-border p-4 dark:border-border"
               >
                 <div className="flex items-center gap-3">
                   <Icon className="h-4 w-4 text-blue-600" />
-                  <p className="font-semibold text-slate-900 dark:text-slate-100">{item.label}</p>
+                  <p className="font-semibold text-foreground dark:text-slate-100">{item.label}</p>
                 </div>
-                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{item.detail}</p>
+                <p className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground">{item.detail}</p>
               </div>
             );
           })}
         </div>
       </article>
 
-      <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <article className="rounded-2xl border border-border bg-card p-6 shadow-sm dark:border-slate-800 dark:bg-background">
         <div className="flex items-center gap-2">
           <Lock className="h-4 w-4 text-emerald-600" />
-          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+          <h2 className="text-2xl font-semibold text-foreground dark:text-slate-100">
             Packaging boundary map
           </h2>
         </div>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+        <p className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground">
           Boundaries are based on repository packages and current public route structure.
         </p>
         <div className="mt-5 space-y-3">
@@ -336,14 +336,14 @@ export function IntegrationAndPackagingMap() {
             return (
               <div
                 key={item.title}
-                className="rounded-xl border border-slate-200 p-4 dark:border-slate-700"
+                className="rounded-xl border border-border p-4 dark:border-border"
               >
                 <div className="flex items-center gap-3">
-                  <Icon className="h-4 w-4 text-slate-700 dark:text-slate-300" />
-                  <p className="font-semibold text-slate-900 dark:text-slate-100">{item.title}</p>
+                  <Icon className="h-4 w-4 text-foreground dark:text-muted-foreground" />
+                  <p className="font-semibold text-foreground dark:text-slate-100">{item.title}</p>
                 </div>
-                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{item.detail}</p>
-                <p className="mt-2 text-xs text-slate-500 dark:text-slate-500">
+                <p className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground">{item.detail}</p>
+                <p className="mt-2 text-xs text-muted-foreground dark:text-muted-foreground">
                   {item.routes.join(" · ")}
                 </p>
               </div>
@@ -358,7 +358,7 @@ export function IntegrationAndPackagingMap() {
 export function VisualProofCTA() {
   return (
     <div className="rounded-2xl border border-blue-200 bg-blue-50 p-5 dark:border-blue-900/40 dark:bg-blue-950/30">
-      <p className="text-sm text-slate-700 dark:text-slate-300">
+      <p className="text-sm text-foreground dark:text-muted-foreground">
         Want deeper implementation proof? See{" "}
         <Link href="/architecture" className="font-semibold text-blue-700 dark:text-blue-300">
           architecture

--- a/packages/web/src/components/shared/ReasonForChangeDialog.tsx
+++ b/packages/web/src/components/shared/ReasonForChangeDialog.tsx
@@ -44,12 +44,12 @@ export function ReasonForChangeDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="text-xl font-bold">{title}</DialogTitle>
-          <DialogDescription className="text-slate-500">
+          <DialogDescription className="text-muted-foreground">
             {description}
           </DialogDescription>
         </DialogHeader>
         <div className="py-4">
-          <label htmlFor="reason" className="text-sm font-semibold text-slate-700 mb-2 block">
+          <label htmlFor="reason" className="text-sm font-semibold text-foreground mb-2 block">
             Reason for change
           </label>
           <Textarea
@@ -57,11 +57,11 @@ export function ReasonForChangeDialog({
             placeholder="Describe why you are making this change..."
             value={reason}
             onChange={(e) => setReason(e.target.value)}
-            className="min-h-[120px] resize-none focus:ring-primary-500 border-slate-200"
+            className="min-h-[120px] resize-none focus:ring-primary-500 border-border"
             autoFocus
           />
-          <p className="mt-2 text-[11px] text-slate-400 italic">
-            This action will be recorded in the audit trail with Trace ID: <span className="font-mono bg-slate-100 px-1 rounded">TRC-{Math.random().toString(36).substring(7).toUpperCase()}</span>
+          <p className="mt-2 text-[11px] text-muted-foreground italic">
+            This action will be recorded in the audit trail with Trace ID: <span className="font-mono bg-muted/40 px-1 rounded">TRC-{Math.random().toString(36).substring(7).toUpperCase()}</span>
           </p>
         </div>
         <DialogFooter className="gap-2 sm:gap-0">

--- a/packages/web/src/components/shared/error-boundary.tsx
+++ b/packages/web/src/components/shared/error-boundary.tsx
@@ -74,16 +74,16 @@ export class ErrorBoundary extends Component<Props, State> {
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
-              <p className="text-sm text-slate-600 dark:text-slate-400">
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground">
                 An unexpected error occurred. Our team has been notified.
               </p>
               
               {process.env.NODE_ENV === 'development' && this.state.error && (
                 <details className="text-xs">
-                  <summary className="cursor-pointer text-slate-500 dark:text-slate-400 mb-2">
+                  <summary className="cursor-pointer text-muted-foreground dark:text-muted-foreground mb-2">
                     Error Details (Development Only)
                   </summary>
-                  <pre className="bg-slate-100 dark:bg-slate-800 p-3 rounded overflow-auto">
+                  <pre className="bg-muted/40 dark:bg-card p-3 rounded overflow-auto">
                     {this.state.error.toString()}
                   </pre>
                 </details>

--- a/packages/web/src/components/shared/loading-state.tsx
+++ b/packages/web/src/components/shared/loading-state.tsx
@@ -47,7 +47,7 @@ export function InlineLoading({ message = "Loading..." }: { message?: string }) 
     <div className="flex items-center justify-center py-8" role="status" aria-live="polite">
       <div className="flex flex-col items-center gap-3">
         <LoadingSpinner size="md" aria-label={message} />
-        <p className="text-sm text-slate-600 dark:text-slate-400">{message}</p>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground">{message}</p>
       </div>
     </div>
   );

--- a/packages/web/src/components/shared/urgency-banner.tsx
+++ b/packages/web/src/components/shared/urgency-banner.tsx
@@ -37,10 +37,10 @@ export function LimitedTimeBanner({
         <div className="flex items-start gap-3">
           <Clock className="w-5 h-5 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
           <div className="flex-1">
-            <div className="font-medium text-slate-900 dark:text-white mb-1">
+            <div className="font-medium text-foreground dark:text-white mb-1">
               Limited Time Offer
             </div>
-            <div className="text-sm text-slate-600 dark:text-slate-400 mb-3">
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground mb-3">
               {message || `This offer expires in ${timeText}.`}
             </div>
             <Link href="/pricing">
@@ -71,10 +71,10 @@ export function UpgradePromptBanner({
         <div className="flex items-start gap-3">
           <Zap className="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" />
           <div className="flex-1">
-            <div className="font-medium text-slate-900 dark:text-white mb-1">
+            <div className="font-medium text-foreground dark:text-white mb-1">
               Unlock {feature}
             </div>
-            <div className="text-sm text-slate-600 dark:text-slate-400 mb-3">
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground mb-3">
               Upgrade from <strong>{currentTier}</strong> to <strong>{recommendedTier}</strong> to access this feature.
             </div>
             <Link href="/console/billing">

--- a/packages/web/src/components/stitch-import/ArchitectureOverview.tsx
+++ b/packages/web/src/components/stitch-import/ArchitectureOverview.tsx
@@ -2,21 +2,21 @@ import React from "react";
 
 const ArchitectureOverview: React.FC = () => {
   return (
-    <div className="bg-background-light dark:bg-background-dark font-display text-slate-900 dark:text-slate-100 antialiased overflow-x-hidden">
+    <div className="bg-background-light dark:bg-background-dark font-display text-foreground text-muted-foreground antialiased overflow-x-hidden">
       <div className="relative flex min-h-screen w-full flex-col max-w-md mx-auto shadow-2xl overflow-hidden bg-background-light dark:bg-background-dark">
         {/* Header / Navigation */}
-        <div className="sticky top-0 z-50 bg-background-light/80 dark:bg-background-dark/80 backdrop-blur-md border-b border-slate-200 dark:border-slate-800">
+        <div className="sticky top-0 z-50 bg-background-light/80 dark:bg-background-dark/80 backdrop-blur-md border-b border-border dark:border-border">
           <div className="flex items-center justify-between p-4">
-            <button className="p-2 -ml-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">
-              <span className="material-symbols-outlined text-slate-600 dark:text-slate-300">
+            <button className="p-2 -ml-2 rounded-full hover:bg-muted/40 dark:hover:bg-card transition-colors">
+              <span className="material-symbols-outlined text-muted-foreground dark:text-muted-foreground">
                 arrow_back
               </span>
             </button>
-            <h1 className="text-base font-semibold text-slate-900 dark:text-white">
+            <h1 className="text-base font-semibold text-foreground dark:text-white">
               Technical Architecture
             </h1>
-            <button className="p-2 -mr-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">
-              <span className="material-symbols-outlined text-slate-600 dark:text-slate-300">
+            <button className="p-2 -mr-2 rounded-full hover:bg-muted/40 dark:hover:bg-card transition-colors">
+              <span className="material-symbols-outlined text-muted-foreground dark:text-muted-foreground">
                 more_vert
               </span>
             </button>
@@ -30,10 +30,10 @@ const ArchitectureOverview: React.FC = () => {
               <span className="w-2 h-2 rounded-full bg-primary animate-pulse"></span>
               <span className="text-xs font-medium text-primary">System Online • v2.4.0</span>
             </div>
-            <h2 className="text-3xl font-bold tracking-tight mb-2 text-slate-900 dark:text-white">
+            <h2 className="text-3xl font-bold tracking-tight mb-2 text-foreground dark:text-white">
               System Architecture
             </h2>
-            <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
+            <p className="text-muted-foreground dark:text-muted-foreground text-sm leading-relaxed">
               Transparent, secure, and scalable design. Follow the flow below to understand how we
               process your data from ingestion to actionable artifacts.
             </p>
@@ -44,29 +44,29 @@ const ArchitectureOverview: React.FC = () => {
             <div className="absolute left-[38px] top-4 bottom-4 w-[2px] bg-gradient-to-b from-primary/20 via-primary/50 to-primary/20"></div>
             {/* Step 1: Connections */}
             <div className="relative flex gap-4 mb-8 group cursor-pointer">
-              <div className="relative z-10 flex-shrink-0 w-10 h-10 rounded-full bg-surface-dark border border-slate-700 flex items-center justify-center shadow-lg group-hover:border-primary group-hover:bg-primary/10 transition-all duration-300">
+              <div className="relative z-10 flex-shrink-0 w-10 h-10 rounded-full bg-surface-dark border border-border flex items-center justify-center shadow-lg group-hover:border-primary group-hover:bg-primary/10 transition-all duration-300">
                 <span className="material-symbols-outlined text-primary text-[20px]">hub</span>
               </div>
-              <div className="flex-1 pt-1 pb-4 border-b border-slate-200 dark:border-slate-800/50">
+              <div className="flex-1 pt-1 pb-4 border-b border-border dark:border-border/50">
                 <div className="flex justify-between items-start">
                   <div>
-                    <h3 className="text-base font-semibold text-slate-900 dark:text-white group-hover:text-primary transition-colors">
+                    <h3 className="text-base font-semibold text-foreground dark:text-white group-hover:text-primary transition-colors">
                       Connections
                     </h3>
-                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                    <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-1">
                       Secure ingestion from external sources.
                     </p>
                   </div>
-                  <span className="material-symbols-outlined text-slate-400 text-lg opacity-0 group-hover:opacity-100 transition-opacity -rotate-90 sm:rotate-0">
+                  <span className="material-symbols-outlined text-muted-foreground text-lg opacity-0 group-hover:opacity-100 transition-opacity -rotate-90 sm:rotate-0">
                     chevron_right
                   </span>
                 </div>
                 {/* Micro-interaction / Detail hint */}
                 <div className="mt-3 flex gap-2">
-                  <span className="px-2 py-0.5 text-[10px] uppercase tracking-wider font-semibold rounded bg-slate-200 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
+                  <span className="px-2 py-0.5 text-[10px] uppercase tracking-wider font-semibold rounded bg-slate-200 dark:bg-card text-muted-foreground dark:text-muted-foreground">
                     REST API
                   </span>
-                  <span className="px-2 py-0.5 text-[10px] uppercase tracking-wider font-semibold rounded bg-slate-200 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
+                  <span className="px-2 py-0.5 text-[10px] uppercase tracking-wider font-semibold rounded bg-slate-200 dark:bg-card text-muted-foreground dark:text-muted-foreground">
                     Webhooks
                   </span>
                 </div>
@@ -74,29 +74,29 @@ const ArchitectureOverview: React.FC = () => {
             </div>
             {/* Step 2: Canonical Primitives */}
             <div className="relative flex gap-4 mb-8 group cursor-pointer">
-              <div className="relative z-10 flex-shrink-0 w-10 h-10 rounded-full bg-surface-dark border border-slate-700 flex items-center justify-center shadow-lg group-hover:border-primary group-hover:bg-primary/10 transition-all duration-300">
+              <div className="relative z-10 flex-shrink-0 w-10 h-10 rounded-full bg-surface-dark border border-border flex items-center justify-center shadow-lg group-hover:border-primary group-hover:bg-primary/10 transition-all duration-300">
                 <span className="material-symbols-outlined text-primary text-[20px]">
                   deployed_code
                 </span>
               </div>
-              <div className="flex-1 pt-1 pb-4 border-b border-slate-200 dark:border-slate-800/50">
+              <div className="flex-1 pt-1 pb-4 border-b border-border dark:border-border/50">
                 <div className="flex justify-between items-start">
                   <div>
-                    <h3 className="text-base font-semibold text-slate-900 dark:text-white group-hover:text-primary transition-colors">
+                    <h3 className="text-base font-semibold text-foreground dark:text-white group-hover:text-primary transition-colors">
                       Canonical Primitives
                     </h3>
-                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                    <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-1">
                       Standardizing raw data into usable blocks.
                     </p>
                   </div>
-                  <span className="material-symbols-outlined text-slate-400 text-lg opacity-0 group-hover:opacity-100 transition-opacity -rotate-90 sm:rotate-0">
+                  <span className="material-symbols-outlined text-muted-foreground text-lg opacity-0 group-hover:opacity-100 transition-opacity -rotate-90 sm:rotate-0">
                     chevron_right
                   </span>
                 </div>
-                <div className="mt-3 bg-slate-900/50 rounded p-2 border border-slate-800/50">
+                <div className="mt-3 bg-background/50 rounded p-2 border border-border/50">
                   <div className="flex items-center gap-2">
                     <span className="w-1.5 h-1.5 rounded-full bg-green-500"></span>
-                    <span className="text-[10px] font-mono text-slate-400">
+                    <span className="text-[10px] font-mono text-muted-foreground">
                       Normalizing data structures...
                     </span>
                   </div>
@@ -105,7 +105,7 @@ const ArchitectureOverview: React.FC = () => {
             </div>
             {/* Step 3: Artifacts */}
             <div className="relative flex gap-4 mb-2 group cursor-pointer">
-              <div className="relative z-10 flex-shrink-0 w-10 h-10 rounded-full bg-surface-dark border border-slate-700 flex items-center justify-center shadow-lg group-hover:border-primary group-hover:bg-primary/10 transition-all duration-300">
+              <div className="relative z-10 flex-shrink-0 w-10 h-10 rounded-full bg-surface-dark border border-border flex items-center justify-center shadow-lg group-hover:border-primary group-hover:bg-primary/10 transition-all duration-300">
                 <span className="material-symbols-outlined text-primary text-[20px]">
                   description
                 </span>
@@ -113,14 +113,14 @@ const ArchitectureOverview: React.FC = () => {
               <div className="flex-1 pt-1 pb-2">
                 <div className="flex justify-between items-start">
                   <div>
-                    <h3 className="text-base font-semibold text-slate-900 dark:text-white group-hover:text-primary transition-colors">
+                    <h3 className="text-base font-semibold text-foreground dark:text-white group-hover:text-primary transition-colors">
                       Artifacts
                     </h3>
-                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                    <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-1">
                       Generating actionable outputs &amp; reports.
                     </p>
                   </div>
-                  <span className="material-symbols-outlined text-slate-400 text-lg opacity-0 group-hover:opacity-100 transition-opacity -rotate-90 sm:rotate-0">
+                  <span className="material-symbols-outlined text-muted-foreground text-lg opacity-0 group-hover:opacity-100 transition-opacity -rotate-90 sm:rotate-0">
                     chevron_right
                   </span>
                 </div>
@@ -136,11 +136,11 @@ const ArchitectureOverview: React.FC = () => {
             </div>
           </div>
           {/* Divider */}
-          <div className="h-px bg-slate-200 dark:bg-slate-800 my-8 mx-5"></div>
+          <div className="h-px bg-slate-200 dark:bg-card my-8 mx-5"></div>
           {/* Security Section */}
           <div className="px-5">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-xl font-bold text-slate-900 dark:text-white">Security Posture</h2>
+              <h2 className="text-xl font-bold text-foreground dark:text-white">Security Posture</h2>
               <a
                 className="text-xs font-medium text-primary hover:text-primary/80"
                 href="/security-and-audit"
@@ -150,16 +150,16 @@ const ArchitectureOverview: React.FC = () => {
             </div>
             <div className="grid grid-cols-1 gap-4">
               {/* Security Card 1 */}
-              <div className="p-4 rounded-xl bg-white dark:bg-surface-dark border border-slate-200 dark:border-slate-800 shadow-sm">
+              <div className="p-4 rounded-xl bg-card dark:bg-surface-dark border border-border dark:border-border shadow-sm">
                 <div className="flex items-start gap-3">
                   <div className="p-2 rounded-lg bg-indigo-500/10 text-indigo-500 dark:text-indigo-400">
                     <span className="material-symbols-outlined text-[24px]">lock_person</span>
                   </div>
                   <div>
-                    <h4 className="font-semibold text-sm text-slate-900 dark:text-white">
+                    <h4 className="font-semibold text-sm text-foreground dark:text-white">
                       Tenant Isolation
                     </h4>
-                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 leading-relaxed">
+                    <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-1 leading-relaxed">
                       Logical separation of customer data ensures your information remains private,
                       even in a multi-tenant environment.
                     </p>
@@ -167,16 +167,16 @@ const ArchitectureOverview: React.FC = () => {
                 </div>
               </div>
               {/* Security Card 2 */}
-              <div className="p-4 rounded-xl bg-white dark:bg-surface-dark border border-slate-200 dark:border-slate-800 shadow-sm">
+              <div className="p-4 rounded-xl bg-card dark:bg-surface-dark border border-border dark:border-border shadow-sm">
                 <div className="flex items-start gap-3">
                   <div className="p-2 rounded-lg bg-emerald-500/10 text-emerald-500 dark:text-emerald-400">
                     <span className="material-symbols-outlined text-[24px]">history_edu</span>
                   </div>
                   <div>
-                    <h4 className="font-semibold text-sm text-slate-900 dark:text-white">
+                    <h4 className="font-semibold text-sm text-foreground dark:text-white">
                       Full Auditability
                     </h4>
-                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 leading-relaxed">
+                    <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-1 leading-relaxed">
                       Immutable logs for all system actions. Every read, write, and modification is
                       tracked with timestamp precision.
                     </p>
@@ -185,19 +185,19 @@ const ArchitectureOverview: React.FC = () => {
               </div>
               {/* Trust Badges */}
               <div className="grid grid-cols-2 gap-3 mt-2">
-                <div className="flex items-center justify-center gap-2 p-3 rounded-lg border border-slate-200 dark:border-slate-700/50 bg-slate-50 dark:bg-slate-800/30">
-                  <span className="material-symbols-outlined text-slate-400 text-[18px]">
+                <div className="flex items-center justify-center gap-2 p-3 rounded-lg border border-border dark:border-border/50 bg-muted/20 dark:bg-card/30">
+                  <span className="material-symbols-outlined text-muted-foreground text-[18px]">
                     verified_user
                   </span>
-                  <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">
+                  <span className="text-xs font-semibold text-muted-foreground dark:text-muted-foreground">
                     SOC2 Type II
                   </span>
                 </div>
-                <div className="flex items-center justify-center gap-2 p-3 rounded-lg border border-slate-200 dark:border-slate-700/50 bg-slate-50 dark:bg-slate-800/30">
-                  <span className="material-symbols-outlined text-slate-400 text-[18px]">
+                <div className="flex items-center justify-center gap-2 p-3 rounded-lg border border-border dark:border-border/50 bg-muted/20 dark:bg-card/30">
+                  <span className="material-symbols-outlined text-muted-foreground text-[18px]">
                     shield
                   </span>
-                  <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">
+                  <span className="text-xs font-semibold text-muted-foreground dark:text-muted-foreground">
                     ISO 27001
                   </span>
                 </div>
@@ -206,13 +206,13 @@ const ArchitectureOverview: React.FC = () => {
           </div>
           {/* CTA Section */}
           <div className="mt-8 px-5 pb-6">
-            <div className="rounded-xl bg-gradient-to-br from-surface-dark to-slate-900 border border-slate-800 p-5 relative overflow-hidden">
+            <div className="rounded-xl bg-gradient-to-br from-surface-dark to-slate-900 border border-border p-5 relative overflow-hidden">
               {/* Abstract Background Pattern */}
               <div className="absolute top-0 right-0 w-32 h-32 bg-primary/20 rounded-full blur-3xl -mr-10 -mt-10"></div>
               <h3 className="relative text-white font-semibold text-sm mb-1">
                 Need technical due diligence?
               </h3>
-              <p className="relative text-slate-400 text-xs mb-4">
+              <p className="relative text-muted-foreground text-xs mb-4">
                 Contact our engineering team for deep dives.
               </p>
               <button className="relative w-full py-2.5 px-4 bg-primary hover:bg-primary/90 text-white text-sm font-medium rounded-lg transition-colors flex items-center justify-center gap-2">

--- a/packages/web/src/components/stitch-import/ConnectionDrawer.tsx
+++ b/packages/web/src/components/stitch-import/ConnectionDrawer.tsx
@@ -6,109 +6,109 @@ import { CheckCircle, X, Copy, Clock, Pencil, ChevronUp, ChevronDown, Play } fro
 const ConnectionDrawer: React.FC = () => {
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center pointer-events-none">
-      <div className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm pointer-events-auto"></div>
-      <div className="bg-white w-full max-w-md rounded-t-3xl shadow-2xl pointer-events-auto flex flex-col max-h-[90vh] relative animate-in slide-in-from-bottom duration-300">
+      <div className="absolute inset-0 bg-background/40 backdrop-blur-sm pointer-events-auto"></div>
+      <div className="bg-card w-full max-w-md rounded-t-3xl shadow-2xl pointer-events-auto flex flex-col max-h-[90vh] relative animate-in slide-in-from-bottom duration-300">
         <div className="w-full flex justify-center pt-3 pb-1 cursor-grab active:cursor-grabbing">
           <div className="w-12 h-1.5 rounded-full bg-slate-200"></div>
         </div>
         <div className="px-6 pt-2 pb-4 border-b border-slate-100 flex items-start justify-between">
           <div>
-            <h2 className="text-xl font-bold text-slate-900">Stripe Payments</h2>
+            <h2 className="text-xl font-bold text-foreground">Stripe Payments</h2>
             <div className="flex items-center gap-2 mt-1">
               <CheckCircle className="h-5 w-5 text-emerald-600" />
-              <span className="text-sm font-medium text-slate-600">
+              <span className="text-sm font-medium text-muted-foreground">
                 Healthy • Last synced 2m ago
               </span>
             </div>
           </div>
-          <button className="p-2 -mr-2 text-slate-400 hover:text-slate-600 bg-slate-50 hover:bg-slate-100 rounded-full transition-colors">
+          <button className="p-2 -mr-2 text-muted-foreground hover:text-muted-foreground bg-muted/20 hover:bg-muted/40 rounded-full transition-colors">
             <X className="h-6 w-6" />
           </button>
         </div>
         <div className="overflow-y-auto p-6 space-y-6">
           <div className="space-y-3">
             <div className="flex items-center justify-between">
-              <h3 className="text-xs font-bold uppercase text-slate-500 tracking-wider">
+              <h3 className="text-xs font-bold uppercase text-muted-foreground tracking-wider">
                 Credentials
               </h3>
               <button className="text-primary text-sm font-semibold hover:underline">Edit</button>
             </div>
-            <div className="bg-slate-50 rounded-lg p-3 border border-slate-200 flex items-center justify-between group">
+            <div className="bg-muted/20 rounded-lg p-3 border border-border flex items-center justify-between group">
               <div className="flex flex-col gap-1">
-                <span className="text-xs font-semibold text-slate-500">API Key</span>
-                <span className="font-mono text-sm text-slate-700">sk_live_••••••••••••••••</span>
+                <span className="text-xs font-semibold text-muted-foreground">API Key</span>
+                <span className="font-mono text-sm text-foreground">sk_live_••••••••••••••••</span>
               </div>
-              <button className="opacity-0 group-hover:opacity-100 transition-opacity text-slate-400 hover:text-primary">
+              <button className="opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-primary">
                 <Copy className="h-5 w-5" />
               </button>
             </div>
-            <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
+            <div className="bg-muted/20 rounded-lg p-3 border border-border">
               <div className="flex flex-col gap-1">
-                <span className="text-xs font-semibold text-slate-500">Environment</span>
-                <span className="font-mono text-sm text-slate-700">Production</span>
+                <span className="text-xs font-semibold text-muted-foreground">Environment</span>
+                <span className="font-mono text-sm text-foreground">Production</span>
               </div>
             </div>
           </div>
           <div className="space-y-3">
-            <h3 className="text-xs font-bold uppercase text-slate-500 tracking-wider">
+            <h3 className="text-xs font-bold uppercase text-muted-foreground tracking-wider">
               Sync Schedule
             </h3>
-            <div className="flex items-center gap-3 bg-slate-50 p-3 rounded-lg border border-slate-200">
-              <div className="w-10 h-10 rounded-lg bg-white border border-slate-200 shadow-sm flex items-center justify-center text-primary">
+            <div className="flex items-center gap-3 bg-muted/20 p-3 rounded-lg border border-border">
+              <div className="w-10 h-10 rounded-lg bg-card border border-border shadow-sm flex items-center justify-center text-primary">
                 <Clock className="h-5 w-5" />
               </div>
               <div>
-                <p className="text-sm font-semibold text-slate-900">Daily at 00:00 UTC</p>
-                <p className="text-xs text-slate-500 font-medium">Next run in 14h 32m</p>
+                <p className="text-sm font-semibold text-foreground">Daily at 00:00 UTC</p>
+                <p className="text-xs text-muted-foreground font-medium">Next run in 14h 32m</p>
               </div>
-              <button className="ml-auto text-slate-400 hover:text-primary transition-colors">
+              <button className="ml-auto text-muted-foreground hover:text-primary transition-colors">
                 <Pencil className="h-5 w-5" />
               </button>
             </div>
           </div>
           <div className="space-y-3">
-            <h3 className="text-xs font-bold uppercase text-slate-500 tracking-wider">
+            <h3 className="text-xs font-bold uppercase text-muted-foreground tracking-wider">
               Schema Preview
             </h3>
-            <div className="border border-slate-200 rounded-lg overflow-hidden shadow-sm">
-              <div className="bg-white px-3 py-3 border-b border-slate-100 flex justify-between items-center cursor-pointer hover:bg-slate-50 transition-colors">
-                <span className="text-sm font-semibold font-mono text-slate-700">Charges</span>
-                <ChevronUp className="h-5 w-5 text-slate-400" />
+            <div className="border border-border rounded-lg overflow-hidden shadow-sm">
+              <div className="bg-card px-3 py-3 border-b border-slate-100 flex justify-between items-center cursor-pointer hover:bg-muted/20 transition-colors">
+                <span className="text-sm font-semibold font-mono text-foreground">Charges</span>
+                <ChevronUp className="h-5 w-5 text-muted-foreground" />
               </div>
-              <div className="bg-slate-50 p-3 space-y-2 border-b border-slate-100">
+              <div className="bg-muted/20 p-3 space-y-2 border-b border-slate-100">
                 <div className="flex justify-between items-center text-xs">
-                  <span className="font-mono font-medium text-slate-600">id</span>
-                  <span className="px-1.5 py-0.5 rounded bg-white border border-slate-200 text-slate-500 font-mono text-[10px]">
+                  <span className="font-mono font-medium text-muted-foreground">id</span>
+                  <span className="px-1.5 py-0.5 rounded bg-card border border-border text-muted-foreground font-mono text-[10px]">
                     string
                   </span>
                 </div>
                 <div className="flex justify-between items-center text-xs">
-                  <span className="font-mono font-medium text-slate-600">amount</span>
-                  <span className="px-1.5 py-0.5 rounded bg-white border border-slate-200 text-slate-500 font-mono text-[10px]">
+                  <span className="font-mono font-medium text-muted-foreground">amount</span>
+                  <span className="px-1.5 py-0.5 rounded bg-card border border-border text-muted-foreground font-mono text-[10px]">
                     integer
                   </span>
                 </div>
                 <div className="flex justify-between items-center text-xs">
-                  <span className="font-mono font-medium text-slate-600">currency</span>
-                  <span className="px-1.5 py-0.5 rounded bg-white border border-slate-200 text-slate-500 font-mono text-[10px]">
+                  <span className="font-mono font-medium text-muted-foreground">currency</span>
+                  <span className="px-1.5 py-0.5 rounded bg-card border border-border text-muted-foreground font-mono text-[10px]">
                     string
                   </span>
                 </div>
               </div>
-              <div className="bg-white px-3 py-3 border-b border-slate-100 flex justify-between items-center cursor-pointer hover:bg-slate-50 transition-colors">
-                <span className="text-sm font-semibold font-mono text-slate-700">Refunds</span>
-                <ChevronDown className="h-5 w-5 text-slate-400" />
+              <div className="bg-card px-3 py-3 border-b border-slate-100 flex justify-between items-center cursor-pointer hover:bg-muted/20 transition-colors">
+                <span className="text-sm font-semibold font-mono text-foreground">Refunds</span>
+                <ChevronDown className="h-5 w-5 text-muted-foreground" />
               </div>
-              <div className="bg-white px-3 py-3 flex justify-between items-center cursor-pointer hover:bg-slate-50 transition-colors">
-                <span className="text-sm font-semibold font-mono text-slate-700">Customers</span>
-                <ChevronDown className="h-5 w-5 text-slate-400" />
+              <div className="bg-card px-3 py-3 flex justify-between items-center cursor-pointer hover:bg-muted/20 transition-colors">
+                <span className="text-sm font-semibold font-mono text-foreground">Customers</span>
+                <ChevronDown className="h-5 w-5 text-muted-foreground" />
               </div>
             </div>
           </div>
           <div className="h-24"></div>
         </div>
-        <div className="absolute bottom-0 left-0 right-0 p-4 bg-white border-t border-slate-200 rounded-b-3xl flex gap-3 z-10 pb-8 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
-          <button className="flex-1 py-3 px-4 rounded-lg border border-slate-300 text-slate-700 font-bold text-sm hover:bg-slate-50 transition-colors shadow-sm">
+        <div className="absolute bottom-0 left-0 right-0 p-4 bg-card border-t border-border rounded-b-3xl flex gap-3 z-10 pb-8 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
+          <button className="flex-1 py-3 px-4 rounded-lg border border-border text-foreground font-bold text-sm hover:bg-muted/20 transition-colors shadow-sm">
             Test Connection
           </button>
           <button className="flex-1 py-3 px-4 rounded-lg bg-primary text-white font-bold text-sm shadow-lg shadow-primary/25 hover:bg-primary/90 transition-colors flex items-center justify-center gap-2">

--- a/packages/web/src/components/stitch-import/ConnectionsPanel.tsx
+++ b/packages/web/src/components/stitch-import/ConnectionsPanel.tsx
@@ -102,10 +102,10 @@ export function ConnectionsPanel() {
       <header className="flex flex-col gap-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground dark:text-white">
               Connections
             </h1>
-            <p className="text-slate-500 dark:text-slate-400 mt-1">
+            <p className="text-muted-foreground dark:text-muted-foreground mt-1">
               Manage your data sources and destinations.
             </p>
           </div>
@@ -120,12 +120,12 @@ export function ConnectionsPanel() {
               <span
                 className={cn(
                   "text-xs font-bold uppercase tracking-wider",
-                  stat.color || "text-slate-500"
+                  stat.color || "text-muted-foreground"
                 )}
               >
                 {stat.label}
               </span>
-              <div className="text-2xl font-bold text-slate-900 dark:text-white mt-1">
+              <div className="text-2xl font-bold text-foreground dark:text-white mt-1">
                 {stat.value}
               </div>
             </Card>
@@ -134,9 +134,9 @@ export function ConnectionsPanel() {
       </header>
 
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 w-5 h-5" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground w-5 h-5" />
         <Input
-          className="pl-10 h-12 bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800 rounded-xl"
+          className="pl-10 h-12 bg-card dark:bg-background border-border dark:border-border rounded-xl"
           placeholder="Search connections by name, ID, or environment..."
         />
       </div>
@@ -148,7 +148,7 @@ export function ConnectionsPanel() {
             <Card
               key={conn.id}
               className={cn(
-                "group p-5 cursor-pointer hover:shadow-md transition-all active:scale-[0.99] border-slate-200 dark:border-slate-800",
+                "group p-5 cursor-pointer hover:shadow-md transition-all active:scale-[0.99] border-border dark:border-border",
                 conn.status === "Error" && "border-red-200 dark:border-red-900/50 bg-red-50/10"
               )}
               onClick={() => setSelectedConnection(conn)}
@@ -165,10 +165,10 @@ export function ConnectionsPanel() {
                     <Icon className="w-6 h-6" />
                   </div>
                   <div>
-                    <h3 className="font-bold text-lg text-slate-900 dark:text-white leading-tight">
+                    <h3 className="font-bold text-lg text-foreground dark:text-white leading-tight">
                       {conn.name}
                     </h3>
-                    <p className="text-xs font-medium text-slate-500 dark:text-slate-400 mt-1">
+                    <p className="text-xs font-medium text-muted-foreground dark:text-muted-foreground mt-1">
                       {conn.env}
                     </p>
                   </div>
@@ -189,10 +189,10 @@ export function ConnectionsPanel() {
                 </Badge>
               </div>
 
-              <div className="flex items-center justify-between pt-4 border-t border-slate-100 dark:border-slate-800">
+              <div className="flex items-center justify-between pt-4 border-t border-slate-100 dark:border-border">
                 <div className="flex gap-8">
                   <div className="flex flex-col">
-                    <span className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
+                    <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest">
                       Error Rate
                     </span>
                     <span
@@ -200,14 +200,14 @@ export function ConnectionsPanel() {
                         "font-mono text-sm font-semibold mt-1",
                         conn.status === "Error"
                           ? "text-red-600"
-                          : "text-slate-700 dark:text-slate-300"
+                          : "text-foreground dark:text-muted-foreground"
                       )}
                     >
                       {conn.errorRate}
                     </span>
                   </div>
                   <div className="flex flex-col">
-                    <span className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
+                    <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest">
                       Freshness
                     </span>
                     <span
@@ -215,14 +215,14 @@ export function ConnectionsPanel() {
                         "font-mono text-sm font-semibold mt-1",
                         conn.status === "Error"
                           ? "text-red-600"
-                          : "text-slate-700 dark:text-slate-300"
+                          : "text-foreground dark:text-muted-foreground"
                       )}
                     >
                       {conn.freshness}
                     </span>
                   </div>
                 </div>
-                <ArrowRight className="w-5 h-5 text-slate-300 group-hover:text-primary-500 transition-colors" />
+                <ArrowRight className="w-5 h-5 text-muted-foreground group-hover:text-primary-500 transition-colors" />
               </div>
             </Card>
           );
@@ -249,7 +249,7 @@ export function ConnectionsPanel() {
                           selectedConnection.status === "Healthy" ? "bg-emerald-500" : "bg-red-500"
                         )}
                       />
-                      <span className="text-sm font-medium text-slate-600 dark:text-slate-400">
+                      <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground">
                         {selectedConnection.status} • Last synced {selectedConnection.freshness}
                       </span>
                     </div>
@@ -260,7 +260,7 @@ export function ConnectionsPanel() {
               <div className="space-y-6">
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">
-                    <h3 className="text-xs font-bold uppercase text-slate-500 tracking-wider">
+                    <h3 className="text-xs font-bold uppercase text-muted-foreground tracking-wider">
                       Credentials
                     </h3>
                     <Button
@@ -272,12 +272,12 @@ export function ConnectionsPanel() {
                       Edit
                     </Button>
                   </div>
-                  <Card className="p-4 bg-slate-50 dark:bg-slate-900 border-slate-200 dark:border-slate-800 group relative">
+                  <Card className="p-4 bg-muted/20 dark:bg-background border-border dark:border-border group relative">
                     <div className="flex flex-col gap-1">
-                      <span className="text-[10px] font-bold text-slate-400 uppercase">
+                      <span className="text-[10px] font-bold text-muted-foreground uppercase">
                         API Key
                       </span>
-                      <span className="font-mono text-sm text-slate-700 dark:text-slate-300">
+                      <span className="font-mono text-sm text-foreground dark:text-muted-foreground">
                         sk_live_••••••••••••••••
                       </span>
                     </div>
@@ -286,15 +286,15 @@ export function ConnectionsPanel() {
                       size="icon"
                       className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity h-8 w-8"
                     >
-                      <Copy className="w-4 h-4 text-slate-400" />
+                      <Copy className="w-4 h-4 text-muted-foreground" />
                     </Button>
                   </Card>
-                  <Card className="p-4 bg-slate-50 dark:bg-slate-900 border-slate-200 dark:border-slate-800">
+                  <Card className="p-4 bg-muted/20 dark:bg-background border-border dark:border-border">
                     <div className="flex flex-col gap-1">
-                      <span className="text-[10px] font-bold text-slate-400 uppercase">
+                      <span className="text-[10px] font-bold text-muted-foreground uppercase">
                         Environment
                       </span>
-                      <span className="font-mono text-sm text-slate-700 dark:text-slate-300">
+                      <span className="font-mono text-sm text-foreground dark:text-muted-foreground">
                         Production
                       </span>
                     </div>
@@ -302,25 +302,25 @@ export function ConnectionsPanel() {
                 </div>
 
                 <div className="space-y-4">
-                  <h3 className="text-xs font-bold uppercase text-slate-500 tracking-wider">
+                  <h3 className="text-xs font-bold uppercase text-muted-foreground tracking-wider">
                     Sync Schedule
                   </h3>
-                  <div className="flex items-center gap-4 bg-slate-50 dark:bg-slate-900 p-4 rounded-xl border border-slate-200 dark:border-slate-800">
-                    <div className="w-10 h-10 rounded-lg bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 flex items-center justify-center text-primary-500 shadow-sm">
+                  <div className="flex items-center gap-4 bg-muted/20 dark:bg-background p-4 rounded-xl border border-border dark:border-border">
+                    <div className="w-10 h-10 rounded-lg bg-card dark:bg-card border border-border dark:border-border flex items-center justify-center text-primary-500 shadow-sm">
                       <Calendar className="w-5 h-5" />
                     </div>
                     <div>
-                      <p className="text-sm font-bold text-slate-900 dark:text-white">
+                      <p className="text-sm font-bold text-foreground dark:text-white">
                         Daily at 00:00 UTC
                       </p>
-                      <p className="text-xs text-slate-500 dark:text-slate-400">
+                      <p className="text-xs text-muted-foreground dark:text-muted-foreground">
                         Next run in 14h 32m
                       </p>
                     </div>
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="ml-auto h-8 w-8 text-slate-400 hover:text-primary-500"
+                      className="ml-auto h-8 w-8 text-muted-foreground hover:text-primary-500"
                       onClick={() => handleAction("edit_schedule")}
                     >
                       <EditIcon className="w-4 h-4" />
@@ -329,19 +329,19 @@ export function ConnectionsPanel() {
                 </div>
 
                 <div className="space-y-4">
-                  <h3 className="text-xs font-bold uppercase text-slate-500 tracking-wider">
+                  <h3 className="text-xs font-bold uppercase text-muted-foreground tracking-wider">
                     Schema Preview
                   </h3>
-                  <div className="border border-slate-200 dark:border-slate-800 rounded-xl overflow-hidden divide-y divide-slate-100 dark:divide-slate-800">
-                    <div className="bg-white dark:bg-slate-900 px-4 py-3 flex justify-between items-center cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors">
-                      <span className="text-sm font-bold font-mono text-slate-700 dark:text-slate-300">
+                  <div className="border border-border dark:border-border rounded-xl overflow-hidden divide-y divide-slate-100 dark:divide-slate-800">
+                    <div className="bg-card dark:bg-background px-4 py-3 flex justify-between items-center cursor-pointer hover:bg-muted/20 dark:hover:bg-card/50 transition-colors">
+                      <span className="text-sm font-bold font-mono text-foreground dark:text-muted-foreground">
                         Charges
                       </span>
-                      <ChevronUp className="w-4 h-4 text-slate-400" />
+                      <ChevronUp className="w-4 h-4 text-muted-foreground" />
                     </div>
-                    <div className="bg-slate-50/50 dark:bg-slate-900/50 p-4 space-y-3">
+                    <div className="bg-muted/20/50 dark:bg-background/50 p-4 space-y-3">
                       <div className="flex justify-between items-center">
-                        <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
+                        <span className="font-mono text-xs text-muted-foreground dark:text-muted-foreground">
                           id
                         </span>
                         <Badge variant="outline" className="text-[10px] font-mono">
@@ -349,7 +349,7 @@ export function ConnectionsPanel() {
                         </Badge>
                       </div>
                       <div className="flex justify-between items-center">
-                        <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
+                        <span className="font-mono text-xs text-muted-foreground dark:text-muted-foreground">
                           amount
                         </span>
                         <Badge variant="outline" className="text-[10px] font-mono">
@@ -357,11 +357,11 @@ export function ConnectionsPanel() {
                         </Badge>
                       </div>
                     </div>
-                    <div className="bg-white dark:bg-slate-900 px-4 py-3 flex justify-between items-center cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors">
-                      <span className="text-sm font-bold font-mono text-slate-700 dark:text-slate-300">
+                    <div className="bg-card dark:bg-background px-4 py-3 flex justify-between items-center cursor-pointer hover:bg-muted/20 dark:hover:bg-card/50 transition-colors">
+                      <span className="text-sm font-bold font-mono text-foreground dark:text-muted-foreground">
                         Refunds
                       </span>
-                      <ChevronDown className="w-4 h-4 text-slate-400" />
+                      <ChevronDown className="w-4 h-4 text-muted-foreground" />
                     </div>
                   </div>
                 </div>

--- a/packages/web/src/components/stitch-import/ConnectionsTable.tsx
+++ b/packages/web/src/components/stitch-import/ConnectionsTable.tsx
@@ -15,24 +15,24 @@ import {
 
 const ConnectionsTable: React.FC = () => {
   return (
-    <main className="flex-1 overflow-y-auto px-4 py-4 space-y-4 pb-24 bg-slate-50">
+    <main className="flex-1 overflow-y-auto px-4 py-4 space-y-4 pb-24 bg-muted/20">
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 h-5 w-5" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground h-5 w-5" />
         <input
-          className="w-full bg-white border border-slate-200 rounded-lg py-3 pl-10 pr-4 text-sm focus:ring-2 focus:ring-primary focus:border-primary shadow-sm placeholder-slate-400 text-slate-700"
+          className="w-full bg-card border border-border rounded-lg py-3 pl-10 pr-4 text-sm focus:ring-2 focus:ring-primary focus:border-primary shadow-sm placeholder-slate-400 text-foreground"
           placeholder="Search connections..."
           type="text"
         />
       </div>
-      <div className="group bg-white rounded-xl p-4 border border-slate-200 shadow-card hover:shadow-card-hover active:scale-[0.99] transition-all duration-200 ease-out cursor-pointer relative overflow-hidden">
+      <div className="group bg-card rounded-xl p-4 border border-border shadow-card hover:shadow-card-hover active:scale-[0.99] transition-all duration-200 ease-out cursor-pointer relative overflow-hidden">
         <div className="flex items-start justify-between mb-3">
           <div className="flex items-center gap-3">
             <div className="w-12 h-12 rounded-xl bg-[#635BFF]/10 border border-[#635BFF]/20 flex items-center justify-center text-[#635BFF] font-bold text-lg">
               <CreditCard className="h-6 w-6" />
             </div>
             <div>
-              <h3 className="font-bold text-base text-slate-900 leading-tight">Stripe Payments</h3>
-              <p className="text-xs font-medium text-slate-500 mt-0.5">Production Environment</p>
+              <h3 className="font-bold text-base text-foreground leading-tight">Stripe Payments</h3>
+              <p className="text-xs font-medium text-muted-foreground mt-0.5">Production Environment</p>
             </div>
           </div>
           <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-emerald-50 text-emerald-800 border border-emerald-200">
@@ -43,26 +43,26 @@ const ConnectionsTable: React.FC = () => {
         <div className="flex items-center justify-between text-xs border-t border-slate-100 pt-3 mt-1">
           <div className="flex gap-6">
             <div className="flex flex-col">
-              <span className="text-slate-400 font-medium mb-0.5 uppercase text-[10px] tracking-wider">
+              <span className="text-muted-foreground font-medium mb-0.5 uppercase text-[10px] tracking-wider">
                 Error Rate
               </span>
-              <span className="font-mono font-semibold text-slate-700 bg-slate-100 px-1.5 py-0.5 rounded w-fit">
+              <span className="font-mono font-semibold text-foreground bg-muted/40 px-1.5 py-0.5 rounded w-fit">
                 0.1%
               </span>
             </div>
             <div className="flex flex-col">
-              <span className="text-slate-400 font-medium mb-0.5 uppercase text-[10px] tracking-wider">
+              <span className="text-muted-foreground font-medium mb-0.5 uppercase text-[10px] tracking-wider">
                 Freshness
               </span>
-              <span className="font-mono font-semibold text-slate-700 bg-slate-100 px-1.5 py-0.5 rounded w-fit">
+              <span className="font-mono font-semibold text-foreground bg-muted/40 px-1.5 py-0.5 rounded w-fit">
                 2m ago
               </span>
             </div>
           </div>
-          <ArrowRight className="h-5 w-5 text-slate-300 group-hover:text-primary transition-colors" />
+          <ArrowRight className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
         </div>
       </div>
-      <div className="group bg-white rounded-xl p-4 border border-red-200 shadow-sm active:scale-[0.99] transition-all duration-200 ease-out cursor-pointer relative overflow-hidden">
+      <div className="group bg-card rounded-xl p-4 border border-red-200 shadow-sm active:scale-[0.99] transition-all duration-200 ease-out cursor-pointer relative overflow-hidden">
         <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-red-600"></div>
         <div className="flex items-start justify-between mb-3 pl-2">
           <div className="flex items-center gap-3">
@@ -70,10 +70,10 @@ const ConnectionsTable: React.FC = () => {
               <Snowflake className="h-6 w-6" />
             </div>
             <div>
-              <h3 className="font-bold text-base text-slate-900 leading-tight">
+              <h3 className="font-bold text-base text-foreground leading-tight">
                 Snowflake Warehouse
               </h3>
-              <p className="text-xs font-medium text-slate-500 mt-0.5">Analytics DB</p>
+              <p className="text-xs font-medium text-muted-foreground mt-0.5">Analytics DB</p>
             </div>
           </div>
           <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-red-50 text-red-800 border border-red-200">
@@ -84,7 +84,7 @@ const ConnectionsTable: React.FC = () => {
         <div className="flex items-center justify-between text-xs border-t border-slate-100 pt-3 mt-1 pl-2">
           <div className="flex gap-6">
             <div className="flex flex-col">
-              <span className="text-slate-400 font-medium mb-0.5 uppercase text-[10px] tracking-wider">
+              <span className="text-muted-foreground font-medium mb-0.5 uppercase text-[10px] tracking-wider">
                 Error Rate
               </span>
               <span className="font-mono font-bold text-red-600 bg-red-50 px-1.5 py-0.5 rounded w-fit border border-red-100">
@@ -92,7 +92,7 @@ const ConnectionsTable: React.FC = () => {
               </span>
             </div>
             <div className="flex flex-col">
-              <span className="text-slate-400 font-medium mb-0.5 uppercase text-[10px] tracking-wider">
+              <span className="text-muted-foreground font-medium mb-0.5 uppercase text-[10px] tracking-wider">
                 Freshness
               </span>
               <span className="font-mono font-bold text-red-600 bg-red-50 px-1.5 py-0.5 rounded w-fit border border-red-100">
@@ -100,18 +100,18 @@ const ConnectionsTable: React.FC = () => {
               </span>
             </div>
           </div>
-          <ArrowRight className="h-5 w-5 text-slate-300 group-hover:text-primary transition-colors" />
+          <ArrowRight className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
         </div>
       </div>
-      <div className="group bg-white rounded-xl p-4 border border-slate-200 shadow-card hover:shadow-card-hover active:scale-[0.99] transition-all duration-200 ease-out cursor-pointer relative overflow-hidden">
+      <div className="group bg-card rounded-xl p-4 border border-border shadow-card hover:shadow-card-hover active:scale-[0.99] transition-all duration-200 ease-out cursor-pointer relative overflow-hidden">
         <div className="flex items-start justify-between mb-3">
           <div className="flex items-center gap-3">
             <div className="w-12 h-12 rounded-xl bg-[#00A1E0]/10 border border-[#00A1E0]/20 flex items-center justify-center text-[#00A1E0]">
               <Cloud className="h-6 w-6" />
             </div>
             <div>
-              <h3 className="font-bold text-base text-slate-900 leading-tight">Salesforce CRM</h3>
-              <p className="text-xs font-medium text-slate-500 mt-0.5">Sales Data</p>
+              <h3 className="font-bold text-base text-foreground leading-tight">Salesforce CRM</h3>
+              <p className="text-xs font-medium text-muted-foreground mt-0.5">Sales Data</p>
             </div>
           </div>
           <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-blue-50 text-blue-800 border border-blue-200">
@@ -122,36 +122,36 @@ const ConnectionsTable: React.FC = () => {
         <div className="flex items-center justify-between text-xs border-t border-slate-100 pt-3 mt-1">
           <div className="flex gap-6">
             <div className="flex flex-col">
-              <span className="text-slate-400 font-medium mb-0.5 uppercase text-[10px] tracking-wider">
+              <span className="text-muted-foreground font-medium mb-0.5 uppercase text-[10px] tracking-wider">
                 Error Rate
               </span>
-              <span className="font-mono font-medium text-slate-400 bg-slate-50 px-1.5 py-0.5 rounded w-fit border border-slate-100">
+              <span className="font-mono font-medium text-muted-foreground bg-muted/20 px-1.5 py-0.5 rounded w-fit border border-slate-100">
                 --
               </span>
             </div>
             <div className="flex flex-col">
-              <span className="text-slate-400 font-medium mb-0.5 uppercase text-[10px] tracking-wider">
+              <span className="text-muted-foreground font-medium mb-0.5 uppercase text-[10px] tracking-wider">
                 Freshness
               </span>
-              <span className="font-mono font-medium text-slate-400 bg-slate-50 px-1.5 py-0.5 rounded w-fit border border-slate-100">
+              <span className="font-mono font-medium text-muted-foreground bg-muted/20 px-1.5 py-0.5 rounded w-fit border border-slate-100">
                 --
               </span>
             </div>
           </div>
-          <ArrowRight className="h-5 w-5 text-slate-300 group-hover:text-primary transition-colors" />
+          <ArrowRight className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
         </div>
       </div>
-      <div className="group bg-white rounded-xl p-4 border border-slate-200 shadow-card hover:shadow-card-hover active:scale-[0.99] transition-all duration-200 ease-out cursor-pointer relative overflow-hidden">
+      <div className="group bg-card rounded-xl p-4 border border-border shadow-card hover:shadow-card-hover active:scale-[0.99] transition-all duration-200 ease-out cursor-pointer relative overflow-hidden">
         <div className="flex items-start justify-between mb-3">
           <div className="flex items-center gap-3">
             <div className="w-12 h-12 rounded-xl bg-[#336791]/10 border border-[#336791]/20 flex items-center justify-center text-[#336791]">
               <Database className="h-6 w-6" />
             </div>
             <div>
-              <h3 className="font-bold text-base text-slate-900 leading-tight">
+              <h3 className="font-bold text-base text-foreground leading-tight">
                 Production Postgres
               </h3>
-              <p className="text-xs font-medium text-slate-500 mt-0.5">User Data</p>
+              <p className="text-xs font-medium text-muted-foreground mt-0.5">User Data</p>
             </div>
           </div>
           <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-emerald-50 text-emerald-800 border border-emerald-200">
@@ -162,23 +162,23 @@ const ConnectionsTable: React.FC = () => {
         <div className="flex items-center justify-between text-xs border-t border-slate-100 pt-3 mt-1">
           <div className="flex gap-6">
             <div className="flex flex-col">
-              <span className="text-slate-400 font-medium mb-0.5 uppercase text-[10px] tracking-wider">
+              <span className="text-muted-foreground font-medium mb-0.5 uppercase text-[10px] tracking-wider">
                 Error Rate
               </span>
-              <span className="font-mono font-semibold text-slate-700 bg-slate-100 px-1.5 py-0.5 rounded w-fit">
+              <span className="font-mono font-semibold text-foreground bg-muted/40 px-1.5 py-0.5 rounded w-fit">
                 0.02%
               </span>
             </div>
             <div className="flex flex-col">
-              <span className="text-slate-400 font-medium mb-0.5 uppercase text-[10px] tracking-wider">
+              <span className="text-muted-foreground font-medium mb-0.5 uppercase text-[10px] tracking-wider">
                 Freshness
               </span>
-              <span className="font-mono font-semibold text-slate-700 bg-slate-100 px-1.5 py-0.5 rounded w-fit">
+              <span className="font-mono font-semibold text-foreground bg-muted/40 px-1.5 py-0.5 rounded w-fit">
                 10m ago
               </span>
             </div>
           </div>
-          <ArrowRight className="h-5 w-5 text-slate-300 group-hover:text-primary transition-colors" />
+          <ArrowRight className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
         </div>
       </div>
     </main>

--- a/packages/web/src/components/stitch-import/ControlPlaneOverview.tsx
+++ b/packages/web/src/components/stitch-import/ControlPlaneOverview.tsx
@@ -28,20 +28,20 @@ const ControlPlaneOverview: React.FC = () => {
       {/* Workspace selector */}
       <div className="flex items-center justify-between">
         <button className="group flex items-center gap-3" aria-label="Switch workspace">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary text-white shadow-sm">
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
             <Building className="h-5 w-5" aria-hidden="true" />
           </div>
           <div className="flex flex-col text-left">
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 leading-none mb-0.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground leading-none mb-0.5">
               Workspace
             </span>
-            <span className="flex items-center gap-1 text-sm font-bold text-slate-900 leading-none">
+            <span className="flex items-center gap-1 text-sm font-bold text-foreground leading-none">
               Acme Corp / Prod
-              <ChevronDown className="h-4 w-4 text-slate-400 group-hover:text-primary transition-colors" aria-hidden="true" />
+              <ChevronDown className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" aria-hidden="true" />
             </span>
           </div>
         </button>
-        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-slate-500">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-muted/60 border border-border px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
           <RefreshCw className="h-3 w-3" aria-hidden="true" />
           Sample data
         </span>
@@ -49,24 +49,24 @@ const ControlPlaneOverview: React.FC = () => {
 
       {/* Critical alert (dismissible) */}
       {!alertDismissed && (
-        <div className="relative overflow-hidden rounded-xl border-l-4 border-red-500 bg-white p-4 shadow-sm flex items-start gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-red-100 bg-red-50">
-            <AlertTriangle className="h-5 w-5 text-red-600" aria-hidden="true" />
+        <div className="relative overflow-hidden rounded-xl border-l-4 border-error bg-card p-4 shadow-sm flex items-start gap-3 border border-border/60">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-red-500/20 bg-red-500/10">
+            <AlertTriangle className="h-5 w-5 text-red-600 dark:text-red-400" aria-hidden="true" />
           </div>
           <div className="flex-1">
-            <h3 className="flex items-center gap-2 text-sm font-bold text-slate-900">
+            <h3 className="flex items-center gap-2 text-sm font-bold text-foreground">
               Critical Alert
-              <span className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-bold text-red-700">
+              <span className="rounded bg-red-500/10 px-1.5 py-0.5 text-[10px] font-bold text-red-700 dark:text-red-400">
                 P0
               </span>
             </h3>
-            <p className="mt-0.5 text-xs font-medium leading-relaxed text-slate-600">
+            <p className="mt-0.5 text-xs font-medium leading-relaxed text-muted-foreground">
               Webhook latency &gt; 500ms in EU-West region. Automatic scaling in progress.
             </p>
           </div>
           <button
             onClick={() => setAlertDismissed(true)}
-            className="shrink-0 rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors"
+            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
             aria-label="Dismiss alert"
           >
             <X className="h-5 w-5" aria-hidden="true" />
@@ -77,40 +77,40 @@ const ControlPlaneOverview: React.FC = () => {
       {/* System health metrics */}
       <div>
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-base font-bold text-slate-900">System Health</h2>
-          <span className="inline-flex items-center gap-1.5 rounded-md border border-green-200 bg-green-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-green-700 shadow-sm">
+          <h2 className="text-base font-bold text-foreground">System Health</h2>
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-green-500/20 bg-green-500/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-green-700 dark:text-green-400 shadow-sm">
             <span className="h-2 w-2 rounded-full bg-green-500" aria-hidden="true" />
             Stable
           </span>
         </div>
         <div className="grid grid-cols-2 gap-4 mb-4">
-          <div className="flex h-[120px] flex-col justify-between rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="flex h-[120px] flex-col justify-between rounded-xl border border-border bg-card p-4 shadow-sm">
             <div className="flex items-start justify-between">
-              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 Uptime (24h)
               </span>
-              <Gauge className="h-5 w-5 rounded-md bg-blue-50 p-1 text-primary" aria-hidden="true" />
+              <Gauge className="h-5 w-5 rounded-md bg-primary/10 p-1 text-primary" aria-hidden="true" />
             </div>
             <div>
-              <div className="text-3xl font-bold tracking-tight text-slate-900">
-                99.98<span className="text-lg text-slate-400">%</span>
+              <div className="text-3xl font-bold tracking-tight text-foreground">
+                99.98<span className="text-lg text-muted-foreground">%</span>
               </div>
-              <div className="mt-1 flex w-fit items-center gap-1 rounded bg-green-50 px-1.5 py-0.5 text-xs font-bold text-green-600">
+              <div className="mt-1 flex w-fit items-center gap-1 rounded bg-green-500/10 px-1.5 py-0.5 text-xs font-bold text-green-600 dark:text-green-400">
                 <TrendingUp className="h-3.5 w-3.5" aria-hidden="true" />
                 +0.01%
               </div>
             </div>
           </div>
-          <div className="flex h-[120px] flex-col justify-between rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="flex h-[120px] flex-col justify-between rounded-xl border border-border bg-card p-4 shadow-sm">
             <div className="flex items-start justify-between">
-              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 Backlog Queue
               </span>
-              <Gauge className="h-5 w-5 rounded-md bg-orange-50 p-1 text-orange-600" aria-hidden="true" />
+              <Gauge className="h-5 w-5 rounded-md bg-amber-500/10 p-1 text-amber-600" aria-hidden="true" />
             </div>
             <div>
-              <div className="text-3xl font-bold tracking-tight text-slate-900">452</div>
-              <div className="mt-1 flex w-fit items-center gap-1 rounded bg-green-50 px-1.5 py-0.5 text-xs font-bold text-green-600">
+              <div className="text-3xl font-bold tracking-tight text-foreground">452</div>
+              <div className="mt-1 flex w-fit items-center gap-1 rounded bg-green-500/10 px-1.5 py-0.5 text-xs font-bold text-green-600 dark:text-green-400">
                 <TrendingDown className="h-3.5 w-3.5" aria-hidden="true" />
                 −12% items
               </div>
@@ -118,24 +118,24 @@ const ControlPlaneOverview: React.FC = () => {
           </div>
         </div>
 
-        <div className="relative overflow-hidden rounded-xl border border-orange-200 bg-white p-5 shadow-sm">
-          <div className="absolute inset-0 bg-gradient-to-l from-orange-50 via-white to-white opacity-80 pointer-events-none" />
+        <div className="relative overflow-hidden rounded-xl border border-amber-500/20 bg-card p-5 shadow-sm">
+          <div className="absolute inset-0 bg-gradient-to-l from-amber-500/5 via-transparent to-transparent opacity-80 pointer-events-none" />
           <div className="relative z-10 flex items-center justify-between mb-3">
-            <span className="flex items-center gap-2 rounded bg-orange-100/50 px-2 py-1 text-xs font-bold uppercase tracking-wider text-orange-800">
+            <span className="flex items-center gap-2 rounded bg-amber-500/10 px-2 py-1 text-xs font-bold uppercase tracking-wider text-amber-800 dark:text-amber-400">
               <span className="relative flex h-2 w-2" aria-hidden="true">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-orange-400 opacity-75" />
-                <span className="relative inline-flex h-2 w-2 rounded-full bg-orange-500" />
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-400 opacity-75" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-amber-500" />
               </span>
               Mismatch Anomaly Risk
             </span>
-            <AlertTriangle className="h-6 w-6 text-orange-600" aria-hidden="true" />
+            <AlertTriangle className="h-6 w-6 text-amber-600" aria-hidden="true" />
           </div>
           <div className="relative z-10 flex items-end justify-between">
             <div>
-              <div className="text-2xl font-bold text-slate-900">12 Spikes</div>
-              <div className="mt-1 text-xs font-medium text-slate-500">Detected in last 60m</div>
+              <div className="text-2xl font-bold text-foreground">12 Spikes</div>
+              <div className="mt-1 text-xs font-medium text-muted-foreground">Detected in last 60m</div>
             </div>
-            <button className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-xs font-bold text-slate-700 shadow-sm transition-all hover:border-primary/30 hover:bg-slate-50 hover:text-primary">
+            <button className="rounded-lg border border-border bg-card px-4 py-2 text-xs font-bold text-foreground shadow-sm transition-all hover:border-primary/30 hover:bg-muted/40 hover:text-primary">
               View Log
             </button>
           </div>
@@ -145,53 +145,53 @@ const ControlPlaneOverview: React.FC = () => {
       {/* Active runs */}
       <div>
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-base font-bold text-slate-900">Active Runs</h2>
-          <button className="rounded-full bg-blue-50 px-3 py-1 text-sm font-semibold text-primary transition-colors hover:bg-blue-100">
+          <h2 className="text-base font-bold text-foreground">Active Runs</h2>
+          <button className="rounded-full bg-primary/10 px-3 py-1 text-sm font-semibold text-primary transition-colors hover:bg-primary/15">
             See All (3)
           </button>
         </div>
         <div className="space-y-3">
           {/* Run 1 */}
-          <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
             <div className="p-4">
               <div className="mb-3 flex items-start justify-between">
                 <div className="flex items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-blue-100 bg-blue-50 text-primary shadow-sm">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-primary/20 bg-primary/10 text-primary shadow-sm">
                     <RefreshCw className="h-6 w-6" aria-hidden="true" />
                   </div>
                   <div>
-                    <h4 className="text-sm font-bold text-slate-900">Run #8821</h4>
+                    <h4 className="text-sm font-bold text-foreground">Run #8821</h4>
                     <div className="mt-0.5 flex items-center gap-2">
-                      <span className="rounded border border-blue-200 bg-blue-100 px-2 py-0.5 text-[10px] font-bold text-blue-700">
+                      <span className="rounded border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 text-[10px] font-bold text-blue-700 dark:text-blue-400">
                         Running
                       </span>
-                      <span className="font-mono text-xs font-medium text-slate-400">2m 14s</span>
+                      <span className="font-mono text-xs font-medium text-muted-foreground">2m 14s</span>
                     </div>
                   </div>
                 </div>
                 <button
                   aria-label="More options for Run #8821"
-                  className="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                  className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <MoreVertical className="h-5 w-5" aria-hidden="true" />
                 </button>
               </div>
-              <div className="grid grid-cols-2 gap-4 border-t border-dashed border-slate-200 py-3">
+              <div className="grid grid-cols-2 gap-4 border-t border-dashed border-border/60 py-3">
                 <div>
-                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                     Volume
                   </div>
-                  <div className="text-sm font-bold text-slate-900">$1.2M</div>
+                  <div className="text-sm font-bold text-foreground">$1.2M</div>
                 </div>
                 <div>
-                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                     Trace ID
                   </div>
-                  <div className="flex w-fit items-center gap-1 rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-sm text-slate-600">
+                  <div className="flex w-fit items-center gap-1 rounded border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-sm text-foreground">
                     trc_8a9...b2
                     <button
                       aria-label="Copy trace ID"
-                      className="ml-1 text-slate-400 transition-colors hover:text-primary"
+                      className="ml-1 text-muted-foreground transition-colors hover:text-primary"
                     >
                       <Copy className="h-3.5 w-3.5" aria-hidden="true" />
                     </button>
@@ -199,12 +199,12 @@ const ControlPlaneOverview: React.FC = () => {
                 </div>
               </div>
             </div>
-            <div className="flex border-t border-slate-200 bg-slate-50/50">
-              <button className="flex h-10 flex-1 items-center justify-center gap-1.5 border-r border-slate-200 text-xs font-bold text-red-600 transition-colors hover:bg-red-50">
+            <div className="flex border-t border-border bg-muted/20">
+              <button className="flex h-10 flex-1 items-center justify-center gap-1.5 border-r border-border text-xs font-bold text-red-600 dark:text-red-400 transition-colors hover:bg-red-500/10">
                 <XCircle className="h-5 w-5" aria-hidden="true" />
                 Abort
               </button>
-              <button className="flex h-10 flex-1 items-center justify-center gap-1.5 text-xs font-bold text-slate-700 transition-colors hover:bg-slate-100">
+              <button className="flex h-10 flex-1 items-center justify-center gap-1.5 text-xs font-bold text-foreground transition-colors hover:bg-muted/50">
                 <Eye className="h-5 w-5" aria-hidden="true" />
                 Details
               </button>
@@ -212,46 +212,46 @@ const ControlPlaneOverview: React.FC = () => {
           </div>
 
           {/* Run 2 */}
-          <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
             <div className="p-4">
               <div className="mb-3 flex items-start justify-between">
                 <div className="flex items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-amber-100 bg-amber-50 text-amber-600 shadow-sm">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-amber-500/20 bg-amber-500/10 text-amber-600 shadow-sm">
                     <RefreshCw className="h-6 w-6" aria-hidden="true" />
                   </div>
                   <div>
-                    <h4 className="text-sm font-bold text-slate-900">Run #8820</h4>
+                    <h4 className="text-sm font-bold text-foreground">Run #8820</h4>
                     <div className="mt-0.5 flex items-center gap-2">
-                      <span className="rounded border border-amber-200 bg-amber-100 px-2 py-0.5 text-[10px] font-bold text-amber-800">
+                      <span className="rounded border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[10px] font-bold text-amber-700 dark:text-amber-400">
                         Retrying
                       </span>
-                      <span className="font-mono text-xs font-medium text-slate-400">0m 45s</span>
+                      <span className="font-mono text-xs font-medium text-muted-foreground">0m 45s</span>
                     </div>
                   </div>
                 </div>
                 <button
                   aria-label="More options for Run #8820"
-                  className="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                  className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <MoreVertical className="h-5 w-5" aria-hidden="true" />
                 </button>
               </div>
-              <div className="grid grid-cols-2 gap-4 border-t border-dashed border-slate-200 py-3">
+              <div className="grid grid-cols-2 gap-4 border-t border-dashed border-border/60 py-3">
                 <div>
-                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                     Volume
                   </div>
-                  <div className="text-sm font-bold text-slate-900">$850K</div>
+                  <div className="text-sm font-bold text-foreground">$850K</div>
                 </div>
                 <div>
-                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                     Trace ID
                   </div>
-                  <div className="flex w-fit items-center gap-1 rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-sm text-slate-600">
+                  <div className="flex w-fit items-center gap-1 rounded border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-sm text-foreground">
                     trc_2c4...e1
                     <button
                       aria-label="Copy trace ID"
-                      className="ml-1 text-slate-400 transition-colors hover:text-primary"
+                      className="ml-1 text-muted-foreground transition-colors hover:text-primary"
                     >
                       <Copy className="h-3.5 w-3.5" aria-hidden="true" />
                     </button>
@@ -259,12 +259,12 @@ const ControlPlaneOverview: React.FC = () => {
                 </div>
               </div>
             </div>
-            <div className="flex border-t border-slate-200 bg-slate-50/50">
-              <button className="flex h-10 flex-1 items-center justify-center gap-1.5 border-r border-slate-200 text-xs font-bold text-red-600 transition-colors hover:bg-red-50">
+            <div className="flex border-t border-border bg-muted/20">
+              <button className="flex h-10 flex-1 items-center justify-center gap-1.5 border-r border-border text-xs font-bold text-red-600 dark:text-red-400 transition-colors hover:bg-red-500/10">
                 <XCircle className="h-5 w-5" aria-hidden="true" />
                 Abort
               </button>
-              <button className="flex h-10 flex-1 items-center justify-center gap-1.5 text-xs font-bold text-slate-700 transition-colors hover:bg-slate-100">
+              <button className="flex h-10 flex-1 items-center justify-center gap-1.5 text-xs font-bold text-foreground transition-colors hover:bg-muted/50">
                 <Eye className="h-5 w-5" aria-hidden="true" />
                 Details
               </button>
@@ -272,46 +272,46 @@ const ControlPlaneOverview: React.FC = () => {
           </div>
 
           {/* Run 3 (queued) */}
-          <div className="overflow-hidden rounded-xl border border-slate-200 bg-white opacity-80 shadow-sm">
+          <div className="overflow-hidden rounded-xl border border-border bg-card opacity-80 shadow-sm">
             <div className="p-4">
               <div className="mb-3 flex items-start justify-between">
                 <div className="flex items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-slate-200 bg-slate-100 text-slate-600">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
                     <Clock className="h-6 w-6" aria-hidden="true" />
                   </div>
                   <div>
-                    <h4 className="text-sm font-bold text-slate-900">Run #8819</h4>
+                    <h4 className="text-sm font-bold text-foreground">Run #8819</h4>
                     <div className="mt-0.5 flex items-center gap-2">
-                      <span className="rounded border border-slate-200 bg-slate-100 px-2 py-0.5 text-[10px] font-bold text-slate-700">
+                      <span className="rounded border border-border bg-muted px-2 py-0.5 text-[10px] font-bold text-muted-foreground">
                         Queued
                       </span>
-                      <span className="font-mono text-xs font-medium text-slate-400">—</span>
+                      <span className="font-mono text-xs font-medium text-muted-foreground">—</span>
                     </div>
                   </div>
                 </div>
                 <button
                   aria-label="More options for Run #8819"
-                  className="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                  className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <MoreVertical className="h-5 w-5" aria-hidden="true" />
                 </button>
               </div>
-              <div className="grid grid-cols-2 gap-4 border-t border-dashed border-slate-200 py-3">
+              <div className="grid grid-cols-2 gap-4 border-t border-dashed border-border/60 py-3">
                 <div>
-                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                     Volume
                   </div>
-                  <div className="text-sm font-bold text-slate-900">$3.4M</div>
+                  <div className="text-sm font-bold text-foreground">$3.4M</div>
                 </div>
                 <div>
-                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                  <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                     Trace ID
                   </div>
-                  <div className="flex w-fit items-center gap-1 rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-sm text-slate-600">
+                  <div className="flex w-fit items-center gap-1 rounded border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-sm text-foreground">
                     trc_x91...p0
                     <button
                       aria-label="Copy trace ID"
-                      className="ml-1 text-slate-400 transition-colors hover:text-primary"
+                      className="ml-1 text-muted-foreground transition-colors hover:text-primary"
                     >
                       <Copy className="h-3.5 w-3.5" aria-hidden="true" />
                     </button>
@@ -319,8 +319,8 @@ const ControlPlaneOverview: React.FC = () => {
                 </div>
               </div>
             </div>
-            <div className="flex border-t border-slate-200 bg-slate-50/50">
-              <button className="flex h-10 w-full items-center justify-center gap-1.5 text-xs font-bold text-slate-700 transition-colors hover:bg-slate-100">
+            <div className="flex border-t border-border bg-muted/20">
+              <button className="flex h-10 w-full items-center justify-center gap-1.5 text-xs font-bold text-foreground transition-colors hover:bg-muted/50">
                 <Eye className="h-5 w-5" aria-hidden="true" />
                 Details
               </button>

--- a/packages/web/src/components/stitch-import/EvidenceViewer.tsx
+++ b/packages/web/src/components/stitch-import/EvidenceViewer.tsx
@@ -5,20 +5,20 @@ import { AlertCircle, X, CheckCircle, XCircle } from "lucide-react";
 
 const EvidenceViewer: React.FC = () => {
   return (
-    <div className="fixed inset-x-0 bottom-[72px] z-30 transform transition-transform duration-300 ease-out translate-y-0 shadow-[0_-8px_30px_rgba(0,0,0,0.5)] bg-background-light dark:bg-surface-dark rounded-t-2xl border-t border-slate-200 dark:border-slate-700 max-h-[70vh] flex flex-col">
+    <div className="fixed inset-x-0 bottom-[72px] z-30 transform transition-transform duration-300 ease-out translate-y-0 shadow-[0_-8px_30px_rgba(0,0,0,0.5)] bg-background-light dark:bg-surface-dark rounded-t-2xl border-t border-border dark:border-border max-h-[70vh] flex flex-col">
       {/* Drag Handle */}
       <div className="w-full flex justify-center pt-3 pb-1 cursor-grab active:cursor-grabbing">
-        <div className="w-12 h-1.5 rounded-full bg-slate-300 dark:bg-slate-600"></div>
+        <div className="w-12 h-1.5 rounded-full bg-slate-300 bg-muted"></div>
       </div>
       {/* Sheet Header */}
-      <div className="px-5 pb-3 border-b border-slate-200 dark:border-slate-700 flex justify-between items-center">
+      <div className="px-5 pb-3 border-b border-border dark:border-border flex justify-between items-center">
         <div>
-          <h3 className="text-lg font-bold text-slate-900 dark:text-white">Evidence Viewer</h3>
+          <h3 className="text-lg font-bold text-foreground dark:text-white">Evidence Viewer</h3>
           <p className="text-xs text-rose-500 font-medium flex items-center gap-1">
             <AlertCircle className="h-3.5 w-3.5" /> Unmatched · Trace 8a9f...2b1
           </p>
         </div>
-        <button className="text-slate-400 hover:text-white">
+        <button className="text-muted-foreground hover:text-white">
           <X className="h-6 w-6" />
         </button>
       </div>
@@ -27,7 +27,7 @@ const EvidenceViewer: React.FC = () => {
         {/* Comparison View */}
         <div className="flex flex-col gap-3">
           <div className="flex justify-between items-center">
-            <span className="text-xs font-semibold uppercase text-slate-500 dark:text-slate-400 tracking-wider">
+            <span className="text-xs font-semibold uppercase text-muted-foreground dark:text-muted-foreground tracking-wider">
               Comparison
             </span>
             <span className="text-xs text-primary font-medium cursor-pointer hover:underline">
@@ -37,34 +37,34 @@ const EvidenceViewer: React.FC = () => {
           <div className="grid grid-cols-2 gap-4">
             {/* Source A */}
             <div className="flex flex-col gap-2">
-              <div className="text-xs font-medium text-slate-500 flex items-center gap-1">
+              <div className="text-xs font-medium text-muted-foreground flex items-center gap-1">
                 <span className="w-2 h-2 rounded-full bg-blue-500"></span> Source: Stripe API
               </div>
-              <div className="p-3 bg-white dark:bg-[#0c1219] border border-slate-200 dark:border-slate-700 rounded-lg">
-                <div className="text-[10px] text-slate-400 uppercase">Amount</div>
-                <div className="font-mono text-sm text-slate-900 dark:text-slate-100">
+              <div className="p-3 bg-card dark:bg-[#0c1219] border border-border dark:border-border rounded-lg">
+                <div className="text-[10px] text-muted-foreground uppercase">Amount</div>
+                <div className="font-mono text-sm text-foreground text-muted-foreground">
                   100.00 USD
                 </div>
-                <div className="w-full h-px bg-slate-100 dark:bg-slate-800 my-2"></div>
-                <div className="text-[10px] text-slate-400 uppercase">Status</div>
-                <div className="font-mono text-sm text-slate-900 dark:text-slate-100">
+                <div className="w-full h-px bg-muted/40 dark:bg-card my-2"></div>
+                <div className="text-[10px] text-muted-foreground uppercase">Status</div>
+                <div className="font-mono text-sm text-foreground text-muted-foreground">
                   succeeded
                 </div>
               </div>
             </div>
             {/* Source B */}
             <div className="flex flex-col gap-2">
-              <div className="text-xs font-medium text-slate-500 flex items-center gap-1">
+              <div className="text-xs font-medium text-muted-foreground flex items-center gap-1">
                 <span className="w-2 h-2 rounded-full bg-purple-500"></span> Source: Internal DB
               </div>
-              <div className="p-3 bg-white dark:bg-[#0c1219] border border-rose-500/50 rounded-lg relative overflow-hidden">
+              <div className="p-3 bg-card dark:bg-[#0c1219] border border-rose-500/50 rounded-lg relative overflow-hidden">
                 {/* Highlight mismatch */}
                 <div className="absolute inset-0 bg-rose-500/5 pointer-events-none"></div>
-                <div className="text-[10px] text-slate-400 uppercase">Amount</div>
+                <div className="text-[10px] text-muted-foreground uppercase">Amount</div>
                 <div className="font-mono text-sm text-rose-500 font-bold">99.00 USD</div>
-                <div className="w-full h-px bg-slate-100 dark:bg-slate-800 my-2"></div>
-                <div className="text-[10px] text-slate-400 uppercase">Status</div>
-                <div className="font-mono text-sm text-slate-900 dark:text-slate-100">
+                <div className="w-full h-px bg-muted/40 dark:bg-card my-2"></div>
+                <div className="text-[10px] text-muted-foreground uppercase">Status</div>
+                <div className="font-mono text-sm text-foreground text-muted-foreground">
                   completed
                 </div>
               </div>
@@ -73,23 +73,23 @@ const EvidenceViewer: React.FC = () => {
         </div>
         {/* Rules Applied */}
         <div>
-          <span className="text-xs font-semibold uppercase text-slate-500 dark:text-slate-400 tracking-wider mb-2 block">
+          <span className="text-xs font-semibold uppercase text-muted-foreground dark:text-muted-foreground tracking-wider mb-2 block">
             Logic Trace
           </span>
           <div className="space-y-2">
-            <div className="flex items-center gap-3 p-3 bg-white dark:bg-[#0c1219] border border-emerald-500/30 rounded-lg">
+            <div className="flex items-center gap-3 p-3 bg-card dark:bg-[#0c1219] border border-emerald-500/30 rounded-lg">
               <CheckCircle className="h-5 w-5 text-emerald-500" />
               <div className="flex-1">
-                <div className="text-sm font-medium text-slate-900 dark:text-slate-200">
+                <div className="text-sm font-medium text-foreground text-muted-foreground">
                   Currency Match
                 </div>
-                <div className="text-xs text-slate-500">Both sources are USD</div>
+                <div className="text-xs text-muted-foreground">Both sources are USD</div>
               </div>
             </div>
-            <div className="flex items-center gap-3 p-3 bg-white dark:bg-[#0c1219] border border-rose-500/30 rounded-lg">
+            <div className="flex items-center gap-3 p-3 bg-card dark:bg-[#0c1219] border border-rose-500/30 rounded-lg">
               <XCircle className="h-5 w-5 text-rose-500" />
               <div className="flex-1">
-                <div className="text-sm font-medium text-slate-900 dark:text-slate-200">
+                <div className="text-sm font-medium text-foreground text-muted-foreground">
                   Exact Amount Match
                 </div>
                 <div className="text-xs text-rose-400">Values differ by &gt; 0.00</div>
@@ -99,8 +99,8 @@ const EvidenceViewer: React.FC = () => {
         </div>
       </div>
       {/* Sheet Footer Actions */}
-      <div className="p-5 border-t border-slate-200 dark:border-slate-700 bg-background-light dark:bg-surface-dark flex gap-3">
-        <button className="flex-1 py-3 px-4 rounded-lg bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-white font-semibold text-sm hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors">
+      <div className="p-5 border-t border-border dark:border-border bg-background-light dark:bg-surface-dark flex gap-3">
+        <button className="flex-1 py-3 px-4 rounded-lg bg-slate-200 dark:bg-muted text-foreground dark:text-white font-semibold text-sm hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors">
           Ignore Mismatch
         </button>
         <button className="flex-1 py-3 px-4 rounded-lg bg-primary text-white font-semibold text-sm hover:bg-blue-600 transition-colors shadow-lg shadow-primary/25">

--- a/packages/web/src/components/stitch-import/IntegrationList.tsx
+++ b/packages/web/src/components/stitch-import/IntegrationList.tsx
@@ -32,49 +32,49 @@ const IntegrationList: React.FC = () => {
 
       <section className="space-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-slate-800">Active Services</h2>
+          <h2 className="text-lg font-semibold text-foreground">Active Services</h2>
           <button className="text-xs font-medium text-primary hover:text-primary/80 transition-colors">
             View All
           </button>
         </div>
 
         {/* GitHub */}
-        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-shadow duration-300 hover:shadow-md">
+        <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-shadow duration-300 hover:shadow-md">
           <div className="p-5">
             <div className="mb-4 flex items-start justify-between">
               <div className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-slate-900 text-white shadow-sm">
+                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-background text-white shadow-sm">
                   <svg fill="currentColor" height="24" viewBox="0 0 24 24" width="24" aria-hidden="true">
                     <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.285 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
                   </svg>
                 </div>
                 <div>
-                  <h3 className="text-lg font-bold text-slate-900">GitHub</h3>
+                  <h3 className="text-lg font-bold text-foreground">GitHub</h3>
                   <div className="mt-0.5 flex items-center gap-2">
                     <span className="inline-flex items-center gap-1 rounded-full border border-emerald-100 bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-600">
                       <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true" />
                       Healthy
                     </span>
-                    <span className="text-xs font-medium text-slate-500">• Repo:Read</span>
+                    <span className="text-xs font-medium text-muted-foreground">• Repo:Read</span>
                   </div>
                 </div>
               </div>
               <button
                 aria-label="More options for GitHub integration"
-                className="rounded-full p-1 text-slate-400 transition-colors hover:bg-slate-100"
+                className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-muted/40"
               >
                 <MoreVertical size={24} aria-hidden="true" />
               </button>
             </div>
             <div className="mb-4 grid grid-cols-2 gap-3">
-              <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
-                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-400">
+              <div className="rounded-lg border border-slate-100 bg-muted/20 p-3">
+                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                   Expires
                 </p>
-                <p className="text-sm font-semibold text-slate-700">28 days</p>
+                <p className="text-sm font-semibold text-foreground">28 days</p>
               </div>
-              <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
-                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-400">
+              <div className="rounded-lg border border-slate-100 bg-muted/20 p-3">
+                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                   Privilege
                 </p>
                 <div className="flex items-center gap-1 text-amber-600">
@@ -88,32 +88,32 @@ const IntegrationList: React.FC = () => {
                 <RefreshCw size={16} aria-hidden="true" />
                 Rotate Token
               </button>
-              <button className="flex h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white text-xs font-medium text-slate-600 shadow-sm transition-colors hover:bg-slate-50">
+              <button className="flex h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border border-border bg-card text-xs font-medium text-muted-foreground shadow-sm transition-colors hover:bg-muted/20">
                 <Settings size={16} aria-hidden="true" />
                 Test
               </button>
             </div>
           </div>
-          <div className="border-t border-slate-100 bg-slate-50/50">
+          <div className="border-t border-slate-100 bg-muted/20/50">
             <details className="group/accordion">
-              <summary className="flex cursor-pointer list-none items-center justify-between px-5 py-3 transition-colors hover:bg-slate-50">
-                <span className="flex items-center gap-2 text-xs font-semibold text-slate-500">
+              <summary className="flex cursor-pointer list-none items-center justify-between px-5 py-3 transition-colors hover:bg-muted/20">
+                <span className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
                   <Clock size={16} aria-hidden="true" />
                   Recent Activity
                 </span>
                 <ChevronDown
-                  className="text-slate-400 transition-transform group-open/accordion:rotate-180"
+                  className="text-muted-foreground transition-transform group-open/accordion:rotate-180"
                   size={18}
                   aria-hidden="true"
                 />
               </summary>
-              <div className="space-y-2 border-t border-slate-100 bg-white px-5 pb-4 pt-3">
+              <div className="space-y-2 border-t border-slate-100 bg-card px-5 pb-4 pt-3">
                 {githubActivity.map(({ ts, status, variant }) => (
                   <div
                     key={ts}
                     className="flex items-center justify-between border-b border-slate-50 pb-2 text-xs last:border-0 last:pb-0"
                   >
-                    <span className="font-mono text-slate-500">{ts}</span>
+                    <span className="font-mono text-muted-foreground">{ts}</span>
                     <span
                       className={
                         variant === "ok"
@@ -134,7 +134,7 @@ const IntegrationList: React.FC = () => {
         </div>
 
         {/* Slack */}
-        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-shadow duration-300 hover:shadow-md">
+        <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-shadow duration-300 hover:shadow-md">
           <div className="p-5">
             <div className="mb-4 flex items-start justify-between">
               <div className="flex items-center gap-3">
@@ -144,35 +144,35 @@ const IntegrationList: React.FC = () => {
                   </svg>
                 </div>
                 <div>
-                  <h3 className="text-lg font-bold text-slate-900">Slack</h3>
+                  <h3 className="text-lg font-bold text-foreground">Slack</h3>
                   <div className="mt-0.5 flex items-center gap-2">
                     <span className="inline-flex items-center gap-1 rounded-full border border-amber-100 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-600">
                       <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden="true" />
                       Degraded
                     </span>
-                    <span className="text-xs font-medium text-slate-500">• Webhook</span>
+                    <span className="text-xs font-medium text-muted-foreground">• Webhook</span>
                   </div>
                 </div>
               </div>
               <button
                 aria-label="More options for Slack integration"
-                className="rounded-full p-1 text-slate-400 transition-colors hover:bg-slate-100"
+                className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-muted/40"
               >
                 <MoreVertical size={24} aria-hidden="true" />
               </button>
             </div>
             <div className="mb-4 grid grid-cols-2 gap-3">
-              <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
-                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-400">
+              <div className="rounded-lg border border-slate-100 bg-muted/20 p-3">
+                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                   Expires
                 </p>
-                <p className="text-sm font-semibold text-slate-700">Never</p>
+                <p className="text-sm font-semibold text-foreground">Never</p>
               </div>
-              <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
-                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-400">
+              <div className="rounded-lg border border-slate-100 bg-muted/20 p-3">
+                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                   Privilege
                 </p>
-                <div className="flex items-center gap-1 text-slate-500">
+                <div className="flex items-center gap-1 text-muted-foreground">
                   <Unlock size={14} aria-hidden="true" />
                   <span className="text-xs font-semibold">Write-Only</span>
                 </div>
@@ -183,7 +183,7 @@ const IntegrationList: React.FC = () => {
                 <Send size={16} aria-hidden="true" />
                 Test Message
               </button>
-              <button className="flex h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white text-xs font-medium text-slate-600 shadow-sm transition-colors hover:bg-slate-50">
+              <button className="flex h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border border-border bg-card text-xs font-medium text-muted-foreground shadow-sm transition-colors hover:bg-muted/20">
                 <SlidersHorizontal size={16} aria-hidden="true" />
                 Config
               </button>
@@ -192,7 +192,7 @@ const IntegrationList: React.FC = () => {
         </div>
 
         {/* Custom Hook */}
-        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-shadow duration-300 hover:shadow-md">
+        <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-shadow duration-300 hover:shadow-md">
           <div className="p-5">
             <div className="mb-4 flex items-start justify-between">
               <div className="flex items-center gap-3">
@@ -200,7 +200,7 @@ const IntegrationList: React.FC = () => {
                   <Webhook size={24} aria-hidden="true" />
                 </div>
                 <div>
-                  <h3 className="text-lg font-bold text-slate-900">Custom Hook</h3>
+                  <h3 className="text-lg font-bold text-foreground">Custom Hook</h3>
                   <div className="mt-0.5 flex items-center gap-2">
                     <span className="inline-flex items-center gap-1 rounded-full border border-red-100 bg-red-50 px-2 py-0.5 text-[10px] font-semibold text-red-600">
                       <span className="h-1.5 w-1.5 rounded-full bg-red-500" aria-hidden="true" />
@@ -211,22 +211,22 @@ const IntegrationList: React.FC = () => {
               </div>
               <button
                 aria-label="More options for Custom Hook integration"
-                className="rounded-full p-1 text-slate-400 transition-colors hover:bg-slate-100"
+                className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-muted/40"
               >
                 <MoreVertical size={24} aria-hidden="true" />
               </button>
             </div>
             <div className="mb-4">
-              <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-400">
+              <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                 Endpoint
               </p>
-              <div className="flex items-center gap-2 rounded border border-slate-200 bg-slate-50 p-2.5 shadow-inner">
-                <code className="flex-1 truncate font-mono text-xs text-slate-600">
+              <div className="flex items-center gap-2 rounded border border-border bg-muted/20 p-2.5 shadow-inner">
+                <code className="flex-1 truncate font-mono text-xs text-muted-foreground">
                   https://api.mysite.com/hook/v1/payment_events
                 </code>
                 <button
                   aria-label="Copy endpoint URL"
-                  className="text-slate-400 transition-colors hover:text-primary"
+                  className="text-muted-foreground transition-colors hover:text-primary"
                 >
                   <Copy size={16} aria-hidden="true" />
                 </button>
@@ -242,26 +242,26 @@ const IntegrationList: React.FC = () => {
         </div>
       </section>
 
-      <hr className="border-slate-200" />
+      <hr className="border-border" />
 
       <section className="space-y-4">
-        <h2 className="text-lg font-semibold text-slate-800">Available to Connect</h2>
+        <h2 className="text-lg font-semibold text-foreground">Available to Connect</h2>
         <div className="grid grid-cols-2 gap-4">
-          <button className="group flex flex-col items-center justify-center rounded-xl border border-slate-200 bg-white p-6 text-center shadow-sm transition-all duration-200 hover:border-slate-300 hover:shadow-md">
+          <button className="group flex flex-col items-center justify-center rounded-xl border border-border bg-card p-6 text-center shadow-sm transition-all duration-200 hover:border-border hover:shadow-md">
             <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 text-blue-600 transition-transform group-hover:scale-110">
               <svg fill="currentColor" height="20" viewBox="0 0 24 24" width="20" aria-hidden="true">
                 <path d="M11.53 2C6.454 1.96 2.073 5.923 2 11h9.53V2zM12.47 2v9h9.53C21.93 5.96 17.546 2.077 12.47 2zM2 13c.073 5.077 4.454 9.04 9.53 9V13H2zm19.47 0H12.47l.06 9C17.576 21.93 21.96 18.01 22 13z" />
               </svg>
             </div>
-            <span className="text-sm font-semibold text-slate-900">Jira</span>
-            <span className="mt-1 text-xs text-slate-500">Issue Tracking</span>
+            <span className="text-sm font-semibold text-foreground">Jira</span>
+            <span className="mt-1 text-xs text-muted-foreground">Issue Tracking</span>
           </button>
-          <button className="group flex flex-col items-center justify-center rounded-xl border border-slate-200 bg-white p-6 text-center shadow-sm transition-all duration-200 hover:border-slate-300 hover:shadow-md">
+          <button className="group flex flex-col items-center justify-center rounded-xl border border-border bg-card p-6 text-center shadow-sm transition-all duration-200 hover:border-border hover:shadow-md">
             <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-orange-50 text-orange-600 transition-transform group-hover:scale-110">
               <Cloud size={24} aria-hidden="true" />
             </div>
-            <span className="text-sm font-semibold text-slate-900">AWS</span>
-            <span className="mt-1 text-xs text-slate-500">CloudWatch</span>
+            <span className="text-sm font-semibold text-foreground">AWS</span>
+            <span className="mt-1 text-xs text-muted-foreground">CloudWatch</span>
           </button>
         </div>
       </section>

--- a/packages/web/src/components/stitch-import/PipelineDrawer.tsx
+++ b/packages/web/src/components/stitch-import/PipelineDrawer.tsx
@@ -5,19 +5,19 @@ import { Download, ArrowLeftRight, Upload, Pencil, GitCommit } from "lucide-reac
 
 const PipelineDrawer: React.FC = () => {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 transform rounded-t-3xl bg-background-light dark:bg-[#111a22] border-t border-slate-200 dark:border-slate-800 shadow-2xl transition-transform translate-y-[calc(100%-80px)] hover:translate-y-0 group">
+    <div className="fixed inset-x-0 bottom-0 z-40 transform rounded-t-3xl bg-background-light dark:bg-[#111a22] border-t border-border dark:border-border shadow-2xl transition-transform translate-y-[calc(100%-80px)] hover:translate-y-0 group">
       {/* Drag Handle */}
       <div className="flex w-full justify-center pt-3 pb-1 cursor-grab">
-        <div className="h-1.5 w-12 rounded-full bg-slate-300 dark:bg-slate-600"></div>
+        <div className="h-1.5 w-12 rounded-full bg-slate-300 bg-muted"></div>
       </div>
       <div className="flex flex-col h-[85vh] overflow-y-auto px-5 pb-6">
         {/* Header (Visible when collapsed) */}
-        <div className="flex items-center justify-between pb-4 border-b border-slate-200 dark:border-slate-800/50">
+        <div className="flex items-center justify-between pb-4 border-b border-border dark:border-border/50">
           <div className="flex flex-col">
-            <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
+            <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground">
               Selected Pipeline
             </span>
-            <h2 className="text-lg font-bold text-slate-900 dark:text-white mt-1">
+            <h2 className="text-lg font-bold text-foreground dark:text-white mt-1">
               payment_reconciliation_v2
             </h2>
           </div>
@@ -33,7 +33,7 @@ const PipelineDrawer: React.FC = () => {
               <span className="sr-only">Use setting</span>
               <span
                 aria-hidden="true"
-                className="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out translate-x-5"
+                className="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-card shadow ring-0 transition duration-200 ease-in-out translate-x-5"
               ></span>
             </div>
           </div>
@@ -42,106 +42,106 @@ const PipelineDrawer: React.FC = () => {
         <div className="space-y-6 pt-6 opacity-40 group-hover:opacity-100 transition-opacity duration-300">
           {/* Stats Grid */}
           <div className="grid grid-cols-2 gap-3">
-            <div className="rounded-xl bg-white dark:bg-[#192633] p-3 border border-slate-200 dark:border-slate-700">
-              <div className="text-slate-500 dark:text-slate-400 text-xs mb-1">Latency (P99)</div>
+            <div className="rounded-xl bg-card dark:bg-[#192633] p-3 border border-border dark:border-border">
+              <div className="text-muted-foreground dark:text-muted-foreground text-xs mb-1">Latency (P99)</div>
               <div className="text-lg font-bold dark:text-white">245ms</div>
             </div>
-            <div className="rounded-xl bg-white dark:bg-[#192633] p-3 border border-slate-200 dark:border-slate-700">
-              <div className="text-slate-500 dark:text-slate-400 text-xs mb-1">Processed</div>
+            <div className="rounded-xl bg-card dark:bg-[#192633] p-3 border border-border dark:border-border">
+              <div className="text-muted-foreground dark:text-muted-foreground text-xs mb-1">Processed</div>
               <div className="text-lg font-bold dark:text-white">1.2M</div>
             </div>
           </div>
           {/* Flow Visualization */}
-          <div className="rounded-xl bg-white dark:bg-[#192633] p-4 border border-slate-200 dark:border-slate-700 flex flex-col items-center gap-4 relative">
+          <div className="rounded-xl bg-card dark:bg-[#192633] p-4 border border-border dark:border-border flex flex-col items-center gap-4 relative">
             {/* Connecting Line */}
-            <div className="absolute left-[24px] top-8 bottom-8 w-0.5 bg-slate-200 dark:bg-slate-700"></div>
+            <div className="absolute left-[24px] top-8 bottom-8 w-0.5 bg-slate-200 dark:bg-muted"></div>
             {/* Step 1 */}
             <div className="relative w-full flex items-center gap-4 z-10">
-              <div className="h-12 w-12 rounded-full bg-blue-500/10 border border-blue-500/30 flex items-center justify-center text-blue-500 shrink-0 bg-white dark:bg-[#192633]">
+              <div className="h-12 w-12 rounded-full bg-blue-500/10 border border-blue-500/30 flex items-center justify-center text-blue-500 shrink-0 bg-card dark:bg-[#192633]">
                 <Download className="h-6 w-6" />
               </div>
               <div className="flex-1">
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                <h4 className="text-sm font-semibold text-foreground dark:text-white">
                   Stripe Connect
                 </h4>
-                <p className="text-xs text-slate-500">Source: API v2</p>
+                <p className="text-xs text-muted-foreground">Source: API v2</p>
               </div>
-              <button className="text-slate-400">
+              <button className="text-muted-foreground">
                 <Pencil className="h-6 w-6" />
               </button>
             </div>
             {/* Step 2 */}
             <div className="relative w-full flex items-center gap-4 z-10">
-              <div className="h-12 w-12 rounded-full bg-purple-500/10 border border-purple-500/30 flex items-center justify-center text-purple-500 shrink-0 bg-white dark:bg-[#192633]">
+              <div className="h-12 w-12 rounded-full bg-purple-500/10 border border-purple-500/30 flex items-center justify-center text-purple-500 shrink-0 bg-card dark:bg-[#192633]">
                 <ArrowLeftRight className="h-6 w-6" />
               </div>
               <div className="flex-1">
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                <h4 className="text-sm font-semibold text-foreground dark:text-white">
                   Normalization
                 </h4>
-                <p className="text-xs text-slate-500">Map: standard_currency</p>
+                <p className="text-xs text-muted-foreground">Map: standard_currency</p>
               </div>
-              <button className="text-slate-400">
+              <button className="text-muted-foreground">
                 <Pencil className="h-6 w-6" />
               </button>
             </div>
             {/* Step 3 */}
             <div className="relative w-full flex items-center gap-4 z-10">
-              <div className="h-12 w-12 rounded-full bg-green-500/10 border border-green-500/30 flex items-center justify-center text-green-500 shrink-0 bg-white dark:bg-[#192633]">
+              <div className="h-12 w-12 rounded-full bg-green-500/10 border border-green-500/30 flex items-center justify-center text-green-500 shrink-0 bg-card dark:bg-[#192633]">
                 <Upload className="h-6 w-6" />
               </div>
               <div className="flex-1">
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">S3 Bucket</h4>
-                <p className="text-xs text-slate-500">Destination: settled-trans</p>
+                <h4 className="text-sm font-semibold text-foreground dark:text-white">S3 Bucket</h4>
+                <p className="text-xs text-muted-foreground">Destination: settled-trans</p>
               </div>
-              <button className="text-slate-400">
+              <button className="text-muted-foreground">
                 <Pencil className="h-6 w-6" />
               </button>
             </div>
           </div>
           {/* Config as Code Action */}
           <div className="flex flex-col gap-3">
-            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">Configuration</h3>
+            <h3 className="text-sm font-semibold text-foreground dark:text-white">Configuration</h3>
             <button className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-3 text-sm font-bold text-white shadow-lg hover:bg-blue-600 active:scale-[0.98] transition-all">
               <GitCommit className="h-6 w-6" />
               Generate Patch / Open PR
             </button>
-            <p className="text-xs text-center text-slate-500 px-4">
+            <p className="text-xs text-center text-muted-foreground px-4">
               This will generate a Terraform configuration patch based on current settings and open
               a PR in your connected repository.
             </p>
           </div>
           {/* Version History */}
           <div className="flex flex-col gap-3 pt-2">
-            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+            <h3 className="text-sm font-semibold text-foreground dark:text-white">
               Deployment History
             </h3>
-            <div className="flex flex-col rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-[#192633] divide-y divide-slate-100 dark:divide-slate-800">
+            <div className="flex flex-col rounded-xl border border-border dark:border-border bg-card dark:bg-[#192633] divide-y divide-slate-100 dark:divide-slate-800">
               {/* History Item 1 */}
               <div className="flex items-center justify-between p-3">
                 <div className="flex items-center gap-3">
                   <div className="h-2 w-2 rounded-full bg-green-500"></div>
                   <div className="flex flex-col">
-                    <span className="text-sm font-medium text-slate-900 dark:text-white">
+                    <span className="text-sm font-medium text-foreground dark:text-white">
                       v1.4.2
                     </span>
-                    <span className="text-xs text-slate-500">Deployed by @jdoe</span>
+                    <span className="text-xs text-muted-foreground">Deployed by @jdoe</span>
                   </div>
                 </div>
-                <span className="text-xs font-mono text-slate-400">2d ago</span>
+                <span className="text-xs font-mono text-muted-foreground">2d ago</span>
               </div>
               {/* History Item 2 */}
               <div className="flex items-center justify-between p-3">
                 <div className="flex items-center gap-3">
                   <div className="h-2 w-2 rounded-full bg-slate-400"></div>
                   <div className="flex flex-col">
-                    <span className="text-sm font-medium text-slate-900 dark:text-white">
+                    <span className="text-sm font-medium text-foreground dark:text-white">
                       v1.4.1
                     </span>
-                    <span className="text-xs text-slate-500">Rolled back (Auto)</span>
+                    <span className="text-xs text-muted-foreground">Rolled back (Auto)</span>
                   </div>
                 </div>
-                <span className="text-xs font-mono text-slate-400">5d ago</span>
+                <span className="text-xs font-mono text-muted-foreground">5d ago</span>
               </div>
             </div>
           </div>

--- a/packages/web/src/components/stitch-import/PipelineTable.tsx
+++ b/packages/web/src/components/stitch-import/PipelineTable.tsx
@@ -24,21 +24,21 @@ const PipelineTable: React.FC = () => {
       {/* Search/Filter */}
       <div className="flex gap-2">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 h-6 w-6" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground h-6 w-6" />
           <input
-            className="w-full rounded-lg bg-white dark:bg-[#192633] border border-slate-200 dark:border-slate-700 py-2.5 pl-10 pr-4 text-sm text-slate-900 dark:text-white focus:border-primary focus:ring-1 focus:ring-primary placeholder:text-slate-400 outline-none transition-all"
+            className="w-full rounded-lg bg-card dark:bg-[#192633] border border-border dark:border-border py-2.5 pl-10 pr-4 text-sm text-foreground dark:text-white focus:border-primary focus:ring-1 focus:ring-primary placeholder:text-muted-foreground outline-none transition-all"
             placeholder="Search pipelines..."
             type="text"
           />
         </div>
-        <button className="flex items-center justify-center rounded-lg bg-white dark:bg-[#192633] border border-slate-200 dark:border-slate-700 px-3 text-slate-500 dark:text-slate-400 hover:text-primary hover:border-primary dark:hover:text-primary transition-colors">
+        <button className="flex items-center justify-center rounded-lg bg-card dark:bg-[#192633] border border-border dark:border-border px-3 text-muted-foreground dark:text-muted-foreground hover:text-primary hover:border-primary dark:hover:text-primary transition-colors">
           <Filter className="h-6 w-6" />
         </button>
       </div>
       {/* Pipeline List */}
       <div className="flex flex-col gap-3">
         {/* Pipeline Item 1: Active/Healthy */}
-        <div className="group relative overflow-hidden rounded-xl bg-white dark:bg-[#192633] border border-slate-200 dark:border-slate-700 p-4 shadow-sm transition-all hover:border-primary/50">
+        <div className="group relative overflow-hidden rounded-xl bg-card dark:bg-[#192633] border border-border dark:border-border p-4 shadow-sm transition-all hover:border-primary/50">
           <div className="flex items-start justify-between mb-3">
             <div className="flex items-center gap-3">
               <div className="relative flex h-10 w-10 items-center justify-center rounded-lg bg-green-500/10 text-green-500">
@@ -49,48 +49,48 @@ const PipelineTable: React.FC = () => {
                 </span>
               </div>
               <div>
-                <h3 className="font-semibold text-slate-900 dark:text-white text-sm">
+                <h3 className="font-semibold text-foreground dark:text-white text-sm">
                   payment_reconciliation_v2
                 </h3>
                 <div className="flex items-center gap-2 mt-0.5">
                   <span className="inline-flex items-center rounded-md bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-500 ring-1 ring-inset ring-green-500/20">
                     Healthy
                   </span>
-                  <span className="text-xs text-slate-500 dark:text-slate-400">• 2m ago</span>
+                  <span className="text-xs text-muted-foreground dark:text-muted-foreground">• 2m ago</span>
                 </div>
               </div>
             </div>
-            <button className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">
+            <button className="text-muted-foreground hover:text-muted-foreground dark:hover:text-slate-200">
               <MoreVertical className="h-6 w-6" />
             </button>
           </div>
           <div className="grid grid-cols-2 gap-4 mb-3">
             <div className="flex flex-col gap-1">
-              <span className="text-[10px] uppercase tracking-wider text-slate-500 font-semibold">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
                 Input
               </span>
               <div className="flex items-center gap-1.5">
                 <ArrowRightCircle className="h-4 w-4 text-primary" />
-                <span className="text-xs text-slate-700 dark:text-slate-300 truncate">
+                <span className="text-xs text-foreground dark:text-muted-foreground truncate">
                   Stripe Connect
                 </span>
               </div>
             </div>
             <div className="flex flex-col gap-1">
-              <span className="text-[10px] uppercase tracking-wider text-slate-500 font-semibold">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
                 Output
               </span>
               <div className="flex items-center gap-1.5">
                 <Webhook className="h-4 w-4 text-purple-400" />
-                <span className="text-xs text-slate-700 dark:text-slate-300 truncate">
+                <span className="text-xs text-foreground dark:text-muted-foreground truncate">
                   S3: settled-trans
                 </span>
               </div>
             </div>
           </div>
-          <div className="flex items-end justify-between border-t border-slate-100 dark:border-slate-800 pt-3 mt-1">
+          <div className="flex items-end justify-between border-t border-slate-100 dark:border-border pt-3 mt-1">
             <div className="flex flex-col gap-1 w-full mr-4">
-              <span className="text-[10px] text-slate-400">Error Trend (24h)</span>
+              <span className="text-[10px] text-muted-foreground">Error Trend (24h)</span>
               {/* Sparkline (SVG) */}
               <svg
                 className="h-6 w-full text-green-500 stroke-current"
@@ -107,7 +107,7 @@ const PipelineTable: React.FC = () => {
               </svg>
             </div>
             <div className="flex gap-2 shrink-0">
-              <button className="flex items-center justify-center h-8 px-3 rounded-lg bg-slate-100 dark:bg-slate-800 text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+              <button className="flex items-center justify-center h-8 px-3 rounded-lg bg-muted/40 dark:bg-card text-xs font-medium text-muted-foreground dark:text-muted-foreground hover:bg-slate-200 dark:hover:bg-muted transition-colors">
                 History
               </button>
               <button className="flex items-center justify-center h-8 px-3 rounded-lg bg-primary/10 text-xs font-medium text-primary hover:bg-primary/20 transition-colors gap-1">
@@ -118,7 +118,7 @@ const PipelineTable: React.FC = () => {
           </div>
         </div>
         {/* Pipeline Item 2: Failed/Critical */}
-        <div className="group relative overflow-hidden rounded-xl bg-white dark:bg-[#192633] border border-red-200 dark:border-red-900/30 p-4 shadow-sm transition-all">
+        <div className="group relative overflow-hidden rounded-xl bg-card dark:bg-[#192633] border border-red-200 dark:border-red-900/30 p-4 shadow-sm transition-all">
           <div className="absolute inset-y-0 left-0 w-1 bg-red-500"></div>
           <div className="flex items-start justify-between mb-3 pl-2">
             <div className="flex items-center gap-3">
@@ -126,48 +126,48 @@ const PipelineTable: React.FC = () => {
                 <AlertTriangle className="h-6 w-6" />
               </div>
               <div>
-                <h3 className="font-semibold text-slate-900 dark:text-white text-sm">
+                <h3 className="font-semibold text-foreground dark:text-white text-sm">
                   ledger_sync_daily
                 </h3>
                 <div className="flex items-center gap-2 mt-0.5">
                   <span className="inline-flex items-center rounded-md bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-500 ring-1 ring-inset ring-red-500/20">
                     Critical
                   </span>
-                  <span className="text-xs text-slate-500 dark:text-slate-400">• 15m ago</span>
+                  <span className="text-xs text-muted-foreground dark:text-muted-foreground">• 15m ago</span>
                 </div>
               </div>
             </div>
-            <button className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">
+            <button className="text-muted-foreground hover:text-muted-foreground dark:hover:text-slate-200">
               <MoreVertical className="h-6 w-6" />
             </button>
           </div>
           <div className="grid grid-cols-2 gap-4 mb-3 pl-2">
             <div className="flex flex-col gap-1">
-              <span className="text-[10px] uppercase tracking-wider text-slate-500 font-semibold">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
                 Input
               </span>
               <div className="flex items-center gap-1.5">
                 <Database className="h-4 w-4 text-primary" />
-                <span className="text-xs text-slate-700 dark:text-slate-300 truncate">
+                <span className="text-xs text-foreground dark:text-muted-foreground truncate">
                   Postgres DB
                 </span>
               </div>
             </div>
             <div className="flex flex-col gap-1">
-              <span className="text-[10px] uppercase tracking-wider text-slate-500 font-semibold">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
                 Output
               </span>
               <div className="flex items-center gap-1.5">
                 <Code className="h-4 w-4 text-orange-400" />
-                <span className="text-xs text-slate-700 dark:text-slate-300 truncate">
+                <span className="text-xs text-foreground dark:text-muted-foreground truncate">
                   Internal API
                 </span>
               </div>
             </div>
           </div>
-          <div className="flex items-end justify-between border-t border-slate-100 dark:border-slate-800 pt-3 mt-1 pl-2">
+          <div className="flex items-end justify-between border-t border-slate-100 dark:border-border pt-3 mt-1 pl-2">
             <div className="flex flex-col gap-1 w-full mr-4">
-              <span className="text-[10px] text-slate-400">Error Trend (24h)</span>
+              <span className="text-[10px] text-muted-foreground">Error Trend (24h)</span>
               <svg
                 className="h-6 w-full text-red-500 stroke-current"
                 fill="none"
@@ -191,61 +191,61 @@ const PipelineTable: React.FC = () => {
           </div>
         </div>
         {/* Pipeline Item 3: Paused */}
-        <div className="group relative overflow-hidden rounded-xl bg-white dark:bg-[#192633] border border-slate-200 dark:border-slate-700 p-4 shadow-sm opacity-75 hover:opacity-100 transition-all">
+        <div className="group relative overflow-hidden rounded-xl bg-card dark:bg-[#192633] border border-border dark:border-border p-4 shadow-sm opacity-75 hover:opacity-100 transition-all">
           <div className="flex items-start justify-between mb-3">
             <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-200 dark:bg-slate-700 text-slate-500 dark:text-slate-400">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-200 dark:bg-muted text-muted-foreground dark:text-muted-foreground">
                 <PauseCircle className="h-6 w-6" />
               </div>
               <div>
-                <h3 className="font-semibold text-slate-900 dark:text-white text-sm">
+                <h3 className="font-semibold text-foreground dark:text-white text-sm">
                   fraud_detection_stream
                 </h3>
                 <div className="flex items-center gap-2 mt-0.5">
-                  <span className="inline-flex items-center rounded-md bg-slate-100 dark:bg-slate-800 px-2 py-0.5 text-xs font-medium text-slate-600 dark:text-slate-400 ring-1 ring-inset ring-slate-500/10">
+                  <span className="inline-flex items-center rounded-md bg-muted/40 dark:bg-card px-2 py-0.5 text-xs font-medium text-muted-foreground dark:text-muted-foreground ring-1 ring-inset ring-slate-500/10">
                     Paused
                   </span>
-                  <span className="text-xs text-slate-500 dark:text-slate-400">• 4h ago</span>
+                  <span className="text-xs text-muted-foreground dark:text-muted-foreground">• 4h ago</span>
                 </div>
               </div>
             </div>
-            <button className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">
+            <button className="text-muted-foreground hover:text-muted-foreground dark:hover:text-slate-200">
               <MoreVertical className="h-6 w-6" />
             </button>
           </div>
-          <div className="flex items-center justify-between border-t border-slate-100 dark:border-slate-800 pt-3 mt-3">
-            <span className="text-xs text-slate-500 italic">Configuration frozen at v1.2.0</span>
+          <div className="flex items-center justify-between border-t border-slate-100 dark:border-border pt-3 mt-3">
+            <span className="text-xs text-muted-foreground italic">Configuration frozen at v1.2.0</span>
             <button className="text-primary hover:text-primary/80 text-xs font-medium flex items-center gap-1">
               <Play className="h-3.5 w-3.5" /> Resume
             </button>
           </div>
         </div>
         {/* Pipeline Item 4: Active/Degraded */}
-        <div className="group relative overflow-hidden rounded-xl bg-white dark:bg-[#192633] border border-slate-200 dark:border-slate-700 p-4 shadow-sm transition-all hover:border-primary/50">
+        <div className="group relative overflow-hidden rounded-xl bg-card dark:bg-[#192633] border border-border dark:border-border p-4 shadow-sm transition-all hover:border-primary/50">
           <div className="flex items-start justify-between mb-3">
             <div className="flex items-center gap-3">
               <div className="relative flex h-10 w-10 items-center justify-center rounded-lg bg-yellow-500/10 text-yellow-500">
                 <Gauge className="h-6 w-6" />
               </div>
               <div>
-                <h3 className="font-semibold text-slate-900 dark:text-white text-sm">
+                <h3 className="font-semibold text-foreground dark:text-white text-sm">
                   inventory_aggregator
                 </h3>
                 <div className="flex items-center gap-2 mt-0.5">
                   <span className="inline-flex items-center rounded-md bg-yellow-500/10 px-2 py-0.5 text-xs font-medium text-yellow-500 ring-1 ring-inset ring-yellow-500/20">
                     Degraded
                   </span>
-                  <span className="text-xs text-slate-500 dark:text-slate-400">• 5m ago</span>
+                  <span className="text-xs text-muted-foreground dark:text-muted-foreground">• 5m ago</span>
                 </div>
               </div>
             </div>
-            <button className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">
+            <button className="text-muted-foreground hover:text-muted-foreground dark:hover:text-slate-200">
               <MoreVertical className="h-6 w-6" />
             </button>
           </div>
-          <div className="flex items-end justify-between border-t border-slate-100 dark:border-slate-800 pt-3 mt-1">
+          <div className="flex items-end justify-between border-t border-slate-100 dark:border-border pt-3 mt-1">
             <div className="flex flex-col gap-1 w-full mr-4">
-              <span className="text-[10px] text-slate-400">Error Trend (24h)</span>
+              <span className="text-[10px] text-muted-foreground">Error Trend (24h)</span>
               <svg
                 className="h-6 w-full text-yellow-500 stroke-current"
                 fill="none"
@@ -261,7 +261,7 @@ const PipelineTable: React.FC = () => {
               </svg>
             </div>
             <div className="flex gap-2 shrink-0">
-              <button className="flex items-center justify-center h-8 px-3 rounded-lg bg-slate-100 dark:bg-slate-800 text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+              <button className="flex items-center justify-center h-8 px-3 rounded-lg bg-muted/40 dark:bg-card text-xs font-medium text-muted-foreground dark:text-muted-foreground hover:bg-slate-200 dark:hover:bg-muted transition-colors">
                 History
               </button>
               <button className="flex items-center justify-center h-8 px-3 rounded-lg bg-primary/10 text-xs font-medium text-primary hover:bg-primary/20 transition-colors gap-1">

--- a/packages/web/src/components/stitch-import/PipelinesPanel.tsx
+++ b/packages/web/src/components/stitch-import/PipelinesPanel.tsx
@@ -88,16 +88,16 @@ export function PipelinesPanel() {
       <header className="flex flex-col gap-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground dark:text-white">
               Pipelines
             </h1>
-            <p className="text-slate-500 dark:text-slate-400 mt-1">
+            <p className="text-muted-foreground dark:text-muted-foreground mt-1">
               Monitor and control your data processing pipelines.
             </p>
           </div>
           <div className="flex items-center gap-2">
             <Button variant="outline" size="icon" className="rounded-full">
-              <RefreshCw className="w-5 h-5 text-slate-500" />
+              <RefreshCw className="w-5 h-5 text-muted-foreground" />
             </Button>
             <Button className="rounded-full w-12 h-12 p-0 shadow-lg shadow-primary-600/20">
               <Plus className="w-6 h-6" />
@@ -105,57 +105,57 @@ export function PipelinesPanel() {
           </div>
         </div>
 
-        <button className="flex w-full items-center justify-between rounded-xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 p-4 shadow-sm group hover:border-primary-500/50 transition-all">
+        <button className="flex w-full items-center justify-between rounded-xl bg-card dark:bg-background border border-border dark:border-border p-4 shadow-sm group hover:border-primary-500/50 transition-all">
           <div className="flex items-center gap-4">
             <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary-50 dark:bg-primary-900/20 text-primary-600 dark:text-primary-400">
               <Globe className="w-6 h-6" />
             </div>
             <div className="flex flex-col items-start">
-              <span className="text-xs font-bold text-slate-500 uppercase tracking-widest">
+              <span className="text-xs font-bold text-muted-foreground uppercase tracking-widest">
                 Active Workspace
               </span>
-              <span className="text-lg font-bold text-slate-900 dark:text-white mt-1">
+              <span className="text-lg font-bold text-foreground dark:text-white mt-1">
                 Production - US East
               </span>
             </div>
           </div>
-          <ChevronDown className="w-5 h-5 text-slate-400 group-hover:text-primary-500" />
+          <ChevronDown className="w-5 h-5 text-muted-foreground group-hover:text-primary-500" />
         </button>
 
         <div className="flex gap-10 px-4">
           <div className="flex flex-col gap-1">
-            <span className="text-xs text-slate-500 font-bold uppercase tracking-wider">
+            <span className="text-xs text-muted-foreground font-bold uppercase tracking-wider">
               Active
             </span>
-            <span className="text-2xl font-bold text-slate-900 dark:text-white">12</span>
+            <span className="text-2xl font-bold text-foreground dark:text-white">12</span>
           </div>
-          <div className="w-[1px] h-10 bg-slate-200 dark:bg-slate-800" />
+          <div className="w-[1px] h-10 bg-slate-200 dark:bg-card" />
           <div className="flex flex-col gap-1">
-            <span className="text-xs text-slate-500 font-bold uppercase tracking-wider">
+            <span className="text-xs text-muted-foreground font-bold uppercase tracking-wider">
               Error Rate
             </span>
             <span className="text-2xl font-bold text-red-500">0.4%</span>
           </div>
-          <div className="w-[1px] h-10 bg-slate-200 dark:bg-slate-800" />
+          <div className="w-[1px] h-10 bg-slate-200 dark:bg-card" />
           <div className="flex flex-col gap-1">
-            <span className="text-xs text-slate-500 font-bold uppercase tracking-wider">
+            <span className="text-xs text-muted-foreground font-bold uppercase tracking-wider">
               Throughput
             </span>
-            <span className="text-2xl font-bold text-slate-900 dark:text-white">45k/s</span>
+            <span className="text-2xl font-bold text-foreground dark:text-white">45k/s</span>
           </div>
         </div>
       </header>
 
       <div className="flex gap-2">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 w-5 h-5" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground w-5 h-5" />
           <Input
-            className="pl-10 h-12 bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800 rounded-xl"
+            className="pl-10 h-12 bg-card dark:bg-background border-border dark:border-border rounded-xl"
             placeholder="Search pipelines..."
           />
         </div>
         <Button variant="outline" size="icon" className="h-12 w-12 rounded-xl">
-          <Filter className="w-5 h-5 text-slate-500" />
+          <Filter className="w-5 h-5 text-muted-foreground" />
         </Button>
       </div>
 
@@ -184,7 +184,7 @@ export function PipelinesPanel() {
                       : pipe.status === "Critical"
                         ? "bg-red-500/10 text-red-500"
                         : pipe.status === "Paused"
-                          ? "bg-slate-500/10 text-slate-500"
+                          ? "bg-slate-500/10 text-muted-foreground"
                           : "bg-yellow-500/10 text-yellow-500"
                   )}
                 >
@@ -205,7 +205,7 @@ export function PipelinesPanel() {
                   )}
                 </div>
                 <div>
-                  <h3 className="font-bold text-slate-900 dark:text-white text-lg leading-tight">
+                  <h3 className="font-bold text-foreground dark:text-white text-lg leading-tight">
                     {pipe.name}
                   </h3>
                   <div className="flex items-center gap-2 mt-1">
@@ -222,13 +222,13 @@ export function PipelinesPanel() {
                     >
                       {pipe.status}
                     </Badge>
-                    <span className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold text-muted-foreground dark:text-muted-foreground">
                       • {pipe.lastRun}
                     </span>
                   </div>
                 </div>
               </div>
-              <Button variant="ghost" size="icon" className="text-slate-400">
+              <Button variant="ghost" size="icon" className="text-muted-foreground">
                 <MoreVertical className="w-5 h-5" />
               </Button>
             </div>
@@ -237,32 +237,32 @@ export function PipelinesPanel() {
               <>
                 <div className="grid grid-cols-2 gap-6 mb-4">
                   <div className="flex flex-col gap-1.5">
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
                       Input
                     </span>
                     <div className="flex items-center gap-2">
                       <ArrowRightCircle className="w-4 h-4 text-primary-500" />
-                      <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 truncate">
+                      <span className="text-sm font-semibold text-foreground dark:text-muted-foreground truncate">
                         {pipe.input || "Default Source"}
                       </span>
                     </div>
                   </div>
                   <div className="flex flex-col gap-1.5">
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
                       Output
                     </span>
                     <div className="flex items-center gap-2">
                       <Webhook className="w-4 h-4 text-purple-500" />
-                      <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 truncate">
+                      <span className="text-sm font-semibold text-foreground dark:text-muted-foreground truncate">
                         {pipe.output || "Default Sync"}
                       </span>
                     </div>
                   </div>
                 </div>
 
-                <div className="flex items-end justify-between pt-4 border-t border-slate-100 dark:border-slate-800">
+                <div className="flex items-end justify-between pt-4 border-t border-slate-100 dark:border-border">
                   <div className="flex flex-col gap-2 w-full mr-8">
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
                       Error Trend (24h)
                     </span>
                     <div className="h-8 w-full flex items-end gap-1">
@@ -315,8 +315,8 @@ export function PipelinesPanel() {
             )}
 
             {pipe.status === "Paused" && (
-              <div className="flex items-center justify-between pt-4 border-t border-slate-100 dark:border-slate-800">
-                <span className="text-sm text-slate-500 italic font-medium">
+              <div className="flex items-center justify-between pt-4 border-t border-slate-100 dark:border-border">
+                <span className="text-sm text-muted-foreground italic font-medium">
                   Configuration frozen at {pipe.version}
                 </span>
                 <Button
@@ -341,7 +341,7 @@ export function PipelinesPanel() {
               <SheetHeader>
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-xs font-bold text-slate-400 uppercase tracking-widest">
+                    <span className="text-xs font-bold text-muted-foreground uppercase tracking-widest">
                       Detail View
                     </span>
                     <SheetTitle className="text-2xl font-bold mt-1">
@@ -363,14 +363,14 @@ export function PipelinesPanel() {
               </SheetHeader>
 
               <div className="grid grid-cols-2 gap-4">
-                <Card className="p-4 bg-slate-50 dark:bg-slate-900 border-slate-200 dark:border-slate-800">
-                  <span className="text-[10px] font-bold text-slate-400 uppercase">
+                <Card className="p-4 bg-muted/20 dark:bg-background border-border dark:border-border">
+                  <span className="text-[10px] font-bold text-muted-foreground uppercase">
                     Latency (P99)
                   </span>
                   <div className="text-xl font-bold mt-1">{selectedPipeline.latency || "---"}</div>
                 </Card>
-                <Card className="p-4 bg-slate-50 dark:bg-slate-900 border-slate-200 dark:border-slate-800">
-                  <span className="text-[10px] font-bold text-slate-400 uppercase">Processed</span>
+                <Card className="p-4 bg-muted/20 dark:bg-background border-border dark:border-border">
+                  <span className="text-[10px] font-bold text-muted-foreground uppercase">Processed</span>
                   <div className="text-xl font-bold mt-1 text-primary-600">
                     {selectedPipeline.throughput || "---"}
                   </div>
@@ -378,51 +378,51 @@ export function PipelinesPanel() {
               </div>
 
               <div className="space-y-4">
-                <h3 className="text-sm font-bold text-slate-900 dark:text-white uppercase tracking-widest">
+                <h3 className="text-sm font-bold text-foreground dark:text-white uppercase tracking-widest">
                   Execution Flow
                 </h3>
-                <div className="relative space-y-8 pl-12 before:absolute before:left-6 before:top-2 before:bottom-2 before:w-0.5 before:bg-slate-200 dark:before:bg-slate-800">
+                <div className="relative space-y-8 pl-12 before:absolute before:left-6 before:top-2 before:bottom-2 before:w-0.5 before:bg-slate-200 dark:before:bg-card">
                   <div className="relative">
-                    <div className="absolute -left-12 h-12 w-12 rounded-full bg-blue-500/10 border border-blue-500/20 flex items-center justify-center text-blue-500 bg-white dark:bg-slate-950 z-10 transition-transform hover:scale-110">
+                    <div className="absolute -left-12 h-12 w-12 rounded-full bg-blue-500/10 border border-blue-500/20 flex items-center justify-center text-blue-500 bg-card bg-muted z-10 transition-transform hover:scale-110">
                       <ArrowRightCircle className="w-5 h-5" />
                     </div>
                     <div>
                       <h4 className="text-sm font-bold">
                         {selectedPipeline.input || "Default Source"}
                       </h4>
-                      <p className="text-xs text-slate-500 font-medium">Type: API Connector</p>
+                      <p className="text-xs text-muted-foreground font-medium">Type: API Connector</p>
                     </div>
                   </div>
                   <div className="relative">
-                    <div className="absolute -left-12 h-12 w-12 rounded-full bg-purple-500/10 border border-purple-500/20 flex items-center justify-center text-purple-500 bg-white dark:bg-slate-950 z-10">
+                    <div className="absolute -left-12 h-12 w-12 rounded-full bg-purple-500/10 border border-purple-500/20 flex items-center justify-center text-purple-500 bg-card bg-muted z-10">
                       <Shuffle className="w-5 h-5" />
                     </div>
                     <div>
                       <h4 className="text-sm font-bold">Normalization Engine</h4>
-                      <p className="text-xs text-slate-500 font-medium">
+                      <p className="text-xs text-muted-foreground font-medium">
                         Rule: standard_currency_mapping
                       </p>
                     </div>
                   </div>
                   <div className="relative">
-                    <div className="absolute -left-12 h-12 w-12 rounded-full bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center text-emerald-500 bg-white dark:bg-slate-950 z-10">
+                    <div className="absolute -left-12 h-12 w-12 rounded-full bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center text-emerald-500 bg-card bg-muted z-10">
                       <LogOut className="w-5 h-5" />
                     </div>
                     <div>
                       <h4 className="text-sm font-bold">
                         {selectedPipeline.output || "Default Sink"}
                       </h4>
-                      <p className="text-xs text-slate-500 font-medium">Storage Class: Standard</p>
+                      <p className="text-xs text-muted-foreground font-medium">Storage Class: Standard</p>
                     </div>
                   </div>
                 </div>
               </div>
 
               <div className="space-y-4">
-                <h3 className="text-sm font-bold text-slate-900 dark:text-white uppercase tracking-widest">
+                <h3 className="text-sm font-bold text-foreground dark:text-white uppercase tracking-widest">
                   Infrastructure
                 </h3>
-                <Card className="p-6 border-slate-200 dark:border-slate-800 space-y-4">
+                <Card className="p-6 border-border dark:border-border space-y-4">
                   <div className="flex flex-col gap-2">
                     <Button
                       className="w-full h-12 bg-primary-600 hover:bg-primary-700 text-white font-bold gap-2 shadow-lg shadow-primary-600/20"
@@ -431,7 +431,7 @@ export function PipelinesPanel() {
                       <GitCommit className="w-5 h-5" />
                       Generate Provisioning Patch
                     </Button>
-                    <p className="text-[11px] text-center text-slate-400 italic font-medium px-4">
+                    <p className="text-[11px] text-center text-muted-foreground italic font-medium px-4">
                       Converts current UI configuration into a Terraform/Kubernetes manifest and
                       opens a CI/CD pull request.
                     </p>
@@ -440,29 +440,29 @@ export function PipelinesPanel() {
               </div>
 
               <div className="space-y-4">
-                <h3 className="text-sm font-bold text-slate-900 dark:text-white uppercase tracking-widest">
+                <h3 className="text-sm font-bold text-foreground dark:text-white uppercase tracking-widest">
                   Version History
                 </h3>
-                <div className="rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden divide-y divide-slate-100 dark:divide-slate-800 font-medium">
-                  <div className="flex items-center justify-between p-4 hover:bg-slate-50 dark:hover:bg-slate-900/50 transition-colors">
+                <div className="rounded-xl border border-border dark:border-border overflow-hidden divide-y divide-slate-100 dark:divide-slate-800 font-medium">
+                  <div className="flex items-center justify-between p-4 hover:bg-muted/20 dark:hover:bg-background/50 transition-colors">
                     <div className="flex items-center gap-3">
                       <div className="h-2 w-2 rounded-full bg-emerald-500" />
                       <div className="flex flex-col">
                         <span className="text-sm font-bold">v1.4.2</span>
-                        <span className="text-xs text-slate-500">Deployed by @jdoe</span>
+                        <span className="text-xs text-muted-foreground">Deployed by @jdoe</span>
                       </div>
                     </div>
-                    <span className="text-xs font-mono text-slate-400">2d ago</span>
+                    <span className="text-xs font-mono text-muted-foreground">2d ago</span>
                   </div>
-                  <div className="flex items-center justify-between p-4 hover:bg-slate-50 dark:hover:bg-slate-900/50 transition-colors">
+                  <div className="flex items-center justify-between p-4 hover:bg-muted/20 dark:hover:bg-background/50 transition-colors">
                     <div className="flex items-center gap-3">
                       <div className="h-2 w-2 rounded-full bg-slate-300" />
                       <div className="flex flex-col">
                         <span className="text-sm font-bold">v1.4.1</span>
-                        <span className="text-xs text-slate-500">Auto-rollback failed</span>
+                        <span className="text-xs text-muted-foreground">Auto-rollback failed</span>
                       </div>
                     </div>
-                    <span className="text-xs font-mono text-slate-400">5d ago</span>
+                    <span className="text-xs font-mono text-muted-foreground">5d ago</span>
                   </div>
                 </div>
               </div>

--- a/packages/web/src/components/stitch-import/ResultsPanel.tsx
+++ b/packages/web/src/components/stitch-import/ResultsPanel.tsx
@@ -79,16 +79,16 @@ export function ResultsPanel() {
       <header className="flex flex-col gap-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground dark:text-white">
               Reconciliation Results
             </h1>
-            <p className="text-slate-500 dark:text-slate-400 mt-1">
+            <p className="text-muted-foreground dark:text-muted-foreground mt-1">
               Review the outcomes of your reconciliation pipelines.
             </p>
           </div>
           <div className="flex items-center gap-2">
             <Button variant="outline" size="icon" className="rounded-full">
-              <Share className="w-5 h-5 text-slate-500" />
+              <Share className="w-5 h-5 text-muted-foreground" />
             </Button>
             <Button
               variant="outline"
@@ -101,9 +101,9 @@ export function ResultsPanel() {
         </div>
 
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 w-5 h-5" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground w-5 h-5" />
           <Input
-            className="pl-10 h-12 bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800 rounded-xl"
+            className="pl-10 h-12 bg-card dark:bg-background border-border dark:border-border rounded-xl"
             placeholder="Search by Trace ID, reference, or pipeline..."
           />
         </div>
@@ -117,19 +117,19 @@ export function ResultsPanel() {
           </Button>
           <Button
             variant="outline"
-            className="rounded-full px-4 h-10 gap-2 border-slate-200 text-slate-600"
+            className="rounded-full px-4 h-10 gap-2 border-border text-muted-foreground"
           >
             <Calendar className="w-4 h-4" /> Last 24h
           </Button>
           <Button
             variant="outline"
-            className="rounded-full px-4 h-10 gap-2 border-slate-200 text-slate-600"
+            className="rounded-full px-4 h-10 gap-2 border-border text-muted-foreground"
           >
             <GitBranch className="w-4 h-4" /> Payments_v2
           </Button>
           <Button
             variant="outline"
-            className="rounded-full px-4 h-10 gap-2 border-slate-200 text-slate-600"
+            className="rounded-full px-4 h-10 gap-2 border-border text-muted-foreground"
           >
             <Filter className="w-4 h-4" /> More
           </Button>
@@ -139,28 +139,28 @@ export function ResultsPanel() {
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <Card className="p-4 border-emerald-500/20 bg-emerald-50/10 relative overflow-hidden group">
           <CheckCircle2 className="absolute -right-2 -top-2 w-16 h-16 text-emerald-500 opacity-5" />
-          <span className="text-xs font-bold text-slate-500 uppercase tracking-widest">
+          <span className="text-xs font-bold text-muted-foreground uppercase tracking-widest">
             Matched
           </span>
-          <div className="text-2xl font-bold text-slate-900 dark:text-white mt-1">982</div>
+          <div className="text-2xl font-bold text-foreground dark:text-white mt-1">982</div>
           <div className="flex items-center gap-1 text-[11px] font-bold text-emerald-600 mt-2">
             <TrendingUp className="w-3 h-3" /> 12%
           </div>
         </Card>
         <Card className="p-4 border-rose-500/20 bg-rose-50/10 relative overflow-hidden group">
           <XCircle className="absolute -right-2 -top-2 w-16 h-16 text-rose-500 opacity-5" />
-          <span className="text-xs font-bold text-slate-500 uppercase tracking-widest">
+          <span className="text-xs font-bold text-muted-foreground uppercase tracking-widest">
             Mismatch
           </span>
-          <div className="text-2xl font-bold text-slate-900 dark:text-white mt-1">14</div>
+          <div className="text-2xl font-bold text-foreground dark:text-white mt-1">14</div>
           <div className="flex items-center gap-1 text-[11px] font-bold text-rose-600 mt-2">
             <TrendingUp className="w-3 h-3" /> 2%
           </div>
         </Card>
         <Card className="p-4 border-amber-500/20 bg-amber-50/10 relative overflow-hidden group">
           <AlertTriangle className="absolute -right-2 -top-2 w-16 h-16 text-amber-500 opacity-5" />
-          <span className="text-xs font-bold text-slate-500 uppercase tracking-widest">Review</span>
-          <div className="text-2xl font-bold text-slate-900 dark:text-white mt-1">244</div>
+          <span className="text-xs font-bold text-muted-foreground uppercase tracking-widest">Review</span>
+          <div className="text-2xl font-bold text-foreground dark:text-white mt-1">244</div>
           <div className="flex items-center gap-1 text-[11px] font-bold text-amber-600 mt-2">
             <TrendingDown className="w-3 h-3" /> 5%
           </div>
@@ -168,7 +168,7 @@ export function ResultsPanel() {
       </div>
 
       <div className="space-y-4">
-        <h2 className="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-widest mb-2">
+        <h2 className="text-xs font-bold text-muted-foreground dark:text-muted-foreground uppercase tracking-widest mb-2">
           Recent Transactions
         </h2>
         <div className="grid grid-cols-1 gap-4">
@@ -206,18 +206,18 @@ export function ResultsPanel() {
                     {res.status}
                   </Badge>
                 </div>
-                <span className="text-xs font-semibold text-slate-400">{res.time}</span>
+                <span className="text-xs font-semibold text-muted-foreground">{res.time}</span>
               </div>
               <div className="flex justify-between items-end">
                 <div>
-                  <div className="text-sm font-mono text-slate-500 mb-1">
+                  <div className="text-sm font-mono text-muted-foreground mb-1">
                     Trace:{" "}
-                    <span className="text-slate-900 dark:text-white font-bold">{res.traceId}</span>
+                    <span className="text-foreground dark:text-white font-bold">{res.traceId}</span>
                   </div>
-                  <div className="text-sm font-bold text-slate-900 dark:text-white">
+                  <div className="text-sm font-bold text-foreground dark:text-white">
                     Tx Ref: {res.ref}
                   </div>
-                  <div className="text-xs font-semibold text-slate-500 mt-1">
+                  <div className="text-xs font-semibold text-muted-foreground mt-1">
                     Pipeline: {res.pipeline}
                   </div>
                 </div>
@@ -262,7 +262,7 @@ export function ResultsPanel() {
 
               <div className="space-y-6">
                 <div className="flex justify-between items-center">
-                  <h3 className="text-xs font-bold uppercase text-slate-500 tracking-wider">
+                  <h3 className="text-xs font-bold uppercase text-muted-foreground tracking-wider">
                     Comparison Matrix
                   </h3>
                   <Button
@@ -276,19 +276,19 @@ export function ResultsPanel() {
 
                 <div className="grid grid-cols-2 gap-6">
                   <div className="space-y-3">
-                    <div className="flex items-center gap-2 text-xs font-bold text-slate-500">
+                    <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground">
                       <div className="w-2 h-2 rounded-full bg-blue-500" /> Source: Stripe API
                     </div>
-                    <Card className="p-4 bg-slate-50 dark:bg-slate-900 border-slate-200 dark:border-slate-800 space-y-4">
+                    <Card className="p-4 bg-muted/20 dark:bg-background border-border dark:border-border space-y-4">
                       <div>
-                        <span className="text-[10px] font-bold text-slate-400 uppercase">
+                        <span className="text-[10px] font-bold text-muted-foreground uppercase">
                           Amount
                         </span>
                         <div className="font-mono text-sm font-bold mt-1">100.00 USD</div>
                       </div>
-                      <div className="h-px bg-slate-200 dark:bg-slate-800" />
+                      <div className="h-px bg-slate-200 dark:bg-card" />
                       <div>
-                        <span className="text-[10px] font-bold text-slate-400 uppercase">
+                        <span className="text-[10px] font-bold text-muted-foreground uppercase">
                           Status
                         </span>
                         <div className="font-mono text-sm font-bold mt-1">succeeded</div>
@@ -296,13 +296,13 @@ export function ResultsPanel() {
                     </Card>
                   </div>
                   <div className="space-y-3">
-                    <div className="flex items-center gap-2 text-xs font-bold text-slate-500">
+                    <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground">
                       <div className="w-2 h-2 rounded-full bg-purple-500" /> Source: Internal DB
                     </div>
                     <Card className="p-4 bg-rose-50/30 dark:bg-rose-950/20 border-rose-500/30 space-y-4 relative">
                       <div className="absolute inset-x-0 top-0 h-1 bg-rose-500/10" />
                       <div>
-                        <span className="text-[10px] font-bold text-slate-400 uppercase">
+                        <span className="text-[10px] font-bold text-muted-foreground uppercase">
                           Amount
                         </span>
                         <div className="font-mono text-sm font-black text-rose-600 mt-1">
@@ -311,7 +311,7 @@ export function ResultsPanel() {
                       </div>
                       <div className="h-px bg-rose-500/10 my-2" />
                       <div>
-                        <span className="text-[10px] font-bold text-slate-400 uppercase">
+                        <span className="text-[10px] font-bold text-muted-foreground uppercase">
                           Status
                         </span>
                         <div className="font-mono text-sm font-bold mt-1">completed</div>
@@ -321,7 +321,7 @@ export function ResultsPanel() {
                 </div>
 
                 <div className="space-y-4">
-                  <h3 className="text-xs font-bold uppercase text-slate-500 tracking-wider">
+                  <h3 className="text-xs font-bold uppercase text-muted-foreground tracking-wider">
                     Logic Trace
                   </h3>
                   <div className="space-y-3">
@@ -329,7 +329,7 @@ export function ResultsPanel() {
                       <CheckCircle2 className="w-5 h-5 text-emerald-500" />
                       <div>
                         <p className="text-sm font-bold">Currency Match</p>
-                        <p className="text-xs text-slate-500 font-medium">
+                        <p className="text-xs text-muted-foreground font-medium">
                           Both sources match ISO-4217 code: USD
                         </p>
                       </div>

--- a/packages/web/src/components/stitch-import/ResultsTable.tsx
+++ b/packages/web/src/components/stitch-import/ResultsTable.tsx
@@ -25,53 +25,53 @@ const ResultsTable: React.FC = () => {
           <span>All Status</span>
           <ChevronDown className="h-4 w-4" />
         </button>
-        <button className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-200 dark:bg-surface-dark border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium">
-          <Calendar className="h-4 w-4 text-slate-400" />
+        <button className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-200 dark:bg-surface-dark border border-border dark:border-border text-foreground dark:text-muted-foreground text-sm font-medium">
+          <Calendar className="h-4 w-4 text-muted-foreground" />
           <span>Last 24h</span>
         </button>
-        <button className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-200 dark:bg-surface-dark border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium">
-          <GitBranch className="h-4 w-4 text-slate-400" />
+        <button className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-200 dark:bg-surface-dark border border-border dark:border-border text-foreground dark:text-muted-foreground text-sm font-medium">
+          <GitBranch className="h-4 w-4 text-muted-foreground" />
           <span>Payments_v2</span>
         </button>
-        <button className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-200 dark:bg-surface-dark border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium">
-          <Filter className="h-4 w-4 text-slate-400" />
+        <button className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-200 dark:bg-surface-dark border border-border dark:border-border text-foreground dark:text-muted-foreground text-sm font-medium">
+          <Filter className="h-4 w-4 text-muted-foreground" />
           <span>More</span>
         </button>
       </div>
       {/* Summary Statistics */}
       <div className="grid grid-cols-3 gap-3 px-4 mb-6">
-        <div className="flex flex-col gap-1 p-3 rounded-xl bg-white dark:bg-surface-dark border border-emerald-500/20 shadow-sm relative overflow-hidden group">
+        <div className="flex flex-col gap-1 p-3 rounded-xl bg-card dark:bg-surface-dark border border-emerald-500/20 shadow-sm relative overflow-hidden group">
           <div className="absolute right-0 top-0 p-2 opacity-10">
             <CheckCircle className="h-8 w-8 text-emerald-500" />
           </div>
-          <span className="text-xs text-slate-500 dark:text-slate-400 font-medium z-10">
+          <span className="text-xs text-muted-foreground dark:text-muted-foreground font-medium z-10">
             Matched
           </span>
-          <span className="text-xl font-bold text-slate-900 dark:text-white z-10">982</span>
+          <span className="text-xl font-bold text-foreground dark:text-white z-10">982</span>
           <span className="text-[10px] text-emerald-600 dark:text-emerald-400 font-medium flex items-center gap-0.5 z-10">
             <TrendingUp className="h-3 w-3" /> 12%
           </span>
         </div>
-        <div className="flex flex-col gap-1 p-3 rounded-xl bg-white dark:bg-surface-dark border border-rose-500/20 shadow-sm relative overflow-hidden">
+        <div className="flex flex-col gap-1 p-3 rounded-xl bg-card dark:bg-surface-dark border border-rose-500/20 shadow-sm relative overflow-hidden">
           <div className="absolute right-0 top-0 p-2 opacity-10">
             <XCircle className="h-8 w-8 text-rose-500" />
           </div>
-          <span className="text-xs text-slate-500 dark:text-slate-400 font-medium z-10">
+          <span className="text-xs text-muted-foreground dark:text-muted-foreground font-medium z-10">
             Mismatch
           </span>
-          <span className="text-xl font-bold text-slate-900 dark:text-white z-10">14</span>
+          <span className="text-xl font-bold text-foreground dark:text-white z-10">14</span>
           <span className="text-[10px] text-rose-600 dark:text-rose-400 font-medium flex items-center gap-0.5 z-10">
             <TrendingUp className="h-3 w-3" /> 2%
           </span>
         </div>
-        <div className="flex flex-col gap-1 p-3 rounded-xl bg-white dark:bg-surface-dark border border-amber-500/20 shadow-sm relative overflow-hidden">
+        <div className="flex flex-col gap-1 p-3 rounded-xl bg-card dark:bg-surface-dark border border-amber-500/20 shadow-sm relative overflow-hidden">
           <div className="absolute right-0 top-0 p-2 opacity-10">
             <AlertTriangle className="h-8 w-8 text-amber-500" />
           </div>
-          <span className="text-xs text-slate-500 dark:text-slate-400 font-medium z-10">
+          <span className="text-xs text-muted-foreground dark:text-muted-foreground font-medium z-10">
             Review
           </span>
-          <span className="text-xl font-bold text-slate-900 dark:text-white z-10">244</span>
+          <span className="text-xl font-bold text-foreground dark:text-white z-10">244</span>
           <span className="text-[10px] text-amber-600 dark:text-amber-400 font-medium flex items-center gap-0.5 z-10">
             <TrendingDown className="h-3 w-3" /> 5%
           </span>
@@ -79,11 +79,11 @@ const ResultsTable: React.FC = () => {
       </div>
       {/* Results List */}
       <div className="px-4 space-y-3">
-        <h2 className="text-sm font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">
+        <h2 className="text-sm font-semibold text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-2">
           Recent Transactions
         </h2>
         {/* Card Item: Mismatch (Active/Open State Simulation) */}
-        <div className="relative bg-white dark:bg-surface-dark rounded-xl p-4 shadow-sm border-l-4 border-rose-500 active:scale-[0.99] transition-transform">
+        <div className="relative bg-card dark:bg-surface-dark rounded-xl p-4 shadow-sm border-l-4 border-rose-500 active:scale-[0.99] transition-transform">
           <div className="flex justify-between items-start mb-2">
             <div className="flex items-center gap-2">
               <AlertCircle className="h-5 w-5 text-rose-500" />
@@ -91,18 +91,18 @@ const ResultsTable: React.FC = () => {
                 Unmatched
               </span>
             </div>
-            <span className="text-xs text-slate-400">10:42 AM</span>
+            <span className="text-xs text-muted-foreground">10:42 AM</span>
           </div>
           <div className="flex justify-between items-end">
             <div>
-              <div className="text-sm text-slate-500 dark:text-slate-400 font-mono mb-1">
+              <div className="text-sm text-muted-foreground dark:text-muted-foreground font-mono mb-1">
                 Trace:{" "}
-                <span className="text-slate-900 dark:text-white font-medium">8a9f...2b1</span>
+                <span className="text-foreground dark:text-white font-medium">8a9f...2b1</span>
               </div>
-              <div className="text-sm font-medium text-slate-900 dark:text-white">
+              <div className="text-sm font-medium text-foreground dark:text-white">
                 Tx Ref: #STR-29384
               </div>
-              <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground mt-1">
                 Pipeline: Payments_v2
               </div>
             </div>
@@ -112,7 +112,7 @@ const ResultsTable: React.FC = () => {
           </div>
         </div>
         {/* Card Item: Review Needed */}
-        <div className="relative bg-white dark:bg-surface-dark rounded-xl p-4 shadow-sm border-l-4 border-amber-500 active:scale-[0.99] transition-transform">
+        <div className="relative bg-card dark:bg-surface-dark rounded-xl p-4 shadow-sm border-l-4 border-amber-500 active:scale-[0.99] transition-transform">
           <div className="flex justify-between items-start mb-2">
             <div className="flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-amber-500" />
@@ -120,28 +120,28 @@ const ResultsTable: React.FC = () => {
                 Needs Review
               </span>
             </div>
-            <span className="text-xs text-slate-400">10:38 AM</span>
+            <span className="text-xs text-muted-foreground">10:38 AM</span>
           </div>
           <div className="flex justify-between items-end">
             <div>
-              <div className="text-sm text-slate-500 dark:text-slate-400 font-mono mb-1">
+              <div className="text-sm text-muted-foreground dark:text-muted-foreground font-mono mb-1">
                 Trace:{" "}
-                <span className="text-slate-900 dark:text-white font-medium">7c2d...9a4</span>
+                <span className="text-foreground dark:text-white font-medium">7c2d...9a4</span>
               </div>
-              <div className="text-sm font-medium text-slate-900 dark:text-white">
+              <div className="text-sm font-medium text-foreground dark:text-white">
                 Tx Ref: #INT-99210
               </div>
-              <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground mt-1">
                 Pipeline: Ledger_Main
               </div>
             </div>
-            <button className="text-slate-400 hover:text-primary transition-colors">
+            <button className="text-muted-foreground hover:text-primary transition-colors">
               <MoreVertical className="h-5 w-5" />
             </button>
           </div>
         </div>
         {/* Card Item: Matched */}
-        <div className="relative bg-white dark:bg-surface-dark rounded-xl p-4 shadow-sm border-l-4 border-emerald-500 active:scale-[0.99] transition-transform">
+        <div className="relative bg-card dark:bg-surface-dark rounded-xl p-4 shadow-sm border-l-4 border-emerald-500 active:scale-[0.99] transition-transform">
           <div className="flex justify-between items-start mb-2">
             <div className="flex items-center gap-2">
               <CheckCircle className="h-5 w-5 text-emerald-500" />
@@ -149,28 +149,28 @@ const ResultsTable: React.FC = () => {
                 Matched
               </span>
             </div>
-            <span className="text-xs text-slate-400">10:35 AM</span>
+            <span className="text-xs text-muted-foreground">10:35 AM</span>
           </div>
           <div className="flex justify-between items-end">
             <div>
-              <div className="text-sm text-slate-500 dark:text-slate-400 font-mono mb-1">
+              <div className="text-sm text-muted-foreground dark:text-muted-foreground font-mono mb-1">
                 Trace:{" "}
-                <span className="text-slate-900 dark:text-white font-medium">b41e...0f2</span>
+                <span className="text-foreground dark:text-white font-medium">b41e...0f2</span>
               </div>
-              <div className="text-sm font-medium text-slate-900 dark:text-white">
+              <div className="text-sm font-medium text-foreground dark:text-white">
                 Tx Ref: #STR-29383
               </div>
-              <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground mt-1">
                 Pipeline: Payments_v2
               </div>
             </div>
-            <button className="text-slate-400 hover:text-primary transition-colors">
+            <button className="text-muted-foreground hover:text-primary transition-colors">
               <MoreVertical className="h-5 w-5" />
             </button>
           </div>
         </div>
         {/* Card Item: Matched */}
-        <div className="relative bg-white dark:bg-surface-dark rounded-xl p-4 shadow-sm border-l-4 border-emerald-500 active:scale-[0.99] transition-transform">
+        <div className="relative bg-card dark:bg-surface-dark rounded-xl p-4 shadow-sm border-l-4 border-emerald-500 active:scale-[0.99] transition-transform">
           <div className="flex justify-between items-start mb-2">
             <div className="flex items-center gap-2">
               <CheckCircle className="h-5 w-5 text-emerald-500" />
@@ -178,22 +178,22 @@ const ResultsTable: React.FC = () => {
                 Matched
               </span>
             </div>
-            <span className="text-xs text-slate-400">10:31 AM</span>
+            <span className="text-xs text-muted-foreground">10:31 AM</span>
           </div>
           <div className="flex justify-between items-end">
             <div>
-              <div className="text-sm text-slate-500 dark:text-slate-400 font-mono mb-1">
+              <div className="text-sm text-muted-foreground dark:text-muted-foreground font-mono mb-1">
                 Trace:{" "}
-                <span className="text-slate-900 dark:text-white font-medium">a12d...8c3</span>
+                <span className="text-foreground dark:text-white font-medium">a12d...8c3</span>
               </div>
-              <div className="text-sm font-medium text-slate-900 dark:text-white">
+              <div className="text-sm font-medium text-foreground dark:text-white">
                 Tx Ref: #STR-29382
               </div>
-              <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground mt-1">
                 Pipeline: Payments_v2
               </div>
             </div>
-            <button className="text-slate-400 hover:text-primary transition-colors">
+            <button className="text-muted-foreground hover:text-primary transition-colors">
               <MoreVertical className="h-5 w-5" />
             </button>
           </div>

--- a/packages/web/src/components/stitch-import/ReviewQueue.tsx
+++ b/packages/web/src/components/stitch-import/ReviewQueue.tsx
@@ -9,7 +9,7 @@ const ReviewQueue: React.FC = () => {
       {/* Triage Carousel (Horizontal Scroll) */}
       <div className="pt-4 pb-2">
         <div className="px-4 mb-2 flex items-center justify-between">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-500">Queue</h2>
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Queue</h2>
           <span className="text-xs text-primary cursor-pointer hover:underline">View All</span>
         </div>
         <div className="flex overflow-x-auto gap-3 px-4 pb-4 no-scrollbar snap-x snap-mandatory">
@@ -19,7 +19,7 @@ const ReviewQueue: React.FC = () => {
             <div className="flex justify-between items-start mb-3">
               <div className="flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-accent-danger animate-pulse"></span>
-                <span className="text-xs font-mono text-slate-400">REC-9021</span>
+                <span className="text-xs font-mono text-muted-foreground">REC-9021</span>
               </div>
               <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-accent-danger/20 text-accent-danger border border-accent-danger/30">
                 HIGH SEVERITY
@@ -27,11 +27,11 @@ const ReviewQueue: React.FC = () => {
             </div>
             <div className="flex justify-between items-end">
               <div>
-                <p className="text-sm text-slate-400 mb-0.5">Discrepancy</p>
+                <p className="text-sm text-muted-foreground mb-0.5">Discrepancy</p>
                 <p className="text-xl font-bold text-white font-mono">$4,500.00</p>
               </div>
               <div className="text-right">
-                <p className="text-xs text-slate-500 mb-1">Confidence</p>
+                <p className="text-xs text-muted-foreground mb-1">Confidence</p>
                 <div className="flex items-center gap-1 text-accent-warning text-xs font-medium">
                   <AlertTriangle className="h-4 w-4" />
                   <span>Low Match</span>
@@ -44,7 +44,7 @@ const ReviewQueue: React.FC = () => {
             <div className="flex justify-between items-start mb-3">
               <div className="flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-accent-warning"></span>
-                <span className="text-xs font-mono text-slate-400">REC-9022</span>
+                <span className="text-xs font-mono text-muted-foreground">REC-9022</span>
               </div>
               <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-accent-warning/20 text-accent-warning border border-accent-warning/30">
                 MEDIUM
@@ -52,7 +52,7 @@ const ReviewQueue: React.FC = () => {
             </div>
             <div className="flex justify-between items-end">
               <div>
-                <p className="text-sm text-slate-400 mb-0.5">Discrepancy</p>
+                <p className="text-sm text-muted-foreground mb-0.5">Discrepancy</p>
                 <p className="text-xl font-bold text-white font-mono">$120.50</p>
               </div>
             </div>
@@ -62,15 +62,15 @@ const ReviewQueue: React.FC = () => {
             <div className="flex justify-between items-start mb-3">
               <div className="flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-slate-500"></span>
-                <span className="text-xs font-mono text-slate-400">REC-9023</span>
+                <span className="text-xs font-mono text-muted-foreground">REC-9023</span>
               </div>
-              <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-slate-700 text-slate-300 border border-slate-600">
+              <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-muted text-muted-foreground border border-slate-600">
                 LOW
               </span>
             </div>
             <div className="flex justify-between items-end">
               <div>
-                <p className="text-sm text-slate-400 mb-0.5">Discrepancy</p>
+                <p className="text-sm text-muted-foreground mb-0.5">Discrepancy</p>
                 <p className="text-xl font-bold text-white font-mono">$0.05</p>
               </div>
             </div>
@@ -82,7 +82,7 @@ const ReviewQueue: React.FC = () => {
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-base font-semibold text-white">Evidence Viewer</h2>
           <div
-            className="flex items-center gap-1.5 px-2 py-1 bg-surface-dark rounded text-xs text-slate-400 border border-border-dark cursor-copy"
+            className="flex items-center gap-1.5 px-2 py-1 bg-surface-dark rounded text-xs text-muted-foreground border border-border-dark cursor-copy"
             title="Copy Trace ID"
           >
             <Fingerprint className="h-3.5 w-3.5" />
@@ -94,25 +94,25 @@ const ReviewQueue: React.FC = () => {
           {/* Headers */}
           <div className="grid grid-cols-2 divide-x divide-border-dark bg-surface-darker border-b border-border-dark">
             <div className="p-3 text-center">
-              <p className="text-xs font-bold text-slate-400 uppercase tracking-wider">
+              <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
                 Source A (ERP)
               </p>
             </div>
             <div className="p-3 text-center">
-              <p className="text-xs font-bold text-slate-400 uppercase tracking-wider">
+              <p className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
                 Source B (Bank)
               </p>
             </div>
           </div>
           {/* Row 1: Match */}
-          <div className="grid grid-cols-2 divide-x divide-border-dark border-b border-border-dark/50 hover:bg-white/5 transition-colors">
+          <div className="grid grid-cols-2 divide-x divide-border-dark border-b border-border-dark/50 hover:bg-card/5 transition-colors">
             <div className="p-3">
-              <p className="text-[10px] text-slate-500 mb-0.5">Transaction ID</p>
-              <p className="text-sm font-mono text-slate-300 truncate">TX_99283811</p>
+              <p className="text-[10px] text-muted-foreground mb-0.5">Transaction ID</p>
+              <p className="text-sm font-mono text-muted-foreground truncate">TX_99283811</p>
             </div>
             <div className="p-3">
-              <p className="text-[10px] text-slate-500 mb-0.5">Transaction ID</p>
-              <p className="text-sm font-mono text-slate-300 truncate">TX_99283811</p>
+              <p className="text-[10px] text-muted-foreground mb-0.5">Transaction ID</p>
+              <p className="text-sm font-mono text-muted-foreground truncate">TX_99283811</p>
             </div>
           </div>
           {/* Row 2: Mismatch (Highlighted) */}
@@ -120,8 +120,8 @@ const ReviewQueue: React.FC = () => {
             {/* Mismatch Indicator Line */}
             <div className="absolute left-0 top-0 bottom-0 w-1 bg-accent-danger"></div>
             <div className="p-3 relative">
-              <p className="text-[10px] text-slate-500 mb-0.5">Amount</p>
-              <p className="text-sm font-mono font-bold text-slate-300">500.00</p>
+              <p className="text-[10px] text-muted-foreground mb-0.5">Amount</p>
+              <p className="text-sm font-mono font-bold text-muted-foreground">500.00</p>
             </div>
             <div className="p-3 bg-accent-danger/10">
               <p className="text-[10px] text-accent-danger/80 mb-0.5 font-bold">
@@ -134,25 +134,25 @@ const ReviewQueue: React.FC = () => {
             </div>
           </div>
           {/* Row 3: Match */}
-          <div className="grid grid-cols-2 divide-x divide-border-dark border-b border-border-dark/50 hover:bg-white/5 transition-colors">
+          <div className="grid grid-cols-2 divide-x divide-border-dark border-b border-border-dark/50 hover:bg-card/5 transition-colors">
             <div className="p-3">
-              <p className="text-[10px] text-slate-500 mb-0.5">Currency</p>
-              <p className="text-sm font-mono text-slate-300">USD</p>
+              <p className="text-[10px] text-muted-foreground mb-0.5">Currency</p>
+              <p className="text-sm font-mono text-muted-foreground">USD</p>
             </div>
             <div className="p-3">
-              <p className="text-[10px] text-slate-500 mb-0.5">Currency</p>
-              <p className="text-sm font-mono text-slate-300">USD</p>
+              <p className="text-[10px] text-muted-foreground mb-0.5">Currency</p>
+              <p className="text-sm font-mono text-muted-foreground">USD</p>
             </div>
           </div>
           {/* Row 4: Match */}
-          <div className="grid grid-cols-2 divide-x divide-border-dark hover:bg-white/5 transition-colors">
+          <div className="grid grid-cols-2 divide-x divide-border-dark hover:bg-card/5 transition-colors">
             <div className="p-3">
-              <p className="text-[10px] text-slate-500 mb-0.5">Date</p>
-              <p className="text-sm font-mono text-slate-300">2023-10-24</p>
+              <p className="text-[10px] text-muted-foreground mb-0.5">Date</p>
+              <p className="text-sm font-mono text-muted-foreground">2023-10-24</p>
             </div>
             <div className="p-3">
-              <p className="text-[10px] text-slate-500 mb-0.5">Date</p>
-              <p className="text-sm font-mono text-slate-300">2023-10-24</p>
+              <p className="text-[10px] text-muted-foreground mb-0.5">Date</p>
+              <p className="text-sm font-mono text-muted-foreground">2023-10-24</p>
             </div>
           </div>
         </div>
@@ -161,7 +161,7 @@ const ReviewQueue: React.FC = () => {
           <Info className="h-6 w-6 text-primary mt-0.5" />
           <div>
             <h3 className="text-sm font-semibold text-primary mb-1">AI Insight</h3>
-            <p className="text-xs text-slate-300 leading-relaxed">
+            <p className="text-xs text-muted-foreground leading-relaxed">
               The discrepancy appears to be a decimal placement error (10x difference).
               Historically, manual overrides favor Source B for this vendor.
             </p>

--- a/packages/web/src/components/stitch-import/ReviewQueuePanel.tsx
+++ b/packages/web/src/components/stitch-import/ReviewQueuePanel.tsx
@@ -54,22 +54,22 @@ export function ReviewQueuePanel() {
       <header className="flex flex-col gap-4">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground dark:text-white">
               Review Queue
             </h1>
-            <p className="text-slate-500 dark:text-slate-400 mt-1">
+            <p className="text-muted-foreground dark:text-muted-foreground mt-1">
               12 Pending reconciliations require human review.
             </p>
           </div>
           <Button variant="outline" size="icon" className="rounded-full">
-            <Filter className="w-5 h-5 text-slate-500" />
+            <Filter className="w-5 h-5 text-muted-foreground" />
           </Button>
         </div>
       </header>
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500">
+          <h2 className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
             Priority Queue
           </h2>
           <Button variant="link" size="sm" className="h-auto p-0 font-bold text-primary-600">
@@ -102,7 +102,7 @@ export function ReviewQueuePanel() {
                         : "bg-amber-500"
                     )}
                   />
-                  <span className="text-xs font-mono font-bold text-slate-500">{item.id}</span>
+                  <span className="text-xs font-mono font-bold text-muted-foreground">{item.id}</span>
                 </div>
                 <Badge
                   variant={
@@ -119,15 +119,15 @@ export function ReviewQueuePanel() {
               </div>
               <div className="flex justify-between items-end">
                 <div>
-                  <p className="text-xs font-bold text-slate-400 uppercase tracking-widest leading-none mb-1">
+                  <p className="text-xs font-bold text-muted-foreground uppercase tracking-widest leading-none mb-1">
                     Discrepancy
                   </p>
-                  <p className="text-2xl font-black text-slate-900 dark:text-white font-mono">
+                  <p className="text-2xl font-black text-foreground dark:text-white font-mono">
                     {item.amount}
                   </p>
                 </div>
                 <div className="text-right">
-                  <p className="text-[10px] font-bold text-slate-400 uppercase mb-1">Confidence</p>
+                  <p className="text-[10px] font-bold text-muted-foreground uppercase mb-1">Confidence</p>
                   <div
                     className={cn(
                       "flex items-center gap-1 text-xs font-bold",
@@ -146,50 +146,50 @@ export function ReviewQueuePanel() {
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-bold text-slate-900 dark:text-white">Evidence Viewer</h2>
-          <div className="flex items-center gap-2 px-3 py-1.5 bg-slate-100 dark:bg-slate-900 rounded-lg text-xs font-bold text-slate-500 border border-slate-200 dark:border-slate-800 cursor-copy group">
+          <h2 className="text-lg font-bold text-foreground dark:text-white">Evidence Viewer</h2>
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-muted/40 dark:bg-background rounded-lg text-xs font-bold text-muted-foreground border border-border dark:border-border cursor-copy group">
             <Fingerprint className="w-4 h-4 text-primary-500" />
             <span className="font-mono">{activeItem?.traceId}</span>
           </div>
         </div>
 
-        <Card className="overflow-hidden border-slate-200 dark:border-slate-800 shadow-sm font-medium">
-          <div className="grid grid-cols-2 divide-x divide-slate-100 dark:divide-slate-800 bg-slate-50 dark:bg-slate-900 border-b border-slate-100 dark:border-slate-800">
+        <Card className="overflow-hidden border-border dark:border-border shadow-sm font-medium">
+          <div className="grid grid-cols-2 divide-x divide-slate-100 dark:divide-slate-800 bg-muted/20 dark:bg-background border-b border-slate-100 dark:border-border">
             <div className="p-4 text-center">
-              <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+              <p className="text-[10px] font-black text-muted-foreground uppercase tracking-widest">
                 Source A (ERP)
               </p>
             </div>
             <div className="p-4 text-center">
-              <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+              <p className="text-[10px] font-black text-muted-foreground uppercase tracking-widest">
                 Source B (Bank)
               </p>
             </div>
           </div>
 
           <div className="divide-y divide-slate-50 dark:divide-slate-800">
-            <div className="grid grid-cols-2 divide-x divide-slate-50 dark:divide-slate-800 hover:bg-slate-50/50 transition-colors">
+            <div className="grid grid-cols-2 divide-x divide-slate-50 dark:divide-slate-800 hover:bg-muted/20/50 transition-colors">
               <div className="p-4">
-                <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1">
+                <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mb-1">
                   Transaction ID
                 </p>
-                <p className="text-sm font-mono text-slate-700 dark:text-slate-300">TX_99283811</p>
+                <p className="text-sm font-mono text-foreground dark:text-muted-foreground">TX_99283811</p>
               </div>
               <div className="p-4">
-                <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1">
+                <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mb-1">
                   Transaction ID
                 </p>
-                <p className="text-sm font-mono text-slate-700 dark:text-slate-300">TX_99283811</p>
+                <p className="text-sm font-mono text-foreground dark:text-muted-foreground">TX_99283811</p>
               </div>
             </div>
 
             <div className="grid grid-cols-2 divide-x divide-slate-50 dark:divide-slate-800 bg-red-50/10 relative">
               <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-600" />
               <div className="p-4">
-                <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1">
+                <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mb-1">
                   Amount
                 </p>
-                <p className="text-lg font-mono font-black text-slate-700 dark:text-slate-300">
+                <p className="text-lg font-mono font-black text-foreground dark:text-muted-foreground">
                   500.00
                 </p>
               </div>
@@ -204,18 +204,18 @@ export function ReviewQueuePanel() {
               </div>
             </div>
 
-            <div className="grid grid-cols-2 divide-x divide-slate-50 dark:divide-slate-800 hover:bg-slate-50/50 transition-colors">
+            <div className="grid grid-cols-2 divide-x divide-slate-50 dark:divide-slate-800 hover:bg-muted/20/50 transition-colors">
               <div className="p-4">
-                <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1">
+                <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mb-1">
                   Currency
                 </p>
-                <p className="text-sm font-mono text-slate-700 dark:text-slate-300">USD</p>
+                <p className="text-sm font-mono text-foreground dark:text-muted-foreground">USD</p>
               </div>
               <div className="p-4">
-                <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1">
+                <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mb-1">
                   Currency
                 </p>
-                <p className="text-sm font-mono text-slate-700 dark:text-slate-300">USD</p>
+                <p className="text-sm font-mono text-foreground dark:text-muted-foreground">USD</p>
               </div>
             </div>
           </div>
@@ -227,7 +227,7 @@ export function ReviewQueuePanel() {
             <h3 className="text-sm font-black text-primary-700 uppercase tracking-widest mb-1">
               AI Decision Co-pilot
             </h3>
-            <p className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed font-semibold">
+            <p className="text-xs text-muted-foreground dark:text-muted-foreground leading-relaxed font-semibold">
               The discrepancy appears to be a decimal placement error (10x difference).
               Historically, manual overrides favor Source B for this vendor. Suggested action:{" "}
               <span className="text-primary-600 underline cursor-pointer">
@@ -253,7 +253,7 @@ export function ReviewQueuePanel() {
           className="flex-1 h-14 rounded-2xl gap-3 flex flex-col items-center justify-center p-0"
           onClick={() => handleAction("override")}
         >
-          <Edit className="w-5 h-5 text-slate-500" />
+          <Edit className="w-5 h-5 text-muted-foreground" />
           <span className="text-[10px] font-black uppercase tracking-widest">Override</span>
         </Button>
         <Button

--- a/packages/web/src/components/ui/data-table.tsx
+++ b/packages/web/src/components/ui/data-table.tsx
@@ -1,0 +1,364 @@
+/**
+ * DataTable — Reusable dense data table system
+ *
+ * Provides consistent search, pagination, loading, empty, and error states
+ * across all operational list views. Designed to be incremental — adopt column
+ * defs and let the shell handle boilerplate.
+ *
+ * Usage:
+ *   <DataTable
+ *     columns={columns}
+ *     data={rows}
+ *     isLoading={false}
+ *     emptyState={{ title: "No runs yet", description: "..." }}
+ *     searchPlaceholder="Search run ID..."
+ *     pagination={{ page, pageSize, total, onPageChange }}
+ *   />
+ */
+
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Search, ChevronLeft, ChevronRight, Loader2, AlertCircle, Inbox } from "lucide-react";
+import { Button } from "./button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table";
+import { Card, CardContent, CardHeader } from "./card";
+
+// ─── Column Definition ────────────────────────────────────────────────────────
+
+export interface DataTableColumn<TRow> {
+  /** Unique key for this column */
+  key: string;
+  /** Column header label */
+  header: string;
+  /** Render the cell content from a row */
+  cell: (row: TRow) => React.ReactNode;
+  /** Optional header className */
+  headerClassName?: string;
+  /** Optional cell className */
+  cellClassName?: string;
+  /** Whether this column is sortable (UI hint only — parent handles sort logic) */
+  sortable?: boolean;
+}
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+export interface DataTablePagination {
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+}
+
+// ─── Empty State ──────────────────────────────────────────────────────────────
+
+export interface DataTableEmptyState {
+  title: string;
+  description: string;
+  /** Optional action button */
+  action?: {
+    label: string;
+    href?: string;
+    onClick?: () => void;
+  };
+}
+
+// ─── DataTable Props ──────────────────────────────────────────────────────────
+
+export interface DataTableProps<TRow> {
+  /** Column definitions */
+  columns: DataTableColumn<TRow>[];
+  /** Row data */
+  data: TRow[];
+  /** Key extractor for rows */
+  getRowKey?: (row: TRow, index: number) => string | number;
+  /** Whether data is loading */
+  isLoading?: boolean;
+  /** Error state message — shown instead of empty state on failure */
+  error?: string | null;
+  /** Empty state shown when data is empty and not loading */
+  emptyState?: DataTableEmptyState;
+  /** Controlled search value */
+  searchValue?: string;
+  /** Called when search input changes */
+  onSearchChange?: (value: string) => void;
+  /** Placeholder text for the search box */
+  searchPlaceholder?: string;
+  /** Pagination config — omit to hide pagination */
+  pagination?: DataTablePagination;
+  /** Optional toolbar slot rendered beside the search box */
+  toolbar?: React.ReactNode;
+  /** Optional title shown in the table header */
+  title?: string;
+  /** Optional description below the title */
+  description?: string;
+  /** Make rows clickable */
+  onRowClick?: (row: TRow) => void;
+  /** Additional className on the outer wrapper */
+  className?: string;
+  /** Show row count summary */
+  showCount?: boolean;
+}
+
+// ─── Internal: Skeleton rows ─────────────────────────────────────────────────
+
+function SkeletonRows({ columns, count = 5 }: { columns: number; count?: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <TableRow key={i} className="border-b border-border/20">
+          {Array.from({ length: columns }).map((_, j) => (
+            <TableCell key={j} className="py-3 px-4">
+              <div
+                className={cn(
+                  "h-4 rounded bg-muted/60 animate-pulse",
+                  j === 0 ? "w-24" : j === columns - 1 ? "w-12 ml-auto" : "w-full max-w-[180px]"
+                )}
+              />
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </>
+  );
+}
+
+// ─── Internal: Empty row ─────────────────────────────────────────────────────
+
+function EmptyRow({
+  columns,
+  state,
+}: {
+  columns: number;
+  state?: DataTableEmptyState;
+}) {
+  return (
+    <TableRow>
+      <TableCell colSpan={columns} className="h-56">
+        <div className="flex flex-col items-center justify-center gap-3 text-center py-6">
+          <div className="rounded-xl border border-border/60 bg-muted/20 p-4">
+            <Inbox className="h-7 w-7 text-muted-foreground/50" aria-hidden="true" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-foreground">
+              {state?.title ?? "No data"}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground max-w-xs leading-relaxed">
+              {state?.description ?? "Nothing to display here yet."}
+            </p>
+          </div>
+          {state?.action && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-1"
+              onClick={state.action.onClick}
+              asChild={!!state.action.href}
+            >
+              {state.action.href ? (
+                <a href={state.action.href}>{state.action.label}</a>
+              ) : (
+                state.action.label
+              )}
+            </Button>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+// ─── Internal: Error row ──────────────────────────────────────────────────────
+
+function ErrorRow({ columns, message }: { columns: number; message: string }) {
+  return (
+    <TableRow>
+      <TableCell colSpan={columns} className="h-40">
+        <div className="flex flex-col items-center justify-center gap-2 text-center py-6">
+          <AlertCircle className="h-6 w-6 text-destructive/70" aria-hidden="true" />
+          <p className="text-sm font-medium text-foreground">Something went wrong</p>
+          <p className="text-xs text-muted-foreground max-w-xs">{message}</p>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+// ─── DataTable ────────────────────────────────────────────────────────────────
+
+export function DataTable<TRow>({
+  columns,
+  data,
+  getRowKey,
+  isLoading = false,
+  error = null,
+  emptyState,
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = "Search…",
+  pagination,
+  toolbar,
+  title,
+  description,
+  onRowClick,
+  className,
+  showCount = true,
+}: DataTableProps<TRow>) {
+  const hasSearch = onSearchChange !== undefined;
+  const hasToolbar = hasSearch || toolbar;
+  const showPagination = !!pagination;
+  const totalPages = pagination ? Math.ceil(pagination.total / pagination.pageSize) : 0;
+
+  return (
+    <Card className={cn("overflow-hidden border-border/60 shadow-sm", className)}>
+      {/* Card header — title + toolbar */}
+      {(title || hasToolbar) && (
+        <CardHeader className="border-b border-border/40 pb-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            {/* Title + description */}
+            {title && (
+              <div className="min-w-0">
+                <h3 className="text-base font-semibold text-foreground leading-tight">{title}</h3>
+                {description && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+                )}
+              </div>
+            )}
+
+            {/* Toolbar: search + custom slot */}
+            {hasToolbar && (
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                {hasSearch && (
+                  <div className="relative">
+                    <Search
+                      className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none"
+                      aria-hidden="true"
+                    />
+                    <input
+                      type="search"
+                      value={searchValue}
+                      onChange={(e) => onSearchChange?.(e.target.value)}
+                      placeholder={searchPlaceholder}
+                      aria-label={searchPlaceholder}
+                      className={cn(
+                        "h-9 w-full sm:w-60 pl-9 pr-3 rounded-[var(--ui-radius-md)]",
+                        "border border-border bg-background text-sm text-foreground",
+                        "placeholder:text-muted-foreground",
+                        "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background",
+                        "transition-colors duration-100"
+                      )}
+                    />
+                  </div>
+                )}
+                {toolbar}
+              </div>
+            )}
+          </div>
+        </CardHeader>
+      )}
+
+      {/* Table */}
+      <CardContent className="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/20 hover:bg-muted/20 border-b border-border/40">
+              {columns.map((col) => (
+                <TableHead key={col.key} className={col.headerClassName}>
+                  {col.header}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <SkeletonRows columns={columns.length} count={5} />
+            ) : error ? (
+              <ErrorRow columns={columns.length} message={error} />
+            ) : data.length === 0 ? (
+              <EmptyRow columns={columns.length} state={emptyState} />
+            ) : (
+              data.map((row, index) => (
+                <TableRow
+                  key={getRowKey ? getRowKey(row, index) : index}
+                  onClick={onRowClick ? () => onRowClick(row) : undefined}
+                  className={cn(
+                    "border-b border-border/20 last:border-0 transition-colors",
+                    onRowClick && "cursor-pointer hover:bg-muted/40"
+                  )}
+                >
+                  {columns.map((col) => (
+                    <TableCell key={col.key} className={col.cellClassName}>
+                      {col.cell(row)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </CardContent>
+
+      {/* Footer: count + pagination */}
+      {(showCount || showPagination) && !isLoading && !error && data.length > 0 && (
+        <div className="border-t border-border/40 px-4 py-3 flex items-center justify-between gap-4">
+          {showCount && pagination ? (
+            <p className="text-xs text-muted-foreground">
+              Showing{" "}
+              <span className="font-medium text-foreground">
+                {(pagination.page - 1) * pagination.pageSize + 1}–
+                {Math.min(pagination.page * pagination.pageSize, pagination.total)}
+              </span>{" "}
+              of{" "}
+              <span className="font-medium text-foreground">
+                {pagination.total.toLocaleString()}
+              </span>
+            </p>
+          ) : showCount ? (
+            <p className="text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">{data.length}</span> row
+              {data.length !== 1 ? "s" : ""}
+            </p>
+          ) : (
+            <span />
+          )}
+
+          {showPagination && totalPages > 1 && (
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 w-7 p-0"
+                onClick={() => pagination?.onPageChange(pagination.page - 1)}
+                disabled={pagination?.page <= 1}
+                aria-label="Previous page"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+              </Button>
+              <span className="px-2 text-xs text-muted-foreground">
+                {pagination?.page} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 w-7 p-0"
+                onClick={() => pagination?.onPageChange(pagination.page + 1)}
+                disabled={pagination ? pagination.page >= totalPages : true}
+                aria-label="Next page"
+              >
+                <ChevronRight className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/packages/web/src/components/ui/page-header.tsx
+++ b/packages/web/src/components/ui/page-header.tsx
@@ -1,0 +1,75 @@
+/**
+ * PageHeader — Standardized app page header
+ *
+ * Provides consistent visual hierarchy across all operational pages:
+ * - Optional eyebrow label
+ * - Page title (h1)
+ * - Optional description
+ * - Optional action buttons in a right-aligned slot
+ * - Optional breadcrumb / back link
+ *
+ * Usage:
+ *   <PageHeader
+ *     eyebrow="Execution Ledger"
+ *     title="Reconciliation Runs"
+ *     description="A complete history of all reconciliation jobs executed within your tenant."
+ *     actions={<Button>New Run</Button>}
+ *   />
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface PageHeaderProps {
+  /** Short uppercase category label above the title */
+  eyebrow?: string;
+  /** Main page heading */
+  title: string;
+  /** Supporting description below the title */
+  description?: string;
+  /** Action buttons rendered right-aligned on desktop, stacked below on mobile */
+  actions?: React.ReactNode;
+  /** Extra content below description (e.g. alert banners, quick-filters) */
+  children?: React.ReactNode;
+  /** Additional className */
+  className?: string;
+}
+
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  children,
+  className,
+}: PageHeaderProps) {
+  return (
+    <header className={cn("pb-2", className)}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="min-w-0">
+          {eyebrow && (
+            <p className="mb-2 text-xs font-bold uppercase tracking-[0.18em] text-primary/70">
+              {eyebrow}
+            </p>
+          )}
+          <h1 className="text-3xl font-bold tracking-tight text-foreground leading-tight">
+            {title}
+          </h1>
+          {description && (
+            <p className="mt-3 max-w-2xl text-sm text-muted-foreground leading-relaxed">
+              {description}
+            </p>
+          )}
+        </div>
+
+        {actions && (
+          <div className="flex flex-wrap items-center gap-2 shrink-0">
+            {actions}
+          </div>
+        )}
+      </div>
+
+      {children && <div className="mt-4">{children}</div>}
+    </header>
+  );
+}

--- a/packages/web/src/components/ui/sparkline.tsx
+++ b/packages/web/src/components/ui/sparkline.tsx
@@ -1,0 +1,182 @@
+/**
+ * Sparkline — Lightweight inline trend chart (pure SVG, zero dependencies)
+ *
+ * Renders a small line or bar sparkline from an array of numeric values.
+ * Designed for stat cards, table rows, and KPI strips.
+ *
+ * Design rules:
+ * - No axis labels, no tooltips, no animation noise
+ * - Color signals trend direction
+ * - Accessible: aria-label conveys summary
+ * - Works in both light and dark mode via CSS variables
+ *
+ * Usage:
+ *   <Sparkline values={[10, 14, 9, 18, 22, 17, 25]} label="Run volume last 7 days" />
+ *   <Sparkline values={runs} variant="bar" tone="success" width={80} height={28} />
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface SparklineProps {
+  /** Data points to plot */
+  values: number[];
+  /** Accessible description of what the chart shows */
+  label: string;
+  /** Chart variant */
+  variant?: "line" | "bar";
+  /** Color tone */
+  tone?: "default" | "success" | "warning" | "danger";
+  /** Width in px */
+  width?: number;
+  /** Height in px */
+  height?: number;
+  /** Additional className */
+  className?: string;
+}
+
+const toneStroke: Record<NonNullable<SparklineProps["tone"]>, string> = {
+  default: "var(--primary)",
+  success: "#22c55e",
+  warning: "#f59e0b",
+  danger: "#ef4444",
+};
+
+const toneFill: Record<NonNullable<SparklineProps["tone"]>, string> = {
+  default: "var(--primary-light)",
+  success: "rgba(34,197,94,0.10)",
+  warning: "rgba(245,158,11,0.10)",
+  danger: "rgba(239,68,68,0.10)",
+};
+
+function buildLinePath(
+  values: number[],
+  width: number,
+  height: number,
+  padV = 3
+): { line: string; area: string } {
+  if (values.length < 2) return { line: "", area: "" };
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const stepX = width / (values.length - 1);
+  const scaleY = (v: number) =>
+    padV + ((max - v) / range) * (height - padV * 2);
+
+  const points = values.map((v, i) => [i * stepX, scaleY(v)] as [number, number]);
+
+  const line = points.map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+  const area = [
+    `M${points[0][0].toFixed(1)},${height}`,
+    ...points.map(([x, y]) => `L${x.toFixed(1)},${y.toFixed(1)}`),
+    `L${points[points.length - 1][0].toFixed(1)},${height}`,
+    "Z",
+  ].join(" ");
+
+  return { line, area };
+}
+
+export function Sparkline({
+  values,
+  label,
+  variant = "line",
+  tone = "default",
+  width = 64,
+  height = 24,
+  className,
+}: SparklineProps) {
+  const stroke = toneStroke[tone];
+  const fill = toneFill[tone];
+
+  if (!values || values.length === 0) {
+    return (
+      <svg
+        width={width}
+        height={height}
+        aria-label={label}
+        role="img"
+        className={cn("opacity-20", className)}
+      >
+        <line x1="0" y1={height / 2} x2={width} y2={height / 2} stroke={stroke} strokeWidth={1} />
+      </svg>
+    );
+  }
+
+  if (variant === "bar") {
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min || 1;
+    const barW = Math.max(2, (width / values.length) - 1);
+    const gap = (width - barW * values.length) / (values.length - 1 || 1);
+
+    return (
+      <svg
+        width={width}
+        height={height}
+        aria-label={label}
+        role="img"
+        className={className}
+      >
+        {values.map((v, i) => {
+          const barH = Math.max(2, ((v - min) / range) * (height - 2) + 2);
+          const x = i * (barW + gap);
+          const y = height - barH;
+          return (
+            <rect
+              key={i}
+              x={x}
+              y={y}
+              width={barW}
+              height={barH}
+              fill={stroke}
+              opacity={0.7}
+              rx={1}
+            />
+          );
+        })}
+      </svg>
+    );
+  }
+
+  // Line variant
+  const { line, area } = buildLinePath(values, width, height);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-label={label}
+      role="img"
+      className={cn("overflow-visible", className)}
+    >
+      {/* Area fill */}
+      {area && (
+        <path d={area} fill={fill} />
+      )}
+      {/* Line */}
+      {line && (
+        <path
+          d={line}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
+      {/* Terminal dot */}
+      {values.length > 0 && (() => {
+        const lastVal = values[values.length - 1];
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        const range = max - min || 1;
+        const x = width;
+        const y = 3 + ((max - lastVal) / range) * (height - 6);
+        return (
+          <circle cx={x} cy={y} r={2} fill={stroke} />
+        );
+      })()}
+    </svg>
+  );
+}


### PR DESCRIPTION
## Light Mode Token System (Phase 6)
- Add complete :root:not(.dark) semantic overrides in css-tokens.css
- Light mode now has distinct bg, surface, text, border, shadow, sidebar,
  and shadcn/ui HSL aliases — both themes feel first-class
- Scrollbar and inline code in globals.css now use semantic tokens

## New Shared UI Primitives (Phase 3)
- Add DataTable<TRow> component with: column defs, search, pagination,
  loading skeletons, empty state, error state, row click, toolbar slot
- Add PageHeader component: eyebrow, title, description, actions slot
- Add Sparkline component: zero-dep SVG line + bar charts for inline trends,
  uses real data only, supports tone variants and accessible aria-labels

## Token Debt Reduction (Phase 4)
Migrated ~270+ raw slate-* class instances to semantic tokens across:
- design-system/css-tokens.css (light mode layer added)
- 10 stitch-import components (ControlPlaneOverview, IntegrationList, etc.)
- 8 admin components (AuditLogViewer, UserImpersonation, etc.)
- 4 AI components (AIAnomalyDetector, SupportAssistant, etc.)
- 4 shared components (error-boundary, loading-state, etc.)
- 12+ page routes (monitoring, runs, console, dashboard, etc.)
- Marketing home page (was highest at 84 raw slate instances)

Replacements: slate-900→foreground, slate-500→muted-foreground,
bg-white→bg-card, bg-slate-50→bg-muted/20, border-slate-200→border-border

## Runs Page (Phase 8)
- Replace hardcoded bg-slate-900 CTA section with token-backed gradient panel
- Uses border-primary/15, bg-gradient-to-br, semantic text colors throughout

https://claude.ai/code/session_01LMzqKnz95wohfE6sEWGJdW