### PR TITLE
fix: demo/production isolation hardening and contract closure

### DIFF
--- a/packages/web/src/__tests__/demo/demo-isolation-boundary.test.ts
+++ b/packages/web/src/__tests__/demo/demo-isolation-boundary.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Demo/Production Isolation Boundary Tests
+ *
+ * Verifies that demo code is properly isolated from production paths
+ * and that the demo response helper adds correct headers.
+ */
+
+describe("demo response module structure", () => {
+  it("demo-response module exports expected functions", async () => {
+    const mod = await import("@/lib/demo/demo-response");
+    expect(typeof mod.demoJsonResponse).toBe("function");
+    expect(typeof mod.checkDemoRateLimit).toBe("function");
+  });
+});
+
+describe("demo import isolation", () => {
+  it("showcase-data does not import from production database modules", async () => {
+    // Read the source file and verify it does not import prisma or supabase
+    const fs = await import("fs");
+    const path = await import("path");
+    const source = fs.readFileSync(
+      path.join(process.cwd(), "src/lib/demo/showcase-data.ts"),
+      "utf8"
+    );
+    expect(source).not.toContain("prismaClient");
+    expect(source).not.toContain("@/shared/db");
+    expect(source).not.toContain("supabase");
+    expect(source).not.toContain("import { prisma");
+  });
+
+  it("demo-response does not import from production auth modules", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const source = fs.readFileSync(
+      path.join(process.cwd(), "src/lib/demo/demo-response.ts"),
+      "utf8"
+    );
+    expect(source).not.toContain("authenticateApiKey");
+    expect(source).not.toContain("requireAuth");
+    expect(source).not.toContain("supabase");
+  });
+});
+
+describe("demo route file isolation", () => {
+  it("demo API routes only import from demo modules and next/server", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const glob = await import("glob");
+
+    const demoRouteDir = path.join(process.cwd(), "src/app/api/demo");
+    const routeFiles = glob.sync("**/route.ts", { cwd: demoRouteDir });
+
+    for (const file of routeFiles) {
+      const source = fs.readFileSync(path.join(demoRouteDir, file), "utf8");
+      // Extract import sources using regex (handles multi-line imports)
+      const importSources = [...source.matchAll(/from\s+["']([^"']+)["']/g)].map((m) => m[1]);
+
+      for (const importPath of importSources) {
+        const isAllowed = importPath!.startsWith("next") || importPath!.startsWith("@/lib/demo/");
+        expect({ file, importPath, isAllowed }).toEqual(
+          expect.objectContaining({ isAllowed: true })
+        );
+      }
+    }
+  });
+});

--- a/packages/web/src/__tests__/demo/showcase-canonical-compat.test.ts
+++ b/packages/web/src/__tests__/demo/showcase-canonical-compat.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Showcase-to-Canonical DTO Compatibility Tests
+ *
+ * Verifies that showcase demo data conforms to the canonical run types
+ * defined in @settler/types, preventing contract drift between demo
+ * and production data shapes.
+ */
+
+import { getShowcaseDataset } from "@/lib/demo/showcase-data";
+
+/**
+ * These canonical values are copied from @settler/types (packages/types/src/run.ts).
+ * If the canonical types change, these tests will catch the drift at test time.
+ * This avoids Jest module resolution issues with workspace packages while still
+ * enforcing contract alignment.
+ */
+const CANONICAL_RUN_STATUSES = ["pending", "running", "completed", "failed", "unknown"] as const;
+const CANONICAL_SUMMARY_STATES = [
+  "success",
+  "review_needed",
+  "in_progress",
+  "failed",
+  "empty",
+  "unknown",
+] as const;
+const CANONICAL_PROGRESS_STATES = [
+  "not_started",
+  "in_progress",
+  "completed",
+  "failed",
+  "unknown",
+] as const;
+
+describe("showcase-to-canonical DTO compatibility", () => {
+  const dataset = getShowcaseDataset();
+
+  describe("run status values match canonical RunStatus", () => {
+    it("all showcase run statuses are valid RunStatus values", () => {
+      for (const run of dataset.runs) {
+        expect(CANONICAL_RUN_STATUSES).toContain(run.status);
+      }
+    });
+  });
+
+  describe("run summaryState values match canonical RunSummaryState", () => {
+    it("all showcase run summaryStates are valid", () => {
+      for (const run of dataset.runs) {
+        expect(CANONICAL_SUMMARY_STATES).toContain(run.summaryState);
+      }
+    });
+  });
+
+  describe("run progressState values match canonical RunProgressState", () => {
+    it("all showcase run progressStates are valid", () => {
+      for (const run of dataset.runs) {
+        expect(CANONICAL_PROGRESS_STATES).toContain(run.progressState);
+      }
+    });
+  });
+
+  describe("run summary shape matches CanonicalRunSummary subset", () => {
+    it("all runs have required summary fields", () => {
+      for (const run of dataset.runs) {
+        expect(typeof run.summary.total).toBe("number");
+        expect(typeof run.summary.sourceCount).toBe("number");
+        expect(typeof run.summary.targetCount).toBe("number");
+        expect(typeof run.summary.matched).toBe("number");
+        expect(typeof run.summary.unmatched).toBe("number");
+        expect(typeof run.summary.conflicts).toBe("number");
+      }
+    });
+
+    it("all runs have summarySemantics fields", () => {
+      for (const run of dataset.runs) {
+        expect(typeof run.summarySemantics.processed).toBe("number");
+        expect(typeof run.summarySemantics.matchedWithTolerance).toBe("number");
+        expect(typeof run.summarySemantics.exceptioned).toBe("number");
+        expect(typeof run.summarySemantics.unresolved).toBe("number");
+        expect(typeof run.summarySemantics.ignored).toBe("number");
+        expect(typeof run.summarySemantics.resolved).toBe("number");
+      }
+    });
+  });
+
+  describe("isTerminal consistency", () => {
+    it("completed runs are terminal", () => {
+      for (const run of dataset.runs.filter((r) => r.status === "completed")) {
+        expect(run.isTerminal).toBe(true);
+      }
+    });
+
+    it("failed runs are terminal", () => {
+      for (const run of dataset.runs.filter((r) => r.status === "failed")) {
+        expect(run.isTerminal).toBe(true);
+      }
+    });
+
+    it("running runs are not terminal", () => {
+      for (const run of dataset.runs.filter((r) => r.status === "running")) {
+        expect(run.isTerminal).toBe(false);
+      }
+    });
+  });
+
+  describe("exception status and severity values", () => {
+    it("all exception statuses are valid", () => {
+      const validStatuses = ["pending", "investigating", "resolved", "ignored"];
+      for (const exc of dataset.exceptions) {
+        expect(validStatuses).toContain(exc.status);
+      }
+    });
+
+    it("all exception severities are valid", () => {
+      const validSeverities = ["low", "medium", "high", "critical"];
+      for (const exc of dataset.exceptions) {
+        expect(validSeverities).toContain(exc.severity);
+      }
+    });
+  });
+
+  describe("alert type and severity values", () => {
+    it("all alert types are valid", () => {
+      const validTypes = ["threshold_breach", "sync_failure", "anomaly", "sla_warning"];
+      for (const alert of dataset.alerts) {
+        expect(validTypes).toContain(alert.type);
+      }
+    });
+
+    it("all alert severities are valid", () => {
+      const validSeverities = ["info", "warning", "critical"];
+      for (const alert of dataset.alerts) {
+        expect(validSeverities).toContain(alert.severity);
+      }
+    });
+  });
+
+  describe("integration status values", () => {
+    it("all integration statuses are valid", () => {
+      const validStatuses = ["connected", "degraded", "disconnected", "pending"];
+      for (const integration of dataset.integrations) {
+        expect(validStatuses).toContain(integration.status);
+      }
+    });
+  });
+});

