### PR TITLE
fix(security): Phase 1 audit remediation — P0/P1 blockers

### DIFF
--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -277,6 +277,8 @@ export const config = {
      * ensure zero auth/env assumptions and maximum performance.
      */
     "/app/:path*",
+    "/console/:path*",
+    "/admin/:path*",
     "/api/:path*",
   ],
 };

--- a/packages/web/src/app/console/reality/page.tsx
+++ b/packages/web/src/app/console/reality/page.tsx
@@ -43,8 +43,8 @@ async function RealityDashboardContent() {
     );
   }
 
-  // Check admin access
-  const isAdmin = user.user_metadata?.role === 'admin' || user.email?.endsWith('@settler.dev');
+  // Check admin access via role metadata only — email domain bypass removed (security)
+  const isAdmin = user.user_metadata?.role === 'admin' || user.user_metadata?.role === 'SUPER_ADMIN' || user.user_metadata?.role === 'super_admin';
   
   if (!isAdmin) {
     return (

--- a/packages/web/src/lib/api/error-handler.ts
+++ b/packages/web/src/lib/api/error-handler.ts
@@ -33,8 +33,9 @@ export enum ErrorCode {
 
 /**
  * Handle errors in API routes
- * Always returns 200 with error envelope (never 500)
- * Includes trace_id in response
+ * Returns semantically correct HTTP status codes so clients and monitors can
+ * act on them without parsing the response body.
+ * Includes trace_id in all error responses.
  */
 export async function handleApiError(
   error: unknown,
@@ -43,11 +44,11 @@ export async function handleApiError(
 ): Promise<NextResponse<ErrorEnvelope & { trace_id: string }>> {
   // Get trace_id
   const traceId = await getTraceId();
-  
+
   // Log error server-side with trace_id (never expose to client)
   const errorMessage = error instanceof Error ? error.message : String(error);
   const errorStack = error instanceof Error ? error.stack : undefined;
-  
+
   await logger.error('API Error', {
     trace_id: traceId,
     route: context?.route,
@@ -76,7 +77,7 @@ export async function handleApiError(
           })),
         },
       },
-      { status: 200 } // Return 200 even for validation errors
+      { status: 400 }
     );
     response.headers.set('x-trace-id', traceId);
     return response;
@@ -90,7 +91,7 @@ export async function handleApiError(
         error: 'Authentication required',
         code: ErrorCode.UNAUTHORIZED,
       },
-      { status: 200 } // Return 200, client can check code
+      { status: 401 }
     );
     response.headers.set('x-trace-id', traceId);
     return response;
@@ -104,7 +105,7 @@ export async function handleApiError(
         error: 'Permission denied',
         code: ErrorCode.FORBIDDEN,
       },
-      { status: 200 }
+      { status: 403 }
     );
     response.headers.set('x-trace-id', traceId);
     return response;
@@ -118,7 +119,7 @@ export async function handleApiError(
         error: 'Resource not found',
         code: ErrorCode.NOT_FOUND,
       },
-      { status: 200 }
+      { status: 404 }
     );
     response.headers.set('x-trace-id', traceId);
     return response;
@@ -132,7 +133,7 @@ export async function handleApiError(
         error: 'Rate limit exceeded',
         code: ErrorCode.RATE_LIMIT,
       },
-      { status: 200 }
+      { status: 429 }
     );
     response.headers.set('x-trace-id', traceId);
     return response;
@@ -146,20 +147,20 @@ export async function handleApiError(
         error: 'Service temporarily unavailable',
         code: ErrorCode.SERVICE_UNAVAILABLE,
       },
-      { status: 200 }
+      { status: 503 }
     );
     response.headers.set('x-trace-id', traceId);
     return response;
   }
 
-  // Default error (never expose internal details)
+  // Default: internal server error
   const response = NextResponse.json(
     {
       ...baseResponse,
       error: defaultMessage,
       code: ErrorCode.INTERNAL_ERROR,
     },
-    { status: 200 } // Always return 200, never 500
+    { status: 500 }
   );
   response.headers.set('x-trace-id', traceId);
   return response;

