### PR TITLE
Reconciliation contract hardening: run-kind UI, capabilities, typecheck, tests

### DIFF
--- a/.github/workflows/reconciliation-merged-list-db.yml
+++ b/.github/workflows/reconciliation-merged-list-db.yml
@@ -1,0 +1,84 @@
+name: Reconciliation merged list (DB)
+
+on:
+  pull_request:
+    paths:
+      - "packages/reconciliation-core/**"
+      - "packages/api/src/__tests__/integration/reconciliation-merged-list.db.test.ts"
+      - "packages/api/package.json"
+      - "prisma/schema.prisma"
+      - "prisma/migrations/**"
+      - "scripts/ci/reconciliation-merged-list-schema.sql"
+      - ".github/workflows/reconciliation-merged-list-db.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/reconciliation-core/**"
+      - "packages/api/src/__tests__/integration/reconciliation-merged-list.db.test.ts"
+      - "packages/api/package.json"
+      - "prisma/schema.prisma"
+      - "prisma/migrations/**"
+      - "scripts/ci/reconciliation-merged-list-schema.sql"
+      - ".github/workflows/reconciliation-merged-list-db.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  recon-merged-list-db:
+    name: Prisma merged list + console projection (Postgres)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: settler_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready -U postgres
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Apply minimal Prisma-aligned schema
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d settler_test -v ON_ERROR_STOP=1 \
+            -f scripts/ci/reconciliation-merged-list-schema.sql
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB integration tests
+        env:
+          NODE_ENV: test
+          RUN_DB_TESTS: "true"
+          RUN_RECON_MERGED_LIST_DB: "1"
+          DB_HOST: localhost
+          DB_PORT: "5432"
+          DB_NAME: settler_test
+          DB_USER: postgres
+          DB_PASSWORD: postgres
+        run: pnpm --filter @settler/api run test:recon-merged-db

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - `capabilities` object on `GET /api/v1/reconciliation/runs/:id` (matches/workbench/compare/export/consoleResults), sourced from `@settler/reconciliation-core` so UI and API clients share one definition of run-kind affordances.
 - Jest contract coverage for v1 reconciliation gates and cursor errors (`reconciliation-v1-contract.test.ts`); expanded merged-pagination unit tests (limit bounds, multi-page exhaustion).
+- Shared `buildConsoleReconciliationListBody` for Next `GET /api/console/reconciliation` list responses; optional DB integration suite `reconciliation-merged-list.db.test.ts` (`RUN_RECON_MERGED_LIST_DB=1` + `RUN_DB_TESTS=true`).
 - Shared `@settler/reconciliation-core` package for canonical reconciliation mapping, dual-stream merged run listing with real cursor pagination, and cross-model run resolution.
 - Express `GET /api/v1/reconciliation/runs` merged list; canonical detail on `GET /api/v1/reconciliation/runs/:id` with `legacy_v1` adapter field group.
 - Operator runbook for `RECONCILIATION_UUID_COLLISION` (`docs/ops/reconciliation-uuid-collision-runbook.md`) and architecture note `docs/architecture/reconciliation-read-contract.md`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - `capabilities` object on `GET /api/v1/reconciliation/runs/:id` (matches/workbench/compare/export/consoleResults), sourced from `@settler/reconciliation-core` so UI and API clients share one definition of run-kind affordances.
 - Jest contract coverage for v1 reconciliation gates and cursor errors (`reconciliation-v1-contract.test.ts`); expanded merged-pagination unit tests (limit bounds, multi-page exhaustion).
 - Shared `buildConsoleReconciliationListBody` for Next `GET /api/console/reconciliation` list responses; optional DB integration suite `reconciliation-merged-list.db.test.ts` (`RUN_RECON_MERGED_LIST_DB=1` + `RUN_DB_TESTS=true`).
+- CI workflow **Reconciliation merged list (DB)** (Postgres 16 + `scripts/ci/reconciliation-merged-list-schema.sql` + `test:recon-merged-db` on relevant path changes).
+- Prisma `@map` for `ReconJob`, `ReconResult`, and `ReconciliationRun` fields to snake_case DB columns; migration adds `snapshot_id` / `proof_capsule` on `recon_results` when absent.
 - Shared `@settler/reconciliation-core` package for canonical reconciliation mapping, dual-stream merged run listing with real cursor pagination, and cross-model run resolution.
 - Express `GET /api/v1/reconciliation/runs` merged list; canonical detail on `GET /api/v1/reconciliation/runs/:id` with `legacy_v1` adapter field group.
 - Operator runbook for `RECONCILIATION_UUID_COLLISION` (`docs/ops/reconciliation-uuid-collision-runbook.md`) and architecture note `docs/architecture/reconciliation-read-contract.md`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- `capabilities` object on `GET /api/v1/reconciliation/runs/:id` (matches/workbench/compare/export/consoleResults), sourced from `@settler/reconciliation-core` so UI and API clients share one definition of run-kind affordances.
+- Jest contract coverage for v1 reconciliation gates and cursor errors (`reconciliation-v1-contract.test.ts`); expanded merged-pagination unit tests (limit bounds, multi-page exhaustion).
 - Shared `@settler/reconciliation-core` package for canonical reconciliation mapping, dual-stream merged run listing with real cursor pagination, and cross-model run resolution.
 - Express `GET /api/v1/reconciliation/runs` merged list; canonical detail on `GET /api/v1/reconciliation/runs/:id` with `legacy_v1` adapter field group.
 - Operator runbook for `RECONCILIATION_UUID_COLLISION` (`docs/ops/reconciliation-uuid-collision-runbook.md`) and architecture note `docs/architecture/reconciliation-read-contract.md`.
@@ -18,6 +20,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - `GET /api/console/reconciliation` list: default `run_kind=recon_job` preserves legacy `reconciliations[]` shape; `run_kind=all` adds canonical `runs` plus real `next_cursor` (dual-stream).
 - Workbench-style v1 routes return **409** `RECONCILIATION_WRONG_RUN_KIND` when the id resolves to a `recon_job` instead of `reconciliation_runs`.
+- `ReconciliationMatches` prefetches canonical run detail when `run_kind` is unknown, uses `capabilitiesForRunKind` to skip matches for `recon_job`, and surfaces typed collision/not-found states instead of a generic failure.
+- Root `pnpm.overrides` pins `@types/pg` to **8.18.0**; API `pretypecheck`/`prebuild` builds `@settler/reconciliation-core` so workspace typecheck resolves the package; Turbo `typecheck` depends on `^build` so dependent `dist` exists before consumer `tsc`.
+- v1 `matches` and `workbench` list endpoints clamp `limit` to 1–500 (was unbounded for matches).
 
 - Added policy-as-code substrate modules (`/policies`, `/runner`, `/economic`, `/evidence`) with deterministic compilation and runtime execution funnel via `executeWithPolicy()`.
 - Added deterministic demo and replay commands that generate evidence artifacts under `examples/demo-output` and replay fixtures under `examples/demo-output-fixtures`.

--- a/docs/INGESTION.md
+++ b/docs/INGESTION.md
@@ -220,6 +220,8 @@ curl -X POST https://api.settler.dev/api/v1/reconciliation/run \
 
 ### Viewing Matches
 
+`{runId}` must be an **ingestion** reconciliation run id (`reconciliation_runs`). Persisted **recon jobs** (`recon_jobs` ids) return **409** `RECONCILIATION_WRONG_RUN_KIND` on this route; use `GET /api/v1/reconciliation/runs/{id}` for canonical detail and console results surfaces for job-shaped outcomes.
+
 ```bash
 curl https://api.settler.dev/api/v1/reconciliation/runs/{runId}/matches \
   -H "Authorization: Bearer YOUR_API_KEY"

--- a/docs/architecture/reconciliation-read-contract.md
+++ b/docs/architecture/reconciliation-read-contract.md
@@ -51,6 +51,18 @@ If the same UUID exists in **both** `recon_jobs` and `reconciliation_runs` for a
 - **`run_kind=all`**: response includes `runs` (canonical merged list) plus `reconciliations` (job-shaped projection for backward compatibility) and real `next_cursor`.
 - **`run_kind=ingestion_run`**: only ingestion stream; `reconciliations` is `[]`.
 
+List JSON (no `id` query) is built via **`buildConsoleReconciliationListBody`** in `@settler/reconciliation-core` so Next and any other consumer stay aligned with the same `runs` / `reconciliations` projection rules.
+
+### DB-backed integration tests (optional)
+
+With PostgreSQL containing `public.recon_jobs` and `public.reconciliation_runs` (golden schema), run:
+
+```bash
+RUN_DB_TESTS=true RUN_RECON_MERGED_LIST_DB=1 pnpm --filter @settler/api exec jest src/__tests__/integration/reconciliation-merged-list.db.test.ts --runInBand --forceExit
+```
+
+`RUN_RECON_MERGED_LIST_DB=1` is required in addition to `RUN_DB_TESTS=true` so generic DB suites do not fail when those tables are absent.
+
 ## Cursor format (v1)
 
 Base64url JSON:
@@ -74,6 +86,8 @@ cd packages/reconciliation-core && pnpm exec jest --runInBand --forceExit
 pnpm --filter @settler/web typecheck:ci
 pnpm --filter @settler/api typecheck
 pnpm --filter @settler/api exec jest src/__tests__/routes/reconciliation-runtime-config-route.test.ts src/__tests__/routes/reconciliation-v1-contract.test.ts --runInBand --forceExit
+# Optional merged-list DB proof (requires DB + both tables):
+# RUN_DB_TESTS=true RUN_RECON_MERGED_LIST_DB=1 pnpm --filter @settler/api run test:recon-merged-db
 ```
 
 Typecheck note: the workspace pins a single `@types/pg` version via root `pnpm.overrides` and reuses the API `db` module’s `Pool` class for `PrismaPg` so adapter and app pools share one `Pool` type identity.

--- a/docs/architecture/reconciliation-read-contract.md
+++ b/docs/architecture/reconciliation-read-contract.md
@@ -63,6 +63,10 @@ RUN_DB_TESTS=true RUN_RECON_MERGED_LIST_DB=1 pnpm --filter @settler/api exec jes
 
 `RUN_RECON_MERGED_LIST_DB=1` is required in addition to `RUN_DB_TESTS=true` so generic DB suites do not fail when those tables are absent.
 
+GitHub Actions runs the same proof on PRs touching reconciliation core, API DB tests, Prisma schema/migrations, or `scripts/ci/reconciliation-merged-list-schema.sql` (workflow **Reconciliation merged list (DB)**).
+
+**Prisma ↔ Postgres:** `ReconJob`, `ReconResult`, and `ReconciliationRun` use `@map` to snake_case columns (`recon_job_id`, `tenant_id`, …) so the client matches existing PostgreSQL naming. CI applies `snapshot_id` and `proof_capsule` on `recon_results` when missing (`prisma/migrations/20260322120000_recon_results_prisma_column_map_parity`).
+
 ## Cursor format (v1)
 
 Base64url JSON:

--- a/docs/architecture/reconciliation-read-contract.md
+++ b/docs/architecture/reconciliation-read-contract.md
@@ -32,11 +32,14 @@ Shared package: `packages/reconciliation-core` (`@settler/reconciliation-core`).
 ### `GET /api/v1/reconciliation/runs/:id`
 
 - Resolves **exactly one** backing row per tenant, or returns typed errors.
-- **Body**: `contract_version`, `run_kind`, `canonical` (full detail DTO), `legacy_v1` (field names matching the historical SQL-shaped detail for ingestion runs where applicable), `traceId`.
+- **Body**: `contract_version`, `run_kind`, `capabilities` (booleans derived from `run_kind`: `matches`, `workbench`, `compare`, `export`, `consoleResults`), `canonical` (full detail DTO), `legacy_v1` (field names matching the historical SQL-shaped detail for ingestion runs where applicable), `traceId`.
+- **UI / clients**: branch on `run_kind` or `capabilities` before calling ingestion-only child routes; do not send `recon_job` ids to matches/workbench/compare/export.
 
 ### Workbench / matches / compare / export
 
 These operate on **`reconciliation_runs` only**. If `:id` resolves to a `recon_job`, the API returns **409** `RECONCILIATION_WRONG_RUN_KIND` with a hint to use the canonical detail route.
+
+`GET .../matches` and workbench routes clamp `limit` to **1–500** (default 100) and reject negative `offset` by normalizing to `0`.
 
 ### UUID collision
 
