### PR TITLE
feat: Set up development environment with Prisma v7 adapter and cloud agent config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Settler – AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service     | Port | Command                                     | Notes                               |
+| ----------- | ---- | ------------------------------------------- | ----------------------------------- |
+| Next.js Web | 3000 | `cd packages/web && pnpm run dev`           | Marketing site + Developer Console  |
+| Express API | 4000 | `cd packages/api && PORT=4000 pnpm run dev` | Requires `.env.local` sourced first |
+| PostgreSQL  | 5432 | System service                              | `sudo pg_ctlcluster 16 main start`  |
+
+### Starting the dev stack
+
+1. Start PostgreSQL: `sudo pg_ctlcluster 16 main start`
+2. Source env vars: `set -a && source .env.local && set +a`
+3. Start API: `cd packages/api && PORT=4000 pnpm run dev`
+4. Start Web: `cd packages/web && pnpm run dev`
+
+Or use the combined command: `pnpm run dev:stack` (starts API + Web together).
+
+### Non-obvious gotchas
+
+- **Prisma v7 driver adapter**: The API's `packages/api/src/infrastructure/db/prisma.ts` uses `@prisma/adapter-pg` for the Prisma v7 "client" engine. Without this adapter, PrismaClient throws `PrismaClientConstructorValidationError`.
+- **API requires env vars loaded from `.env.local`**: The API validates env vars on startup. Run `set -a && source .env.local && set +a` before starting the API, or use the `dev:stack` script which does this automatically.
+- **Redis is optional**: The API falls back to in-memory cache when Redis is unavailable. Redis warnings in the API logs are expected in local dev.
+- **TigerBeetle is optional**: Disabled by default (`TIGERBEETLE_ENABLED=false`). The API uses a fallback implementation.
+- **Sentry blocks production builds**: The `@sentry/nextjs` v7 plugin runs `sentry-cli` even when `disable: true`. Production builds (`pnpm build`) fail without valid Sentry credentials. Dev mode (`next dev`) is unaffected.
+- **Database schema**: The golden schema migration at `supabase/migrations/20240101000000_settler_golden_schema.sql` requires `analytics`, `auth`, and `app_private` schemas pre-created. Run with `BEGIN`/`COMMIT` removed for non-Supabase PostgreSQL.
+- **Node.js 24 required**: The `engines` field requires `>=24.0.0 <25.0.0`. Use `nvm use 24` before running any commands.
+- **Husky hooks**: Pre-commit runs lint-staged and conflict-marker checks. Pre-push runs `pnpm verify:fast`.
+
+### Lint / Test / Build
+
+See `CONTRIBUTING.md` and root `package.json` scripts. Key commands:
+
+- Lint: `pnpm lint`
+- Test: `pnpm test` (runs all workspace tests via Turborepo)
+- API tests: `pnpm --filter @settler/api test`
+- Web tests: `pnpm --filter @settler/web test`
+- Typecheck: `pnpm typecheck`
+- Build: `pnpm build` (blocked by Sentry in production mode; dev mode works fine)

--- a/package.json
+++ b/package.json
@@ -362,7 +362,20 @@
       "glob": "^10.5.0",
       "minimatch": ">=10.2.1",
       "eslint": "^9.26.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "bcrypt",