--- a/packages/web/src/__tests__/demo/showcase-data-determinism.test.ts
+++ b/packages/web/src/__tests__/demo/showcase-data-determinism.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Showcase Data Determinism Tests
+ *
+ * Verifies that the demo data generator produces identical output
+ * across invocations — critical for reliable demos and screenshots.
+ */
+
+import {
+  getShowcaseDataset,
+  getDefaultShowcaseTenant,
+  getShowcaseForTenant,
+  type ShowcaseDataset,
+  type ShowcaseRun,
+  type ShowcaseException,
+} from "@/lib/demo/showcase-data";
+
+describe("showcase-data determinism", () => {
+  let dataset1: ShowcaseDataset;
+  let dataset2: ShowcaseDataset;
+
+  beforeAll(() => {
+    dataset1 = getShowcaseDataset();
+    dataset2 = getShowcaseDataset();
+  });
+
+  it("produces identical output across invocations", () => {
+    expect(JSON.stringify(dataset1)).toBe(JSON.stringify(dataset2));
+  });
+
+  it("generates exactly 5 tenant scenarios", () => {
+    expect(dataset1.tenants).toHaveLength(5);
+  });
+
+  it("has a default tenant (Acme Commerce)", () => {
+    const defaultTenant = getDefaultShowcaseTenant();
+    expect(defaultTenant.name).toContain("Acme Commerce");
+    expect(defaultTenant.slug).toBeTruthy();
+  });
+
+  it("generates runs for all tenants", () => {
+    for (const tenant of dataset1.tenants) {
+      const tenantRuns = dataset1.runs.filter((r) => r.tenantId === tenant.id);
+      expect(tenantRuns.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("generates exceptions for all tenants", () => {
+    for (const tenant of dataset1.tenants) {
+      const tenantExceptions = dataset1.exceptions.filter((e) => e.tenantId === tenant.id);
+      expect(tenantExceptions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("generates metrics for all tenants", () => {
+    for (const tenant of dataset1.tenants) {
+      const tenantMetrics = dataset1.metrics.find((m) => m.tenantId === tenant.id);
+      expect(tenantMetrics).toBeDefined();
+      expect(tenantMetrics!.matchRate).toBeGreaterThanOrEqual(0);
+      expect(tenantMetrics!.matchRate).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("getShowcaseForTenant returns scoped data", () => {
+    const defaultTenant = getDefaultShowcaseTenant();
+    const scoped = getShowcaseForTenant(defaultTenant.id);
+
+    // All runs belong to this tenant
+    for (const run of scoped.runs) {
+      expect(run.tenantId).toBe(defaultTenant.id);
+    }
+    // All exceptions belong to this tenant
+    for (const exc of scoped.exceptions) {
+      expect(exc.tenantId).toBe(defaultTenant.id);
+    }
+  });
+
+  describe("run data shape conformance", () => {
+    let run: ShowcaseRun;
+
+    beforeAll(() => {
+      run = dataset1.runs[0];
+    });
+
+    it("has required fields", () => {
+      expect(run.id).toBeTruthy();
+      expect(run.tenantId).toBeTruthy();
+      expect(run.name).toBeTruthy();
+      expect(run.status).toBeTruthy();
+      expect(run.startedAt).toBeTruthy();
+    });
+
+    it("has valid status", () => {
+      const validStatuses = ["completed", "running", "failed", "pending"];
+      expect(validStatuses).toContain(run.status);
+    });
+
+    it("has valid summaryState", () => {
+      const validStates = ["success", "review_needed", "in_progress", "failed", "empty"];
+      expect(validStates).toContain(run.summaryState);
+    });
+
+    it("summary counts are non-negative", () => {
+      expect(run.summary.total).toBeGreaterThanOrEqual(0);
+      expect(run.summary.matched).toBeGreaterThanOrEqual(0);
+      expect(run.summary.unmatched).toBeGreaterThanOrEqual(0);
+      expect(run.summary.conflicts).toBeGreaterThanOrEqual(0);
+    });
+
+    it("progress is between 0 and 100", () => {
+      expect(run.progress).toBeGreaterThanOrEqual(0);
+      expect(run.progress).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe("exception data shape conformance", () => {
+    let exc: ShowcaseException;
+
+    beforeAll(() => {
+      exc = dataset1.exceptions[0];
+    });
+
+    it("has required fields", () => {
+      expect(exc.id).toBeTruthy();
+      expect(exc.tenantId).toBeTruthy();
+      expect(exc.runId).toBeTruthy();
+      expect(exc.type).toBeTruthy();
+      expect(exc.status).toBeTruthy();
+      expect(exc.severity).toBeTruthy();
+    });
+
+    it("has valid status", () => {
+      const validStatuses = ["pending", "investigating", "resolved", "ignored"];
+      expect(validStatuses).toContain(exc.status);
+    });
+
+    it("has valid severity", () => {
+      const validSeverities = ["low", "medium", "high", "critical"];
+      expect(validSeverities).toContain(exc.severity);
+    });
+
+    it("amount is a finite number", () => {
+      expect(Number.isFinite(exc.amount)).toBe(true);
+    });
+  });
+
+  describe("metrics trend data", () => {
+    it("trend arrays have 12 data points", () => {
+      for (const m of dataset1.metrics) {
+        expect(m.trendMatchRate).toHaveLength(12);
+        expect(m.trendExceptions).toHaveLength(12);
+        expect(m.trendVolume).toHaveLength(12);
+      }
+    });
+
+    it("match rate trends are percentages", () => {
+      for (const m of dataset1.metrics) {
+        for (const v of m.trendMatchRate) {
+          expect(v).toBeGreaterThanOrEqual(0);
+          expect(v).toBeLessThanOrEqual(100);
+        }
+      }
+    });
+  });
+
+  describe("data integrity", () => {
+    it("all exception runIds reference existing runs", () => {
+      const runIds = new Set(dataset1.runs.map((r) => r.id));
+      for (const exc of dataset1.exceptions) {
+        expect(runIds.has(exc.runId)).toBe(true);
+      }
+    });
+
+    it("all IDs are unique within their collection", () => {
+      const runIds = dataset1.runs.map((r) => r.id);
+      expect(new Set(runIds).size).toBe(runIds.length);
+
+      const excIds = dataset1.exceptions.map((e) => e.id);
+      expect(new Set(excIds).size).toBe(excIds.length);
+
+      const alertIds = dataset1.alerts.map((a) => a.id);
+      expect(new Set(alertIds).size).toBe(alertIds.length);
+    });
+
+    it("completed runs have completedAt timestamps", () => {
+      const completedRuns = dataset1.runs.filter((r) => r.status === "completed");
+      for (const run of completedRuns) {
+        expect(run.completedAt).toBeTruthy();
+      }
+    });
+
+    it("running/pending runs have null completedAt", () => {
+      const activeRuns = dataset1.runs.filter(
+        (r) => r.status === "running" || r.status === "pending"
+      );
+      for (const run of activeRuns) {
+        expect(run.completedAt).toBeNull();
+      }
+    });
+  });
+});

--- a/packages/web/src/app/api/demo/alerts/route.ts
+++ b/packages/web/src/app/api/demo/alerts/route.ts
@@ -5,22 +5,20 @@
  * No auth required. Read-only, deterministic.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import {
-  getShowcaseDataset,
-  getDefaultShowcaseTenant,
-} from "@/lib/demo/showcase-data";
+import { NextRequest } from "next/server";
+import { getShowcaseDataset, getDefaultShowcaseTenant } from "@/lib/demo/showcase-data";
+import { checkDemoRateLimit, demoJsonResponse } from "@/lib/demo/demo-response";
 
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
+  const limited = checkDemoRateLimit(request);
+  if (limited) return limited;
+
   const { searchParams } = new URL(request.url);
-  const tenantId =
-    searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
+  const tenantId = searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
 
-  const alerts = getShowcaseDataset().alerts.filter(
-    (a) => a.tenantId === tenantId
-  );
+  const alerts = getShowcaseDataset().alerts.filter((a) => a.tenantId === tenantId);
 
-  return NextResponse.json(alerts);
+  return demoJsonResponse(alerts);
 }

--- a/packages/web/src/app/api/demo/audit/route.ts
+++ b/packages/web/src/app/api/demo/audit/route.ts
@@ -5,22 +5,20 @@
  * No auth required. Read-only, deterministic.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import {
-  getShowcaseDataset,
-  getDefaultShowcaseTenant,
-} from "@/lib/demo/showcase-data";
+import { NextRequest } from "next/server";
+import { getShowcaseDataset, getDefaultShowcaseTenant } from "@/lib/demo/showcase-data";
+import { checkDemoRateLimit, demoJsonResponse } from "@/lib/demo/demo-response";
 
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
+  const limited = checkDemoRateLimit(request);
+  if (limited) return limited;
+
   const { searchParams } = new URL(request.url);
-  const tenantId =
-    searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
+  const tenantId = searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
 
-  const audit = getShowcaseDataset().auditTrail.filter(
-    (a) => a.tenantId === tenantId
-  );
+  const audit = getShowcaseDataset().auditTrail.filter((a) => a.tenantId === tenantId);
 
-  return NextResponse.json(audit);
+  return demoJsonResponse(audit);
 }

--- a/packages/web/src/app/api/demo/exceptions/route.ts
+++ b/packages/web/src/app/api/demo/exceptions/route.ts
@@ -5,25 +5,23 @@
  * No auth required. Read-only, deterministic.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import {
-  getShowcaseDataset,
-  getDefaultShowcaseTenant,
-} from "@/lib/demo/showcase-data";
+import { NextRequest } from "next/server";
+import { getShowcaseDataset, getDefaultShowcaseTenant } from "@/lib/demo/showcase-data";
+import { checkDemoRateLimit, demoJsonResponse } from "@/lib/demo/demo-response";
 
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
+  const limited = checkDemoRateLimit(request);
+  if (limited) return limited;
+
   const { searchParams } = new URL(request.url);
-  const tenantId =
-    searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
+  const tenantId = searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
   const statusFilter = searchParams.get("status")?.toLowerCase();
   const severityFilter = searchParams.get("severity")?.toLowerCase();
   const runIdFilter = searchParams.get("runId");
 
-  let exceptions = getShowcaseDataset().exceptions.filter(
-    (e) => e.tenantId === tenantId
-  );
+  let exceptions = getShowcaseDataset().exceptions.filter((e) => e.tenantId === tenantId);
 
   if (statusFilter) {
     exceptions = exceptions.filter((e) => e.status === statusFilter);
@@ -35,5 +33,5 @@ export async function GET(request: NextRequest) {
     exceptions = exceptions.filter((e) => e.runId === runIdFilter);
   }
 
-  return NextResponse.json(exceptions);
+  return demoJsonResponse(exceptions);
 }

--- a/packages/web/src/app/api/demo/integrations/route.ts
+++ b/packages/web/src/app/api/demo/integrations/route.ts
@@ -5,22 +5,20 @@
  * No auth required. Read-only, deterministic.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import {
-  getShowcaseDataset,
-  getDefaultShowcaseTenant,
-} from "@/lib/demo/showcase-data";
+import { NextRequest } from "next/server";
+import { getShowcaseDataset, getDefaultShowcaseTenant } from "@/lib/demo/showcase-data";
+import { checkDemoRateLimit, demoJsonResponse } from "@/lib/demo/demo-response";
 
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
+  const limited = checkDemoRateLimit(request);
+  if (limited) return limited;
+
   const { searchParams } = new URL(request.url);
-  const tenantId =
-    searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
+  const tenantId = searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
 
-  const integrations = getShowcaseDataset().integrations.filter(
-    (i) => i.tenantId === tenantId
-  );
+  const integrations = getShowcaseDataset().integrations.filter((i) => i.tenantId === tenantId);
 
-  return NextResponse.json(integrations);
+  return demoJsonResponse(integrations);
 }

--- a/packages/web/src/app/api/demo/metrics/route.ts
+++ b/packages/web/src/app/api/demo/metrics/route.ts
@@ -5,29 +5,24 @@
  * No auth required. Read-only, deterministic.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import {
-  getShowcaseDataset,
-  getDefaultShowcaseTenant,
-} from "@/lib/demo/showcase-data";
+import { NextRequest } from "next/server";
+import { getShowcaseDataset, getDefaultShowcaseTenant } from "@/lib/demo/showcase-data";
+import { checkDemoRateLimit, demoJsonResponse } from "@/lib/demo/demo-response";
 
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const tenantId =
-    searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
+  const limited = checkDemoRateLimit(request);
+  if (limited) return limited;
 
-  const metrics = getShowcaseDataset().metrics.find(
-    (m) => m.tenantId === tenantId
-  );
+  const { searchParams } = new URL(request.url);
+  const tenantId = searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
+
+  const metrics = getShowcaseDataset().metrics.find((m) => m.tenantId === tenantId);
 
   if (!metrics) {
-    return NextResponse.json(
-      { error: "Tenant not found" },
-      { status: 404 }
-    );
+    return demoJsonResponse({ error: "Tenant not found" }, 404);
   }
 
-  return NextResponse.json(metrics);
+  return demoJsonResponse(metrics);
 }

--- a/packages/web/src/app/api/demo/runs/route.ts
+++ b/packages/web/src/app/api/demo/runs/route.ts
@@ -6,33 +6,29 @@
  * No auth required. Read-only, deterministic.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import {
-  getShowcaseDataset,
-  getDefaultShowcaseTenant,
-} from "@/lib/demo/showcase-data";
+import { NextRequest } from "next/server";
+import { getShowcaseDataset, getDefaultShowcaseTenant } from "@/lib/demo/showcase-data";
+import { checkDemoRateLimit, demoJsonResponse } from "@/lib/demo/demo-response";
 
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
+  const limited = checkDemoRateLimit(request);
+  if (limited) return limited;
+
   const { searchParams } = new URL(request.url);
-  const tenantId =
-    searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
+  const tenantId = searchParams.get("tenantId") || getDefaultShowcaseTenant().id;
   const statusFilter = searchParams.get("status")?.toLowerCase();
   const searchFilter = searchParams.get("search")?.trim().toLowerCase();
 
-  let runs = getShowcaseDataset().runs.filter(
-    (r) => r.tenantId === tenantId
-  );
+  let runs = getShowcaseDataset().runs.filter((r) => r.tenantId === tenantId);
 
   if (statusFilter) {
     runs = runs.filter((r) => r.status === statusFilter);
   }
   if (searchFilter) {
-    runs = runs.filter((r) =>
-      `${r.id} ${r.name}`.toLowerCase().includes(searchFilter)
-    );
+    runs = runs.filter((r) => `${r.id} ${r.name}`.toLowerCase().includes(searchFilter));
   }
 
-  return NextResponse.json(runs);
+  return demoJsonResponse(runs);
 }

--- a/packages/web/src/app/api/demo/tenants/route.ts
+++ b/packages/web/src/app/api/demo/tenants/route.ts
@@ -5,12 +5,16 @@
  * No auth required. Read-only, deterministic.
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { getShowcaseDataset } from "@/lib/demo/showcase-data";
+import { checkDemoRateLimit, demoJsonResponse } from "@/lib/demo/demo-response";
 
 export const runtime = "nodejs";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const limited = checkDemoRateLimit(request);
+  if (limited) return limited;
+
   const { tenants } = getShowcaseDataset();
-  return NextResponse.json(tenants);
+  return demoJsonResponse(tenants);
 }

--- a/packages/web/src/app/api/v1/recon/jobs/route.ts
+++ b/packages/web/src/app/api/v1/recon/jobs/route.ts
@@ -22,14 +22,18 @@ export const maxDuration = 60;
 export const POST = withSecurity(
   async function POST(request: NextRequest) {
     try {
-      // Try to authenticate, but don't fail if unauthenticated (for playground)
-      let isAuthenticated = false;
-
+      // Authenticate — production endpoints require valid API key
       const auth = await authenticateApiKey(request);
-      if (auth) {
-        isAuthenticated = true;
+      if (!auth) {
+        return NextResponse.json(
+          {
+            error: "Authentication required",
+            code: "SETTLER_UNAUTHORIZED",
+            message: "A valid API key is required. For demo access, use /api/demo/* endpoints.",
+          },
+          { status: 401 }
+        );
       }
-      // Unauthenticated access allowed for playground (graceful degradation)
 
       // Parse request body
       let body;
@@ -43,24 +47,7 @@ export const POST = withSecurity(
       if (!body.name && !body.sourceAdapter) {
         return NextResponse.json({ error: "name or sourceAdapter is required" }, { status: 400 });
       }
-
-      // For unauthenticated users, return demo response
-      if (!isAuthenticated) {
-        const demoJobId = `demo_${Date.now()}`;
-        const demoResponse = {
-          id: demoJobId,
-          jobId: demoJobId,
-          name: body.name || "Demo Reconciliation Job",
-          status: "queued",
-          sourceAdapter: body.sourceAdapter || "stripe",
-          targetAdapter: body.targetAdapter || "shopify",
-          createdAt: new Date().toISOString(),
-          message: "This is a demo response. Sign in to create real reconciliation jobs.",
-          demo: true,
-        };
-
-        return NextResponse.json(demoResponse, { status: 201 });
-      }
+      const isAuthenticated = true;
 
       // CRITICAL: Enforce active subscription requirement
       const subscriptionCheck = await requireActiveSubscription(request, auth?.userId);
@@ -167,7 +154,7 @@ export const POST = withSecurity(
       );
     }
   },
-  { rateLimit: { windowMs: 60000, maxRequests: 20 }, requireAuth: false }
+  { rateLimit: { windowMs: 60000, maxRequests: 20 }, requireAuth: true }
 );
 
 /**
@@ -192,18 +179,16 @@ export const GET = withSecurity(
       const limit = Math.min(parseInt(searchParams.get("limit") || "100", 10), 1000);
       const offset = Math.max(parseInt(searchParams.get("offset") || "0", 10), 0);
 
-      // Try to authenticate, but don't fail if unauthenticated
-      let isAuthenticated = false;
+      // Authenticate — production endpoints require valid API key or session
       let tenantId: string | null = null;
       let userId: string | null = null;
 
       const auth = await authenticateApiKey(request);
       if (auth) {
-        isAuthenticated = true;
         tenantId = auth.tenantId || null;
         userId = auth.userId || null;
       } else {
-        // Try Supabase auth as fallback (graceful degradation)
+        // Try Supabase auth as fallback for console users
         try {
           const { createClient } = await import("@/lib/supabase/server");
           const supabase = await createClient();
@@ -211,9 +196,7 @@ export const GET = withSecurity(
             data: { user },
           } = await supabase.auth.getUser();
           if (user) {
-            isAuthenticated = true;
             userId = user.id;
-            // Get tenant from billing account
             const { prisma } = await import("@/shared/db/prismaClient");
             const billingAccount = await prisma.billingAccount.findFirst({
               where: { userId: user.id },
@@ -222,25 +205,20 @@ export const GET = withSecurity(
             tenantId = billingAccount?.tenantId || null;
           }
         } catch {
-          // Unauthenticated access allowed for playground
+          // Auth failed — reject below
         }
       }
 
-      // For unauthenticated users, return demo response
-      if (!isAuthenticated || !tenantId) {
-        const demoJobs = [
+      if (!tenantId) {
+        return NextResponse.json(
           {
-            id: "demo_1",
-            name: "Demo Monthly Reconciliation",
-            status: "completed",
-            sourceAdapter: "stripe",
-            targetAdapter: "shopify",
-            createdAt: new Date(Date.now() - 86400000).toISOString(),
-            demo: true,
+            error: "Authentication required",
+            code: "SETTLER_UNAUTHORIZED",
+            message:
+              "A valid API key or session is required. For demo access, use /api/demo/* endpoints.",
           },
-        ];
-
-        return NextResponse.json(demoJobs, { status: 200 });
+          { status: 401 }
+        );
       }
 
       // For authenticated users, fetch actual jobs from database
@@ -353,5 +331,5 @@ export const GET = withSecurity(
       );
     }
   },
-  { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: false }
+  { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: true }
 );

--- a/packages/web/src/app/demo/console/page.tsx
+++ b/packages/web/src/app/demo/console/page.tsx
@@ -22,13 +22,7 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { StatCard } from "@/components/ui/stat-card";
 import { StatusBadge, type StatusType } from "@/components/ui/status-badge";
 import type {
@@ -48,6 +42,8 @@ interface DemoData {
   integrations: ShowcaseIntegration[];
   metrics: ShowcaseMetrics | null;
 }
+
+type LoadError = { message: string } | null;
 
 function formatCount(n: number): string {
   if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
@@ -98,9 +94,7 @@ function integrationStatusColor(status: string): string {
   }
 }
 
-function alertSeverityVariant(
-  severity: string
-): "destructive" | "warning" | "outline" {
+function alertSeverityVariant(severity: string): "destructive" | "warning" | "outline" {
   switch (severity) {
     case "critical":
       return "destructive";
@@ -119,9 +113,7 @@ function MiniSparkline({ data, color = "text-blue-500" }: { data: number[]; colo
   const h = 32;
   const w = 120;
   const step = w / (data.length - 1);
-  const points = data
-    .map((v, i) => `${i * step},${h - ((v - min) / range) * h}`)
-    .join(" ");
+  const points = data.map((v, i) => `${i * step},${h - ((v - min) / range) * h}`).join(" ");
   return (
     <svg viewBox={`0 0 ${w} ${h}`} className={`w-[120px] h-8 ${color}`} aria-hidden="true">
       <polyline
@@ -140,9 +132,11 @@ export default function DemoConsolePage() {
   const [data, setData] = useState<DemoData | null>(null);
   const [selectedTenant, setSelectedTenant] = useState<string>("");
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<LoadError>(null);
 
   const loadData = useCallback(async (tenantId?: string) => {
     setLoading(true);
+    setError(null);
     try {
       const tenantParam = tenantId ? `?tenantId=${tenantId}` : "";
       const [tenantsRes, runsRes, exceptionsRes, alertsRes, integrationsRes, metricsRes] =
@@ -154,6 +148,25 @@ export default function DemoConsolePage() {
           fetch(`/api/demo/integrations${tenantParam}`),
           fetch(`/api/demo/metrics${tenantParam}`),
         ]);
+
+      // Check for rate limiting or server errors
+      const responses = [
+        tenantsRes,
+        runsRes,
+        exceptionsRes,
+        alertsRes,
+        integrationsRes,
+        metricsRes,
+      ];
+      const failedResponse = responses.find((r) => !r.ok);
+      if (failedResponse) {
+        if (failedResponse.status === 429) {
+          setError({ message: "Rate limit reached. Please wait a moment before refreshing." });
+          return;
+        }
+        setError({ message: `Failed to load demo data (HTTP ${failedResponse.status}).` });
+        return;
+      }
 
       const [tenants, runs, exceptions, alerts, integrations, metrics] = await Promise.all([
         tenantsRes.json(),
@@ -168,8 +181,10 @@ export default function DemoConsolePage() {
       if (!tenantId && tenants.length > 0) {
         setSelectedTenant(tenants[0].id);
       }
-    } catch {
-      // Demo mode — gracefully degrade
+    } catch (err) {
+      setError({
+        message: err instanceof Error ? err.message : "Failed to load demo data. Please try again.",
+      });
     } finally {
       setLoading(false);
     }
@@ -199,6 +214,27 @@ export default function DemoConsolePage() {
     );
   }
 
+  if (error) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-6 text-center">
+          <AlertTriangle className="w-8 h-8 text-red-500 mx-auto mb-3" />
+          <h2 className="text-lg font-semibold text-red-900 dark:text-red-100 mb-1">
+            Unable to Load Demo
+          </h2>
+          <p className="text-sm text-red-700 dark:text-red-300 mb-4">{error.message}</p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void loadData(selectedTenant || undefined)}
+          >
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   if (!data) return null;
 
   const currentTenant = data.tenants.find((t) => t.id === selectedTenant);
@@ -223,7 +259,8 @@ export default function DemoConsolePage() {
               Showcase Mode — Live Product Demo
             </p>
             <p className="text-xs text-blue-700 dark:text-blue-300">
-              All data is deterministic and read-only. Switch tenants to explore different reconciliation scenarios.
+              All data is deterministic and read-only. Switch tenants to explore different
+              reconciliation scenarios.
             </p>
           </div>
         </div>
@@ -256,7 +293,10 @@ export default function DemoConsolePage() {
         </div>
 
         <div className="flex-shrink-0">
-          <label htmlFor="tenant-select" className="block text-xs font-medium text-muted-foreground mb-1">
+          <label
+            htmlFor="tenant-select"
+            className="block text-xs font-medium text-muted-foreground mb-1"
+          >
             Scenario
           </label>
           <select
@@ -287,7 +327,9 @@ export default function DemoConsolePage() {
                 <p className="text-sm font-medium text-red-900 dark:text-red-100">{alert.title}</p>
                 <p className="text-xs text-red-700 dark:text-red-300 mt-0.5">{alert.message}</p>
               </div>
-              <Badge variant="destructive" className="flex-shrink-0">Critical</Badge>
+              <Badge variant="destructive" className="flex-shrink-0">
+                Critical
+              </Badge>
             </div>
           ))}
         </div>
@@ -300,7 +342,9 @@ export default function DemoConsolePage() {
             label="Match Rate"
             value={`${metrics.matchRate}%`}
             icon={CheckCircle2}
-            tone={metrics.matchRate >= 95 ? "success" : metrics.matchRate >= 90 ? "warning" : "danger"}
+            tone={
+              metrics.matchRate >= 95 ? "success" : metrics.matchRate >= 90 ? "warning" : "danger"
+            }
             description={`${metrics.totalRunsCompleted} runs completed`}
           />
           <StatCard
@@ -313,7 +357,13 @@ export default function DemoConsolePage() {
             label="Open Exceptions"
             value={metrics.openExceptions}
             icon={AlertTriangle}
-            tone={metrics.openExceptions > 10 ? "danger" : metrics.openExceptions > 0 ? "warning" : "success"}
+            tone={
+              metrics.openExceptions > 10
+                ? "danger"
+                : metrics.openExceptions > 0
+                  ? "warning"
+                  : "success"
+            }
             description={`${metrics.resolvedExceptions} resolved`}
           />
           <StatCard
@@ -330,7 +380,9 @@ export default function DemoConsolePage() {
         <div className="grid gap-4 md:grid-cols-3">
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Match Rate Trend</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                Match Rate Trend
+              </CardTitle>
             </CardHeader>
             <CardContent className="flex items-center justify-between">
               <span className="text-2xl font-bold tabular-nums">{metrics.matchRate}%</span>
@@ -339,7 +391,9 @@ export default function DemoConsolePage() {
           </Card>
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Exception Trend</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                Exception Trend
+              </CardTitle>
             </CardHeader>
             <CardContent className="flex items-center justify-between">
               <span className="text-2xl font-bold tabular-nums">{metrics.openExceptions}</span>
@@ -348,10 +402,14 @@ export default function DemoConsolePage() {
           </Card>
           <Card>
             <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Volume Trend</CardTitle>
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                Volume Trend
+              </CardTitle>
             </CardHeader>
             <CardContent className="flex items-center justify-between">
-              <span className="text-2xl font-bold tabular-nums">{formatCount(metrics.totalRecordsProcessed)}</span>
+              <span className="text-2xl font-bold tabular-nums">
+                {formatCount(metrics.totalRecordsProcessed)}
+              </span>
               <MiniSparkline data={metrics.trendVolume} color="text-blue-500" />
             </CardContent>
           </Card>
@@ -431,12 +489,23 @@ export default function DemoConsolePage() {
                 >
                   <div className="flex items-start justify-between gap-2 mb-1">
                     <p className="text-sm text-foreground line-clamp-2">{exc.description}</p>
-                    <Badge variant={exc.severity === "critical" ? "destructive" : exc.severity === "high" ? "warning" : "outline"} className="flex-shrink-0">
+                    <Badge
+                      variant={
+                        exc.severity === "critical"
+                          ? "destructive"
+                          : exc.severity === "high"
+                            ? "warning"
+                            : "outline"
+                      }
+                      className="flex-shrink-0"
+                    >
                       {exc.severity}
                     </Badge>
                   </div>
                   <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                    <Badge variant="outline" className="text-[10px]">{exc.type.replace(/_/g, " ")}</Badge>
+                    <Badge variant="outline" className="text-[10px]">
+                      {exc.type.replace(/_/g, " ")}
+                    </Badge>
                     <span>${exc.amount.toFixed(2)}</span>
                     <span>{exc.statusDetail}</span>
                   </div>
@@ -457,7 +526,8 @@ export default function DemoConsolePage() {
         <CardHeader>
           <CardTitle>Connected Integrations</CardTitle>
           <CardDescription>
-            Data sources and destinations configured for this tenant. Status reflects last sync health.
+            Data sources and destinations configured for this tenant. Status reflects last sync
+            health.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -467,7 +537,9 @@ export default function DemoConsolePage() {
                 key={integration.id}
                 className="flex items-center gap-3 rounded-lg border border-border p-3"
               >
-                <div className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${integrationStatusColor(integration.status)}`} />
+                <div
+                  className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${integrationStatusColor(integration.status)}`}
+                />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-foreground">{integration.name}</p>
                   <p className="text-xs text-muted-foreground">
@@ -523,7 +595,9 @@ export default function DemoConsolePage() {
                 </div>
                 <div className="flex items-center gap-2 flex-shrink-0">
                   {alert.acknowledged && (
-                    <Badge variant="outline" className="text-[10px]">Ack</Badge>
+                    <Badge variant="outline" className="text-[10px]">
+                      Ack
+                    </Badge>
                   )}
                   <Badge variant={alertSeverityVariant(alert.severity)}>{alert.severity}</Badge>
                 </div>
@@ -547,20 +621,37 @@ export default function DemoConsolePage() {
         <CardContent>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div className="space-y-1">
-              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Deterministic Engine</p>
-              <p className="text-sm text-foreground">Same inputs always produce identical outputs. Every run is replayable.</p>
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Deterministic Engine
+              </p>
+              <p className="text-sm text-foreground">
+                Same inputs always produce identical outputs. Every run is replayable.
+              </p>
             </div>
             <div className="space-y-1">
-              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Audit Trail</p>
-              <p className="text-sm text-foreground">Every operator action, rule change, and exception resolution is logged with actor and timestamp.</p>
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Audit Trail
+              </p>
+              <p className="text-sm text-foreground">
+                Every operator action, rule change, and exception resolution is logged with actor
+                and timestamp.
+              </p>
             </div>
             <div className="space-y-1">
-              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Tenant Isolation</p>
-              <p className="text-sm text-foreground">All data is scoped to your tenant. No cross-tenant data leakage is possible.</p>
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Tenant Isolation
+              </p>
+              <p className="text-sm text-foreground">
+                All data is scoped to your tenant. No cross-tenant data leakage is possible.
+              </p>
             </div>
             <div className="space-y-1">
-              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Evidence Manifests</p>
-              <p className="text-sm text-foreground">Each run produces hash-linked evidence that can be independently verified.</p>
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Evidence Manifests
+              </p>
+              <p className="text-sm text-foreground">
+                Each run produces hash-linked evidence that can be independently verified.
+              </p>
             </div>
           </div>
         </CardContent>
@@ -572,8 +663,8 @@ export default function DemoConsolePage() {
           Ready to reconcile your own data?
         </h2>
         <p className="text-sm text-muted-foreground mb-4 max-w-lg mx-auto">
-          Start a free trial to connect your payment processors, banks, and accounting systems.
-          See real reconciliation results in minutes.
+          Start a free trial to connect your payment processors, banks, and accounting systems. See
+          real reconciliation results in minutes.
         </p>
         <div className="flex justify-center gap-3">
           <Button asChild>

--- a/packages/web/src/app/demo/layout.tsx
+++ b/packages/web/src/app/demo/layout.tsx
@@ -7,6 +7,11 @@ export const metadata: Metadata = {
   title: "Demo Preview - Settler",
   description:
     "Interactive demo of Settler's reconciliation engine, receipt ingestion, and API playground. No authentication required.",
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export default function DemoLayout({ children }: { children: React.ReactNode }) {

--- a/packages/web/src/app/robots.ts
+++ b/packages/web/src/app/robots.ts
@@ -20,6 +20,7 @@ export default function robots(): MetadataRoute.Robots {
           "/billing/",
           "/review/",
           "/invite/",
+          "/demo/console",
           "/_next/",
           "/static/",
         ],

--- a/packages/web/src/lib/demo/demo-response.ts
+++ b/packages/web/src/lib/demo/demo-response.ts
@@ -1,0 +1,107 @@
+/**
+ * Demo Response Helpers
+ *
+ * Shared utilities for demo API routes. Ensures consistent:
+ * - Response headers (X-Demo-Mode, cache control)
+ * - Rate limiting via simple in-memory token bucket
+ * - Analytics tagging to separate demo traffic from production
+ *
+ * All demo routes should use `demoJsonResponse()` instead of `NextResponse.json()`
+ * and `checkDemoRateLimit()` at the top of each handler.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Demo response headers
+// ---------------------------------------------------------------------------
+
+const DEMO_HEADERS = {
+  "X-Demo-Mode": "true",
+  "X-Data-Source": "showcase-deterministic",
+  "Cache-Control": "public, max-age=300, s-maxage=600, stale-while-revalidate=60",
+} as const;
+
+/**
+ * Wrap data in a NextResponse with consistent demo headers.
+ */
+export function demoJsonResponse<T>(data: T, status = 200): NextResponse {
+  const response = NextResponse.json(data, { status });
+  for (const [key, value] of Object.entries(DEMO_HEADERS)) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
+
+// ---------------------------------------------------------------------------
+// Simple in-memory rate limiter for demo endpoints
+// ---------------------------------------------------------------------------
+
+const WINDOW_MS = 60_000; // 1 minute
+const MAX_REQUESTS_PER_WINDOW = 120; // generous but bounded
+
+interface BucketEntry {
+  count: number;
+  resetAt: number;
+}
+
+const buckets = new Map<string, BucketEntry>();
+
+// Periodic cleanup to prevent memory leak (every 5 minutes)
+let cleanupScheduled = false;
+function scheduleCleanup() {
+  if (cleanupScheduled) return;
+  cleanupScheduled = true;
+  if (typeof setInterval !== "undefined") {
+    setInterval(() => {
+      const now = Date.now();
+      for (const [key, entry] of buckets) {
+        if (entry.resetAt < now) {
+          buckets.delete(key);
+        }
+      }
+    }, 5 * 60_000).unref?.();
+  }
+}
+
+function getClientKey(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown"
+  );
+}
+
+/**
+ * Check rate limit for a demo request.
+ * Returns null if allowed, or a 429 NextResponse if rate-limited.
+ */
+export function checkDemoRateLimit(request: NextRequest): NextResponse | null {
+  scheduleCleanup();
+  const key = `demo:${getClientKey(request)}`;
+  const now = Date.now();
+  const entry = buckets.get(key);
+
+  if (!entry || entry.resetAt < now) {
+    buckets.set(key, { count: 1, resetAt: now + WINDOW_MS });
+    return null;
+  }
+
+  entry.count += 1;
+  if (entry.count > MAX_REQUESTS_PER_WINDOW) {
+    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+    const response = NextResponse.json(
+      {
+        error: "Rate limit exceeded",
+        message: "Demo API is rate-limited. Please wait before making more requests.",
+        retry_after_seconds: retryAfter,
+      },
+      { status: 429 }
+    );
+    response.headers.set("Retry-After", String(retryAfter));
+    response.headers.set("X-Demo-Mode", "true");
+    return response;
+  }
+
+  return null;
+}

--- a/packages/web/src/lib/demo/showcase-data.ts
+++ b/packages/web/src/lib/demo/showcase-data.ts
@@ -37,12 +37,10 @@ function createRng(seed: number): SeededRng {
       return min + Math.floor(next() * (max - min + 1));
     },
     pick<T>(arr: readonly T[]): T {
-      return arr[Math.floor(next() * arr.length)];
+      return arr[Math.floor(next() * arr.length)]!;
     },
     uuid() {
-      const h = Array.from({ length: 32 }, () =>
-        Math.floor(next() * 16).toString(16)
-      ).join("");
+      const h = Array.from({ length: 32 }, () => Math.floor(next() * 16).toString(16)).join("");
       return `${h.slice(0, 8)}-${h.slice(8, 12)}-4${h.slice(13, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
     },
   };
@@ -274,9 +272,7 @@ const ACTOR_NAMES = [
 
 function relativeDate(daysAgo: number, rng: SeededRng): string {
   const now = new Date();
-  const d = new Date(
-    now.getTime() - daysAgo * 86400000 + rng.nextInt(0, 86400000)
-  );
+  const d = new Date(now.getTime() - daysAgo * 86400000 + rng.nextInt(0, 86400000));
   return d.toISOString();
 }
 
@@ -307,20 +303,14 @@ function generateRuns(
     const conflicts = rng.nextInt(0, Math.max(1, Math.round(unmatched * 0.1)));
     const isFailed = rng.next() < profile.failRate;
     const isRunning = !isFailed && i === 0 && rng.next() < 0.15;
-    const status: ShowcaseRun["status"] = isFailed
-      ? "failed"
-      : isRunning
-        ? "running"
-        : "completed";
+    const status: ShowcaseRun["status"] = isFailed ? "failed" : isRunning ? "running" : "completed";
     const daysAgo = i * 2 + rng.nextInt(0, 1);
     const startedAt = relativeDate(daysAgo, rng);
     const durationMs = rng.nextInt(3000, 45000);
     const completedAt =
       status === "running"
         ? null
-        : new Date(
-            new Date(startedAt).getTime() + durationMs
-          ).toISOString();
+        : new Date(new Date(startedAt).getTime() + durationMs).toISOString();
 
     const exceptioned = rng.nextInt(0, Math.max(1, unmatchedSource));
     const unresolved = rng.nextInt(0, exceptioned);
@@ -371,7 +361,7 @@ function generateRuns(
         resolved,
       },
       summaryState,
-      isTerminal: status !== "running" && status !== "pending",
+      isTerminal: status !== "running",
       progress:
         status === "completed" || status === "failed"
           ? 100
@@ -403,9 +393,7 @@ function generateExceptions(
   const exceptions: ShowcaseException[] = [];
   for (const run of runs) {
     if (run.status === "pending") continue;
-    const count = Math.round(
-      run.summarySemantics.exceptioned * density
-    );
+    const count = Math.round(run.summarySemantics.exceptioned * density);
     for (let i = 0; i < count; i++) {
       const type = rng.pick(EXCEPTION_TYPES);
       const templates = EXCEPTION_DESCRIPTIONS[type] || ["Exception detected"];
@@ -492,11 +480,7 @@ function generateExceptions(
   return exceptions;
 }
 
-function generateAlerts(
-  tenantId: string,
-  count: number,
-  rng: SeededRng
-): ShowcaseAlert[] {
+function generateAlerts(tenantId: string, count: number, rng: SeededRng): ShowcaseAlert[] {
   const alerts: ShowcaseAlert[] = [];
   const alertTemplates: Array<{
     type: ShowcaseAlert["type"];
@@ -548,7 +532,7 @@ function generateAlerts(
     },
   ];
   for (let i = 0; i < count; i++) {
-    const tpl = alertTemplates[i % alertTemplates.length];
+    const tpl = alertTemplates[i % alertTemplates.length]!;
     alerts.push({
       id: rng.uuid(),
       tenantId,
@@ -593,12 +577,8 @@ function generateIntegrations(
       name: adapter.charAt(0).toUpperCase() + adapter.slice(1).replace(/-/g, " "),
       adapter,
       status,
-      lastSyncAt:
-        status === "disconnected"
-          ? null
-          : relativeDate(rng.nextInt(0, 2), rng),
-      recordsSynced:
-        status === "pending" ? 0 : rng.nextInt(500, 50000),
+      lastSyncAt: status === "disconnected" ? null : relativeDate(rng.nextInt(0, 2), rng),
+      recordsSynced: status === "pending" ? 0 : rng.nextInt(500, 50000),
       errorCount:
         status === "degraded"
           ? rng.nextInt(1, 15)
@@ -610,11 +590,7 @@ function generateIntegrations(
   });
 }
 
-function generateAuditTrail(
-  tenantId: string,
-  count: number,
-  rng: SeededRng
-): ShowcaseAuditEntry[] {
+function generateAuditTrail(tenantId: string, count: number, rng: SeededRng): ShowcaseAuditEntry[] {
   const entries: ShowcaseAuditEntry[] = [];
   for (let i = 0; i < count; i++) {
     const action = rng.pick(AUDIT_ACTIONS);
@@ -660,30 +636,17 @@ function generateMetrics(
   rng: SeededRng
 ): ShowcaseMetrics {
   const completedRuns = runs.filter((r) => r.status === "completed");
-  const totalRecords = completedRuns.reduce(
-    (s, r) => s + r.summary.total,
-    0
-  );
-  const totalMatched = completedRuns.reduce(
-    (s, r) => s + r.summary.matched,
-    0
-  );
-  const matchRate =
-    totalRecords > 0
-      ? Math.round((totalMatched / totalRecords) * 10000) / 100
-      : 0;
+  const totalRecords = completedRuns.reduce((s, r) => s + r.summary.total, 0);
+  const totalMatched = completedRuns.reduce((s, r) => s + r.summary.matched, 0);
+  const matchRate = totalRecords > 0 ? Math.round((totalMatched / totalRecords) * 10000) / 100 : 0;
   const openExceptions = exceptions.filter(
     (e) => e.status === "pending" || e.status === "investigating"
   ).length;
-  const resolvedExceptions = exceptions.filter(
-    (e) => e.status === "resolved"
-  ).length;
+  const resolvedExceptions = exceptions.filter((e) => e.status === "resolved").length;
   const avgDuration =
     completedRuns.length > 0
       ? completedRuns.reduce((s, r) => {
-          const d =
-            new Date(r.completedAt!).getTime() -
-            new Date(r.startedAt).getTime();
+          const d = new Date(r.completedAt!).getTime() - new Date(r.startedAt).getTime();
           return s + d;
         }, 0) / completedRuns.length
       : 0;
@@ -704,19 +667,13 @@ function generateMetrics(
     tenantId,
     matchRate,
     exceptionRate:
-      totalRecords > 0
-        ? Math.round(
-            (exceptions.length / totalRecords) * 10000
-          ) / 100
-        : 0,
+      totalRecords > 0 ? Math.round((exceptions.length / totalRecords) * 10000) / 100 : 0,
     avgRunDurationMs: Math.round(avgDuration),
     totalRecordsProcessed: totalRecords,
     totalRunsCompleted: completedRuns.length,
     openExceptions,
     resolvedExceptions,
-    activeIntegrations: integrations.filter(
-      (i) => i.status === "connected"
-    ).length,
+    activeIntegrations: integrations.filter((i) => i.status === "connected").length,
     trendMatchRate,
     trendExceptions,
     trendVolume,
@@ -881,24 +838,11 @@ export function getShowcaseDataset(): ShowcaseDataset {
     );
     allRuns.push(...runs);
 
-    const exceptions = generateExceptions(
-      tenantId,
-      runs,
-      scenario.exceptionDensity,
-      rng
-    );
+    const exceptions = generateExceptions(tenantId, runs, scenario.exceptionDensity, rng);
     allExceptions.push(...exceptions);
 
-    const adapters = [
-      scenario.sourceAdapter,
-      scenario.targetAdapter,
-      ...scenario.extraAdapters,
-    ];
-    const integrations = generateIntegrations(
-      tenantId,
-      [...new Set(adapters)],
-      rng
-    );
+    const adapters = [scenario.sourceAdapter, scenario.targetAdapter, ...scenario.extraAdapters];
+    const integrations = generateIntegrations(tenantId, [...new Set(adapters)], rng);
     allIntegrations.push(...integrations);
 
     const alerts = generateAlerts(tenantId, scenario.alertCount, rng);
@@ -907,13 +851,7 @@ export function getShowcaseDataset(): ShowcaseDataset {
     const audit = generateAuditTrail(tenantId, scenario.auditCount, rng);
     allAudit.push(...audit);
 
-    const metrics = generateMetrics(
-      tenantId,
-      runs,
-      exceptions,
-      integrations,
-      rng
-    );
+    const metrics = generateMetrics(tenantId, runs, exceptions, integrations, rng);
     allMetrics.push(metrics);
   }
 
@@ -932,7 +870,7 @@ export function getShowcaseDataset(): ShowcaseDataset {
 
 /** Get the default showcase tenant (Acme Commerce) */
 export function getDefaultShowcaseTenant(): ShowcaseTenant {
-  return getShowcaseDataset().tenants[0];
+  return getShowcaseDataset().tenants[0]!;
 }
 
 /** Get data scoped to a single tenant */


### PR DESCRIPTION
Security:
- Remove demo data fallback from /api/v1/recon/jobs (POST + GET) — production
  endpoints now require authentication, directing unauthenticated users to
  /api/demo/* instead of silently returning mock data
- Set requireAuth: true on both recon/jobs handlers

Demo isolation:
- Add shared demo-response helper with rate limiting (120 req/min per IP),
  X-Demo-Mode header, X-Data-Source header, and cache control
- Apply demo response helper to all 7 /api/demo/* routes
- Add noindex/nofollow metadata to demo layout preventing search indexing
- Add /demo/console to robots.txt disallow list
- Add error state with retry to demo console (was silently swallowing errors)

Type safety:
- Fix 4 pre-existing TypeScript strict errors in showcase-data.ts:
  array indexing (non-null assertions), unreachable comparison, spread type

Tests (39 new, all passing):
- Showcase data determinism (identity across invocations, data integrity)
- Showcase-to-canonical DTO compatibility (status/severity/progressState values)
- Demo import isolation boundary (no production db/auth imports in demo code)
- Demo response helper module structure

Verification:
- typecheck: 27/27 packages pass
- lint: 0 errors (47 pre-existing warnings)
- tests: 55/73 suites pass (18 pre-existing failures, 0 new failures)
- build: requires env vars (pre-existing requirement)

https://claude.ai/code/session_01XHDqtWMLrD5zswLdJ1WeB8