--- a/packages/web/src/lib/api/v1/recon/core.ts
+++ b/packages/web/src/lib/api/v1/recon/core.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateApiKey } from "@/shared/auth/apiKey";
 import { prisma } from "@/shared/db/prismaClient";
+import { encrypt } from "@/lib/security/encryption";
 import { z } from "zod";
 
 export const runtime = "nodejs";
@@ -13,6 +14,7 @@ type ProblemCode =
   | "SETTLER_INVALID_INPUT"
   | "SETTLER_CONFLICT"
   | "SETTLER_NOT_FOUND"
+  | "SETTLER_NOT_IMPLEMENTED"
   | "SETTLER_INTERNAL";
 
 export const RunCreateSchema = z
@@ -194,7 +196,19 @@ export function storeIdempotent(
 }
 
 export async function createRun(ctx: ApiContext, body: z.infer<typeof RunCreateSchema>) {
-  const startedAt = Date.now();
+  if (!body.async) {
+    // Synchronous execution is not yet implemented. Callers must use async: true
+    // and poll /runs/:id for status. Returning 501 prevents a fake "succeeded"
+    // result from being written without any actual reconciliation work.
+    throw Object.assign(new Error("Synchronous run mode is not yet supported. Set async: true and poll for completion."), {
+      code: "SETTLER_NOT_IMPLEMENTED",
+      status: 501,
+    });
+  }
+
+  const sourceConfigEncrypted = encrypt(JSON.stringify(body.sourceConfig));
+  const targetConfigEncrypted = encrypt(JSON.stringify(body.targetConfig));
+
   const job = await prisma.reconJob.create({
     data: {
       tenantId: ctx.tenantId,
@@ -202,47 +216,14 @@ export async function createRun(ctx: ApiContext, body: z.infer<typeof RunCreateS
       name: body.name,
       description: body.description || null,
       sourceAdapter: body.sourceAdapter,
-      sourceConfigEncrypted: JSON.stringify(body.sourceConfig),
+      sourceConfigEncrypted,
       targetAdapter: body.targetAdapter,
-      targetConfigEncrypted: JSON.stringify(body.targetConfig),
+      targetConfigEncrypted,
       validationRules: body.rules,
-      status: body.async ? "queued" : "running",
-      metadata: { mode: body.async ? "async" : "sync" },
+      status: "queued",
+      metadata: { mode: "async" },
     },
   });
-
-  if (!body.async) {
-    const fingerprint = createHash("sha256").update(job.id).digest("hex");
-    await prisma.reconResult.create({
-      data: {
-        reconJobId: job.id,
-        tenantId: ctx.tenantId,
-        status: "succeeded",
-        completedAt: new Date(),
-        summary: { message: "sync execution completed" },
-        metadata: { fingerprint },
-      },
-    });
-    await prisma.reconJob.update({ where: { id: job.id }, data: { status: "completed" } });
-
-    await recordRunMetrics(ctx, {
-      runId: job.id,
-      status: "succeeded",
-      durationMs: Date.now() - startedAt,
-      fingerprint,
-      replayOk: null,
-      evidenceSizeBytes: JSON.stringify(body).length,
-      policyId: "default",
-      policyHash: createHash("sha256").update("default-policy").digest("hex"),
-    });
-
-    await recordEconomicMetrics(ctx, job.id, {
-      computeUnits: 1,
-      memoryUnits: 1,
-      casIoUnits: 1,
-      replayCalls: 0,
-    });
-  }
 
   return job;
 }
@@ -354,6 +335,25 @@ export function fail(error: unknown, request: NextRequest, requestId: string) {
       requestId,
       request.nextUrl.pathname
     );
+  }
+  // Typed errors with an explicit status (e.g. 501 Not Implemented)
+  if (error instanceof Error && typeof (error as NodeJS.ErrnoException & { status?: number }).status === "number") {
+    const typedError = error as Error & { code?: ProblemCode; status: number };
+    const knownCodes: ProblemCode[] = [
+      "SETTLER_AUTH_REQUIRED",
+      "SETTLER_RATE_LIMITED",
+      "SETTLER_TENANT_REQUIRED",
+      "SETTLER_INVALID_INPUT",
+      "SETTLER_CONFLICT",
+      "SETTLER_NOT_FOUND",
+      "SETTLER_NOT_IMPLEMENTED",
+      "SETTLER_INTERNAL",
+    ];
+    const code: ProblemCode =
+      typedError.code && knownCodes.includes(typedError.code as ProblemCode)
+        ? (typedError.code as ProblemCode)
+        : "SETTLER_INTERNAL";
+    return problem(typedError.status, code, "Request failed", typedError.message, requestId, request.nextUrl.pathname);
   }
   const message = error instanceof Error ? error.message : "Unhandled API error";
   return problem(

--- a/packages/web/src/lib/auth/super-admin.ts
+++ b/packages/web/src/lib/auth/super-admin.ts
@@ -32,12 +32,7 @@ export async function isSuperAdmin(): Promise<boolean> {
     if (userMetadata?.role === 'SUPER_ADMIN' || userMetadata?.role === 'super_admin') {
       return true;
     }
-    
-    // Fallback: Check email domain (for Settler team)
-    if (user.email?.endsWith('@settler.dev')) {
-      return true;
-    }
-    
+
     return false;
   } catch (error) {
     console.error('[isSuperAdmin] Error checking super admin status:', error);

--- a/packages/web/src/lib/routing/route-groups.ts
+++ b/packages/web/src/lib/routing/route-groups.ts
@@ -3,6 +3,8 @@ export const ROUTE_GROUPS = {
   app: 'app',
 } as const;
 
-export const APP_ROUTE_PREFIXES = ['/app'] as const;
+// Routes that REQUIRE authentication at the middleware layer (redirect to /login if not authed).
+// /console is intentionally excluded — pages handle their own gating for free-view support.
+export const APP_ROUTE_PREFIXES = ['/app', '/admin'] as const;
 
 export const MARKETING_ROUTE_GROUP_ROOTS = ['packages/web/src/app/(marketing)'] as const;


### PR DESCRIPTION
P0 — Credential encryption (core.ts):
- sourceConfigEncrypted / targetConfigEncrypted now use AES-256-GCM
  via the existing encrypt() utility instead of raw JSON.stringify.

P0 — Admin email-domain bypass (super-admin.ts, reality/page.tsx):
- Removed the @settler.dev email-domain shortcut that granted full
  super-admin to any matching address without a database role check.
- Both isSuperAdmin() and the reality dashboard now gate solely on
  getUserRole() / user_metadata.role.

P1 — Sync-mode fake success (core.ts):
- createRun() with async:false previously wrote a "succeeded" result
  immediately without any reconciliation work.  It now throws a typed
  501 Not Implemented error so callers know to use async:true.
- fail() updated to propagate typed errors with explicit HTTP status
  codes, including the new SETTLER_NOT_IMPLEMENTED problem code.

P1 — Middleware coverage gap (middleware.ts, route-groups.ts):
- Added /console/:path* and /admin/:path* to the middleware matcher
  so security headers and Supabase cookie refresh run for these routes.
- Added /admin to APP_ROUTE_PREFIXES (middleware-enforced auth).
- /console intentionally left out of auth-required prefixes because
  the console layout supports an unauthenticated free-view mode.

P1 — HTTP status codes (error-handler.ts):
- handleApiError() previously returned HTTP 200 for every error type
  (validation, auth, 404, rate-limit, 503, 500).
- Now returns semantically correct status codes: 400, 401, 403, 404,
  429, 503, 500 so monitors, clients, and load-balancers can act
  on them without inspecting the response body.

https://claude.ai/code/session_01E9oiBp69QpjwisWAaG5MwF