+      "better-sqlite3",
+      "prisma",
+      "@prisma/engines",
+      "@prisma/client",
+      "protobufjs",
+      "isolated-vm",
+      "msgpackr-extract",
+      "unrs-resolver"
+    ]
   },
   "dependencies": {
     "turbo": "^2.6.2"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -106,6 +106,7 @@
     "@opentelemetry/resources": "^2.6.0",
     "@opentelemetry/sdk-node": "^0.52.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@prisma/adapter-pg": "^7.5.0",
     "@sentry/node": "^10.44.0",
     "@sentry/profiling-node": "^7.91.0",
     "@settler/adapters": "workspace:*",

--- a/packages/api/src/infrastructure/db/prisma.ts
+++ b/packages/api/src/infrastructure/db/prisma.ts
@@ -1,4 +1,6 @@
 import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import pg from "pg";
 import { config } from "../../config";
 
 // Global variable to prevent multiple instances of Prisma Client in development
@@ -8,17 +10,37 @@ const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
  * Prisma Client Singleton
  *
  * Ensures only one instance of Prisma Client is created.
- * Configured with connection pooling based on environment.
+ * Prisma 7 "client" engine requires a driver adapter or accelerateUrl.
+ * We use @prisma/adapter-pg for direct PostgreSQL connections.
  */
-const prismaOptions: any = {
-  log: config.nodeEnv === "development" ? ["query", "error", "warn"] : ["error"],
-  // Prisma 7 "client" engine requires an adapter or accelerateUrl.
-  // In test environments we provide a stub so the constructor doesn't throw —
-  // tests that exercise DB operations must mock prisma themselves.
-  ...(config.nodeEnv === "test" && { accelerateUrl: "prisma://localhost/?api_key=test" }),
-};
+function buildPrismaOptions(): any {
+  const logLevel = config.nodeEnv === "development" ? ["query", "error", "warn"] : ["error"];
 
-export const prisma = globalForPrisma.prisma || new PrismaClient(prismaOptions);
+  if (config.nodeEnv === "test") {
+    return {
+      log: logLevel,
+      accelerateUrl: "prisma://localhost/?api_key=test",
+    };
+  }
+
+  const pool = new pg.Pool({
+    host: config.database.host,
+    port: config.database.port,
+    database: config.database.name,
+    user: config.database.user,
+    password: config.database.password,
+    ssl: config.database.ssl ? { rejectUnauthorized: false } : false,
+    min: config.database.poolMin,
+    max: config.database.poolMax,
+    connectionTimeoutMillis: config.database.connectionTimeout,
+    statement_timeout: config.database.statementTimeout,
+  });
+  const adapter = new PrismaPg(pool);
+
+  return { log: logLevel, adapter };
+}
+
+export const prisma = globalForPrisma.prisma || new PrismaClient(buildPrismaOptions());
 
 if (config.nodeEnv !== "production") {
   globalForPrisma.prisma = prisma;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.28.0
         version: 1.40.0
+      '@prisma/adapter-pg':
+        specifier: ^7.5.0
+        version: 7.5.0
       '@sentry/node':
         specifier: ^10.44.0
         version: 10.44.0
@@ -3530,6 +3533,9 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@prisma/adapter-pg@7.5.0':
+    resolution: {integrity: sha512-EJx7OLULahcC3IjJgdx2qRDNCT+ToY2v66UkeETMCLhNOTgqVzRzYvOEphY7Zp0eHyzfkC33Edd/qqeadf9R4A==}
+
   '@prisma/client-runtime-utils@7.5.0':
     resolution: {integrity: sha512-KnJ2b4Si/pcWEtK68uM+h0h1oh80CZt2suhLTVuLaSKg4n58Q9jBF/A42Kw6Ma+aThy1yAhfDeTC0JvEmeZnFQ==}
 
@@ -3556,6 +3562,9 @@ packages:
 
   '@prisma/dev@0.20.0':
     resolution: {integrity: sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==}
+
+  '@prisma/driver-adapter-utils@7.5.0':
+    resolution: {integrity: sha512-B79N/amgV677mFesFDBAdrW0OIaqawap9E0sjgLBtzIz2R3hIMS1QB8mLZuUEiS4q5Y8Oh3I25Kw4SLxMypk9Q==}
 
   '@prisma/engines-version@7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e':
     resolution: {integrity: sha512-E+iRV/vbJLl8iGjVr6g/TEWokA+gjkV/doZkaQN1i/ULVdDwGnPJDfLUIFGS3BVwlG/m6L8T4x1x5isl8hGMxA==}
@@ -4770,6 +4779,9 @@ packages:
 
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
+
+  '@types/pg@8.11.11':
+    resolution: {integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==}
 
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
@@ -8629,6 +8641,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -8840,6 +8855,10 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
   pg-pool@3.13.0:
     resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
     peerDependencies:
@@ -8851,6 +8870,10 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
+
+  pg-types@4.1.0:
+    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
+    engines: {node: '>=10'}
 
   pg@8.20.0:
     resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
@@ -8986,17 +9009,36 @@ packages:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
 
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
   postgres-bytea@1.0.1:
     resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
 
   postgres-date@1.0.7:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
     engines: {node: '>=0.10.0'}
 
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   postgres@3.4.7:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
@@ -14539,6 +14581,15 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@prisma/adapter-pg@7.5.0':
+    dependencies:
+      '@prisma/driver-adapter-utils': 7.5.0
+      '@types/pg': 8.11.11
+      pg: 8.20.0
+      postgres-array: 3.0.4
+    transitivePeerDependencies:
+      - pg-native
+
   '@prisma/client-runtime-utils@7.5.0': {}
 
   '@prisma/client@7.5.0(prisma@7.5.0(@types/react@18.3.28)(better-sqlite3@12.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)':
@@ -14582,6 +14633,10 @@ snapshots:
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
+
+  '@prisma/driver-adapter-utils@7.5.0':
+    dependencies:
+      '@prisma/debug': 7.5.0
 
   '@prisma/engines-version@7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e': {}
 
@@ -15989,6 +16044,12 @@ snapshots:
   '@types/pg-pool@2.0.7':
     dependencies:
       '@types/pg': 8.18.0
+
+  '@types/pg@8.11.11':
+    dependencies:
+      '@types/node': 24.12.0
+      pg-protocol: 1.13.0
+      pg-types: 4.1.0
 
   '@types/pg@8.15.6':
     dependencies:
@@ -20941,6 +21002,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obuf@1.1.2: {}
+
   ohash@2.0.11: {}
 
   on-finished@2.4.1:
@@ -21165,6 +21228,8 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
+  pg-numeric@1.0.2: {}
+
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
       pg: 8.20.0
@@ -21178,6 +21243,16 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+
+  pg-types@4.1.0:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
 
   pg@8.20.0:
     dependencies:
@@ -21295,13 +21370,25 @@ snapshots:
 
   postgres-array@2.0.0: {}
 
+  postgres-array@3.0.4: {}
+
   postgres-bytea@1.0.1: {}
 
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
   postgres-date@1.0.7: {}
+
+  postgres-date@2.1.0: {}
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
 
   postgres@3.4.7: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## Description

Sets up the development environment for the Settler monorepo with the following changes:
- Add `@prisma/adapter-pg` to `packages/api` for Prisma v7 "client" engine compatibility
- Update `packages/api/src/infrastructure/db/prisma.ts` to use the `PrismaPg` driver adapter (required by Prisma v7's default engine type)
- Add `pnpm.onlyBuiltDependencies` to root `package.json` to allow critical native modules (esbuild, sharp, bcrypt, prisma, etc.) to build during install
- Create `AGENTS.md` at repo root with Cursor Cloud specific instructions for future agents

## Type of Change

- [x] New feature
- [x] Documentation update

## CI Verification Checklist

**⚠️ CI MUST PASS BEFORE MERGE**

- [ ] CI link: (paste link to CI run after pushing)
- [x] ✅ Lint and typecheck passed
- [x] ✅ Tests passed (API: 64 suites, 339 tests passed)
- [ ] ✅ Build succeeded (blocked by pre-existing Sentry CLI issue in production build)
- [ ] ✅ Vercel parity check passed
- [ ] ✅ Canonical production check passed

## Testing

- [x] Local testing completed
- [x] Manual testing completed (API health check, Web UI walkthrough)

### Verified working:
- **Lint**: `pnpm lint` passes (0 errors, 46 warnings)
- **API tests**: 64 suites passed, 339 tests passed
- **Web tests**: 55/70 suites passed (pre-existing failures)
- **API server**: Running on port 4000, health endpoint returns OK
- **Web server**: Running on port 3000, all pages load correctly
- **PostgreSQL**: Running locally with golden schema applied

## Deployment Notes

- [x] Environment variables documented (in AGENTS.md)
- [ ] Database migrations included (N/A - uses existing golden schema)
- [ ] Breaking changes documented

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (AGENTS.md created)
- [x] No console.logs or debug code left behind
- [x] No secrets or sensitive data committed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee215472-d1b8-4670-9952-35c32157cbbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee215472-d1b8-4670-9952-35c32157cbbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