@@ -67,9 +70,10 @@ Pagination is **read-committed**: concurrent inserts may appear or move between 
 ```bash
 pnpm --filter @settler/types build
 pnpm --filter @settler/reconciliation-core build
-pnpm --filter @settler/reconciliation-core test
+cd packages/reconciliation-core && pnpm exec jest --runInBand --forceExit
 pnpm --filter @settler/web typecheck:ci
-pnpm --filter @settler/api exec jest src/__tests__/routes/reconciliation-runtime-config-route.test.ts --runInBand --forceExit
+pnpm --filter @settler/api typecheck
+pnpm --filter @settler/api exec jest src/__tests__/routes/reconciliation-runtime-config-route.test.ts src/__tests__/routes/reconciliation-v1-contract.test.ts --runInBand --forceExit
 ```
 
-Note: `pnpm --filter @settler/api typecheck` may fail in some workspaces due to duplicate `@types/pg` resolution on `PrismaPg` adapter typing; reconciliation route changes compile under the same constraints as before.
+Typecheck note: the workspace pins a single `@types/pg` version via root `pnpm.overrides` and reuses the API `db` module’s `Pool` class for `PrismaPg` so adapter and app pools share one `Pool` type identity.

--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
     "@playwright/test": "^1.40.0",
     "@prisma/client": "^7.1.0",
     "@types/node": "^24.0.0",
-    "@types/pg": "^8.16.0",
+    "@types/pg": "8.18.0",
     "@typescript-eslint/eslint-plugin": "^8.54.0",
     "@typescript-eslint/parser": "^8.57.1",
     "cross-env": "^10.1.0",
@@ -361,7 +361,8 @@
       "esbuild": "^0.25.0",
       "glob": "^10.5.0",
       "minimatch": ">=10.2.1",
