### PR TITLE
Production readiness: reconciliation config provenance, ingestion guards, problem+json errors

### DIFF
--- a/packages/api/src/__tests__/routes/reconciliation-runtime-config-route.test.ts
+++ b/packages/api/src/__tests__/routes/reconciliation-runtime-config-route.test.ts
@@ -96,9 +96,10 @@ describe("reconciliation runtime config route", () => {
       })
       .expect(400);
 
-    expect(response.body.error).toBe("Bad Request");
-    expect(response.body.message).toContain("config.amountTolerance");
-    expect(response.body.message).toContain("config.dateWindowDays");
+    expect(response.headers["content-type"]).toMatch(/application\/problem\+json/);
+    expect(response.body.code).toBe("VALIDATION_ERROR");
+    expect(response.body.detail).toContain("config.amountTolerance");
+    expect(response.body.detail).toContain("config.dateWindowDays");
     expect(runReconciliationMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/__tests__/services/reconciliation-matcher-ingestion-guard.test.ts
+++ b/packages/api/src/__tests__/services/reconciliation-matcher-ingestion-guard.test.ts
@@ -1,0 +1,88 @@
+import { runReconciliation } from "../../services/ingestion/reconciliation-matcher";
+
+const queryMock = jest.fn();
+const transactionMock = jest.fn();
+
+jest.mock("../../db", () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+  transaction: (fn: (client: { query: typeof queryMock }) => Promise<void>) =>
+    transactionMock(fn),
+}));
+
+jest.mock("../../utils/logger", () => ({
+  logError: jest.fn(),
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+}));
+
+jest.mock("../../services/matching-rules-loader", () => ({
+  getMatchingRulesForJob: jest.fn().mockResolvedValue({
+    amountTolerance: 0.02,
+    dateToleranceDays: 5,
+    matchingRules: [],
+    configVersion: "test-v1",
+    configSource: "default" as const,
+    tenantId: "tenant-1",
+    jobId: "job-1",
+  }),
+}));
+
+jest.mock("../../services/matching/ml-matching-engine", () => ({
+  mlMatchingEngine: { predictMatch: jest.fn().mockResolvedValue(null) },
+}));
+
+jest.mock("../../services/matching/enhanced-cross-customer-intelligence", () => ({
+  enhancedCrossCustomerIntelligence: { recordPattern: jest.fn() },
+}));
+
+jest.mock("../../services/reconciliation/integrity", () => ({
+  appendRunIntegrityEntry: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../services/ops-intelligence/runtime-events", () => ({
+  emitOperatorRuntimeEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe("runReconciliation ingestion guard", () => {
+  const tenantId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const userId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const ingestionId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryMock.mockReset();
+    transactionMock.mockReset();
+    transactionMock.mockImplementation(async (fn) => {
+      const client = { query: queryMock };
+      await fn(client as never);
+    });
+  });
+
+  test("rejects invalid ingestion UUID before creating a run row", async () => {
+    await expect(
+      runReconciliation("not-a-uuid", tenantId, userId, undefined, undefined, {})
+    ).rejects.toMatchObject({ errorCode: "VALIDATION_ERROR" });
+
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects missing ingestion with NOT_FOUND", async () => {
+    queryMock.mockResolvedValueOnce([]);
+
+    await expect(
+      runReconciliation(ingestionId, tenantId, userId, undefined, undefined, {})
+    ).rejects.toMatchObject({ errorCode: "NOT_FOUND" });
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects non-completed ingestion", async () => {
+    queryMock.mockResolvedValueOnce([{ id: ingestionId, status: "processing" }]);
+
+    await expect(
+      runReconciliation(ingestionId, tenantId, userId, undefined, undefined, {})
+    ).rejects.toMatchObject({ errorCode: "VALIDATION_ERROR" });
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/routes/v1/reconciliation.ts
+++ b/packages/api/src/routes/v1/reconciliation.ts
@@ -7,6 +7,8 @@ import { Router, Response } from "express";
 import { AuthRequest } from "../../middleware/auth";
 import { enforceFreezeState } from "../../middleware/governance";
 import { logError, logInfo } from "../../utils/logger";
+import { isApiError, ValidationError } from "../../utils/typed-errors";
+import { sendProblemJson } from "../../utils/problem-json";
 import { runReconciliation } from "../../services/ingestion/reconciliation-matcher";
 import { query } from "../../db";
 import { ReconciliationConfig } from "../../services/ingestion/types";
@@ -29,11 +31,14 @@ router.post("/run", enforceFreezeState(), async (req: AuthRequest, res: Response
     const userId = req.userId!;
 
     if (!ingestionId) {
-      return res.status(400).json({
-        error: "Bad Request",
-        message: "ingestionId is required",
-        traceId: req.traceId,
+      sendProblemJson(req, res, {
+        status: 400,
+        title: "Validation Error",
+        detail: "ingestionId is required",
+        code: "VALIDATION_ERROR",
+        extra: { field: "ingestionId" },
       });
+      return;
     }
 
     const rawConfig = (config ?? {}) as Record<string, unknown>;
@@ -90,11 +95,14 @@ router.post("/run", enforceFreezeState(), async (req: AuthRequest, res: Response
     }
 
     if (invalidConfigFields.length > 0) {
-      return res.status(400).json({
-        error: "Bad Request",
-        message: `Invalid config fields: ${invalidConfigFields.join(", ")}`,
-        traceId: req.traceId,
+      sendProblemJson(req, res, {
+        status: 400,
+        title: "Validation Error",
+        detail: `Invalid config fields: ${invalidConfigFields.join(", ")}`,
+        code: "VALIDATION_ERROR",
+        extra: { fields: invalidConfigFields },
       });
+      return;
     }
 
     // Extract jobId and templateId from request if available
@@ -121,6 +129,23 @@ router.post("/run", enforceFreezeState(), async (req: AuthRequest, res: Response
     });
   } catch (error) {
     logError("Failed to run reconciliation", error, { traceId: req.traceId });
+    if (isApiError(error)) {
+      const extra: Record<string, unknown> = {};
+      if (error instanceof ValidationError && error.field) {
+        extra.field = error.field;
+      }
+      if (error.details !== undefined) {
+        extra.details = error.details;
+      }
+      sendProblemJson(req, res, {
+        status: error.statusCode,
+        title: error.errorCode.replace(/_/g, " "),
+        detail: error.message,
+        code: error.errorCode,
+        ...(Object.keys(extra).length > 0 ? { extra } : {}),
+      });
+      return;
+    }
     return res.status(500).json({
       error: "Internal Server Error",
       message: "Failed to run reconciliation",

--- a/packages/api/src/services/ingestion/reconciliation-matcher.ts
+++ b/packages/api/src/services/ingestion/reconciliation-matcher.ts
@@ -5,8 +5,10 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
 import { query, transaction } from "../../db";
 import { logError, logInfo, logWarn } from "../../utils/logger";
+import { NotFoundError, ValidationError } from "../../utils/typed-errors";
 import { MatchResult, ReconciliationConfig } from "./types";
 import { mlMatchingEngine } from "../matching/ml-matching-engine";
 import { enhancedCrossCustomerIntelligence } from "../matching/enhanced-cross-customer-intelligence";
@@ -34,6 +36,57 @@ const DEFAULT_TOLERANCES = {
   amount: 0.01,
   dateDays: 7,
 } as const;
+
+const UUID_SCHEMA = z.string().uuid();
+
+function pickDefined<T>(...values: (T | undefined)[]): T | undefined {
+  for (const v of values) {
+    if (v !== undefined) return v;
+  }
+  return undefined;
+}
+
+function recordResolution(
+  field: string,
+  requested: unknown,
+  stored: unknown,
+  effective: unknown
+): { field: string; source: "request" | "tenant_template" | "system_default"; value: unknown } {
+  if (requested !== undefined) {
+    return { field, source: "request", value: requested };
+  }
+  if (stored !== undefined) {
+    return { field, source: "tenant_template", value: stored };
+  }
+  return { field, source: "system_default", value: effective };
+}
+
+async function assertIngestionReadyForReconciliation(
+  ingestionId: string,
+  tenantId: string
+): Promise<void> {
+  const parsed = UUID_SCHEMA.safeParse(ingestionId);
+  if (!parsed.success) {
+    throw new ValidationError("ingestionId must be a valid UUID", "ingestionId");
+  }
+
+  const rows = await query(
+    `SELECT id, status FROM ingestions WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+    [ingestionId, tenantId]
+  );
+
+  if (rows.length === 0) {
+    throw new NotFoundError("Ingestion not found for this tenant", "ingestion", ingestionId);
+  }
+
+  const status = String((rows[0] as { status?: string }).status ?? "").toLowerCase();
+  if (status !== "completed") {
+    throw new ValidationError(
+      `Ingestion must be in "completed" status before reconciliation (current: ${status || "unknown"})`,
+      "ingestionId"
+    );
+  }
+}
 
 /**
  * Calculate Levenshtein distance (edit distance) between two strings
@@ -436,6 +489,8 @@ export async function runReconciliation(
   const runId = uuidv4();
   const traceId = uuidv4();
 
+  await assertIngestionReadyForReconciliation(ingestionId, tenantId);
+
   // Load matching rules config from canonical loader
   let matchingConfig: LoaderReconciliationConfig;
   try {
@@ -473,13 +528,58 @@ export async function runReconciliation(
     };
   }
 
-  // Merge user-provided config with loader config (user config takes precedence)
+  // Merge: explicit request wins, then tenant/template loader, then engine defaults.
+  const effectiveAmountTolerance = pickDefined(
+    config.amountTolerance,
+    matchingConfig.amountTolerance,
+    DEFAULT_CONFIG.amountTolerance
+  ) as number;
+  const effectiveDateWindowDays = pickDefined(
+    config.dateWindowDays,
+    matchingConfig.dateToleranceDays,
+    DEFAULT_CONFIG.dateWindowDays
+  ) as number;
+  const effectiveFuzzyDescriptionThreshold = pickDefined(
+    config.fuzzyDescriptionThreshold,
+    DEFAULT_CONFIG.fuzzyDescriptionThreshold
+  ) as number;
+  const effectiveRequireExactAmount = pickDefined(
+    config.requireExactAmount,
+    DEFAULT_CONFIG.requireExactAmount
+  ) as boolean;
+
   const effectiveConfig: Required<ReconciliationConfig> = {
-    ...DEFAULT_CONFIG,
-    amountTolerance: config.amountTolerance ?? matchingConfig.amountTolerance,
-    dateWindowDays: config.dateWindowDays ?? matchingConfig.dateToleranceDays,
-    fuzzyDescriptionThreshold: config.fuzzyDescriptionThreshold ?? 0.8,
-    requireExactAmount: config.requireExactAmount ?? false,
+    dateWindowDays: effectiveDateWindowDays,
+    amountTolerance: effectiveAmountTolerance,
+    fuzzyDescriptionThreshold: effectiveFuzzyDescriptionThreshold,
+    requireExactAmount: effectiveRequireExactAmount,
+  };
+
+  const configResolution = {
+    amountTolerance: recordResolution(
+      "amountTolerance",
+      config.amountTolerance,
+      matchingConfig.amountTolerance,
+      effectiveAmountTolerance
+    ),
+    dateWindowDays: recordResolution(
+      "dateWindowDays",
+      config.dateWindowDays,
+      matchingConfig.dateToleranceDays,
+      effectiveDateWindowDays
+    ),
+    fuzzyDescriptionThreshold: recordResolution(
+      "fuzzyDescriptionThreshold",
+      config.fuzzyDescriptionThreshold,
+      undefined,
+      effectiveFuzzyDescriptionThreshold
+    ),
+    requireExactAmount: recordResolution(
+      "requireExactAmount",
+      config.requireExactAmount,
+      undefined,
+      effectiveRequireExactAmount
+    ),
   };
 
   const runMetadata = {
@@ -489,6 +589,7 @@ export async function runReconciliation(
     templateId: templateId ?? null,
     requestedConfig: config,
     effectiveConfig,
+    configResolution,
     matchingConfig: {
       amountTolerance: matchingConfig.amountTolerance,
       dateToleranceDays: matchingConfig.dateToleranceDays,

--- a/packages/web/src/components/console/ReconciliationView.tsx
+++ b/packages/web/src/components/console/ReconciliationView.tsx
@@ -198,6 +198,63 @@ export function ReconciliationView({
               run reaches a terminal state.
             </div>
           )}
+          {summary.executionConfig && (
+            <div className="mb-4 rounded-lg border border-border bg-muted/20 p-4 text-sm">
+              <p className="font-medium text-foreground mb-2">Configuration used for this run</p>
+              <p className="text-muted-foreground mb-3">
+                Tolerances and fuzzy settings below are frozen on the run record. Changing workspace
+                rules does not rewrite history for past runs.
+              </p>
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-muted-foreground">
+                <div>
+                  <dt className="text-xs uppercase tracking-wide">Amount tolerance</dt>
+                  <dd className="font-mono text-foreground">
+                    {summary.executionConfig.amountTolerance}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide">Date window (days)</dt>
+                  <dd className="font-mono text-foreground">
+                    {summary.executionConfig.dateWindowDays}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide">Description similarity min</dt>
+                  <dd className="font-mono text-foreground">
+                    {summary.executionConfig.fuzzyDescriptionThreshold}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide">Require exact amount</dt>
+                  <dd className="font-mono text-foreground">
+                    {summary.executionConfig.requireExactAmount ? "Yes" : "No"}
+                  </dd>
+                </div>
+              </dl>
+              {(summary.configVersion || summary.configSource) && (
+                <p className="mt-3 text-xs text-muted-foreground">
+                  {summary.configSource && (
+                    <span>
+                      Rule source: <span className="font-mono">{summary.configSource}</span>
+                    </span>
+                  )}
+                  {summary.configSource && summary.configVersion && " · "}
+                  {summary.configVersion && (
+                    <span>
+                      Version: <span className="font-mono">{summary.configVersion}</span>
+                    </span>
+                  )}
+                  {typeof summary.matchingRulesCount === "number" && (
+                    <span>
+                      {" "}
+                      · Rules loaded:{" "}
+                      <span className="font-mono">{summary.matchingRulesCount}</span>
+                    </span>
+                  )}
+                </p>
+              )}
+            </div>
+          )}
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div className="p-4 bg-muted/10 rounded-lg">
               <p className="text-sm text-muted-foreground mb-1">Total Delta</p>

--- a/packages/web/src/lib/domain/types.ts
+++ b/packages/web/src/lib/domain/types.ts
@@ -102,6 +102,20 @@ export interface ReconciliationItem {
 
 import type { ReconciliationProofCapsule } from '@settler/protocol';
 
+/** Snapshot of tolerances and fuzzy settings used for a specific run (from run metadata). */
+export interface ReconciliationExecutionConfigSnapshot {
+  amountTolerance: number;
+  dateWindowDays: number;
+  fuzzyDescriptionThreshold: number;
+  requireExactAmount: boolean;
+}
+
+export interface ReconciliationConfigResolutionEntry {
+  field: string;
+  source: 'request' | 'tenant_template' | 'system_default';
+  value: unknown;
+}
+
 export interface ReconciliationSummary {
   id: ReconciliationId;
   tenantId: TenantId;
@@ -114,6 +128,13 @@ export interface ReconciliationSummary {
   startedAt: Date;
   completedAt?: Date;
   proofCapsule?: ReconciliationProofCapsule;
+  /** Present for ingestion-backed runs: settings that were applied at execution time. */
+  executionConfig?: ReconciliationExecutionConfigSnapshot;
+  /** Which fields came from the API request vs tenant rules vs engine defaults. */
+  configResolution?: ReconciliationConfigResolutionEntry[];
+  matchingRulesCount?: number;
+  configVersion?: string;
+  configSource?: string;
 }
 
 // ============================================================================

--- a/packages/web/src/lib/server/settler/reconciliation.ts
+++ b/packages/web/src/lib/server/settler/reconciliation.ts
@@ -10,9 +10,56 @@ import type {
   ReconciliationSummary,
   ReconciliationItem,
   TenantId,
+  ReconciliationExecutionConfigSnapshot,
+  ReconciliationConfigResolutionEntry,
 } from "@/lib/domain/types";
 import { calculateImpact, generateExplanation } from "@/lib/judgment/rules";
 import { safeLogger } from "@/lib/observability/safe-logger";
+
+function asExecutionConfig(
+  raw: unknown
+): ReconciliationExecutionConfigSnapshot | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const o = raw as Record<string, unknown>;
+  const amountTolerance = o.amountTolerance;
+  const dateWindowDays = o.dateWindowDays;
+  const fuzzyDescriptionThreshold = o.fuzzyDescriptionThreshold;
+  const requireExactAmount = o.requireExactAmount;
+  if (
+    typeof amountTolerance !== "number" ||
+    typeof dateWindowDays !== "number" ||
+    typeof fuzzyDescriptionThreshold !== "number" ||
+    typeof requireExactAmount !== "boolean"
+  ) {
+    return undefined;
+  }
+  return {
+    amountTolerance,
+    dateWindowDays,
+    fuzzyDescriptionThreshold,
+    requireExactAmount,
+  };
+}
+
+function asConfigResolution(raw: unknown): ReconciliationConfigResolutionEntry[] | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const o = raw as Record<string, unknown>;
+  const entries: ReconciliationConfigResolutionEntry[] = [];
+  for (const [field, v] of Object.entries(o)) {
+    if (!v || typeof v !== "object") continue;
+    const entry = v as Record<string, unknown>;
+    const source = entry.source;
+    if (
+      source !== "request" &&
+      source !== "tenant_template" &&
+      source !== "system_default"
+    ) {
+      continue;
+    }
+    entries.push({ field, source, value: entry.value });
+  }
+  return entries.length > 0 ? entries : undefined;
+}
 
 function mapStatus(raw: string | null | undefined): "running" | "completed" | "failed" {
   const value = (raw || "").toLowerCase();
@@ -56,6 +103,17 @@ export async function getReconciliationSummary(
     });
 
     if (run) {
+      const meta =
+        run.metadata && typeof run.metadata === "object"
+          ? (run.metadata as Record<string, unknown>)
+          : {};
+      const effectiveConfig = asExecutionConfig(meta.effectiveConfig);
+      const configResolution = asConfigResolution(meta.configResolution);
+      const matchingConfig =
+        meta.matchingConfig && typeof meta.matchingConfig === "object"
+          ? (meta.matchingConfig as Record<string, unknown>)
+          : {};
+
       return {
         id: run.id,
         tenantId,
@@ -66,6 +124,17 @@ export async function getReconciliationSummary(
         mismatchCount: run.unmatchedSourceCount + run.unmatchedTargetCount,
         startedAt: run.startedAt,
         completedAt: run.completedAt || undefined,
+        ...(effectiveConfig ? { executionConfig: effectiveConfig } : {}),
+        ...(configResolution ? { configResolution } : {}),
+        ...(typeof matchingConfig.matchingRulesCount === "number"
+          ? { matchingRulesCount: matchingConfig.matchingRulesCount as number }
+          : {}),
+        ...(typeof matchingConfig.configVersion === "string"
+          ? { configVersion: matchingConfig.configVersion as string }
+          : {}),
+        ...(typeof matchingConfig.configSource === "string"
+          ? { configSource: matchingConfig.configSource as string }
+          : {}),
       };
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Update (canonical run + billing + matcher + typecheck)

### Canonical run contract
- New DTOs in `packages/web/src/lib/reconciliation/canonical-run-detail.ts` with `runKind` (`ingestion_match` | `recon_job_execution`) and `sourceModel`.
- `resolveCanonicalRunDetail` parallel-loads both tables; **409** if the same UUID exists in both (data integrity), **404** if neither.
- `GET /api/console/reconciliation` list now returns merged canonical `runs[]` (plus `reconciliations` alias). Detail includes `schemaVersion`, `run` + `reconciliation` mirrors.
- Removed silent cross-model fallback from `getReconciliationSummary` / `listReconciliationItems`.

### Billing
- `requireConsoleApiAccess` **fails closed** on subscription lookup errors (**503** `SUBSCRIPTION_LOOKUP_FAILED`). Opt-in break-glass: `CONSOLE_API_SUBSCRIPTION_FAIL_OPEN=true` (`packages/web/src/env/server.ts`).

### Matcher
- `RECON_ML_ASSIST_ENABLED` and `RECON_CROSS_CUSTOMER_INTELLIGENCE_ENABLED` default **false** (`packages/api/src/config/validation.ts`).
- Deterministic matches persist `metadata.decisionPath`; ML path labeled `heuristic_ml_assist` when enabled.

### Typecheck
- Root `pnpm` override + api devDep align `@types/pg`; `PrismaPg` constructor uses `ConstructorParameters` cast to avoid duplicate `@types/pg` structural clash.

### Docs
- `docs/canonical-run-contract.md` (trackable path; `docs/internal/` is gitignored).

### Tests
- Web: resolver + console-auth + fixed run detail test import (`api/runs/[id]`, `params.id`).
- API: ML guard test.

### Verification run
- `pnpm --filter @settler/web typecheck` ✅
- `pnpm --filter @settler/api typecheck` ✅
- Targeted Jest suites listed in the doc ✅

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b6735dc-3d11-49d8-9de2-2a9f46958f48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b6735dc-3d11-49d8-9de2-2a9f46958f48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

