### PR TITLE
feat(hardening): Redis-backed rate limiting & idempotency, internal-API safety, real recon list

### DIFF
--- a/packages/web/src/app/api/console/reconciliation/route.ts
+++ b/packages/web/src/app/api/console/reconciliation/route.ts
@@ -17,6 +17,7 @@ import {
   resolveTenantMembershipScope,
   TenantMembershipError,
 } from "@/lib/supabase/tenant-membership";
+import { prisma } from "@/shared/db/prismaClient";
 import { z } from "zod";
 import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
 import { appLogger } from "@/lib/utils/logger";
@@ -194,8 +195,81 @@ export const GET = withSecurity(
           });
         }
 
-        // List all reconciliations (placeholder - would need list function)
-        return NextResponse.json({ reconciliations: [] }, { status: 200 });
+        // List reconciliation jobs for this tenant with their latest result
+        const cursor = request.nextUrl.searchParams.get("cursor") ?? undefined;
+        const limit = Math.min(Number(request.nextUrl.searchParams.get("limit") || 50), 500);
+
+        const jobs = await prisma.reconJob.findMany({
+          where: { tenantId, deletedAt: null },
+          orderBy: { createdAt: "desc" },
+          take: limit,
+          ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+          select: {
+            id: true,
+            name: true,
+            status: true,
+            sourceAdapter: true,
+            targetAdapter: true,
+            createdAt: true,
+            updatedAt: true,
+            results: {
+              orderBy: { startedAt: "desc" },
+              take: 1,
+              select: {
+                id: true,
+                status: true,
+                startedAt: true,
+                completedAt: true,
+                sourceCount: true,
+                targetCount: true,
+                matchedCount: true,
+                unmatchedSourceCount: true,
+                unmatchedTargetCount: true,
+                conflictCount: true,
+                errorMessage: true,
+              },
+            },
+          },
+        });
+
+        const reconciliations = jobs.map((job) => {
+          const latest = job.results[0] ?? null;
+          return {
+            id: job.id,
+            name: job.name,
+            status: job.status,
+            sourceAdapter: job.sourceAdapter,
+            targetAdapter: job.targetAdapter,
+            createdAt: job.createdAt.toISOString(),
+            updatedAt: job.updatedAt.toISOString(),
+            latestResult: latest
+              ? {
+                  id: latest.id,
+                  status: latest.status,
+                  startedAt: latest.startedAt.toISOString(),
+                  completedAt: latest.completedAt?.toISOString() ?? null,
+                  counts: {
+                    source: latest.sourceCount,
+                    target: latest.targetCount,
+                    matched: latest.matchedCount,
+                    unmatchedSource: latest.unmatchedSourceCount,
+                    unmatchedTarget: latest.unmatchedTargetCount,
+                    conflicts: latest.conflictCount,
+                  },
+                  errorMessage: latest.errorMessage ?? null,
+                }
+              : null,
+          };
+        });
+
+        return NextResponse.json(
+          {
+            reconciliations,
+            next_cursor:
+              jobs.length === limit ? (jobs[jobs.length - 1]?.id ?? null) : null,
+          },
+          { status: 200 }
+        );
       } catch (error) {
         if (error instanceof TenantMembershipError) {
           return NextResponse.json(

--- a/packages/web/src/app/api/v1/datasets/route.ts
+++ b/packages/web/src/app/api/v1/datasets/route.ts
@@ -14,14 +14,14 @@ export const runtime = "nodejs";
 export async function GET(request: NextRequest) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) return limited;
 
   try {
     const url = new URL(request.url);
     const limit = Math.min(Number(url.searchParams.get("limit") || 50), 100);
     const cursor = Number(url.searchParams.get("cursor") || 0);
-    const all = listDatasets(ctx.tenantId);
+    const all = await listDatasets(ctx.tenantId);
     const data = all.slice(cursor, cursor + limit);
     const nextCursor = cursor + limit < all.length ? String(cursor + limit) : undefined;
     return ok(
@@ -36,12 +36,12 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "write");
+  const limited = await applyRateLimit(ctx, "write");
   if (limited) return limited;
 
   try {
     const parsed = DatasetCreateSchema.parse(await request.json());
-    const dataset = addDataset(ctx.tenantId, parsed);
+    const dataset = await addDataset(ctx.tenantId, parsed);
     return ok(NextResponse.json(dataset, { status: 201 }), ctx.requestId);
   } catch (error) {
     return fail(error, request, ctx.requestId);

--- a/packages/web/src/app/api/v1/metrics/summary/route.ts
+++ b/packages/web/src/app/api/v1/metrics/summary/route.ts
@@ -10,7 +10,7 @@ export const runtime = "nodejs";
 export async function GET(request: NextRequest) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) return limited;
 
   try {

--- a/packages/web/src/app/api/v1/metrics/timeseries/route.ts
+++ b/packages/web/src/app/api/v1/metrics/timeseries/route.ts
@@ -15,7 +15,7 @@ export const runtime = "nodejs";
 export async function GET(request: NextRequest) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) return limited;
 
   try {

--- a/packages/web/src/app/api/v1/metrics/top/route.ts
+++ b/packages/web/src/app/api/v1/metrics/top/route.ts
@@ -14,7 +14,7 @@ export const runtime = "nodejs";
 export async function GET(request: NextRequest) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) return limited;
 
   try {

--- a/packages/web/src/app/api/v1/runs/[id]/[runId]/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/[runId]/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   }
 
   const started = Date.now();
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) {
     await recordRequestMetrics(ctx, {
       route: `/api/v1/runs/${params.id}`,

--- a/packages/web/src/app/api/v1/runs/[id]/evidence/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/evidence/route.ts
@@ -15,7 +15,7 @@ export const runtime = "nodejs";
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) return limited;
 
   try {

--- a/packages/web/src/app/api/v1/runs/[id]/replay/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/replay/route.ts
@@ -16,7 +16,7 @@ export const runtime = "nodejs";
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) return limited;
 
   try {
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "write");
+  const limited = await applyRateLimit(ctx, "write");
   if (limited) return limited;
 
   try {

--- a/packages/web/src/app/api/v1/runs/[id]/results/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/results/route.ts
@@ -14,7 +14,7 @@ export const runtime = "nodejs";
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) return limited;
 
   try {

--- a/packages/web/src/app/api/v1/runs/[id]/route.ts
+++ b/packages/web/src/app/api/v1/runs/[id]/route.ts
@@ -14,7 +14,7 @@ export const runtime = "nodejs";
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const ctx = await buildContext(request);
   if (ctx instanceof NextResponse) return ctx;
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) return limited;
 
   try {

--- a/packages/web/src/app/api/v1/runs/route.ts
+++ b/packages/web/src/app/api/v1/runs/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: NextRequest) {
   }
 
   const started = Date.now();
-  const limited = applyRateLimit(ctx, "read");
+  const limited = await applyRateLimit(ctx, "read");
   if (limited) {
     await recordRequestMetrics(ctx, {
       route: "/api/v1/runs",
@@ -234,7 +234,7 @@ export async function POST(request: NextRequest) {
   }
 
   const started = Date.now();
-  const limited = applyRateLimit(ctx, "write");
+  const limited = await applyRateLimit(ctx, "write");
   if (limited) {
     await recordRequestMetrics(ctx, {
       route: "/api/v1/runs",
@@ -258,7 +258,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const idem = getIdempotent(ctx.tenantId, idempotencyKey, parsed);
+    const idem = await getIdempotent(ctx.tenantId, idempotencyKey, parsed);
     if ((idem as { conflict?: boolean }).conflict) {
       return NextResponse.json(
         { error: "Idempotency key reuse with different request", code: "SETTLER_CONFLICT" },
@@ -279,7 +279,7 @@ export async function POST(request: NextRequest) {
       mode: parsed.async ? "async" : "sync",
       created_at: run.createdAt.toISOString(),
     };
-    storeIdempotent(ctx.tenantId, idempotencyKey, idem.reqHash, payload);
+    await storeIdempotent(ctx.tenantId, idempotencyKey, idem.reqHash, payload);
 
     await recordRequestMetrics(ctx, {
       route: "/api/v1/runs",

--- a/packages/web/src/lib/api/v1/recon/core.ts
+++ b/packages/web/src/lib/api/v1/recon/core.ts
@@ -3,9 +3,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { authenticateApiKey } from "@/shared/auth/apiKey";
 import { prisma } from "@/shared/db/prismaClient";
 import { encrypt } from "@/lib/security/encryption";
+import { getRedisClient } from "@/lib/redis/client";
 import { z } from "zod";
 
 export const runtime = "nodejs";
+
+// ─── TTLs ─────────────────────────────────────────────────────────────────────
+const RATE_LIMIT_WINDOW_SEC = 60;
+const IDEMPOTENCY_TTL_SEC = 60 * 60 * 24; // 24 h
+const DATASET_TTL_SEC = 60 * 60 * 24 * 7; // 7 d
 
 type ProblemCode =
   | "SETTLER_AUTH_REQUIRED"
@@ -37,14 +43,15 @@ export const DatasetCreateSchema = z
   })
   .strict();
 
-const routeBuckets = new Map<string, { count: number; resetAt: number }>();
-const idempotencyStore = new Map<string, { hash: string; response: Record<string, unknown> }>();
-const datasetStore = new Map<
+// ─── In-memory fallbacks (single-instance only) ───────────────────────────────
+const _routeBuckets = new Map<string, { count: number; resetAt: number }>();
+const _idempotencyStore = new Map<string, { hash: string; response: Record<string, unknown> }>();
+const _datasetStore = new Map<
   string,
   Array<{ id: string; name: string; source: string; createdAt: string }>
 >();
 
-type ApiContext = { requestId: string; tenantId: string; userId: string; ip: string };
+export type ApiContext = { requestId: string; tenantId: string; userId: string; ip: string };
 
 type RunMetricsPayload = {
   runId: string;
@@ -134,14 +141,48 @@ export async function buildContext(request: NextRequest): Promise<ApiContext | N
   return { requestId, tenantId: auth.tenantId, userId: auth.userId, ip };
 }
 
-export function applyRateLimit(ctx: ApiContext, routeClass: "read" | "write"): NextResponse | null {
-  const now = Date.now();
+// ─── Rate limiting (Redis-backed, in-memory fallback) ─────────────────────────
+export async function applyRateLimit(
+  ctx: ApiContext,
+  routeClass: "read" | "write"
+): Promise<NextResponse | null> {
   const envKey = `SETTLER_RATE_LIMIT_${routeClass.toUpperCase()}`;
   const limit = Number(process.env[envKey] || (routeClass === "write" ? 30 : 120));
+  const redisKey = `rl:v1:${ctx.tenantId}:${ctx.ip}:${routeClass}`;
+
+  const redis = await getRedisClient();
+
+  if (redis) {
+    try {
+      const count: number = await redis.incr(redisKey);
+      if (count === 1) {
+        await redis.expire(redisKey, RATE_LIMIT_WINDOW_SEC);
+      }
+      if (count > limit) {
+        const ttl: number = Math.max(await redis.ttl(redisKey), 1);
+        const res = problem(
+          429,
+          "SETTLER_RATE_LIMITED",
+          "Rate limited",
+          "Too many requests for this tenant and IP.",
+          ctx.requestId,
+          "rate-limit"
+        );
+        res.headers.set("retry-after", String(ttl));
+        return res;
+      }
+      return null;
+    } catch {
+      // Fall through to in-memory fallback
+    }
+  }
+
+  // In-memory fallback (single-instance; not suitable for multi-replica deployments without Redis)
+  const now = Date.now();
   const key = `${ctx.tenantId}:${ctx.ip}:${routeClass}`;
-  const current = routeBuckets.get(key);
+  const current = _routeBuckets.get(key);
   if (!current || current.resetAt < now) {
-    routeBuckets.set(key, { count: 1, resetAt: now + 60_000 });
+    _routeBuckets.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_SEC * 1000 });
     return null;
   }
   if (current.count >= limit) {
@@ -157,7 +198,7 @@ export function applyRateLimit(ctx: ApiContext, routeClass: "read" | "write"): N
     return res;
   }
   current.count += 1;
-  routeBuckets.set(key, current);
+  _routeBuckets.set(key, current);
   return null;
 }
 
@@ -178,21 +219,99 @@ export function setCachingHeaders(res: NextResponse, payload: unknown, immutable
   return res;
 }
 
-export function getIdempotent(tenantId: string, key: string, body: unknown) {
+// ─── Idempotency (Redis-backed, in-memory fallback) ───────────────────────────
+export async function getIdempotent(tenantId: string, key: string, body: unknown) {
   const reqHash = createHash("sha256").update(JSON.stringify(body)).digest("hex");
-  const lookup = idempotencyStore.get(`${tenantId}:${key}`);
+  const redisKey = `idem:v1:${tenantId}:${key}`;
+
+  const redis = await getRedisClient();
+
+  if (redis) {
+    try {
+      const stored = await redis.get<{ hash: string; response: Record<string, unknown> }>(redisKey);
+      if (!stored) return { reqHash, replay: null };
+      if (stored.hash !== reqHash) return { reqHash, conflict: true };
+      return { reqHash, replay: stored.response };
+    } catch {
+      // Fall through to in-memory fallback
+    }
+  }
+
+  const lookup = _idempotencyStore.get(`${tenantId}:${key}`);
   if (!lookup) return { reqHash, replay: null };
   if (lookup.hash !== reqHash) return { reqHash, conflict: true };
   return { reqHash, replay: lookup.response };
 }
 
-export function storeIdempotent(
+export async function storeIdempotent(
   tenantId: string,
   key: string,
   reqHash: string,
   response: Record<string, unknown>
 ) {
-  idempotencyStore.set(`${tenantId}:${key}`, { hash: reqHash, response });
+  const redisKey = `idem:v1:${tenantId}:${key}`;
+  const redis = await getRedisClient();
+
+  if (redis) {
+    try {
+      await redis.set(redisKey, { hash: reqHash, response }, { ex: IDEMPOTENCY_TTL_SEC });
+      return;
+    } catch {
+      // Fall through to in-memory fallback
+    }
+  }
+
+  _idempotencyStore.set(`${tenantId}:${key}`, { hash: reqHash, response });
+}
+
+// ─── Dataset store (Redis-backed, in-memory fallback) ─────────────────────────
+type DatasetEntry = { id: string; name: string; source: string; createdAt: string };
+
+export async function listDatasets(tenantId: string): Promise<DatasetEntry[]> {
+  const redisKey = `datasets:v1:${tenantId}`;
+  const redis = await getRedisClient();
+
+  if (redis) {
+    try {
+      const stored = await redis.get<DatasetEntry[]>(redisKey);
+      return stored ?? [];
+    } catch {
+      // Fall through to in-memory fallback
+    }
+  }
+
+  return _datasetStore.get(tenantId) ?? [];
+}
+
+export async function addDataset(
+  tenantId: string,
+  payload: { name: string; source: string }
+): Promise<DatasetEntry> {
+  const entry: DatasetEntry = {
+    id: randomUUID(),
+    name: payload.name,
+    source: payload.source,
+    createdAt: new Date().toISOString(),
+  };
+
+  const redisKey = `datasets:v1:${tenantId}`;
+  const redis = await getRedisClient();
+
+  if (redis) {
+    try {
+      const current = (await redis.get<DatasetEntry[]>(redisKey)) ?? [];
+      current.unshift(entry);
+      await redis.set(redisKey, current, { ex: DATASET_TTL_SEC });
+      return entry;
+    } catch {
+      // Fall through to in-memory fallback
+    }
+  }
+
+  const current = _datasetStore.get(tenantId) ?? [];
+  current.unshift(entry);
+  _datasetStore.set(tenantId, current);
+  return entry;
 }
 
 export async function createRun(ctx: ApiContext, body: z.infer<typeof RunCreateSchema>) {
@@ -200,10 +319,12 @@ export async function createRun(ctx: ApiContext, body: z.infer<typeof RunCreateS
     // Synchronous execution is not yet implemented. Callers must use async: true
     // and poll /runs/:id for status. Returning 501 prevents a fake "succeeded"
     // result from being written without any actual reconciliation work.
-    throw Object.assign(new Error("Synchronous run mode is not yet supported. Set async: true and poll for completion."), {
-      code: "SETTLER_NOT_IMPLEMENTED",
-      status: 501,
-    });
+    throw Object.assign(
+      new Error(
+        "Synchronous run mode is not yet supported. Set async: true and poll for completion."
+      ),
+      { code: "SETTLER_NOT_IMPLEMENTED", status: 501 }
+    );
   }
 
   const sourceConfigEncrypted = encrypt(JSON.stringify(body.sourceConfig));
@@ -304,23 +425,6 @@ export async function getLatestResult(ctx: ApiContext, runId: string) {
   });
 }
 
-export function listDatasets(tenantId: string) {
-  return datasetStore.get(tenantId) || [];
-}
-
-export function addDataset(tenantId: string, payload: { name: string; source: string }) {
-  const current = datasetStore.get(tenantId) || [];
-  const entry = {
-    id: randomUUID(),
-    name: payload.name,
-    source: payload.source,
-    createdAt: new Date().toISOString(),
-  };
-  current.unshift(entry);
-  datasetStore.set(tenantId, current);
-  return entry;
-}
-
 export function ok(res: NextResponse, requestId: string) {
   return withSecurityHeaders(res, requestId);
 }
@@ -337,7 +441,10 @@ export function fail(error: unknown, request: NextRequest, requestId: string) {
     );
   }
   // Typed errors with an explicit status (e.g. 501 Not Implemented)
-  if (error instanceof Error && typeof (error as NodeJS.ErrnoException & { status?: number }).status === "number") {
+  if (
+    error instanceof Error &&
+    typeof (error as NodeJS.ErrnoException & { status?: number }).status === "number"
+  ) {
     const typedError = error as Error & { code?: ProblemCode; status: number };
     const knownCodes: ProblemCode[] = [
       "SETTLER_AUTH_REQUIRED",
@@ -353,15 +460,15 @@ export function fail(error: unknown, request: NextRequest, requestId: string) {
       typedError.code && knownCodes.includes(typedError.code as ProblemCode)
         ? (typedError.code as ProblemCode)
         : "SETTLER_INTERNAL";
-    return problem(typedError.status, code, "Request failed", typedError.message, requestId, request.nextUrl.pathname);
+    return problem(
+      typedError.status,
+      code,
+      "Request failed",
+      typedError.message,
+      requestId,
+      request.nextUrl.pathname
+    );
   }
   const message = error instanceof Error ? error.message : "Unhandled API error";
-  return problem(
-    500,
-    "SETTLER_INTERNAL",
-    "Internal error",
-    message,
-    requestId,
-    request.nextUrl.pathname
-  );
+  return problem(500, "SETTLER_INTERNAL", "Internal error", message, requestId, request.nextUrl.pathname);
 }

--- a/packages/web/src/lib/redis/client.ts
+++ b/packages/web/src/lib/redis/client.ts
@@ -1,86 +1,67 @@
 /**
  * Redis Client (Upstash)
- * 
+ *
  * Provides Redis client for rate limiting, caching, and queues.
  * Gracefully falls back to in-memory store if Redis unavailable.
  */
 
-// Optional Redis import - gracefully handles if package not installed
- 
-type Redis = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RedisClient = any;
 
-let redisClient: Redis | null = null;
-let redisAvailable = false;
+let redisInstance: RedisClient | null = null;
+let initializationPromise: Promise<RedisClient | null> | null = null;
 
-/**
- * Initialize Redis client
- * Falls back gracefully if Redis not configured
- */
-function initRedis(): Redis | null {
-  if (redisClient) {
-    return redisClient;
-  }
-
+async function initRedis(): Promise<RedisClient | null> {
   const restUrl = process.env.UPSTASH_REDIS_REST_URL;
   const restToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 
   if (!restUrl || !restToken) {
-    console.warn('[Redis] Upstash Redis not configured, using in-memory fallback');
-    redisAvailable = false;
+    console.warn("[Redis] Upstash Redis not configured — using in-memory fallback");
     return null;
   }
 
-  // Use dynamic import with promise handling
-  return import('@upstash/redis')
-    .then(({ Redis: RedisClient }) => {
-      redisClient = new RedisClient({
-        url: restUrl,
-        token: restToken,
-      });
-      redisAvailable = true;
-      return redisClient;
-    })
-    .catch((error) => {
-      console.warn('[Redis] Failed to initialize Redis client (package may not be installed), using in-memory fallback:', error);
-      redisAvailable = false;
-      return null;
-    });
-}
-
-/**
- * Get Redis client (lazy initialization)
- */
-export function getRedisClient(): Redis | null {
-  return initRedis();
-}
-
-/**
- * Check if Redis is available
- */
-export function isRedisAvailable(): boolean {
-  if (redisClient === null) {
-    initRedis();
+  try {
+    const { Redis } = await import("@upstash/redis");
+    const client = new Redis({ url: restUrl, token: restToken });
+    console.info("[Redis] Connected to Upstash Redis");
+    return client;
+  } catch (error) {
+    console.warn("[Redis] Failed to initialise Redis client — using in-memory fallback:", error);
+    return null;
   }
-  return redisAvailable;
 }
 
 /**
- * Safe Redis operation wrapper
- * Falls back gracefully if Redis unavailable
+ * Get Redis client (lazy, singleton, async).
+ * Resolves to null if Redis is not configured or unavailable.
+ */
+export async function getRedisClient(): Promise<RedisClient | null> {
+  if (redisInstance !== null) return redisInstance;
+  if (initializationPromise) return initializationPromise;
+
+  initializationPromise = initRedis().then((client) => {
+    redisInstance = client;
+    return client;
+  });
+
+  return initializationPromise;
+}
+
+/**
+ * Safe Redis operation wrapper.
+ * Falls back gracefully if Redis unavailable.
  */
 export async function safeRedisOperation<T>(
-  operation: (client: Redis) => Promise<T>,
+  operation: (client: RedisClient) => Promise<T>,
   fallback: () => T | Promise<T>
 ): Promise<T> {
-  const client = getRedisClient();
-  if (!client) {
-    return fallback();
-  }
+  const client = await getRedisClient();
+  if (!client) return fallback();
 
   try {
     return await operation(client);
   } catch (error) {
-    console.warn('[Redis] Operation failed, using fallback:', error);
+    console.warn("[Redis] Operation failed — using fallback:", error);
     return fallback();
   }
 }

--- a/packages/web/src/lib/server/internal-api.ts
+++ b/packages/web/src/lib/server/internal-api.ts
@@ -1,67 +1,146 @@
 import { safeLogger } from "@/lib/observability/safe-logger";
-const INTERNAL_API_URL = process.env.INTERNAL_API_URL || "http://localhost:3002";
 
-interface ReconciliationRunPayload {
-  ingestionId: string;
-  config?: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ReconciliationRunPayload = { ingestionId: string; config?: any };
+
+/**
+ * Internal engine base URL. Must be explicitly set in production.
+ * Defaults to localhost only for local dev — no silent fallback in production.
+ */
+function getInternalApiUrl(): string {
+  const url = process.env.INTERNAL_API_URL;
+  if (!url) {
+    if (process.env.NODE_ENV === "production") {
+      throw Object.assign(
+        new Error("INTERNAL_API_URL is not configured. Reconciliation engine unavailable."),
+        { code: "ENGINE_NOT_CONFIGURED", status: 503 }
+      );
+    }
+    return "http://localhost:3002";
+  }
+  return url;
+}
+
+/** Exported to allow callers to surface a 503 before making real network calls. */
+export function assertInternalEngineConfigured(): void {
+  getInternalApiUrl(); // throws if misconfigured in production
 }
 
 /**
- * Calls the internal 'api' service to trigger a real reconciliation run.
- * This acts as a bridge from the 'web' frontend service to the core backend engine.
+ * Check whether the internal reconciliation engine is reachable.
+ * Returns { ok: true } or { ok: false, reason: string }.
+ */
+export async function checkInternalEngineHealth(): Promise<
+  { ok: true } | { ok: false; reason: string }
+> {
+  let baseUrl: string;
+  try {
+    baseUrl = getInternalApiUrl();
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : "Engine not configured" };
+  }
+
+  const internalServiceKey = process.env.INTERNAL_SERVICE_TO_SERVICE_KEY;
+  if (!internalServiceKey) {
+    return { ok: false, reason: "INTERNAL_SERVICE_TO_SERVICE_KEY not set" };
+  }
+
+  try {
+    const headers: Record<string, string> = internalServiceKey.startsWith("rk_")
+      ? { "X-API-Key": internalServiceKey }
+      : { Authorization: `Bearer ${internalServiceKey}` };
+
+    const res = await fetch(`${baseUrl}/health`, {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(5_000),
+    });
+
+    if (!res.ok) {
+      return { ok: false, reason: `Engine health check returned HTTP ${res.status}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    return { ok: false, reason: `Engine unreachable: ${msg}` };
+  }
+}
+
+/**
+ * Calls the internal reconciliation engine to trigger a real run.
+ * Fails fast with a 503 if the engine is not configured or unreachable.
  */
 export async function triggerInternalReconciliationRun(
   tenantId: string,
   userId: string,
   payload: ReconciliationRunPayload
 ) {
-  const url = `${INTERNAL_API_URL}/api/v1/reconciliation/run`;
   const internalServiceKey = process.env.INTERNAL_SERVICE_TO_SERVICE_KEY;
 
   if (!internalServiceKey) {
     safeLogger.error(
       "[InternalApiClient] INTERNAL_SERVICE_TO_SERVICE_KEY is not set. Cannot make internal API call."
     );
-    throw new Error("Internal service communication is not configured.");
+    throw Object.assign(
+      new Error("Reconciliation engine not configured. Contact your system administrator."),
+      { code: "ENGINE_NOT_CONFIGURED", status: 503 }
+    );
   }
 
+  let baseUrl: string;
   try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      // Pass tenant and user context for strict downstream scoping.
-      "X-Tenant-Id": tenantId,
-      "X-User-Id": userId,
-    };
+    baseUrl = getInternalApiUrl();
+  } catch (err) {
+    throw Object.assign(
+      new Error("Reconciliation engine not configured."),
+      { code: "ENGINE_NOT_CONFIGURED", status: 503, cause: err }
+    );
+  }
 
-    if (internalServiceKey.startsWith("rk_")) {
-      headers["X-API-Key"] = internalServiceKey;
-    } else {
-      headers.Authorization = `Bearer ${internalServiceKey}`;
-    }
+  const url = `${baseUrl}/api/v1/reconciliation/run`;
 
-    const response = await fetch(url, {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Tenant-Id": tenantId,
+    "X-User-Id": userId,
+    ...(internalServiceKey.startsWith("rk_")
+      ? { "X-API-Key": internalServiceKey }
+      : { Authorization: `Bearer ${internalServiceKey}` }),
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
       method: "POST",
       headers,
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(30_000),
     });
-
-    if (!response.ok) {
-      const errorBody = await response.text();
-      safeLogger.error("[InternalApiClient] Failed to trigger reconciliation run", {
-        status: response.status,
-        url,
-        errorBody,
-      });
-      throw new Error(`Internal API call failed with status ${response.status}`);
-    }
-
-    const { runId } = await response.json();
-    return { runId };
-  } catch (error) {
-    safeLogger.error("[InternalApiClient] Internal API call threw an exception", {
-      url,
-      errorMessage: error instanceof Error ? error.message : "Unknown error",
-    });
-    throw error;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    safeLogger.error("[InternalApiClient] Engine unreachable", { url, error: msg });
+    throw Object.assign(
+      new Error(`Reconciliation engine unreachable: ${msg}`),
+      { code: "ENGINE_UNAVAILABLE", status: 503 }
+    );
   }
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "");
+    safeLogger.error("[InternalApiClient] Failed to trigger reconciliation run", {
+      status: response.status,
+      url,
+      errorBody,
+    });
+    if (response.status === 503 || response.status === 502) {
+      throw Object.assign(
+        new Error("Reconciliation engine is currently unavailable. Please try again later."),
+        { code: "ENGINE_UNAVAILABLE", status: 503 }
+      );
+    }
+    throw new Error(`Internal API call failed with status ${response.status}`);
+  }
+
+  const { runId } = await response.json();
+  return { runId };
 }


### PR DESCRIPTION
Redis client (redis/client.ts):
- Replace sync init with an async singleton using a shared Promise to
  prevent concurrent initialisation races.
- Remove the now-redundant isRedisAvailable() helper; callers simply
  await getRedisClient() and treat null as "unavailable".

Rate limiting & idempotency (recon/core.ts):
- applyRateLimit(), getIdempotent(), storeIdempotent() are now async.
- Each first tries Redis (Upstash) with scoped keys and proper TTLs
  (RATE_LIMIT_WINDOW_SEC=60, IDEMPOTENCY_TTL_SEC=24 h).
- Silently falls back to the existing in-memory Maps when Redis is
  unavailable, preserving single-instance behaviour.
- In-memory Maps renamed with _ prefix to make their non-distributed
  nature explicit.

Route callers updated to await:
- runs/route.ts, runs/[id]/route.ts, runs/[id]/[runId]/route.ts,
  runs/[id]/results/route.ts, runs/[id]/evidence/route.ts,
  runs/[id]/replay/route.ts, metrics/summary, timeseries, top,
  datasets/route.ts.

Internal API (internal-api.ts):
- getInternalApiUrl() throws a typed 503 in production when
  INTERNAL_API_URL is unset, rather than silently defaulting to
  localhost.
- New assertInternalEngineConfigured() and checkInternalEngineHealth()
  helpers for pre-flight checks and health-check integrations.

Reconciliation list endpoint (console/reconciliation/route.ts):
- GET was returning a hardcoded empty array.
- Now queries prisma.reconJob with cursor-based pagination, joins the
  latest ReconResult, and returns structured JSON with next_cursor.

https://claude.ai/code/session_01USdNkoPhYDjKQc9koduaqb