-      "eslint": "^9.26.0"
+      "eslint": "^9.26.0",
+      "@types/pg": "8.18.0"
     },
     "onlyBuiltDependencies": [
       "esbuild",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -91,6 +91,7 @@
     "worker:queue": "tsx src/jobs/queue/index.ts",
     "test:tenant-safety": "jest src/__tests__/application/job-service-invocation-order.test.ts src/__tests__/application/user-service-invocation-order.test.ts src/__tests__/application/webhook-ingestion-invocation-order.test.ts src/__tests__/repositories/job-repository-tenant-contract.test.ts src/__tests__/repositories/user-repository-tenant-contract.test.ts src/__tests__/repositories/tenant-repository-tenant-contract.test.ts src/__tests__/eventsourcing/event-store-tenant-contract.test.ts",
     "test:resilience": "jest src/__tests__/resilience/api-resilience.test.ts --runInBand --forceExit",
+    "test:recon-merged-db": "jest src/__tests__/integration/reconciliation-merged-list.db.test.ts --runInBand --forceExit",
     "test:tb": "jest src/__tests__/integration/tigerbeetle.test.ts --runInBand --forceExit",
     "tb:start": "docker-compose up -d tigerbeetle",
     "tb:stop": "docker-compose stop tigerbeetle",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -70,8 +70,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "prebuild": "cd ../.. && pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed'",
-    "pretypecheck": "cd ../.. && pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed'",
+    "prebuild": "cd ../.. && (pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed') && pnpm --filter @settler/reconciliation-core run build",
+    "pretypecheck": "cd ../.. && (pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed') && pnpm --filter @settler/reconciliation-core run build",
     "build": "tsc --skipLibCheck --noEmit false",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
@@ -162,7 +162,7 @@
     "@types/node": "^24.0.0",
     "@types/node-cron": "^3.0.11",
     "@types/pdfkit": "^0.13.3",
-    "@types/pg": "^8.10.9",
+    "@types/pg": "8.18.0",
     "@types/uuid": "^9.0.7",
     "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/packages/api/src/__tests__/integration/reconciliation-merged-list.db.test.ts
+++ b/packages/api/src/__tests__/integration/reconciliation-merged-list.db.test.ts
@@ -1,0 +1,291 @@
+/**
+ * DB-backed contract tests for merged reconciliation listing and run resolution.
+ * Requires PostgreSQL with `recon_jobs` and `reconciliation_runs` (golden / Prisma schema).
+ *
+ * Opt-in (separate from generic RUN_DB_TESTS so tenant suites do not require these tables):
+ *   RUN_RECON_MERGED_LIST_DB=1 RUN_DB_TESTS=true pnpm --filter @settler/api exec jest src/__tests__/integration/reconciliation-merged-list.db.test.ts --runInBand --forceExit
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import {
+  buildConsoleReconciliationListBody,
+  decodeMergedRunsCursor,
+  encodeMergedRunsCursor,
+  fetchMergedReconciliationRunsPage,
+  resolveReconciliationRunForTenant,
+} from "@settler/reconciliation-core";
+
+const runDb = process.env.RUN_DB_TESTS === "true" && process.env.RUN_RECON_MERGED_LIST_DB === "1";
+const describeDb = runDb ? describe : describe.skip;
+
+describeDb("reconciliation merged list (database)", () => {
+  let ctx: { pool: Pool; prisma: PrismaClient } | undefined;
+
+  const tenantA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const userA = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const tenantB = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+  const userB = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+  const jobNew = "22222222-2222-4222-8222-222222222222";
+  const jobOld = "33333333-3333-4333-8333-333333333333";
+  const ingNew = "11111111-1111-4111-8111-111111111111";
+  const ingOld = "44444444-4444-4444-8444-444444444444";
+  const collisionId = "55555555-5555-4555-8555-555555555555";
+  const otherTenantJob = "66666666-6666-4666-8666-666666666666";
+
+  beforeAll(async () => {
+    const pool = new Pool({
+      host: process.env.DB_HOST || "localhost",
+      port: parseInt(process.env.DB_PORT || "5432", 10),
+      database: process.env.DB_NAME || "settler_test",
+      user: process.env.DB_USER || "postgres",
+      password: process.env.DB_PASSWORD || "postgres",
+    });
+
+    const chk = await pool.query(
+      `SELECT COUNT(DISTINCT table_name)::int AS c
+       FROM information_schema.tables
+       WHERE table_schema = 'public'
+         AND table_name IN ('recon_jobs', 'reconciliation_runs')`
+    );
+    if (Number(chk.rows[0]?.c) !== 2) {
+      await pool.end();
+      throw new Error(
+        "reconciliation-merged-list.db.test requires public.recon_jobs and public.reconciliation_runs; apply golden schema."
+      );
+    }
+
+    const adapter = new PrismaPg(pool);
+    const prismaClient = new PrismaClient({ adapter });
+    ctx = { pool, prisma: prismaClient };
+  });
+
+  afterAll(async () => {
+    if (!ctx) return;
+    await ctx.prisma.$disconnect();
+    await ctx.pool.end();
+  });
+
+  beforeEach(async () => {
+    if (!ctx) throw new Error("reconciliation DB harness not initialized");
+    const { pool } = ctx;
+    await pool.query(`DELETE FROM reconciliation_runs WHERE tenant_id = ANY($1::uuid[])`, [
+      [tenantA, tenantB],
+    ]);
+    await pool.query(`DELETE FROM recon_jobs WHERE tenant_id = ANY($1::uuid[])`, [
+      [tenantA, tenantB],
+    ]);
+    await pool.query(`DELETE FROM users WHERE id = ANY($1::uuid[])`, [[userA, userB]]);
+    await pool.query(`DELETE FROM tenants WHERE id = ANY($1::uuid[])`, [[tenantA, tenantB]]);
+
+    await pool.query(
+      `INSERT INTO tenants (id, name, slug, created_at, updated_at)
+       VALUES ($1, 'Recon Int A', 'recon-int-a-' || substr($1::text, 1, 8), NOW(), NOW()),
+              ($2, 'Recon Int B', 'recon-int-b-' || substr($2::text, 1, 8), NOW(), NOW())`,
+      [tenantA, tenantB]
+    );
+
+    await pool.query(
+      `INSERT INTO users (id, tenant_id, email, password_hash, created_at, updated_at)
+       VALUES ($1, $2, 'recon-a@test.local', 'x', NOW(), NOW()),
+              ($3, $4, 'recon-b@test.local', 'x', NOW(), NOW())`,
+      [userA, tenantA, userB, tenantB]
+    );
+
+    const enc = "e".repeat(32);
+    await pool.query(
+      `INSERT INTO recon_jobs (id, tenant_id, user_id, name, source_adapter, source_config_encrypted, target_adapter, target_config_encrypted, created_at, updated_at)
+       VALUES ($1, $2, $3, 'job-new', 'src', $6, 'tgt', $6, $4::timestamptz, $4::timestamptz),
+              ($5, $2, $3, 'job-old', 'src', $6, 'tgt', $6, $7::timestamptz, $7::timestamptz)`,
+      [jobNew, tenantA, userA, "2024-06-02T12:00:00.000Z", jobOld, enc, "2024-06-01T12:00:00.000Z"]
+    );
+
+    await pool.query(
+      `INSERT INTO reconciliation_runs (id, tenant_id, user_id, name, status, started_at, completed_at, created_at, updated_at, source_count, target_count, matched_count, unmatched_source_count, unmatched_target_count, metadata)
+       VALUES ($1, $2, $3, 'ing-new', 'completed', $4::timestamptz, $4::timestamptz, $4::timestamptz, $4::timestamptz, 0, 0, 0, 0, 0, '{}'),
+              ($5, $2, $3, 'ing-old', 'completed', $6::timestamptz, $6::timestamptz, $6::timestamptz, $6::timestamptz, 0, 0, 0, 0, 0, '{}')`,
+      [ingNew, tenantA, userA, "2024-06-03T12:00:00.000Z", ingOld, "2024-06-01T12:00:00.000Z"]
+    );
+
+    await pool.query(
+      `INSERT INTO recon_jobs (id, tenant_id, user_id, name, source_adapter, source_config_encrypted, target_adapter, target_config_encrypted, created_at, updated_at)
+       VALUES ($1, $2, $3, 'other-tenant', 'src', $4, 'tgt', $4, NOW(), NOW())`,
+      [otherTenantJob, tenantB, userB, enc]
+    );
+  });
+
+  test("merged pagination: deterministic order, no duplicates across pages", async () => {
+    if (!ctx) throw new Error("reconciliation DB harness not initialized");
+    const limit = 2;
+    const p1 = await fetchMergedReconciliationRunsPage({
+      prisma: ctx.prisma,
+      tenantId: tenantA,
+      limit,
+      cursorState: null,
+      runKind: "all",
+      encodeCursor: encodeMergedRunsCursor,
+    });
+
+    expect(p1.pagination.returned).toBe(2);
+    expect(p1.runs.map((r) => r.id)).toEqual([ingNew, jobNew]);
+    expect(p1.next_cursor).toBeTruthy();
+
+    const cursor = decodeMergedRunsCursor(p1.next_cursor);
+    const p2 = await fetchMergedReconciliationRunsPage({
+      prisma: ctx.prisma,
+      tenantId: tenantA,
+      limit,
+      cursorState: cursor,
+      runKind: "all",
+      encodeCursor: encodeMergedRunsCursor,
+    });
+
+    expect(p2.runs.map((r) => r.id)).toEqual([ingOld, jobOld]);
+    const allIds = [...p1.runs.map((r) => r.id), ...p2.runs.map((r) => r.id)];
+    expect(new Set(allIds).size).toBe(4);
+
+    const p3 = await fetchMergedReconciliationRunsPage({
+      prisma: ctx.prisma,
+      tenantId: tenantA,
+      limit,
+      cursorState: decodeMergedRunsCursor(p2.next_cursor),
+      runKind: "all",
+      encodeCursor: encodeMergedRunsCursor,
+    });
+    expect(p3.runs.length).toBe(0);
+    expect(p3.next_cursor).toBeNull();
+  });
+
+  test("tenant isolation: other tenant job never appears", async () => {
+    if (!ctx) throw new Error("reconciliation DB harness not initialized");
+    const page = await fetchMergedReconciliationRunsPage({
+      prisma: ctx.prisma,
+      tenantId: tenantA,
+      limit: 50,
+      cursorState: null,
+      runKind: "recon_job",
+      encodeCursor: encodeMergedRunsCursor,
+    });
+    const ids = page.runs.map((r) => r.id);
+    expect(ids).toContain(jobNew);
+    expect(ids).toContain(jobOld);
+    expect(ids).not.toContain(otherTenantJob);
+  });
+
+  test("run_kind filters: recon_job stream only jobs", async () => {
+    if (!ctx) throw new Error("reconciliation DB harness not initialized");
+    const page = await fetchMergedReconciliationRunsPage({
+      prisma: ctx.prisma,
+      tenantId: tenantA,
+      limit: 10,
+      cursorState: null,
+      runKind: "recon_job",
+      encodeCursor: encodeMergedRunsCursor,
+    });
+    expect(page.runs.every((r) => r.runKind === "recon_job")).toBe(true);
+    expect(page.runs.length).toBe(2);
+  });
+
+  test("run_kind filters: ingestion_run stream only ingestion", async () => {
+    if (!ctx) throw new Error("reconciliation DB harness not initialized");
+    const page = await fetchMergedReconciliationRunsPage({
+      prisma: ctx.prisma,
+      tenantId: tenantA,
+      limit: 10,
+      cursorState: null,
+      runKind: "ingestion_run",
+      encodeCursor: encodeMergedRunsCursor,
+    });
+    expect(page.runs.every((r) => r.runKind === "ingestion_run")).toBe(true);
+    expect(page.runs.length).toBe(2);
+  });
+
+  test("console list body matrix matches Next route projection", async () => {
+    if (!ctx) throw new Error("reconciliation DB harness not initialized");
+    const page = await fetchMergedReconciliationRunsPage({
+      prisma: ctx.prisma,
+      tenantId: tenantA,
+      limit: 10,
+      cursorState: null,
+      runKind: "all",
+      encodeCursor: encodeMergedRunsCursor,
+    });
+
+    const allBody = buildConsoleReconciliationListBody(page, "all");
+    expect(allBody.runs).toBeDefined();
+    expect((allBody.reconciliations as unknown[]).length).toBe(2);
+
+    const jobOnly = await fetchMergedReconciliationRunsPage({
+      prisma: ctx.prisma,
+      tenantId: tenantA,
+      limit: 10,
+      cursorState: null,
+      runKind: "recon_job",
+      encodeCursor: encodeMergedRunsCursor,
+    });
+    const jobBody = buildConsoleReconciliationListBody(jobOnly, "recon_job");
+    expect(jobBody.runs).toBeUndefined();
+    expect((jobBody.reconciliations as { id: string }[]).map((x) => x.id).sort()).toEqual(
+      [jobOld, jobNew].sort()
+    );
+
+    const ingOnly = await fetchMergedReconciliationRunsPage({
+      prisma: ctx.prisma,
+      tenantId: tenantA,
+      limit: 10,
+      cursorState: null,
+      runKind: "ingestion_run",
+      encodeCursor: encodeMergedRunsCursor,
+    });
+    const ingBody = buildConsoleReconciliationListBody(ingOnly, "ingestion_run");
+    expect(ingBody.runs).toBeUndefined();
+    expect(ingBody.reconciliations).toEqual([]);
+  });
+
+  test("resolveReconciliationRunForTenant: ambiguous UUID returns collision", async () => {
+    if (!ctx) throw new Error("reconciliation DB harness not initialized");
+    const { pool, prisma } = ctx;
+    const enc = "f".repeat(32);
+    await pool.query(`DELETE FROM reconciliation_runs WHERE id = $1`, [collisionId]);
+    await pool.query(`DELETE FROM recon_jobs WHERE id = $1`, [collisionId]);
+
+    await pool.query(
+      `INSERT INTO recon_jobs (id, tenant_id, user_id, name, source_adapter, source_config_encrypted, target_adapter, target_config_encrypted, created_at, updated_at)
+       VALUES ($1, $2, $3, 'collision-job', 'src', $4, 'tgt', $4, NOW(), NOW())`,
+      [collisionId, tenantA, userA, enc]
+    );
+    await pool.query(
+      `INSERT INTO reconciliation_runs (id, tenant_id, user_id, name, status, started_at, created_at, updated_at, source_count, target_count, matched_count, unmatched_source_count, unmatched_target_count, metadata)
+       VALUES ($1, $2, $3, 'collision-run', 'completed', NOW(), NOW(), NOW(), 0, 0, 0, 0, 0, '{}')`,
+      [collisionId, tenantA, userA]
+    );
+
+    const res = await resolveReconciliationRunForTenant(prisma, tenantA, collisionId);
+    expect(res.kind).toBe("ambiguous_uuid_collision");
+    if (res.kind === "ambiguous_uuid_collision") {
+      expect(res.jobId).toBe(collisionId);
+      expect(res.ingestionRunId).toBe(collisionId);
+    }
+  });
+
+  test("resolveReconciliationRunForTenant: recon_job id resolves to recon_job", async () => {
+    if (!ctx) throw new Error("reconciliation DB harness not initialized");
+    const res = await resolveReconciliationRunForTenant(ctx.prisma, tenantA, jobNew);
+    expect(res.kind).toBe("recon_job");
+    if (res.kind === "recon_job") {
+      expect(res.detail.runKind).toBe("recon_job");
+      expect(res.detail.id).toBe(jobNew);
+    }
+  });
+
+  test("resolveReconciliationRunForTenant: ingestion id resolves to ingestion_run", async () => {
+    if (!ctx) throw new Error("reconciliation DB harness not initialized");
+    const res = await resolveReconciliationRunForTenant(ctx.prisma, tenantA, ingNew);
+    expect(res.kind).toBe("ingestion_run");
+    if (res.kind === "ingestion_run") {
+      expect(res.detail.runKind).toBe("ingestion_run");
+    }
+  });
+});

--- a/packages/api/src/__tests__/integration/reconciliation-merged-list.db.test.ts
+++ b/packages/api/src/__tests__/integration/reconciliation-merged-list.db.test.ts
@@ -1,9 +1,12 @@
 /**
  * DB-backed contract tests for merged reconciliation listing and run resolution.
- * Requires PostgreSQL with `recon_jobs` and `reconciliation_runs` (golden / Prisma schema).
+ * Adapts INSERT shape to whatever `public.tenants`, `public.users`, `public.recon_jobs`,
+ * and `public.reconciliation_runs` columns exist (Prisma-shaped vs slimmer baselines).
  *
  * Opt-in (separate from generic RUN_DB_TESTS so tenant suites do not require these tables):
- *   RUN_RECON_MERGED_LIST_DB=1 RUN_DB_TESTS=true pnpm --filter @settler/api exec jest src/__tests__/integration/reconciliation-merged-list.db.test.ts --runInBand --forceExit
+ *   RUN_RECON_MERGED_LIST_DB=1 RUN_DB_TESTS=true pnpm --filter @settler/api run test:recon-merged-db
+ *
+ * CI applies `scripts/ci/reconciliation-merged-list-schema.sql` for a guaranteed Prisma match.
  */
 
 import { PrismaClient } from "@prisma/client";
@@ -20,8 +23,82 @@ import {
 const runDb = process.env.RUN_DB_TESTS === "true" && process.env.RUN_RECON_MERGED_LIST_DB === "1";
 const describeDb = runDb ? describe : describe.skip;
 
+const PRISMA_RECONCILIATION_RUN_COLUMNS = [
+  "id",
+  "tenant_id",
+  "user_id",
+  "ingestion_id",
+  "name",
+  "status",
+  "started_at",
+  "completed_at",
+  "source_count",
+  "target_count",
+  "matched_count",
+  "unmatched_source_count",
+  "unmatched_target_count",
+  "confidence_avg",
+  "error_message",
+  "trace_id",
+  "metadata",
+  "created_at",
+  "updated_at",
+] as const;
+
+async function loadColumns(pool: Pool, table: string): Promise<Set<string>> {
+  const r = await pool.query<{ column_name: string }>(
+    `SELECT column_name FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1`,
+    [table]
+  );
+  return new Set(r.rows.map((x) => x.column_name));
+}
+
+async function tableExists(pool: Pool, table: string): Promise<boolean> {
+  const r = await pool.query<{ c: string }>(
+    `SELECT COUNT(*)::text AS c FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = $1`,
+    [table]
+  );
+  return Number(r.rows[0]?.c) > 0;
+}
+
+function pickColumns(
+  available: Set<string>,
+  row: Record<string, unknown>
+): { names: string[]; values: unknown[] } {
+  const names: string[] = [];
+  const values: unknown[] = [];
+  for (const [k, v] of Object.entries(row)) {
+    if (available.has(k) && v !== undefined) {
+      names.push(k);
+      values.push(v);
+    }
+  }
+  return { names, values };
+}
+
+async function insertRow(
+  pool: Pool,
+  table: string,
+  available: Set<string>,
+  row: Record<string, unknown>
+) {
+  const { names, values } = pickColumns(available, row);
+  if (names.length === 0) throw new Error(`No insertable columns for ${table}`);
+  const placeholders = names.map((_, i) => `$${i + 1}`).join(", ");
+  const sql = `INSERT INTO ${table} (${names.join(", ")}) VALUES (${placeholders})`;
+  await pool.query(sql, values);
+}
+
 describeDb("reconciliation merged list (database)", () => {
   let ctx: { pool: Pool; prisma: PrismaClient } | undefined;
+  let columns: {
+    tenants: Set<string>;
+    users: Set<string> | null;
+    reconJobs: Set<string>;
+    reconciliationRuns: Set<string>;
+  };
 
   const tenantA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
   const userA = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
@@ -53,9 +130,30 @@ describeDb("reconciliation merged list (database)", () => {
     if (Number(chk.rows[0]?.c) !== 2) {
       await pool.end();
       throw new Error(
-        "reconciliation-merged-list.db.test requires public.recon_jobs and public.reconciliation_runs; apply golden schema."
+        "reconciliation-merged-list.db.test requires public.recon_jobs and public.reconciliation_runs."
       );
     }
+
+    const tenants = await loadColumns(pool, "tenants");
+    const reconJobs = await loadColumns(pool, "recon_jobs");
+    const reconciliationRuns = await loadColumns(pool, "reconciliation_runs");
+    const usersExist = await tableExists(pool, "users");
+    const users = usersExist ? await loadColumns(pool, "users") : null;
+
+    const ingestionMergeCapable = PRISMA_RECONCILIATION_RUN_COLUMNS.every((c) =>
+      reconciliationRuns.has(c)
+    );
+    if (!ingestionMergeCapable) {
+      const missing = PRISMA_RECONCILIATION_RUN_COLUMNS.filter((c) => !reconciliationRuns.has(c));
+      await pool.end();
+      throw new Error(
+        `reconciliation_runs is missing columns required by Prisma merge queries: ${missing.join(
+          ", "
+        )}. Apply scripts/ci/reconciliation-merged-list-schema.sql to a test database, or use a DB that matches prisma/schema.prisma for this table.`
+      );
+    }
+
+    columns = { tenants, users, reconJobs, reconciliationRuns };
 
     const adapter = new PrismaPg(pool);
     const prismaClient = new PrismaClient({ adapter });
@@ -71,49 +169,142 @@ describeDb("reconciliation merged list (database)", () => {
   beforeEach(async () => {
     if (!ctx) throw new Error("reconciliation DB harness not initialized");
     const { pool } = ctx;
+
     await pool.query(`DELETE FROM reconciliation_runs WHERE tenant_id = ANY($1::uuid[])`, [
       [tenantA, tenantB],
     ]);
     await pool.query(`DELETE FROM recon_jobs WHERE tenant_id = ANY($1::uuid[])`, [
       [tenantA, tenantB],
     ]);
-    await pool.query(`DELETE FROM users WHERE id = ANY($1::uuid[])`, [[userA, userB]]);
+    if (columns.users) {
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::uuid[])`, [[userA, userB]]);
+    }
     await pool.query(`DELETE FROM tenants WHERE id = ANY($1::uuid[])`, [[tenantA, tenantB]]);
 
-    await pool.query(
-      `INSERT INTO tenants (id, name, slug, created_at, updated_at)
-       VALUES ($1, 'Recon Int A', 'recon-int-a-' || substr($1::text, 1, 8), NOW(), NOW()),
-              ($2, 'Recon Int B', 'recon-int-b-' || substr($2::text, 1, 8), NOW(), NOW())`,
-      [tenantA, tenantB]
-    );
+    const slugA = `recon-int-a-${tenantA.slice(0, 8)}`;
+    const slugB = `recon-int-b-${tenantB.slice(0, 8)}`;
 
-    await pool.query(
-      `INSERT INTO users (id, tenant_id, email, password_hash, created_at, updated_at)
-       VALUES ($1, $2, 'recon-a@test.local', 'x', NOW(), NOW()),
-              ($3, $4, 'recon-b@test.local', 'x', NOW(), NOW())`,
-      [userA, tenantA, userB, tenantB]
-    );
+    const tenantRowA: Record<string, unknown> = {
+      id: tenantA,
+      name: "Recon Int A",
+      slug: slugA,
+      created_at: new Date(),
+      updated_at: new Date(),
+      is_active: true,
+      metadata: {},
+    };
+    const tenantRowB: Record<string, unknown> = {
+      id: tenantB,
+      name: "Recon Int B",
+      slug: slugB,
+      created_at: new Date(),
+      updated_at: new Date(),
+      is_active: true,
+      metadata: {},
+    };
+
+    await insertRow(pool, "tenants", columns.tenants, tenantRowA);
+    await insertRow(pool, "tenants", columns.tenants, tenantRowB);
+
+    if (columns.users) {
+      await insertRow(pool, "users", columns.users, {
+        id: userA,
+        tenant_id: tenantA,
+        email: "recon-a@test.local",
+        password_hash: "x",
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+      await insertRow(pool, "users", columns.users, {
+        id: userB,
+        tenant_id: tenantB,
+        email: "recon-b@test.local",
+        password_hash: "x",
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+    }
 
     const enc = "e".repeat(32);
-    await pool.query(
-      `INSERT INTO recon_jobs (id, tenant_id, user_id, name, source_adapter, source_config_encrypted, target_adapter, target_config_encrypted, created_at, updated_at)
-       VALUES ($1, $2, $3, 'job-new', 'src', $6, 'tgt', $6, $4::timestamptz, $4::timestamptz),
-              ($5, $2, $3, 'job-old', 'src', $6, 'tgt', $6, $7::timestamptz, $7::timestamptz)`,
-      [jobNew, tenantA, userA, "2024-06-02T12:00:00.000Z", jobOld, enc, "2024-06-01T12:00:00.000Z"]
-    );
+    const jobBase: Record<string, unknown> = {
+      tenant_id: tenantA,
+      user_id: userA,
+      name: "job",
+      source_adapter: "src",
+      source_config_encrypted: enc,
+      target_adapter: "tgt",
+      target_config_encrypted: enc,
+      validation_rules: [],
+      recon_strategy: "deterministic",
+      schedule_timezone: "UTC",
+      status: "active",
+      version: 1,
+      metadata: {},
+      deleted_at: null,
+    };
 
-    await pool.query(
-      `INSERT INTO reconciliation_runs (id, tenant_id, user_id, name, status, started_at, completed_at, created_at, updated_at, source_count, target_count, matched_count, unmatched_source_count, unmatched_target_count, metadata)
-       VALUES ($1, $2, $3, 'ing-new', 'completed', $4::timestamptz, $4::timestamptz, $4::timestamptz, $4::timestamptz, 0, 0, 0, 0, 0, '{}'),
-              ($5, $2, $3, 'ing-old', 'completed', $6::timestamptz, $6::timestamptz, $6::timestamptz, $6::timestamptz, 0, 0, 0, 0, 0, '{}')`,
-      [ingNew, tenantA, userA, "2024-06-03T12:00:00.000Z", ingOld, "2024-06-01T12:00:00.000Z"]
-    );
+    await insertRow(pool, "recon_jobs", columns.reconJobs, {
+      ...jobBase,
+      id: jobNew,
+      name: "job-new",
+      created_at: new Date("2024-06-02T12:00:00.000Z"),
+      updated_at: new Date("2024-06-02T12:00:00.000Z"),
+    });
+    await insertRow(pool, "recon_jobs", columns.reconJobs, {
+      ...jobBase,
+      id: jobOld,
+      name: "job-old",
+      created_at: new Date("2024-06-01T12:00:00.000Z"),
+      updated_at: new Date("2024-06-01T12:00:00.000Z"),
+    });
 
-    await pool.query(
-      `INSERT INTO recon_jobs (id, tenant_id, user_id, name, source_adapter, source_config_encrypted, target_adapter, target_config_encrypted, created_at, updated_at)
-       VALUES ($1, $2, $3, 'other-tenant', 'src', $4, 'tgt', $4, NOW(), NOW())`,
-      [otherTenantJob, tenantB, userB, enc]
-    );
+    {
+      const ingBase: Record<string, unknown> = {
+        tenant_id: tenantA,
+        user_id: userA,
+        status: "completed",
+        source_count: 0,
+        target_count: 0,
+        matched_count: 0,
+        unmatched_source_count: 0,
+        unmatched_target_count: 0,
+        metadata: {},
+        confidence_avg: null,
+        error_message: null,
+        trace_id: null,
+        ingestion_id: null,
+      };
+      const tNew = new Date("2024-06-03T12:00:00.000Z");
+      const tOld = new Date("2024-06-01T12:00:00.000Z");
+      await insertRow(pool, "reconciliation_runs", columns.reconciliationRuns, {
+        ...ingBase,
+        id: ingNew,
+        name: "ing-new",
+        started_at: tNew,
+        completed_at: tNew,
+        created_at: tNew,
+        updated_at: tNew,
+      });
+      await insertRow(pool, "reconciliation_runs", columns.reconciliationRuns, {
+        ...ingBase,
+        id: ingOld,
+        name: "ing-old",
+        started_at: tOld,
+        completed_at: tOld,
+        created_at: tOld,
+        updated_at: tOld,
+      });
+    }
+
+    await insertRow(pool, "recon_jobs", columns.reconJobs, {
+      ...jobBase,
+      id: otherTenantJob,
+      tenant_id: tenantB,
+      user_id: userB,
+      name: "other-tenant",
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
   });
 
   test("merged pagination: deterministic order, no duplicates across pages", async () => {
@@ -146,16 +337,7 @@ describeDb("reconciliation merged list (database)", () => {
     const allIds = [...p1.runs.map((r) => r.id), ...p2.runs.map((r) => r.id)];
     expect(new Set(allIds).size).toBe(4);
 
-    const p3 = await fetchMergedReconciliationRunsPage({
-      prisma: ctx.prisma,
-      tenantId: tenantA,
-      limit,
-      cursorState: decodeMergedRunsCursor(p2.next_cursor),
-      runKind: "all",
-      encodeCursor: encodeMergedRunsCursor,
-    });
-    expect(p3.runs.length).toBe(0);
-    expect(p3.next_cursor).toBeNull();
+    expect(p2.next_cursor).toBeNull();
   });
 
   test("tenant isolation: other tenant job never appears", async () => {
@@ -247,26 +429,62 @@ describeDb("reconciliation merged list (database)", () => {
   test("resolveReconciliationRunForTenant: ambiguous UUID returns collision", async () => {
     if (!ctx) throw new Error("reconciliation DB harness not initialized");
     const { pool, prisma } = ctx;
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const enc = "f".repeat(32);
     await pool.query(`DELETE FROM reconciliation_runs WHERE id = $1`, [collisionId]);
     await pool.query(`DELETE FROM recon_jobs WHERE id = $1`, [collisionId]);
 
-    await pool.query(
-      `INSERT INTO recon_jobs (id, tenant_id, user_id, name, source_adapter, source_config_encrypted, target_adapter, target_config_encrypted, created_at, updated_at)
-       VALUES ($1, $2, $3, 'collision-job', 'src', $4, 'tgt', $4, NOW(), NOW())`,
-      [collisionId, tenantA, userA, enc]
-    );
-    await pool.query(
-      `INSERT INTO reconciliation_runs (id, tenant_id, user_id, name, status, started_at, created_at, updated_at, source_count, target_count, matched_count, unmatched_source_count, unmatched_target_count, metadata)
-       VALUES ($1, $2, $3, 'collision-run', 'completed', NOW(), NOW(), NOW(), 0, 0, 0, 0, 0, '{}')`,
-      [collisionId, tenantA, userA]
-    );
+    await insertRow(pool, "recon_jobs", columns.reconJobs, {
+      id: collisionId,
+      tenant_id: tenantA,
+      user_id: userA,
+      name: "collision-job",
+      source_adapter: "src",
+      source_config_encrypted: enc,
+      target_adapter: "tgt",
+      target_config_encrypted: enc,
+      validation_rules: [],
+      recon_strategy: "deterministic",
+      schedule_timezone: "UTC",
+      status: "active",
+      version: 1,
+      metadata: {},
+      deleted_at: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    const now = new Date();
+    await insertRow(pool, "reconciliation_runs", columns.reconciliationRuns, {
+      id: collisionId,
+      tenant_id: tenantA,
+      user_id: userA,
+      name: "collision-run",
+      status: "completed",
+      started_at: now,
+      completed_at: now,
+      created_at: now,
+      updated_at: now,
+      source_count: 0,
+      target_count: 0,
+      matched_count: 0,
+      unmatched_source_count: 0,
+      unmatched_target_count: 0,
+      metadata: {},
+      confidence_avg: null,
+      error_message: null,
+      trace_id: null,
+      ingestion_id: null,
+    });
 
-    const res = await resolveReconciliationRunForTenant(prisma, tenantA, collisionId);
-    expect(res.kind).toBe("ambiguous_uuid_collision");
-    if (res.kind === "ambiguous_uuid_collision") {
-      expect(res.jobId).toBe(collisionId);
-      expect(res.ingestionRunId).toBe(collisionId);
+    try {
+      const res = await resolveReconciliationRunForTenant(prisma, tenantA, collisionId);
+      expect(res.kind).toBe("ambiguous_uuid_collision");
+      if (res.kind === "ambiguous_uuid_collision") {
+        expect(res.jobId).toBe(collisionId);
+        expect(res.ingestionRunId).toBe(collisionId);
+      }
+    } finally {
+      errSpy.mockRestore();
     }
   });
 

--- a/packages/api/src/__tests__/routes/reconciliation-v1-contract.test.ts
+++ b/packages/api/src/__tests__/routes/reconciliation-v1-contract.test.ts
@@ -1,0 +1,145 @@
+import express, { Express } from "express";
+import request from "supertest";
+import reconciliationRouter from "../../routes/v1/reconciliation";
+import {
+  fetchMergedReconciliationRunsPage,
+  resolveReconciliationRunForTenant,
+} from "@settler/reconciliation-core";
+
+jest.mock("../../middleware/governance", () => ({
+  enforceFreezeState: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../../services/ingestion/reconciliation-matcher", () => ({
+  runReconciliation: jest.fn().mockResolvedValue("33333333-3333-4333-8333-333333333333"),
+}));
+
+jest.mock("../../infrastructure/db/prisma", () => ({
+  prisma: {},
+}));
+
+jest.mock("@settler/reconciliation-core", () => {
+  const actual = jest.requireActual<typeof import("@settler/reconciliation-core")>(
+    "@settler/reconciliation-core"
+  );
+  return {
+    ...actual,
+    fetchMergedReconciliationRunsPage: jest.fn(),
+    resolveReconciliationRunForTenant: jest.fn(),
+  };
+});
+
+jest.mock("../../db", () => ({
+  query: jest.fn(),
+}));
+
+jest.mock("../../utils/logger", () => ({
+  logError: jest.fn(),
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+}));
+
+import { query } from "../../db";
+
+const tenantId = "11111111-1111-4111-8111-111111111111";
+
+describe("reconciliation v1 contract", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as { tenantId?: string; userId?: string; traceId?: string }).tenantId = tenantId;
+      (req as { tenantId?: string; userId?: string; traceId?: string }).userId =
+        "22222222-2222-4222-8222-222222222222";
+      (req as { tenantId?: string; userId?: string; traceId?: string }).traceId = "trace-contract";
+      next();
+    });
+    app.use("/api/v1/reconciliation", reconciliationRouter);
+
+    (fetchMergedReconciliationRunsPage as jest.Mock).mockReset();
+    (fetchMergedReconciliationRunsPage as jest.Mock).mockResolvedValue({
+      runs: [],
+      next_cursor: null,
+      pagination: {
+        limit: 50,
+        returned: 0,
+        has_more: false,
+        job_stream_has_more: false,
+        ingestion_stream_has_more: false,
+        job_stream_exhausted: true,
+        ingestion_stream_exhausted: true,
+      },
+      response_meta: {
+        contract_version: 1,
+        included_run_kinds: ["recon_job", "ingestion_run"],
+        ordering: "test",
+        consistency: "read_committed",
+      },
+    });
+    (resolveReconciliationRunForTenant as jest.Mock).mockReset();
+    (query as jest.Mock).mockReset();
+  });
+
+  test("GET /runs rejects malformed cursor with RECONCILIATION_CURSOR_INVALID", async () => {
+    const res = await request(app)
+      .get("/api/v1/reconciliation/runs?cursor=not-valid-base64url!!!")
+      .expect(400);
+
+    expect(res.headers["content-type"]).toMatch(/application\/problem\+json/);
+    expect(res.body.code).toBe("RECONCILIATION_CURSOR_INVALID");
+  });
+
+  test("GET /runs/:id/matches returns 409 RECONCILIATION_WRONG_RUN_KIND for recon_job id", async () => {
+    (resolveReconciliationRunForTenant as jest.Mock).mockResolvedValue({
+      kind: "recon_job",
+      detail: { runKind: "recon_job" },
+    });
+
+    const res = await request(app)
+      .get("/api/v1/reconciliation/runs/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/matches")
+      .expect(409);
+
+    expect(res.headers["content-type"]).toMatch(/application\/problem\+json/);
+    expect(res.body.code).toBe("RECONCILIATION_WRONG_RUN_KIND");
+    expect(res.body.resolved_run_kind).toBe("recon_job");
+    expect(query as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  test("GET /runs/:id returns 409 RECONCILIATION_UUID_COLLISION when both tables share an id", async () => {
+    (resolveReconciliationRunForTenant as jest.Mock).mockResolvedValue({
+      kind: "ambiguous_uuid_collision",
+      jobId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      ingestionRunId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    });
+
+    const res = await request(app)
+      .get("/api/v1/reconciliation/runs/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .expect(409);
+
+    expect(res.headers["content-type"]).toMatch(/application\/problem\+json/);
+    expect(res.body.code).toBe("RECONCILIATION_UUID_COLLISION");
+    expect(res.body.recon_job_id).toBe("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+    expect(res.body.reconciliation_run_id).toBe("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+  });
+
+  test("GET /runs/:id/matches caps limit at 500", async () => {
+    (resolveReconciliationRunForTenant as jest.Mock).mockResolvedValue({ kind: "ingestion_run" });
+    (query as jest.Mock).mockResolvedValueOnce([]).mockResolvedValueOnce([{ count: "0" }]);
+
+    const res = await request(app)
+      .get("/api/v1/reconciliation/runs/cccccccc-cccc-4ccc-8ccc-cccccccccccc/matches?limit=99999")
+      .expect(200);
+
+    expect(res.body.pagination.limit).toBe(500);
+    const q = query as jest.Mock;
+    expect(q).toHaveBeenCalled();
+    const matchArgs = q.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === "string" && (c[0] as string).includes("FROM reconciliation_matches rm")
+    );
+    expect(matchArgs).toBeDefined();
+    expect(matchArgs![1]).toContain("500");
+  });
+});

--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Pool, PoolClient } from "pg";
+
+/** Re-export so Prisma adapter wiring shares the same `Pool` type identity as this module. */
+export { Pool, PoolClient };
 import { config } from "../config";
 import { logError, logWarn } from "../utils/logger";
 import { TenantContext } from "../infrastructure/tenancy/TenantContext";

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -80,7 +80,10 @@ import {
   isLedgerUsingFallback,
   getLedgerDisabledReason,
 } from "./domain/services/LedgerService";
-import { setReconciliationCollisionLogger } from "@settler/reconciliation-core";
+import {
+  setReconciliationCollisionLogger,
+  type UuidCollisionLogInput,
+} from "@settler/reconciliation-core";
 
 const app: Express = express();
 const PORT = config.port;
@@ -375,7 +378,7 @@ async function startServer() {
     await initDatabase();
     logInfo("Database initialized");
 
-    setReconciliationCollisionLogger((entry) => {
+    setReconciliationCollisionLogger((entry: UuidCollisionLogInput) => {
       logWarn("reconciliation_uuid_collision", {
         event: "reconciliation_uuid_collision",
         tenant_id: entry.tenantId,

--- a/packages/api/src/infrastructure/db/prisma.ts
+++ b/packages/api/src/infrastructure/db/prisma.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
-import pg from "pg";
 import { config } from "../../config";
+import { Pool } from "../../db";
 
 // Global variable to prevent multiple instances of Prisma Client in development
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
@@ -23,7 +23,7 @@ function buildPrismaOptions(): any {
     };
   }
 
-  const pool = new pg.Pool({
+  const pool = new Pool({
     host: config.database.host,
     port: config.database.port,
     database: config.database.name,

--- a/packages/api/src/routes/v1/reconciliation.ts
+++ b/packages/api/src/routes/v1/reconciliation.ts
@@ -264,11 +264,16 @@ router.get("/runs", async (req: AuthRequest, res: Response) => {
     if (cursorParam) {
       try {
         cursorState = decodeMergedRunsCursor(cursorParam);
-      } catch (e) {
+      } catch (e: unknown) {
         sendProblemJson(req, res, {
           status: 400,
           title: "Invalid cursor",
-          detail: e instanceof MergedRunsCursorError ? e.message : "Invalid cursor",
+          detail:
+            e instanceof MergedRunsCursorError
+              ? e.message
+              : e instanceof Error
+                ? e.message
+                : "Invalid cursor",
           code: CURSOR_INVALID,
         });
         return;
@@ -362,8 +367,10 @@ router.get("/runs/:runId/matches", async (req: AuthRequest, res: Response) => {
     const gate = await gateIngestionRunForWorkbench(runId, tenantId);
     if (!respondIngestionWorkbenchGate(req, res, gate)) return;
 
-    const limit = parseInt(req.query.limit as string) || 100;
-    const offset = parseInt(req.query.offset as string) || 0;
+    const limitRaw = parseInt(String(req.query.limit || "100"), 10);
+    const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 500) : 100;
+    const offsetRaw = parseInt(String(req.query.offset || "0"), 10);
+    const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? offsetRaw : 0;
     const matchType = req.query.matchType as string | undefined;
     const reviewed = req.query.reviewed as string | undefined;
 
@@ -464,8 +471,10 @@ router.get("/runs/:runId/workbench", async (req: AuthRequest, res: Response) => 
     const gate = await gateIngestionRunForWorkbench(runId, tenantId);
     if (!respondIngestionWorkbenchGate(req, res, gate)) return;
 
-    const limit = parseInt(req.query.limit as string) || 100;
-    const offset = parseInt(req.query.offset as string) || 0;
+    const limitRaw = parseInt(String(req.query.limit || "100"), 10);
+    const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 500) : 100;
+    const offsetRaw = parseInt(String(req.query.offset || "0"), 10);
+    const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? offsetRaw : 0;
     const queue = req.query.queue as string | undefined;
 
     const runs = await query(

--- a/packages/reconciliation-core/src/console-reconciliation-list.test.ts
+++ b/packages/reconciliation-core/src/console-reconciliation-list.test.ts
@@ -1,0 +1,109 @@
+import type { CanonicalReconciliationListItem } from "./canonical-reconciliation.js";
+import { buildConsoleReconciliationListBody } from "./console-reconciliation-list";
+import type { MergedReconciliationListResponse } from "./merged-runs-query.js";
+
+function mockPage(runs: CanonicalReconciliationListItem[]): MergedReconciliationListResponse {
+  return {
+    runs,
+    next_cursor: null,
+    pagination: {
+      limit: 50,
+      returned: runs.length,
+      has_more: false,
+      job_stream_has_more: false,
+      ingestion_stream_has_more: false,
+      job_stream_exhausted: true,
+      ingestion_stream_exhausted: true,
+    },
+    response_meta: {
+      contract_version: 1,
+      included_run_kinds: ["recon_job", "ingestion_run"],
+      ordering: "test",
+      consistency: "read_committed",
+    },
+  };
+}
+
+describe("buildConsoleReconciliationListBody", () => {
+  const job: CanonicalReconciliationListItem = {
+    runKind: "recon_job",
+    id: "j1",
+    tenantId: "t",
+    name: "Job",
+    reconResultId: null,
+    lifecycle: {
+      status: "completed",
+      statusLabel: "Completed",
+      isTerminal: true,
+      progressPercent: 100,
+      progressState: "completed",
+    },
+    summaryState: "success",
+    summary: {
+      total: 0,
+      sourceCount: 1,
+      targetCount: 1,
+      processed: 0,
+      matched: 0,
+      matchedWithTolerance: 0,
+      unmatched: 0,
+      unmatchedSourceCount: 0,
+      unmatchedTargetCount: 0,
+      conflicts: 0,
+      exceptioned: 0,
+      unresolved: 0,
+      ignored: 0,
+      resolved: 0,
+    },
+    provenance: {
+      sourceModel: "recon_jobs",
+      runKind: "recon_job",
+      ingestionId: null,
+      reconJobId: "j1",
+    },
+    adapters: { sourceAdapter: "a", targetAdapter: "b" },
+    timestamps: {
+      createdAt: "2024-01-01T00:00:00.000Z",
+      startedAt: null,
+      completedAt: null,
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    },
+  };
+
+  const ing: CanonicalReconciliationListItem = {
+    ...job,
+    runKind: "ingestion_run",
+    id: "i1",
+    provenance: {
+      sourceModel: "reconciliation_runs",
+      runKind: "ingestion_run",
+      ingestionId: null,
+      reconJobId: null,
+    },
+  };
+
+  it("run_kind=all includes runs and job-shaped reconciliations", () => {
+    const body = buildConsoleReconciliationListBody(mockPage([job, ing]), "all");
+    expect(body.runs).toEqual([job, ing]);
+    expect(Array.isArray(body.reconciliations)).toBe(true);
+    expect((body.reconciliations as unknown[]).length).toBe(1);
+    const recs = body.reconciliations as { id: string }[];
+    expect(recs[0]?.id).toBe("j1");
+    expect(body.response_meta).toMatchObject({
+      requested_run_kind: "all",
+      default_run_kind: "recon_job",
+    });
+  });
+
+  it("run_kind=recon_job omits runs key", () => {
+    const body = buildConsoleReconciliationListBody(mockPage([job, ing]), "recon_job");
+    expect(body.runs).toBeUndefined();
+    expect((body.reconciliations as unknown[]).length).toBe(1);
+  });
+
+  it("run_kind=ingestion_run yields empty reconciliations and omits runs", () => {
+    const body = buildConsoleReconciliationListBody(mockPage([ing]), "ingestion_run");
+    expect(body.runs).toBeUndefined();
+    expect(body.reconciliations).toEqual([]);
+  });
+});

--- a/packages/reconciliation-core/src/console-reconciliation-list.ts
+++ b/packages/reconciliation-core/src/console-reconciliation-list.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared JSON body for Next `GET /api/console/reconciliation` list (no `id` query).
+ * Keeps Express merged pagination and console legacy projection aligned.
+ */
+
+import type { CanonicalReconciliationListItem } from "./canonical-reconciliation.js";
+import type { MergedReconciliationListResponse } from "./merged-runs-query.js";
+
+export type ConsoleReconciliationRunKindParam = "all" | "recon_job" | "ingestion_run";
+
+function toLegacyReconciliation(r: CanonicalReconciliationListItem) {
+  return {
+    id: r.id,
+    name: r.name,
+    status: r.lifecycle.status,
+    sourceAdapter: r.adapters.sourceAdapter ?? "",
+    targetAdapter: r.adapters.targetAdapter ?? "",
+    createdAt: r.timestamps.createdAt,
+    updatedAt: r.timestamps.updatedAt,
+    latestResult: r.reconResultId
+      ? {
+          id: r.reconResultId,
+          status: r.lifecycle.status,
+          startedAt: r.timestamps.startedAt ?? r.timestamps.createdAt,
+          completedAt: r.timestamps.completedAt,
+          counts: {
+            source: r.summary.sourceCount,
+            target: r.summary.targetCount,
+            matched: r.summary.matched,
+            unmatchedSource: r.summary.unmatchedSourceCount,
+            unmatchedTarget: r.summary.unmatchedTargetCount,
+            conflicts: r.summary.conflicts,
+          },
+          errorMessage: null,
+        }
+      : null,
+  };
+}
+
+/**
+ * @param page — result of {@link fetchMergedReconciliationRunsPage}
+ * @param runKind — validated `run_kind` query (`recon_job` default in route)
+ */
+export function buildConsoleReconciliationListBody(
+  page: MergedReconciliationListResponse,
+  runKind: ConsoleReconciliationRunKindParam
+): Record<string, unknown> {
+  const reconciliations =
+    runKind === "ingestion_run"
+      ? []
+      : page.runs.filter((r) => r.runKind === "recon_job").map(toLegacyReconciliation);
+
+  const body: Record<string, unknown> = {
+    contract_version: 1,
+    next_cursor: page.next_cursor,
+    pagination: page.pagination,
+    response_meta: {
+      ...page.response_meta,
+      default_run_kind: "recon_job",
+      requested_run_kind: runKind,
+    },
+  };
+
+  if (runKind === "all") {
+    body.runs = page.runs;
+  }
+
+  body.reconciliations = reconciliations;
+  return body;
+}

--- a/packages/reconciliation-core/src/index.ts
+++ b/packages/reconciliation-core/src/index.ts
@@ -6,3 +6,4 @@ export * from "./run-resolution.js";
 export * from "./uuid-collision-log.js";
 export * from "./v1-serializer.js";
 export * from "./run-capabilities.js";
+export * from "./console-reconciliation-list.js";

--- a/packages/reconciliation-core/src/index.ts
+++ b/packages/reconciliation-core/src/index.ts
@@ -5,3 +5,4 @@ export * from "./merged-runs-query.js";
 export * from "./run-resolution.js";
 export * from "./uuid-collision-log.js";
 export * from "./v1-serializer.js";
+export * from "./run-capabilities.js";

--- a/packages/reconciliation-core/src/merged-list-pagination.test.ts
+++ b/packages/reconciliation-core/src/merged-list-pagination.test.ts
@@ -47,4 +47,69 @@ describe("merged list pagination", () => {
     const b = { row: "b", sortTimeMs: 200, id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" };
     expect(compareMergeCandidates(a, b)).toBeGreaterThan(0);
   });
+
+  it("rejects limit outside 1..500", () => {
+    const t = new Date("2024-06-01T12:00:00.000Z").getTime();
+    const one = [{ row: "j", sortTimeMs: t, id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }];
+    expect(() =>
+      mergeDualStreamPage({
+        limit: 0,
+        jobCandidates: one,
+        ingestionCandidates: [],
+        mapJob: (x) => x,
+        mapIngestion: (x) => x,
+        prev: null,
+      })
+    ).toThrow(MergedRunsCursorError);
+    expect(() =>
+      mergeDualStreamPage({
+        limit: 501,
+        jobCandidates: one,
+        ingestionCandidates: [],
+        mapJob: (x) => x,
+        mapIngestion: (x) => x,
+        prev: null,
+      })
+    ).toThrow(MergedRunsCursorError);
+  });
+
+  it("paginates deterministically across pages when one stream exhausts mid-sequence", () => {
+    const t = new Date("2024-06-01T12:00:00.000Z").getTime();
+    const i1 = { row: "i1", sortTimeMs: t, id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc" };
+    const j1 = { row: "j1", sortTimeMs: t, id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" };
+    const j0 = { row: "j0", sortTimeMs: t, id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" };
+
+    const page1 = mergeDualStreamPage({
+      limit: 1,
+      jobCandidates: [j1, j0],
+      ingestionCandidates: [i1],
+      mapJob: (x) => x,
+      mapIngestion: (x) => x,
+      prev: null,
+    });
+    expect(page1.items).toEqual(["i1"]);
+    expect(page1.nextCursor).not.toBeNull();
+
+    const page2 = mergeDualStreamPage({
+      limit: 1,
+      jobCandidates: [j1, j0],
+      ingestionCandidates: [],
+      mapJob: (x) => x,
+      mapIngestion: (x) => x,
+      prev: page1.nextCursor,
+    });
+    expect(page2.items).toEqual(["j1"]);
+    expect(page2.nextCursor).not.toBeNull();
+
+    const page3 = mergeDualStreamPage({
+      limit: 1,
+      jobCandidates: [j0],
+      ingestionCandidates: [],
+      mapJob: (x) => x,
+      mapIngestion: (x) => x,
+      prev: page2.nextCursor,
+    });
+    expect(page3.items).toEqual(["j0"]);
+    expect(page3.nextCursor).toBeNull();
+  });
 });

--- a/packages/reconciliation-core/src/run-capabilities.test.ts
+++ b/packages/reconciliation-core/src/run-capabilities.test.ts
@@ -1,0 +1,12 @@
+import { capabilitiesForRunKind } from "./run-capabilities";
+
+describe("run capabilities", () => {
+  it("enables workbench-style routes only for ingestion_run", () => {
+    const ing = capabilitiesForRunKind("ingestion_run");
+    expect(ing.matches && ing.workbench && ing.compare && ing.export).toBe(true);
+
+    const job = capabilitiesForRunKind("recon_job");
+    expect(job.matches || job.workbench || job.compare || job.export).toBe(false);
+    expect(job.consoleResults).toBe(true);
+  });
+});

--- a/packages/reconciliation-core/src/run-capabilities.ts
+++ b/packages/reconciliation-core/src/run-capabilities.ts
@@ -1,0 +1,37 @@
+/**
+ * Machine-readable capabilities for reconciliation run kinds.
+ * Keep in sync with ingestion-only gates on Express v1 workbench routes.
+ */
+
+import type { ReconciliationRunKind } from "./canonical-reconciliation.js";
+
+export interface ReconciliationRunCapabilities {
+  /** Row-level matches from reconciliation_matches (ingestion runs only) */
+  matches: boolean;
+  workbench: boolean;
+  compare: boolean;
+  export: boolean;
+  /** Console result summary + ranked items (recon_results / ingestion-shaped) */
+  consoleResults: boolean;
+}
+
+export function capabilitiesForRunKind(
+  runKind: ReconciliationRunKind
+): ReconciliationRunCapabilities {
+  if (runKind === "ingestion_run") {
+    return {
+      matches: true,
+      workbench: true,
+      compare: true,
+      export: true,
+      consoleResults: true,
+    };
+  }
+  return {
+    matches: false,
+    workbench: false,
+    compare: false,
+    export: false,
+    consoleResults: true,
+  };
+}

--- a/packages/reconciliation-core/src/v1-serializer.ts
+++ b/packages/reconciliation-core/src/v1-serializer.ts
@@ -3,6 +3,7 @@
  */
 
 import type { CanonicalReconciliationRunDetail } from "./canonical-reconciliation.js";
+import { capabilitiesForRunKind } from "./run-capabilities.js";
 
 export function serializeV1ReconciliationRunDetail(
   detail: CanonicalReconciliationRunDetail
@@ -45,6 +46,7 @@ export function serializeV1ReconciliationRunDetail(
   return {
     contract_version: 1,
     run_kind: detail.runKind,
+    capabilities: capabilitiesForRunKind(detail.runKind),
     canonical: detail,
     legacy_v1: legacy,
   };

--- a/packages/web/src/app/api/console/reconciliation/route.ts
+++ b/packages/web/src/app/api/console/reconciliation/route.ts
@@ -22,8 +22,8 @@ import { z } from "zod";
 import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
 import { appLogger } from "@/lib/utils/logger";
 import { withSecurity } from "@/lib/middleware/api-security";
-import type { CanonicalReconciliationListItem } from "@settler/reconciliation-core";
 import {
+  buildConsoleReconciliationListBody,
   decodeMergedRunsCursor,
   encodeMergedRunsCursor,
   fetchMergedReconciliationRunsPage,
@@ -235,54 +235,7 @@ export const GET = withSecurity(
           encodeCursor: encodeMergedRunsCursor,
         });
 
-        const toLegacyReconciliation = (r: CanonicalReconciliationListItem) => ({
-          id: r.id,
-          name: r.name,
-          status: r.lifecycle.status,
-          sourceAdapter: r.adapters.sourceAdapter ?? "",
-          targetAdapter: r.adapters.targetAdapter ?? "",
-          createdAt: r.timestamps.createdAt,
-          updatedAt: r.timestamps.updatedAt,
-          latestResult: r.reconResultId
-            ? {
-                id: r.reconResultId,
-                status: r.lifecycle.status,
-                startedAt: r.timestamps.startedAt ?? r.timestamps.createdAt,
-                completedAt: r.timestamps.completedAt,
-                counts: {
-                  source: r.summary.sourceCount,
-                  target: r.summary.targetCount,
-                  matched: r.summary.matched,
-                  unmatchedSource: r.summary.unmatchedSourceCount,
-                  unmatchedTarget: r.summary.unmatchedTargetCount,
-                  conflicts: r.summary.conflicts,
-                },
-                errorMessage: null,
-              }
-            : null,
-        });
-
-        const reconciliations =
-          runKind === "ingestion_run"
-            ? []
-            : page.runs.filter((r) => r.runKind === "recon_job").map(toLegacyReconciliation);
-
-        const body: Record<string, unknown> = {
-          contract_version: 1,
-          next_cursor: page.next_cursor,
-          pagination: page.pagination,
-          response_meta: {
-            ...page.response_meta,
-            default_run_kind: "recon_job",
-            requested_run_kind: runKind,
-          },
-        };
-
-        if (runKind === "all") {
-          body.runs = page.runs;
-        }
-
-        body.reconciliations = reconciliations;
+        const body = buildConsoleReconciliationListBody(page, runKind);
 
         return NextResponse.json(body, { status: 200 });
       } catch (error) {

--- a/packages/web/src/components/console/ReconciliationMatches.tsx
+++ b/packages/web/src/components/console/ReconciliationMatches.tsx
@@ -5,7 +5,7 @@
 
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -18,7 +18,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Checkbox } from "@/components/ui/checkbox";
-import { AlertCircle, CheckCircle2 } from "lucide-react";
+import { AlertCircle, CheckCircle2, Info } from "lucide-react";
+import { capabilitiesForRunKind, type ReconciliationRunKind } from "@settler/reconciliation-core";
 
 interface Match {
   id: string;
@@ -48,20 +49,97 @@ interface Match {
 
 interface ReconciliationMatchesProps {
   runId: string;
+  /** When known (e.g. from canonical list/detail), avoids a detail prefetch before matches. */
+  runKind?: ReconciliationRunKind | null;
 }
 
-export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
+type LoadBlockReason =
+  | null
+  | { kind: "wrong_run_kind" }
+  | { kind: "uuid_collision"; detail: string }
+  | { kind: "not_found" }
+  | { kind: "other"; message: string };
+
+export function ReconciliationMatches({ runId, runKind: runKindProp }: ReconciliationMatchesProps) {
   const [matches, setMatches] = useState<Match[]>([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<"all" | "matched" | "unmatched" | "unreviewed">("all");
+  const [resolvedRunKind, setResolvedRunKind] = useState<ReconciliationRunKind | null>(
+    runKindProp ?? null
+  );
+  const [blockReason, setBlockReason] = useState<LoadBlockReason>(null);
 
   useEffect(() => {
-    loadMatches();
-  }, [runId, filter]);
+    setResolvedRunKind(runKindProp ?? null);
+    setBlockReason(null);
+  }, [runId, runKindProp]);
 
-  const loadMatches = async () => {
+  const loadMatches = useCallback(async () => {
     try {
       setLoading(true);
+      setBlockReason(null);
+
+      let runKind = resolvedRunKind;
+      if (runKind == null) {
+        const detailRes = await fetch(`/api/v1/reconciliation/runs/${runId}`, {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("apiKey")}`,
+          },
+        });
+
+        if (detailRes.status === 404) {
+          setBlockReason({ kind: "not_found" });
+          setMatches([]);
+          return;
+        }
+
+        if (detailRes.status === 409) {
+          const problem = (await detailRes.json().catch(() => ({}))) as {
+            code?: string;
+            detail?: string;
+          };
+          if (problem.code === "RECONCILIATION_UUID_COLLISION") {
+            setBlockReason({
+              kind: "uuid_collision",
+              detail:
+                problem.detail ||
+                "This id exists as both a recon job and an ingestion reconciliation run.",
+            });
+          } else if (problem.code === "RECONCILIATION_WRONG_RUN_KIND") {
+            setBlockReason({ kind: "wrong_run_kind" });
+          } else {
+            setBlockReason({
+              kind: "other",
+              message: problem.detail || "Unable to resolve run for matches.",
+            });
+          }
+          setMatches([]);
+          return;
+        }
+
+        if (!detailRes.ok) {
+          setBlockReason({ kind: "other", message: "Failed to load run detail for matches." });
+          setMatches([]);
+          return;
+        }
+
+        const detailBody = (await detailRes.json()) as { run_kind?: ReconciliationRunKind };
+        if (detailBody.run_kind !== "recon_job" && detailBody.run_kind !== "ingestion_run") {
+          setBlockReason({ kind: "other", message: "Unexpected run_kind in detail response." });
+          setMatches([]);
+          return;
+        }
+        runKind = detailBody.run_kind;
+        setResolvedRunKind(runKind);
+      }
+
+      const caps = capabilitiesForRunKind(runKind);
+      if (!caps.matches) {
+        setBlockReason({ kind: "wrong_run_kind" });
+        setMatches([]);
+        return;
+      }
+
       const params = new URLSearchParams();
       if (filter === "unmatched") {
         params.append("matchType", "unmatched");
@@ -78,6 +156,17 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
         }
       );
 
+      if (response.status === 409) {
+        const problem = (await response.json().catch(() => ({}))) as { code?: string };
+        if (problem.code === "RECONCILIATION_WRONG_RUN_KIND") {
+          setBlockReason({ kind: "wrong_run_kind" });
+        } else {
+          setBlockReason({ kind: "other", message: "Conflict loading matches." });
+        }
+        setMatches([]);
+        return;
+      }
+
       if (!response.ok) {
         throw new Error("Failed to load matches");
       }
@@ -86,10 +175,18 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
       setMatches(data.matches || []);
     } catch (error: unknown) {
       console.error("Failed to load matches:", error);
+      setBlockReason({
+        kind: "other",
+        message: error instanceof Error ? error.message : "Failed to load matches",
+      });
     } finally {
       setLoading(false);
     }
-  };
+  }, [runId, filter, resolvedRunKind]);
+
+  useEffect(() => {
+    void loadMatches();
+  }, [loadMatches]);
 
   const toggleReviewed = async (matchId: string, reviewed: boolean) => {
     try {
@@ -131,9 +228,36 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
     return "text-red-600";
   };
 
-  const matchedCount = matches.filter((m: any) => m.target !== null).length;
-  const unmatchedCount = matches.filter((m: any) => m.target === null).length;
-  const reviewedCount = matches.filter((m: any) => m.reviewed).length;
+  const blockedCopy = (() => {
+    if (!blockReason) return null;
+    if (blockReason.kind === "wrong_run_kind") {
+      return {
+        title: "Matches not available for this run type",
+        body: "Row-level matches are stored on ingestion reconciliation runs (reconciliation_runs). Recon jobs use job results and the console results view instead—do not call the v1 matches route with a recon_job id.",
+      };
+    }
+    if (blockReason.kind === "uuid_collision") {
+      return {
+        title: "Id collision",
+        body: blockReason.detail,
+      };
+    }
+    if (blockReason.kind === "not_found") {
+      return {
+        title: "Run not found",
+        body: "No reconciliation run exists for this id in your tenant, or you do not have access.",
+      };
+    }
+    return {
+      title: "Unable to load matches",
+      body: blockReason.message,
+    };
+  })();
+
+  const matchedCount = matches.filter((m) => m.target !== null).length;
+  const unmatchedCount = matches.filter((m) => m.target === null).length;
+  const reviewedCount = matches.filter((m) => m.reviewed).length;
+  const filtersDisabled = loading || Boolean(blockedCopy);
 
   return (
     <Card>
@@ -142,13 +266,16 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
           <div>
             <CardTitle>Reconciliation Matches</CardTitle>
             <CardDescription>
-              {matchedCount} matched, {unmatchedCount} unmatched, {reviewedCount} reviewed
+              {blockedCopy
+                ? blockedCopy.title
+                : `${matchedCount} matched, ${unmatchedCount} unmatched, ${reviewedCount} reviewed`}
             </CardDescription>
           </div>
           <div className="flex gap-2">
             <Button
               variant={filter === "all" ? "default" : "outline"}
               size="sm"
+              disabled={filtersDisabled}
               onClick={() => setFilter("all")}
             >
               All
@@ -156,6 +283,7 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
             <Button
               variant={filter === "matched" ? "default" : "outline"}
               size="sm"
+              disabled={filtersDisabled}
               onClick={() => setFilter("matched")}
             >
               Matched
@@ -163,6 +291,7 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
             <Button
               variant={filter === "unmatched" ? "default" : "outline"}
               size="sm"
+              disabled={filtersDisabled}
               onClick={() => setFilter("unmatched")}
             >
               Unmatched
@@ -170,6 +299,7 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
             <Button
               variant={filter === "unreviewed" ? "default" : "outline"}
               size="sm"
+              disabled={filtersDisabled}
               onClick={() => setFilter("unreviewed")}
             >
               Unreviewed
@@ -178,11 +308,20 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
         </div>
       </CardHeader>
       <CardContent>
+        {blockedCopy && !loading ? (
+          <div className="flex gap-3 rounded-lg border border-border bg-muted/30 p-4 text-sm">
+            <Info className="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+            <div>
+              <p className="font-medium text-foreground">{blockedCopy.title}</p>
+              <p className="mt-1 text-muted-foreground">{blockedCopy.body}</p>
+            </div>
+          </div>
+        ) : null}
         {loading ? (
           <div className="flex items-center justify-center p-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
           </div>
-        ) : (
+        ) : !blockedCopy ? (
           <div className="overflow-x-auto">
             <Table>
               <TableHeader>
@@ -223,12 +362,11 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
                       </TableCell>
                       <TableCell>
                         {match.matchReason ? (
-                          <span className="text-sm text-muted-foreground">
-                            {match.matchReason}
-                          </span>
-                        ) : match.matchType === 'unmatched' ? (
+                          <span className="text-sm text-muted-foreground">{match.matchReason}</span>
+                        ) : match.matchType === "unmatched" ? (
                           <span className="text-sm text-amber-600 dark:text-amber-400">
-                            No matching transaction found. Check source data or adjust matching rules.
+                            No matching transaction found. Check source data or adjust matching
+                            rules.
                           </span>
                         ) : (
                           <span className="text-sm text-muted-foreground/60">-</span>
@@ -300,7 +438,7 @@ export function ReconciliationMatches({ runId }: ReconciliationMatchesProps) {
               </TableBody>
             </Table>
           </div>
-        )}
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   glob: ^10.5.0
   minimatch: '>=10.2.1'
   eslint: ^9.26.0
+  '@types/pg': 8.18.0
 
 importers:
 
@@ -46,7 +47,7 @@ importers:
         specifier: ^24.0.0
         version: 24.12.0
       '@types/pg':
-        specifier: ^8.16.0
+        specifier: 8.18.0
         version: 8.18.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.54.0
@@ -315,7 +316,7 @@ importers:
         specifier: ^0.13.3
         version: 0.13.9
       '@types/pg':
-        specifier: ^8.10.9
+        specifier: 8.18.0
         version: 8.18.0
       '@types/uuid':
         specifier: ^9.0.7
@@ -4814,17 +4815,8 @@ packages:
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
 
-  '@types/pg@8.11.11':
-    resolution: {integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==}
-
-  '@types/pg@8.15.6':
-    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
-
   '@types/pg@8.18.0':
     resolution: {integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==}
-
-  '@types/pg@8.6.1':
-    resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
 
   '@types/phoenix@1.6.7':
     resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
@@ -8675,9 +8667,6 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  obuf@1.1.2:
-    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
-
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -8889,10 +8878,6 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
-  pg-numeric@1.0.2:
-    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
-    engines: {node: '>=4'}
-
   pg-pool@3.13.0:
     resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
     peerDependencies:
@@ -8904,10 +8889,6 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
-
-  pg-types@4.1.0:
-    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
-    engines: {node: '>=10'}
 
   pg@8.20.0:
     resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
@@ -9051,28 +9032,13 @@ packages:
     resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
     engines: {node: '>=0.10.0'}
 
-  postgres-bytea@3.0.0:
-    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
-    engines: {node: '>= 6'}
-
   postgres-date@1.0.7:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
     engines: {node: '>=0.10.0'}
 
-  postgres-date@2.1.0:
-    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
-    engines: {node: '>=12'}
-
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
-
-  postgres-interval@3.0.0:
-    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
-    engines: {node: '>=12'}
-
-  postgres-range@1.1.4:
-    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   postgres@3.4.7:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
@@ -13994,7 +13960,7 @@ snapshots:
       '@opentelemetry/instrumentation': 0.54.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
       '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.0)
-      '@types/pg': 8.6.1
+      '@types/pg': 8.18.0
       '@types/pg-pool': 2.0.6
     transitivePeerDependencies:
       - supports-color
@@ -14006,7 +13972,7 @@ snapshots:
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
-      '@types/pg': 8.15.6
+      '@types/pg': 8.18.0
       '@types/pg-pool': 2.0.7
     transitivePeerDependencies:
       - supports-color
@@ -14618,7 +14584,7 @@ snapshots:
   '@prisma/adapter-pg@7.5.0':
     dependencies:
       '@prisma/driver-adapter-utils': 7.5.0
-      '@types/pg': 8.11.11
+      '@types/pg': 8.18.0
       pg: 8.20.0
       postgres-array: 3.0.4
     transitivePeerDependencies:
@@ -16079,25 +16045,7 @@ snapshots:
     dependencies:
       '@types/pg': 8.18.0
 
-  '@types/pg@8.11.11':
-    dependencies:
-      '@types/node': 24.12.0
-      pg-protocol: 1.13.0
-      pg-types: 4.1.0
-
-  '@types/pg@8.15.6':
-    dependencies:
-      '@types/node': 24.12.0
-      pg-protocol: 1.13.0
-      pg-types: 2.2.0
-
   '@types/pg@8.18.0':
-    dependencies:
-      '@types/node': 24.12.0
-      pg-protocol: 1.13.0
-      pg-types: 2.2.0
-
-  '@types/pg@8.6.1':
     dependencies:
       '@types/node': 24.12.0
       pg-protocol: 1.13.0
@@ -21036,8 +20984,6 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  obuf@1.1.2: {}
-
   ohash@2.0.11: {}
 
   on-finished@2.4.1:
@@ -21262,8 +21208,6 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
-  pg-numeric@1.0.2: {}
-
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
       pg: 8.20.0
@@ -21277,16 +21221,6 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
-
-  pg-types@4.1.0:
-    dependencies:
-      pg-int8: 1.0.1
-      pg-numeric: 1.0.2
-      postgres-array: 3.0.4
-      postgres-bytea: 3.0.0
-      postgres-date: 2.1.0
-      postgres-interval: 3.0.0
-      postgres-range: 1.1.4
 
   pg@8.20.0:
     dependencies:
@@ -21408,21 +21342,11 @@ snapshots:
 
   postgres-bytea@1.0.1: {}
 
-  postgres-bytea@3.0.0:
-    dependencies:
-      obuf: 1.1.2
-
   postgres-date@1.0.7: {}
-
-  postgres-date@2.1.0: {}
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
-
-  postgres-interval@3.0.0: {}
-
-  postgres-range@1.1.4: {}
 
   postgres@3.4.7: {}
 

--- a/prisma/migrations/20260322120000_recon_results_prisma_column_map_parity/migration.sql
+++ b/prisma/migrations/20260322120000_recon_results_prisma_column_map_parity/migration.sql
@@ -1,0 +1,5 @@
+-- Align recon_results with Prisma ReconResult field mappings (snapshot_id, proof_capsule).
+-- Safe on databases that already have these columns (IF NOT EXISTS).
+
+ALTER TABLE recon_results ADD COLUMN IF NOT EXISTS snapshot_id uuid;
+ALTER TABLE recon_results ADD COLUMN IF NOT EXISTS proof_capsule jsonb;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -225,27 +225,27 @@ model UsageCounter {
 
 model ReconJob {
   id                String    @id @default(uuid())
-  tenantId           String    @db.Uuid
-  userId             String    @db.Uuid
+  tenantId           String    @map("tenant_id") @db.Uuid
+  userId             String    @map("user_id") @db.Uuid
   name               String
   description        String?
-  templateId         String?   @db.Uuid
-  sourceAdapter      String
-  sourceConfigEncrypted String @db.Text
-  targetAdapter      String
-  targetConfigEncrypted String @db.Text
-  mappingTemplateId  String?   @db.Uuid
-  transformRecipeId  String?   @db.Uuid
-  validationRules    Json      @default("[]")
-  reconStrategy      String    @default("deterministic")
-  scheduleCron       String?
-  scheduleTimezone   String    @default("UTC")
+  templateId         String?   @map("template_id") @db.Uuid
+  sourceAdapter      String    @map("source_adapter")
+  sourceConfigEncrypted String @map("source_config_encrypted") @db.Text
+  targetAdapter      String    @map("target_adapter")
+  targetConfigEncrypted String @map("target_config_encrypted") @db.Text
+  mappingTemplateId  String?   @map("mapping_template_id") @db.Uuid
+  transformRecipeId  String?   @map("transform_recipe_id") @db.Uuid
+  validationRules    Json      @default("[]") @map("validation_rules")
+  reconStrategy      String    @default("deterministic") @map("recon_strategy")
+  scheduleCron       String?   @map("schedule_cron")
+  scheduleTimezone   String    @default("UTC") @map("schedule_timezone")
   status             String    @default("active")
   version            Int       @default(1)
   metadata           Json      @default("{}")
-  createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
-  deletedAt          DateTime?
+  createdAt          DateTime  @default(now()) @map("created_at")
+  updatedAt          DateTime  @updatedAt @map("updated_at")
+  deletedAt          DateTime? @map("deleted_at")
 
   template           ReconTemplate? @relation(fields: [templateId], references: [id], onDelete: SetNull)
   mappingTemplate    MappingTemplate? @relation(fields: [mappingTemplateId], references: [id], onDelete: SetNull)
@@ -262,36 +262,36 @@ model ReconJob {
 
 model ReconResult {
   id                    String    @id @default(uuid())
-  reconJobId            String    @db.Uuid
-  tenantId              String    @db.Uuid
-  executionId           String?   @db.Uuid
-  snapshotId            String?   @db.Uuid
-  inputHash             String?
+  reconJobId            String    @map("recon_job_id") @db.Uuid
+  tenantId              String    @map("tenant_id") @db.Uuid
+  executionId           String?   @map("execution_id") @db.Uuid
+  snapshotId            String?   @map("snapshot_id") @db.Uuid
+  inputHash             String?   @map("input_hash")
   status                String    @default("running")
-  startedAt             DateTime  @default(now())
-  completedAt           DateTime?
-  sourceCount           Int       @default(0)
-  targetCount           Int       @default(0)
-  matchedCount          Int       @default(0)
-  unmatchedSourceCount  Int       @default(0)
-  unmatchedTargetCount  Int       @default(0)
-  conflictCount         Int       @default(0)
-  totalAmountSource     Decimal?  @db.Decimal(15, 2)
-  totalAmountTarget     Decimal?  @db.Decimal(15, 2)
-  totalAmountMatched    Decimal?  @db.Decimal(15, 2)
-  totalAmountUnmatched  Decimal?  @db.Decimal(15, 2)
+  startedAt             DateTime  @default(now()) @map("started_at")
+  completedAt           DateTime? @map("completed_at")
+  sourceCount           Int       @default(0) @map("source_count")
+  targetCount           Int       @default(0) @map("target_count")
+  matchedCount          Int       @default(0) @map("matched_count")
+  unmatchedSourceCount  Int       @default(0) @map("unmatched_source_count")
+  unmatchedTargetCount  Int       @default(0) @map("unmatched_target_count")
+  conflictCount         Int       @default(0) @map("conflict_count")
+  totalAmountSource     Decimal?  @map("total_amount_source") @db.Decimal(15, 2)
+  totalAmountTarget     Decimal?  @map("total_amount_target") @db.Decimal(15, 2)
+  totalAmountMatched    Decimal?  @map("total_amount_matched") @db.Decimal(15, 2)
+  totalAmountUnmatched  Decimal?  @map("total_amount_unmatched") @db.Decimal(15, 2)
   currency              String?
-  confidenceAvg         Decimal?  @db.Decimal(5, 4)
-  confidenceMin         Decimal?  @db.Decimal(5, 4)
-  confidenceMax         Decimal?  @db.Decimal(5, 4)
-  durationMs            BigInt?
-  errorMessage          String?   @db.Text
-  errorStack            String?   @db.Text
+  confidenceAvg         Decimal?  @map("confidence_avg") @db.Decimal(5, 4)
+  confidenceMin         Decimal?  @map("confidence_min") @db.Decimal(5, 4)
+  confidenceMax         Decimal?  @map("confidence_max") @db.Decimal(5, 4)
+  durationMs            BigInt?   @map("duration_ms")
+  errorMessage          String?   @map("error_message") @db.Text
+  errorStack            String?   @map("error_stack") @db.Text
   summary               Json      @default("{}")
   metadata              Json      @default("{}")
-  proofCapsule          Json?     @default("{}")
-  createdAt             DateTime  @default(now())
-  updatedAt             DateTime  @updatedAt
+  proofCapsule          Json?     @default("{}") @map("proof_capsule")
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
 
   reconJob              ReconJob @relation(fields: [reconJobId], references: [id], onDelete: Cascade)
   snapshot              RunSnapshot? @relation(fields: [snapshotId], references: [id], onDelete: SetNull)
@@ -1363,24 +1363,24 @@ model NormalizedTransaction {
 
 model ReconciliationRun {
   id                String    @id @default(uuid())
-  ingestionId       String?   @db.Uuid
-  tenantId          String    @db.Uuid
-  userId            String    @db.Uuid
+  ingestionId       String?   @map("ingestion_id") @db.Uuid
+  tenantId          String    @map("tenant_id") @db.Uuid
+  userId            String    @map("user_id") @db.Uuid
   name              String?
   status            String    @default("pending") // pending, running, completed, failed
-  startedAt         DateTime  @default(now())
-  completedAt       DateTime?
-  sourceCount       Int       @default(0)
-  targetCount       Int       @default(0)
-  matchedCount      Int       @default(0)
-  unmatchedSourceCount Int    @default(0)
-  unmatchedTargetCount Int    @default(0)
-  confidenceAvg     Decimal?  @db.Decimal(5, 4)
-  errorMessage      String?   @db.Text
-  traceId           String?
+  startedAt         DateTime  @default(now()) @map("started_at")
+  completedAt       DateTime? @map("completed_at")
+  sourceCount       Int       @default(0) @map("source_count")
+  targetCount       Int       @default(0) @map("target_count")
+  matchedCount      Int       @default(0) @map("matched_count")
+  unmatchedSourceCount Int    @default(0) @map("unmatched_source_count")
+  unmatchedTargetCount Int    @default(0) @map("unmatched_target_count")
+  confidenceAvg     Decimal?  @map("confidence_avg") @db.Decimal(5, 4)
+  errorMessage      String?   @map("error_message") @db.Text
+  traceId           String?   @map("trace_id")
   metadata          Json      @default("{}")
-  createdAt         DateTime  @default(now())
-  updatedAt         DateTime  @updatedAt
+  createdAt         DateTime  @default(now()) @map("created_at")
+  updatedAt         DateTime  @updatedAt @map("updated_at")
 
   ingestion         Ingestion? @relation(fields: [ingestionId], references: [id], onDelete: SetNull)
   matches           ReconciliationMatch[]

--- a/scripts/ci/reconciliation-merged-list-schema.sql
+++ b/scripts/ci/reconciliation-merged-list-schema.sql
@@ -1,0 +1,134 @@
+-- Minimal schema for @settler/reconciliation-core merged-list + resolve integration tests.
+-- Matches Prisma column expectations for recon_jobs, recon_results, reconciliation_runs,
+-- tenants, users (see prisma/schema.prisma).
+-- Safe to re-apply: drops and recreates the listed tables (CI uses a fresh database).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+DROP TABLE IF EXISTS public.recon_results CASCADE;
+DROP TABLE IF EXISTS public.reconciliation_runs CASCADE;
+DROP TABLE IF EXISTS public.recon_jobs CASCADE;
+DROP TABLE IF EXISTS public.users CASCADE;
+DROP TABLE IF EXISTS public.tenants CASCADE;
+
+CREATE TABLE public.tenants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  billing_account_id uuid,
+  slug text NOT NULL UNIQUE,
+  primary_domain text,
+  custom_domain text,
+  name text NOT NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.users (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants (id) ON DELETE CASCADE,
+  email varchar NOT NULL,
+  password_hash varchar NOT NULL,
+  name varchar,
+  role varchar DEFAULT 'developer',
+  deleted_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_users_tenant_id ON public.users (tenant_id);
+
+CREATE TABLE public.recon_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants (id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users (id) ON DELETE CASCADE,
+  name varchar NOT NULL,
+  description text,
+  template_id uuid,
+  source_adapter varchar NOT NULL,
+  source_config_encrypted text NOT NULL,
+  target_adapter varchar NOT NULL,
+  target_config_encrypted text NOT NULL,
+  mapping_template_id uuid,
+  transform_recipe_id uuid,
+  validation_rules jsonb NOT NULL DEFAULT '[]'::jsonb,
+  recon_strategy varchar NOT NULL DEFAULT 'deterministic',
+  schedule_cron varchar,
+  schedule_timezone varchar NOT NULL DEFAULT 'UTC',
+  status varchar NOT NULL DEFAULT 'active',
+  version int NOT NULL DEFAULT 1,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz
+);
+
+CREATE INDEX idx_recon_jobs_tenant_id ON public.recon_jobs (tenant_id);
+CREATE INDEX idx_recon_jobs_created_at_desc ON public.recon_jobs (created_at DESC);
+
+CREATE TABLE public.recon_results (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recon_job_id uuid NOT NULL REFERENCES public.recon_jobs (id) ON DELETE CASCADE,
+  tenant_id uuid NOT NULL,
+  execution_id uuid,
+  snapshot_id uuid,
+  input_hash text,
+  status varchar NOT NULL DEFAULT 'running',
+  started_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  source_count int NOT NULL DEFAULT 0,
+  target_count int NOT NULL DEFAULT 0,
+  matched_count int NOT NULL DEFAULT 0,
+  unmatched_source_count int NOT NULL DEFAULT 0,
+  unmatched_target_count int NOT NULL DEFAULT 0,
+  conflict_count int NOT NULL DEFAULT 0,
+  total_amount_source numeric(15, 2),
+  total_amount_target numeric(15, 2),
+  total_amount_matched numeric(15, 2),
+  total_amount_unmatched numeric(15, 2),
+  currency text,
+  confidence_avg numeric(5, 4),
+  confidence_min numeric(5, 4),
+  confidence_max numeric(5, 4),
+  duration_ms bigint,
+  error_message text,
+  error_stack text,
+  summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  proof_capsule jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_recon_results_recon_job_id ON public.recon_results (recon_job_id);
+CREATE INDEX idx_recon_results_tenant_id ON public.recon_results (tenant_id);
+
+CREATE TABLE public.reconciliation_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  ingestion_id uuid,
+  tenant_id uuid NOT NULL REFERENCES public.tenants (id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users (id) ON DELETE CASCADE,
+  name varchar(255),
+  status varchar(50) NOT NULL DEFAULT 'pending',
+  started_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  source_count int NOT NULL DEFAULT 0,
+  target_count int NOT NULL DEFAULT 0,
+  matched_count int NOT NULL DEFAULT 0,
+  unmatched_source_count int NOT NULL DEFAULT 0,
+  unmatched_target_count int NOT NULL DEFAULT 0,
+  confidence_avg numeric(5, 4),
+  error_message text,
+  trace_id varchar(255),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_reconciliation_runs_tenant_id ON public.reconciliation_runs (tenant_id);
+CREATE INDEX idx_reconciliation_runs_tenant_greatest_started_created
+  ON public.reconciliation_runs (
+    tenant_id,
+    (GREATEST(started_at, created_at)) DESC NULLS LAST,
+    id DESC
+  );

--- a/turbo.json
+++ b/turbo.json
@@ -197,6 +197,7 @@
       "env": ["NODE_ENV"]
     },
     "typecheck": {
+      "dependsOn": ["^build"],
       "outputs": [".next/tsconfig.tsbuildinfo", "tsconfig.tsbuildinfo"],
       "cache": true,
       "inputs": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reconciliation read contract hardening: run-kind-safe UI (`ReconciliationMatches`), v1 `capabilities`, shared console list body, API typecheck/pg Pool alignment, route contract tests, optional DB integration suite, and **CI job** that runs `test:recon-merged-db` against Postgres with `scripts/ci/reconciliation-merged-list-schema.sql`.

**Prisma parity:** `ReconJob`, `ReconResult`, and `ReconciliationRun` now `@map` to snake_case PostgreSQL columns so Prisma queries match real DBs. Migration `20260322120000_recon_results_prisma_column_map_parity` adds `snapshot_id` / `proof_capsule` on `recon_results` when missing.

## Verification

- `pnpm exec prisma generate`
- `pnpm --filter @settler/api typecheck`
- `RUN_DB_TESTS=true RUN_RECON_MERGED_LIST_DB=1 DB_*=… pnpm --filter @settler/api run test:recon-merged-db` → **8 passed** (local `settler_test` + CI schema)

## CI

Workflow: `.github/workflows/reconciliation-merged-list-db.yml` — Postgres 16 service, apply `scripts/ci/reconciliation-merged-list-schema.sql`, env `RUN_DB_TESTS=true` + `RUN_RECON_MERGED_LIST_DB=1`, run `pnpm --filter @settler/api run test:recon-merged-db`.

(Human-edited sections above this block in the GitHub UI are preserved by editors when merging descriptions—this update adds technical closure notes.)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ac3669f-a13e-4b86-aafe-abb31e7522df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ac3669f-a13e-4b86-aafe-abb31e7522df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

