### PR TITLE
feat: exception detail workflow closure pass

### DIFF
--- a/packages/web/src/__tests__/api/admin-exception-detail.test.ts
+++ b/packages/web/src/__tests__/api/admin-exception-detail.test.ts
@@ -1,0 +1,361 @@
+/** @jest-environment node */
+
+/**
+ * Admin exception detail API tests.
+ *
+ * Verifies:
+ * - GET returns expected shape for a valid exception
+ * - 404 returned when exception does not exist
+ * - 400 returned for invalid UUID
+ * - 403 returned without super admin access
+ * - Provenance fields derived correctly from metadata
+ * - Missing provenance fields expressed as null, not fabricated
+ * - Status derivation from acknowledged + metadata.resolution
+ * - No list-fetch-filter anti-pattern (findUnique, not findMany)
+ */
+
+import { GET } from "@/app/api/admin/exceptions/[id]/route";
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────────
+
+const isSuperAdminMock = jest.fn();
+const driftEventFindUniqueMock = jest.fn();
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/auth/super-admin", () => ({
+  isSuperAdmin: (...args: unknown[]) => isSuperAdminMock(...args),
+}));
+
+jest.mock("@/shared/db/prismaClient", () => ({
+  prisma: {
+    driftEvent: {
+      findUnique: (...args: unknown[]) => driftEventFindUniqueMock(...args),
+    },
+  },
+}));
+
+jest.mock("@/lib/admin/utils/logger", () => ({
+  adminLogger: {
+    error: jest.fn(),
+  },
+}));
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRequest(id: string) {
+  return {
+    url: `http://localhost/api/admin/exceptions/${id}`,
+    nextUrl: new URL(`http://localhost/api/admin/exceptions/${id}`),
+  } as unknown as import("next/server").NextRequest;
+}
+
+function makeParams(id: string) {
+  return {
+    params: Promise.resolve({ id }),
+  };
+}
+
+const VALID_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const TENANT_UUID = "11111111-2222-4333-8444-555555555555";
+const RUN_UUID = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+
+function makeException(overrides: Record<string, unknown> = {}) {
+  return {
+    id: VALID_UUID,
+    tenantId: TENANT_UUID,
+    driftType: "amount_mismatch",
+    severity: "critical",
+    acknowledged: false,
+    acknowledgedBy: null,
+    acknowledgedAt: null,
+    createdAt: new Date("2026-01-15T10:00:00.000Z"),
+    updatedAt: new Date("2026-01-15T10:00:00.000Z"),
+    reconJobId: RUN_UUID,
+    fieldPath: "amount",
+    expectedValue: "100.00",
+    actualValue: "110.00",
+    driftMetrics: null,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// ─── Test suite ────────────────────────────────────────────────────────────────
+
+describe("GET /api/admin/exceptions/[id]", () => {
+  beforeEach(() => {
+    isSuperAdminMock.mockReset();
+    driftEventFindUniqueMock.mockReset();
+
+    // Default: super admin access granted
+    isSuperAdminMock.mockResolvedValue(true);
+  });
+
+  // ── Auth ──────────────────────────────────────────────────────────────────────
+
+  test("returns 403 when caller is not super admin", async () => {
+    isSuperAdminMock.mockResolvedValue(false);
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+
+    expect(res.status).toBe(403);
+    const payload = await res.json();
+    expect(payload.error).toBe("Forbidden");
+  });
+
+  // ── Validation ───────────────────────────────────────────────────────────────
+
+  test("returns 400 for an invalid UUID", async () => {
+    const res = await GET(makeRequest("not-a-uuid"), makeParams("not-a-uuid"));
+
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toBe("Invalid exception ID");
+  });
+
+  // ── Not found ────────────────────────────────────────────────────────────────
+
+  test("returns 404 when exception does not exist", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(null);
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+
+    expect(res.status).toBe(404);
+    const payload = await res.json();
+    expect(payload.error).toBe("Not found");
+    expect(payload.message).toMatch(/no longer exists/);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────────────
+
+  test("returns 200 with expected shape for a valid exception", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(makeException());
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+
+    // Core identity
+    expect(payload.id).toBe(VALID_UUID);
+    expect(payload.tenantId).toBe(TENANT_UUID);
+    expect(payload.source).toBe("amount_mismatch");
+    expect(payload.severity).toBe("critical");
+    expect(payload.status).toBe("new");
+    expect(payload.reason).toBe("Field mismatch: amount");
+
+    // Evidence
+    expect(payload.evidence.expected).toBe("100.00");
+    expect(payload.evidence.actual).toBe("110.00");
+
+    // Timestamps present
+    expect(payload.createdAt).toBe("2026-01-15T10:00:00.000Z");
+    expect(typeof payload.updatedAt).toBe("string");
+
+    // Provenance must be present (fields may be null but must be declared)
+    expect(payload.provenance).toBeDefined();
+    expect(payload.provenance.runId).toBe(RUN_UUID);
+    expect(payload.provenance.fieldPath).toBe("amount");
+    expect(payload.provenance.ruleId).toBeNull();
+    expect(payload.provenance.detectorId).toBeNull();
+    expect(payload.provenance.sourceAdapter).toBeNull();
+    expect(payload.provenance.confidenceScore).toBeNull();
+  });
+
+  // ── Uses findUnique, not findMany ─────────────────────────────────────────────
+
+  test("queries by ID via findUnique, not by list scan", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(makeException());
+
+    await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+
+    expect(driftEventFindUniqueMock).toHaveBeenCalledTimes(1);
+    const callArg = driftEventFindUniqueMock.mock.calls[0]?.[0];
+    expect(callArg?.where?.id).toBe(VALID_UUID);
+  });
+
+  // ── Status derivation ────────────────────────────────────────────────────────
+
+  test("derives status=new when acknowledged=false and no resolution", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(
+      makeException({ acknowledged: false, metadata: {} })
+    );
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+    expect(payload.status).toBe("new");
+  });
+
+  test("derives status=in_review when acknowledged=true and no resolution", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(
+      makeException({
+        acknowledged: true,
+        acknowledgedBy: "user-x",
+        acknowledgedAt: new Date("2026-01-15T11:00:00.000Z"),
+        metadata: {},
+      })
+    );
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+    expect(payload.status).toBe("in_review");
+  });
+
+  test("derives status=resolved when metadata.resolution.status=resolved", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(
+      makeException({
+        acknowledged: true,
+        metadata: {
+          resolution: {
+            status: "resolved",
+            resolvedBy: "user-x",
+            resolvedAt: "2026-01-15T12:00:00.000Z",
+          },
+        },
+      })
+    );
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+    expect(payload.status).toBe("resolved");
+  });
+
+  test("derives status=resolved when metadata.resolution.status=ignored", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(
+      makeException({
+        acknowledged: true,
+        metadata: {
+          resolution: {
+            status: "ignored",
+            ignoredBy: "user-x",
+            ignoredAt: "2026-01-15T12:00:00.000Z",
+          },
+        },
+      })
+    );
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+    expect(payload.status).toBe("resolved");
+  });
+
+  // ── Provenance from metadata ──────────────────────────────────────────────────
+
+  test("extracts ruleId and detectorId from metadata", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(
+      makeException({
+        metadata: {
+          ruleId: "rule_amount_tolerance_v2",
+          detectorId: "detector_001",
+          sourceAdapter: "stripe",
+          targetAdapter: "netsuite",
+          sourceTransactionId: "txn_src_111",
+          targetTransactionId: "txn_tgt_222",
+          ingestionId: "ing_333",
+        },
+      })
+    );
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+
+    expect(payload.provenance.ruleId).toBe("rule_amount_tolerance_v2");
+    expect(payload.provenance.detectorId).toBe("detector_001");
+    expect(payload.provenance.sourceAdapter).toBe("stripe");
+    expect(payload.provenance.targetAdapter).toBe("netsuite");
+    expect(payload.provenance.sourceTransactionId).toBe("txn_src_111");
+    expect(payload.provenance.targetTransactionId).toBe("txn_tgt_222");
+    expect(payload.provenance.ingestionId).toBe("ing_333");
+  });
+
+  test("extracts confidenceScore from driftMetrics", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(
+      makeException({
+        driftMetrics: { confidenceScore: 0.87 },
+        metadata: {},
+      })
+    );
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+    expect(payload.provenance.confidenceScore).toBeCloseTo(0.87);
+  });
+
+  // ── Missing data graceful degradation ─────────────────────────────────────────
+
+  test("returns null provenance fields rather than fabricating them", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(
+      makeException({ reconJobId: null, fieldPath: null, metadata: {}, driftMetrics: null })
+    );
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+
+    expect(payload.provenance.runId).toBeNull();
+    expect(payload.provenance.fieldPath).toBeNull();
+    expect(payload.provenance.ruleId).toBeNull();
+    expect(payload.provenance.detectorId).toBeNull();
+    expect(payload.provenance.sourceAdapter).toBeNull();
+    expect(payload.provenance.targetAdapter).toBeNull();
+    expect(payload.provenance.sourceTransactionId).toBeNull();
+    expect(payload.provenance.targetTransactionId).toBeNull();
+    expect(payload.provenance.ingestionId).toBeNull();
+    expect(payload.provenance.matchReason).toBeNull();
+    expect(payload.provenance.confidenceScore).toBeNull();
+  });
+
+  test("handles null expectedValue and actualValue without throwing", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(
+      makeException({ expectedValue: null, actualValue: null })
+    );
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.evidence.expected).toBeNull();
+    expect(payload.evidence.actual).toBeNull();
+  });
+
+  test("uses fallback severity=info when severity is null", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(makeException({ severity: null }));
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+    expect(payload.severity).toBe("info");
+  });
+
+  test("uses fallback source=unknown when driftType is null", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(makeException({ driftType: null }));
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+    expect(payload.source).toBe("unknown");
+  });
+
+  // ── Reviewed metadata ────────────────────────────────────────────────────────
+
+  test("exposes reviewedBy and reviewedAt when present", async () => {
+    const reviewedAt = new Date("2026-01-15T14:00:00.000Z");
+    driftEventFindUniqueMock.mockResolvedValue(
+      makeException({
+        acknowledged: true,
+        acknowledgedBy: "admin-user",
+        acknowledgedAt: reviewedAt,
+        metadata: {},
+      })
+    );
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+    expect(payload.reviewedBy).toBe("admin-user");
+    expect(payload.reviewedAt).toBe(reviewedAt.toISOString());
+  });
+
+  test("returns reviewedBy=null and reviewedAt=null when not reviewed", async () => {
+    driftEventFindUniqueMock.mockResolvedValue(makeException());
+
+    const res = await GET(makeRequest(VALID_UUID), makeParams(VALID_UUID));
+    const payload = await res.json();
+    expect(payload.reviewedBy).toBeNull();
+    expect(payload.reviewedAt).toBeNull();
+  });
+});

--- a/packages/web/src/app/admin/exceptions/[id]/page.tsx
+++ b/packages/web/src/app/admin/exceptions/[id]/page.tsx
@@ -1,34 +1,397 @@
 /**
- * Exception Detail Page
+ * Admin Exception Detail Page
  *
- * Detailed view of a single exception with AI assist recommendations.
+ * Operator workbench for a single exception.
+ * Fetches via a dedicated single-exception API – no list filtering.
  */
 
 "use client";
 
-import { useAdminExceptions } from "@/lib/admin/hooks/use-admin-metrics";
-import { AIAssistCard, AIRecommendation } from "@/components/admin/ai-assist";
+import { use, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ArrowLeft,
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  Copy,
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+} from "lucide-react";
 import Link from "next/link";
 
-export default function ExceptionDetailPage({ params }: { params: { id: string } }) {
-  const { id } = params;
+// ─── Types ────────────────────────────────────────────────────────────────────
 
-  const { data: exceptionsData } = useAdminExceptions({ limit: 1000 });
-  const exception = exceptionsData?.items?.find((ex: { id: string }) => ex.id === id);
+type ExceptionSeverity = "info" | "warn" | "critical";
+type ExceptionStatus = "new" | "in_review" | "resolved";
 
-  // AI recommendations require the AI analysis pipeline to be configured.
-  // When available, these would come from /api/ai/data-insights.
-  const aiRecommendation: AIRecommendation | null = null;
+interface ExceptionProvenance {
+  runId: string | null;
+  fieldPath: string | null;
+  ruleId: string | null;
+  detectorId: string | null;
+  sourceAdapter: string | null;
+  targetAdapter: string | null;
+  sourceTransactionId: string | null;
+  targetTransactionId: string | null;
+  ingestionId: string | null;
+  matchReason: string | null;
+  confidenceScore: number | null;
+}
 
-  if (!exception) {
+interface AdminExceptionDetail {
+  id: string;
+  tenantId: string;
+  source: string;
+  severity: ExceptionSeverity;
+  status: ExceptionStatus;
+  reason: string;
+  evidence: {
+    expected: unknown;
+    actual: unknown;
+  };
+  provenance: ExceptionProvenance;
+  reviewedBy: string | null;
+  reviewedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  metadata: Record<string, unknown>;
+}
+
+// ─── Data fetching ────────────────────────────────────────────────────────────
+
+async function fetchAdminException(id: string): Promise<AdminExceptionDetail> {
+  const res = await fetch(`/api/admin/exceptions/${id}`, { cache: "no-store" });
+  if (res.status === 404) {
+    throw new NotFoundError();
+  }
+  if (!res.ok) {
+    const payload = await res.json().catch(() => ({}));
+    throw new Error((payload as { message?: string }).message || `Request failed: ${res.status}`);
+  }
+  return res.json() as Promise<AdminExceptionDetail>;
+}
+
+class NotFoundError extends Error {
+  constructor() {
+    super("Exception not found");
+    this.name = "NotFoundError";
+  }
+}
+
+// ─── Severity helpers ─────────────────────────────────────────────────────────
+
+const severityLabel: Record<ExceptionSeverity, string> = {
+  critical: "CRITICAL",
+  warn: "WARN",
+  info: "INFO",
+};
+
+const severityClasses: Record<ExceptionSeverity, string> = {
+  critical: "bg-red-100 text-red-800 border border-red-300 dark:bg-red-950 dark:text-red-200",
+  warn: "bg-yellow-100 text-yellow-800 border border-yellow-300 dark:bg-yellow-950 dark:text-yellow-200",
+  info: "bg-blue-100 text-blue-800 border border-blue-300 dark:bg-blue-950 dark:text-blue-200",
+};
+
+const statusLabel: Record<ExceptionStatus, string> = {
+  new: "New",
+  in_review: "In Review",
+  resolved: "Resolved",
+};
+
+const statusIcon: Record<ExceptionStatus, typeof Clock> = {
+  new: Clock,
+  in_review: AlertTriangle,
+  resolved: CheckCircle2,
+};
+
+const statusClasses: Record<ExceptionStatus, string> = {
+  new: "bg-yellow-100 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-200",
+  in_review: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200",
+  resolved: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200",
+};
+
+// ─── Small components ─────────────────────────────────────────────────────────
+
+function SeverityBadge({ severity }: { severity: ExceptionSeverity }) {
+  return (
+    <Badge className={`font-mono text-xs px-3 py-1 ${severityClasses[severity]}`}>
+      {severityLabel[severity]}
+    </Badge>
+  );
+}
+
+function StatusBadge({ status }: { status: ExceptionStatus }) {
+  const Icon = statusIcon[status];
+  return (
+    <Badge className={`gap-1 ${statusClasses[status]}`}>
+      <Icon className="w-3 h-3" />
+      {statusLabel[status]}
+    </Badge>
+  );
+}
+
+function ProvenanceRow({
+  label,
+  value,
+  mono = false,
+  link,
+}: {
+  label: string;
+  value: string | null | undefined;
+  mono?: boolean;
+  link?: string;
+}) {
+  if (!value) {
+    return (
+      <div className="flex items-start gap-2 py-1.5 border-b border-border last:border-0">
+        <span className="text-xs text-muted-foreground w-44 shrink-0">{label}</span>
+        <span className="text-xs text-muted-foreground italic">unavailable</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-2 py-1.5 border-b border-border last:border-0">
+      <span className="text-xs text-muted-foreground w-44 shrink-0">{label}</span>
+      <div className="flex items-center gap-1.5 min-w-0">
+        {link ? (
+          <Link
+            href={link}
+            className="text-xs text-blue-600 hover:underline dark:text-blue-400 font-mono break-all"
+          >
+            {value}
+            <ExternalLink className="inline w-3 h-3 ml-1" />
+          </Link>
+        ) : (
+          <span className={`text-xs text-foreground break-all ${mono ? "font-mono" : ""}`}>
+            {value}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => navigator.clipboard.writeText(value)}
+          className="shrink-0 p-0.5 rounded hover:bg-muted/60 text-muted-foreground hover:text-foreground"
+          title="Copy to clipboard"
+        >
+          <Copy className="w-3 h-3" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CollapsibleJson({ label, value }: { label: string; value: unknown }) {
+  const [open, setOpen] = useState(false);
+  const isEmpty =
+    value === null ||
+    value === undefined ||
+    (typeof value === "object" && Object.keys(value as object).length === 0);
+
+  if (isEmpty) {
+    return (
+      <div>
+        <p className="text-xs text-muted-foreground italic">{label}: empty</p>
+      </div>
+    );
+  }
+
+  const json = (() => {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  })();
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground mb-1"
+      >
+        {open ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        {label}
+      </button>
+      {open && (
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => navigator.clipboard.writeText(json)}
+            className="absolute top-2 right-2 text-xs text-muted-foreground hover:text-foreground bg-muted/60 rounded px-1.5 py-0.5"
+          >
+            Copy
+          </button>
+          <pre className="text-xs bg-muted/40 p-3 rounded overflow-auto max-h-64 border border-border">
+            {json}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Action wiring ─────────────────────────────────────────────────────────────
+
+type ReviewAction = "review" | "mark_expected" | "unmatch";
+
+interface ActionResult {
+  error: string | null;
+}
+
+async function postAdminResolve(id: string): Promise<ActionResult> {
+  try {
+    const res = await fetch(`/api/admin/exceptions/${id}/resolve`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    if (!res.ok) {
+      const payload = await res.json().catch(() => ({}));
+      return {
+        error: (payload as { message?: string }).message || `Action failed: ${res.status}`,
+      };
+    }
+    return { error: null };
+  } catch {
+    return { error: "Network error. Please try again." };
+  }
+}
+
+// ─── Action bar ────────────────────────────────────────────────────────────────
+
+function ActionBar({
+  exception,
+  onActionComplete,
+}: {
+  exception: AdminExceptionDetail;
+  onActionComplete: () => void;
+}) {
+  const [pending, setPending] = useState<ReviewAction | "resolve" | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const handleResolve = async () => {
+    setPending("resolve");
+    setActionError(null);
+    const result = await postAdminResolve(exception.id);
+    setPending(null);
+    if (result.error) {
+      setActionError(result.error);
+    } else {
+      onActionComplete();
+    }
+  };
+
+  if (exception.status === "resolved") {
+    return (
+      <Card>
+        <CardContent className="py-4">
+          <div className="flex items-center gap-2 text-green-700 dark:text-green-300">
+            <CheckCircle2 className="w-4 h-4" />
+            <span className="text-sm font-medium">Exception resolved.</span>
+            {exception.reviewedBy && (
+              <span className="text-xs text-muted-foreground ml-1">
+                Reviewed by {exception.reviewedBy}
+                {exception.reviewedAt
+                  ? ` on ${new Date(exception.reviewedAt).toLocaleString()}`
+                  : ""}
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Operator Actions</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {actionError && (
+          <div className="rounded-md bg-red-50 dark:bg-red-950 border border-red-300 dark:border-red-700 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+            {actionError}
+          </div>
+        )}
+        <div className="flex flex-wrap gap-3">
+          <Button
+            size="sm"
+            className="bg-green-700 hover:bg-green-800 text-white"
+            onClick={handleResolve}
+            disabled={pending !== null}
+          >
+            <CheckCircle2 className="w-4 h-4 mr-2" />
+            {pending === "resolve" ? "Marking resolved…" : "Mark Resolved"}
+          </Button>
+          <Button size="sm" variant="outline" asChild>
+            <Link href="/admin/exceptions">
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Back to Queue
+            </Link>
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Resolving marks this exception as acknowledged in the admin queue. The audit record is
+          stored against this tenant.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Main page ─────────────────────────────────────────────────────────────────
+
+export default function AdminExceptionDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const queryClient = useQueryClient();
+
+  const {
+    data: exception,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery<AdminExceptionDetail, Error>({
+    queryKey: ["admin", "exception", id],
+    queryFn: () => fetchAdminException(id),
+    staleTime: 20 * 1000,
+    retry: (failureCount, err) => {
+      if (err instanceof NotFoundError) return false;
+      return failureCount < 2;
+    },
+  });
+
+  const handleActionComplete = () => {
+    void queryClient.invalidateQueries({ queryKey: ["admin", "exception", id] });
+    void queryClient.invalidateQueries({ queryKey: ["admin", "exceptions"] });
+    void refetch();
+  };
+
+  // ── Loading ──
+  if (isLoading) {
+    return (
+      <div className="p-8 space-y-6">
+        <Skeleton className="h-8 w-72" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  // ── Not found ──
+  if (error instanceof NotFoundError) {
     return (
       <div className="p-8">
-        <div className="text-center py-12">
-          <p className="text-muted-foreground">Exception not found</p>
+        <div className="text-center py-16">
+          <p className="text-muted-foreground font-medium">
+            This exception no longer exists or you do not have access.
+          </p>
           <Link href="/admin/exceptions">
             <Button variant="outline" className="mt-4">
               <ArrowLeft className="w-4 h-4 mr-2" />
@@ -40,11 +403,28 @@ export default function ExceptionDetailPage({ params }: { params: { id: string }
     );
   }
 
+  // ── Error ──
+  if (error || !exception) {
+    return (
+      <div className="p-8">
+        <div className="rounded-md bg-red-50 dark:bg-red-950 border border-red-300 dark:border-red-700 px-4 py-3 text-sm text-red-700 dark:text-red-300 max-w-xl">
+          <p className="font-medium">Failed to load exception</p>
+          <p className="mt-1">{error?.message || "Unknown error"}</p>
+        </div>
+        <Button variant="outline" className="mt-4" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  const prov = exception.provenance;
+
   return (
     <div className="p-8 space-y-6 bg-muted/10 min-h-screen">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
+      {/* ── Header ── */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-4">
           <Link href="/admin/exceptions">
             <Button variant="ghost" size="sm">
               <ArrowLeft className="w-4 h-4 mr-2" />
@@ -52,76 +432,135 @@ export default function ExceptionDetailPage({ params }: { params: { id: string }
             </Button>
           </Link>
           <div>
-            <h1 className="text-3xl font-bold text-foreground">Exception Details</h1>
-            <p className="text-muted-foreground mt-1">{exception.reason}</p>
+            <div className="flex items-center gap-3 flex-wrap">
+              <SeverityBadge severity={exception.severity} />
+              <StatusBadge status={exception.status} />
+            </div>
+            <h1 className="text-2xl font-bold text-foreground mt-2">{exception.reason}</h1>
+            <p className="text-xs text-muted-foreground mt-1 font-mono">{exception.id}</p>
           </div>
         </div>
-        <Badge
-          className={
-            exception.severity === "critical"
-              ? "bg-red-100 text-red-800"
-              : exception.severity === "warn"
-                ? "bg-yellow-100 text-yellow-800"
-                : "bg-blue-100 text-blue-800"
-          }
-        >
-          {exception.severity}
-        </Badge>
       </div>
 
-      {/* AI Assist Recommendation */}
-      {aiRecommendation && (
-        <AIAssistCard
-          recommendation={aiRecommendation}
-          enabled={true}
-          onAccept={() => {
-            // AI recommendation accepted - would trigger action
-            // Implementation depends on specific use case
-          }}
-          onReject={() => {
-            // AI recommendation rejected - using baseline
-            // Implementation depends on specific use case
-          }}
-        />
-      )}
+      {/* ── Summary strip ── */}
+      <Card>
+        <CardContent className="py-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-sm">
+            <div>
+              <span className="text-xs text-muted-foreground block">Type</span>
+              <span className="font-medium font-mono">{exception.source}</span>
+            </div>
+            <div>
+              <span className="text-xs text-muted-foreground block">Tenant</span>
+              <span className="font-mono text-xs break-all">{exception.tenantId}</span>
+            </div>
+            <div>
+              <span className="text-xs text-muted-foreground block">Detected</span>
+              <span>{new Date(exception.createdAt).toLocaleString()}</span>
+            </div>
+            <div>
+              <span className="text-xs text-muted-foreground block">Last updated</span>
+              <span>{new Date(exception.updatedAt).toLocaleString()}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
 
-      {/* Exception Details */}
+      {/* ── Provenance / lineage ── */}
       <Card>
         <CardHeader>
-          <CardTitle>Exception Information</CardTitle>
+          <CardTitle className="text-base">Provenance &amp; Lineage</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <span className="text-muted-foreground">Source:</span>
-              <span className="ml-2 font-medium text-foreground">{exception.source}</span>
-            </div>
-            <div>
-              <span className="text-muted-foreground">Status:</span>
-              <span className="ml-2 font-medium text-foreground">{exception.status}</span>
-            </div>
-            <div>
-              <span className="text-muted-foreground">Created:</span>
-              <span className="ml-2 font-medium text-foreground">
-                {new Date(exception.createdAt).toLocaleString()}
-              </span>
-            </div>
-            {exception.ruleId && (
-              <div>
-                <span className="text-muted-foreground">Rule ID:</span>
-                <span className="ml-2 font-mono text-xs text-foreground">{exception.ruleId}</span>
-              </div>
-            )}
-          </div>
+        <CardContent className="space-y-0">
+          <ProvenanceRow
+            label="Reconciliation run"
+            value={prov.runId}
+            mono
+            link={prov.runId ? `/admin/runs/${prov.runId}` : undefined}
+          />
+          <ProvenanceRow label="Field path" value={prov.fieldPath} mono />
+          <ProvenanceRow label="Rule ID" value={prov.ruleId} mono />
+          <ProvenanceRow label="Detector ID" value={prov.detectorId} mono />
+          <ProvenanceRow label="Source adapter" value={prov.sourceAdapter} />
+          <ProvenanceRow label="Target adapter" value={prov.targetAdapter} />
+          <ProvenanceRow label="Source transaction" value={prov.sourceTransactionId} mono />
+          <ProvenanceRow label="Target transaction" value={prov.targetTransactionId} mono />
+          <ProvenanceRow label="Ingestion ID" value={prov.ingestionId} mono />
+          <ProvenanceRow label="Match reason" value={prov.matchReason} />
+          <ProvenanceRow
+            label="Confidence score"
+            value={
+              prov.confidenceScore !== null ? `${(prov.confidenceScore * 100).toFixed(1)}%` : null
+            }
+          />
+        </CardContent>
+      </Card>
 
-          {exception.evidence && (
-            <div>
-              <h3 className="text-sm font-medium text-muted-foreground mb-2">Evidence</h3>
-              <pre className="text-xs bg-muted/40 p-3 rounded overflow-auto">
-                {JSON.stringify(exception.evidence, null, 2)}
-              </pre>
+      {/* ── Evidence comparison ── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Observed Difference</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-md border border-border bg-muted/20 p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
+                Expected
+              </p>
+              {exception.evidence.expected === null || exception.evidence.expected === undefined ? (
+                <p className="text-xs text-muted-foreground italic">No expected value</p>
+              ) : (
+                <pre className="text-xs whitespace-pre-wrap break-words text-foreground">
+                  {typeof exception.evidence.expected === "string"
+                    ? exception.evidence.expected
+                    : JSON.stringify(exception.evidence.expected, null, 2)}
+                </pre>
+              )}
             </div>
-          )}
+            <div className="rounded-md border border-border bg-muted/20 p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
+                Actual
+              </p>
+              {exception.evidence.actual === null || exception.evidence.actual === undefined ? (
+                <p className="text-xs text-muted-foreground italic">No actual value</p>
+              ) : (
+                <pre className="text-xs whitespace-pre-wrap break-words text-foreground">
+                  {typeof exception.evidence.actual === "string"
+                    ? exception.evidence.actual
+                    : JSON.stringify(exception.evidence.actual, null, 2)}
+                </pre>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Operator actions ── */}
+      <ActionBar exception={exception} onActionComplete={handleActionComplete} />
+
+      {/* ── Review history ── */}
+      {exception.reviewedBy && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Review Record</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-1">
+            <p>
+              Reviewed by{" "}
+              <span className="font-medium text-foreground">{exception.reviewedBy}</span>
+              {exception.reviewedAt ? ` on ${new Date(exception.reviewedAt).toLocaleString()}` : ""}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Raw metadata (collapsible, bounded) ── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Diagnostic Metadata</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CollapsibleJson label="Full metadata payload" value={exception.metadata} />
         </CardContent>
       </Card>
     </div>

--- a/packages/web/src/app/api/admin/exceptions/[id]/route.ts
+++ b/packages/web/src/app/api/admin/exceptions/[id]/route.ts
@@ -1,0 +1,180 @@
+/**
+ * Admin Exception Detail API
+ *
+ * GET /api/admin/exceptions/[id] – Returns full detail for a single exception.
+ * Requires super admin access.
+ * Replaces the previous anti-pattern of fetching up to 1000 exceptions and
+ * filtering client-side on the admin detail page.
+ */
+
+// ROUTE_CLASS: admin-internal
+// AUTH: session + superAdmin
+
+import { NextRequest, NextResponse } from "next/server";
+import { isSuperAdmin } from "@/lib/auth/super-admin";
+import { prisma } from "@/shared/db/prismaClient";
+import { adminLogger } from "@/lib/admin/utils/logger";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const ExceptionIdParamSchema = z.string().uuid("Exception ID must be a valid UUID");
+
+function deriveStatus(
+  acknowledged: boolean,
+  metadata: Record<string, unknown>
+): "new" | "in_review" | "resolved" {
+  const resolution = metadata.resolution;
+  if (resolution && typeof resolution === "object" && !Array.isArray(resolution)) {
+    const resolutionStatus = (resolution as Record<string, unknown>).status;
+    if (resolutionStatus === "resolved" || resolutionStatus === "ignored") {
+      return "resolved";
+    }
+  }
+  if (acknowledged) {
+    return "in_review";
+  }
+  return "new";
+}
+
+/**
+ * GET /api/admin/exceptions/[id]
+ * Returns full provenance detail for a single exception.
+ */
+export const GET = withSecurity(
+  async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    try {
+      const adminCheck = await isSuperAdmin();
+      if (!adminCheck) {
+        return NextResponse.json(
+          { error: "Forbidden", message: "Super admin access required" },
+          { status: 403 }
+        );
+      }
+
+      const { id } = await params;
+      const parsedId = ExceptionIdParamSchema.safeParse(id);
+      if (!parsedId.success) {
+        return NextResponse.json(
+          {
+            error: "Invalid exception ID",
+            message: "Exception ID must be a valid UUID",
+            details: parsedId.error.issues,
+          },
+          { status: 400 }
+        );
+      }
+
+      const exception = await prisma.driftEvent.findUnique({
+        where: { id: parsedId.data },
+        select: {
+          id: true,
+          tenantId: true,
+          driftType: true,
+          severity: true,
+          acknowledged: true,
+          acknowledgedBy: true,
+          acknowledgedAt: true,
+          createdAt: true,
+          updatedAt: true,
+          reconJobId: true,
+          fieldPath: true,
+          expectedValue: true,
+          actualValue: true,
+          driftMetrics: true,
+          metadata: true,
+        },
+      });
+
+      if (!exception) {
+        return NextResponse.json(
+          {
+            error: "Not found",
+            message: "This exception no longer exists or you do not have access",
+          },
+          { status: 404 }
+        );
+      }
+
+      const metadata = (exception.metadata as Record<string, unknown>) || {};
+      const driftMetrics = (exception.driftMetrics as Record<string, unknown>) || {};
+
+      const status = deriveStatus(exception.acknowledged, metadata);
+
+      // Extract best available provenance from metadata fields
+      const provenance = {
+        runId: exception.reconJobId || null,
+        fieldPath: exception.fieldPath || null,
+        ruleId:
+          (metadata.ruleId as string | undefined) ??
+          (metadata.rule_id as string | undefined) ??
+          null,
+        detectorId:
+          (metadata.detectorId as string | undefined) ??
+          (metadata.detector_id as string | undefined) ??
+          null,
+        sourceAdapter:
+          (metadata.sourceAdapter as string | undefined) ??
+          (metadata.sourceSystem as string | undefined) ??
+          null,
+        targetAdapter:
+          (metadata.targetAdapter as string | undefined) ??
+          (metadata.targetSystem as string | undefined) ??
+          null,
+        sourceTransactionId: (metadata.sourceTransactionId as string | undefined) ?? null,
+        targetTransactionId: (metadata.targetTransactionId as string | undefined) ?? null,
+        ingestionId: (metadata.ingestionId as string | undefined) ?? null,
+        matchReason:
+          (metadata.matchReason as string | undefined) ??
+          (driftMetrics.matchReason as string | undefined) ??
+          null,
+        confidenceScore:
+          typeof driftMetrics.confidenceScore === "number"
+            ? (driftMetrics.confidenceScore as number)
+            : typeof metadata.confidenceScore === "number"
+              ? (metadata.confidenceScore as number)
+              : null,
+      };
+
+      const reviewedAt = exception.acknowledgedAt?.toISOString() ?? null;
+      const updatedAt =
+        (exception.updatedAt as Date | null)?.toISOString() ?? exception.createdAt.toISOString();
+
+      const result = {
+        id: exception.id,
+        tenantId: exception.tenantId,
+        source: exception.driftType || "unknown",
+        severity: (exception.severity || "info") as "info" | "warn" | "critical",
+        status,
+        reason: exception.fieldPath
+          ? `Field mismatch: ${exception.fieldPath}`
+          : exception.driftType || "Drift detected",
+        evidence: {
+          expected: exception.expectedValue ?? null,
+          actual: exception.actualValue ?? null,
+        },
+        provenance,
+        reviewedBy: exception.acknowledgedBy ?? null,
+        reviewedAt,
+        createdAt: exception.createdAt.toISOString(),
+        updatedAt,
+        // Include raw metadata for diagnostics – bounded by collapsibility in UI
+        metadata,
+      };
+
+      return NextResponse.json(result);
+    } catch (error) {
+      adminLogger.error("Failed to retrieve exception detail", error);
+      return NextResponse.json(
+        {
+          error: "Failed to retrieve exception",
+          message: "Please try again later or contact support if the issue persists",
+        },
+        { status: 500 }
+      );
+    }
+  },
+  { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: true }
+);

--- a/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
+++ b/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -9,10 +10,22 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { safeFetch } from "@/lib/safe-fetch";
-import { RefreshCw, CheckCircle2, XCircle, Clock, AlertCircle, Copy } from "lucide-react";
+import {
+  RefreshCw,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  AlertCircle,
+  Copy,
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+} from "lucide-react";
 import Link from "next/link";
 import { useGovernanceState } from "@/hooks/use-governance-state";
 import { FreezeBlockedButton } from "@/components/shared/FreezeBlockedButton";
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
 
 interface ExceptionDetail {
   id: string;
@@ -48,143 +61,334 @@ interface ExceptionDetail {
   }[];
 }
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const severityClasses: Record<ExceptionDetail["severity"], string> = {
+  critical: "bg-red-100 text-red-700 border border-red-300 dark:bg-red-900 dark:text-red-300",
+  high: "bg-orange-100 text-orange-700 border border-orange-300 dark:bg-orange-900 dark:text-orange-300",
+  medium:
+    "bg-yellow-100 text-yellow-700 border border-yellow-300 dark:bg-yellow-900 dark:text-yellow-300",
+  low: "bg-green-100 text-green-700 border border-green-300 dark:bg-green-900 dark:text-green-300",
+};
+
+const severityLabel: Record<ExceptionDetail["severity"], string> = {
+  critical: "CRITICAL",
+  high: "HIGH",
+  medium: "MEDIUM",
+  low: "LOW",
+};
+
+const statusClasses: Record<ExceptionDetail["status"], string> = {
+  resolved: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+  ignored: "bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground",
+  investigating: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+  pending: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300",
+};
+
+const statusIcon: Record<ExceptionDetail["status"], typeof Clock> = {
+  resolved: CheckCircle2,
+  ignored: XCircle,
+  investigating: RefreshCw,
+  pending: Clock,
+};
+
+// ─── Small components ─────────────────────────────────────────────────────────
+
+function SeverityBadge({ severity }: { severity: ExceptionDetail["severity"] }) {
+  return (
+    <Badge className={`font-mono text-xs px-3 py-1 ${severityClasses[severity]}`}>
+      {severityLabel[severity]}
+    </Badge>
+  );
+}
+
+function StatusBadge({ status }: { status: ExceptionDetail["status"] }) {
+  const Icon = statusIcon[status];
+  return (
+    <Badge className={`gap-1 ${statusClasses[status]}`}>
+      <Icon className="w-3 h-3" />
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </Badge>
+  );
+}
+
+function CopyableId({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="font-mono text-xs break-all text-foreground dark:text-muted-foreground">
+        {value}
+      </span>
+      <button
+        type="button"
+        onClick={() => navigator.clipboard.writeText(value)}
+        className="shrink-0 p-0.5 rounded hover:bg-muted/60 text-muted-foreground hover:text-foreground"
+        title={`Copy ${label}`}
+      >
+        <Copy className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}
+
+function CollapsibleJson({ label, value }: { label: string; value: unknown }) {
+  const [open, setOpen] = useState(false);
+
+  const isEmpty =
+    value === null ||
+    value === undefined ||
+    (typeof value === "object" && Object.keys(value as object).length === 0);
+
+  if (isEmpty) {
+    return (
+      <p className="text-xs text-muted-foreground italic">
+        {label}: <span className="not-italic">empty</span>
+      </p>
+    );
+  }
+
+  const json = (() => {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  })();
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+      >
+        {open ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        {label}
+      </button>
+      {open && (
+        <div className="relative mt-2">
+          <button
+            type="button"
+            onClick={() => navigator.clipboard.writeText(json)}
+            className="absolute top-2 right-2 text-xs text-muted-foreground hover:text-foreground bg-muted/60 rounded px-1.5 py-0.5"
+          >
+            Copy
+          </button>
+          <pre className="text-xs bg-muted/40 dark:bg-background/60 p-3 rounded overflow-auto max-h-64 border border-border">
+            {json}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Data fetching ─────────────────────────────────────────────────────────────
+
+async function fetchExceptionDetail(exceptionId: string): Promise<ExceptionDetail> {
+  const result = await safeFetch<{ exception?: ExceptionDetail } | ExceptionDetail>(
+    `/api/exceptions/${exceptionId}`
+  );
+
+  if (!result.success || !result.data) {
+    throw new Error(result.error?.message || "Failed to load exception detail");
+  }
+
+  const payload = result.data;
+  const detail: ExceptionDetail | null =
+    payload && typeof payload === "object" && "exception" in payload
+      ? ((payload.exception ?? null) as ExceptionDetail | null)
+      : (payload as ExceptionDetail);
+
+  if (!detail) {
+    throw new Error("Exception not found");
+  }
+
+  return detail;
+}
+
+// ─── Action helpers ────────────────────────────────────────────────────────────
+
+type ExceptionAction = "resolve" | "ignore" | "reopen";
+
+async function performExceptionAction(
+  exceptionId: string,
+  action: ExceptionAction
+): Promise<{ success: boolean; message?: string }> {
+  const result = await safeFetch<{ success: boolean; message?: string }>(
+    `/api/exceptions/${exceptionId}?action=${action}`,
+    { method: "POST" }
+  );
+
+  if (!result.success) {
+    return {
+      success: false,
+      message: result.error?.message || `Failed to ${action} exception`,
+    };
+  }
+
+  return { success: true };
+}
+
+// ─── Action bar ────────────────────────────────────────────────────────────────
+
+function ActionBar({
+  exception,
+  isFrozen,
+  freezeReason,
+  onActionComplete,
+}: {
+  exception: ExceptionDetail;
+  isFrozen: boolean;
+  freezeReason?: string;
+  onActionComplete: () => void;
+}) {
+  const [pending, setPending] = useState<ExceptionAction | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const execute = async (action: ExceptionAction) => {
+    setPending(action);
+    setActionError(null);
+
+    const result = await performExceptionAction(exception.id, action);
+    setPending(null);
+
+    if (!result.success) {
+      setActionError(result.message || `Failed to ${action} exception`);
+    } else {
+      onActionComplete();
+    }
+  };
+
+  const isActive = exception.status === "pending" || exception.status === "investigating";
+  const isTerminal = exception.status === "resolved" || exception.status === "ignored";
+
+  return (
+    <div className="space-y-3">
+      {actionError && (
+        <div className="rounded-md bg-red-50 dark:bg-red-950 border border-red-300 dark:border-red-700 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+          {actionError}
+        </div>
+      )}
+
+      {isActive && (
+        <div className="flex flex-wrap gap-3">
+          <FreezeBlockedButton
+            onClick={() => void execute("resolve")}
+            className="bg-green-600 hover:bg-green-700 disabled:opacity-50"
+            isFrozen={isFrozen}
+            freezeReason={freezeReason}
+            frozenMessage="Exception resolution blocked by tenant freeze"
+            disabled={pending !== null}
+          >
+            <CheckCircle2 className="mr-2 w-4 h-4" />
+            {pending === "resolve" ? "Marking resolved…" : "Mark Resolved"}
+          </FreezeBlockedButton>
+
+          <FreezeBlockedButton
+            onClick={() => void execute("ignore")}
+            className="bg-slate-600 hover:bg-muted disabled:opacity-50"
+            isFrozen={isFrozen}
+            freezeReason={freezeReason}
+            frozenMessage="Ignoring exceptions is blocked by tenant freeze"
+            disabled={pending !== null}
+          >
+            <XCircle className="mr-2 w-4 h-4" />
+            {pending === "ignore" ? "Ignoring…" : "Ignore Exception"}
+          </FreezeBlockedButton>
+        </div>
+      )}
+
+      {isTerminal && (
+        <div className="flex flex-wrap gap-3">
+          <FreezeBlockedButton
+            onClick={() => void execute("reopen")}
+            className="bg-yellow-600 hover:bg-yellow-700 disabled:opacity-50"
+            isFrozen={isFrozen}
+            freezeReason={freezeReason}
+            frozenMessage="Reopening exceptions is blocked by tenant freeze"
+            disabled={pending !== null}
+          >
+            <AlertCircle className="mr-2 w-4 h-4" />
+            {pending === "reopen" ? "Reopening…" : "Reopen Exception"}
+          </FreezeBlockedButton>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main page ─────────────────────────────────────────────────────────────────
+
 export default function ExceptionDetailPage() {
   const params = useParams();
   const exceptionId =
     params && typeof params.exceptionId === "string" ? params.exceptionId : undefined;
-  const [exception, setException] = useState<ExceptionDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+
+  const queryClient = useQueryClient();
   const { isFrozen, governanceState } = useGovernanceState();
 
-  useEffect(() => {
-    if (!exceptionId) {
-      setError("Missing exception ID");
-      setLoading(false);
-      return;
-    }
+  const {
+    data: exception,
+    isLoading,
+    error,
+    refetch,
+    isFetching,
+  } = useQuery<ExceptionDetail, Error>({
+    queryKey: ["exception", exceptionId],
+    queryFn: () => fetchExceptionDetail(exceptionId!),
+    enabled: !!exceptionId,
+    staleTime: 20 * 1000,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return false;
+      return data.status === "pending" || data.status === "investigating" ? 15_000 : false;
+    },
+    retry: (failureCount, err) => {
+      if (err.message === "Exception not found") return false;
+      return failureCount < 2;
+    },
+  });
 
-    loadExceptionDetail();
+  const handleActionComplete = () => {
+    void queryClient.invalidateQueries({ queryKey: ["exception", exceptionId] });
+    void refetch();
+  };
 
-    // Poll for updates if exception is still active
-    if (exception?.status === "pending" || exception?.status === "investigating") {
-      const interval = setInterval(loadExceptionDetail, 15000); // Poll every 15 seconds
-      return () => clearInterval(interval);
-    }
-    return undefined;
-  }, [exceptionId, exception?.status]);
-
-  const loadExceptionDetail = async () => {
-    if (!exceptionId) {
-      return;
-    }
-
-    setLoading(true);
-    const result = await safeFetch<{ exception?: ExceptionDetail } | ExceptionDetail>(
-      `/api/exceptions/${exceptionId}`
+  if (!exceptionId) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          title="Invalid exception URL"
+          description="No exception ID was found in this URL."
+          action={{
+            label: "Go to Exceptions List",
+            onClick: () => (window.location.href = "/console/exceptions"),
+          }}
+        />
+      </div>
     );
+  }
 
-    if (result.success && result.data) {
-      const payload = result.data;
-      const nextException: ExceptionDetail | null =
-        payload && typeof payload === "object" && "exception" in payload
-          ? (payload.exception ?? null)
-          : (payload as ExceptionDetail);
-      setException(nextException);
-      setError(null);
-    } else {
-      setError(result.error?.message || "Failed to load exception detail");
-      setException(null);
-    }
-    setLoading(false);
-  };
-
-  const handleResolve = async () => {
-    const result = await safeFetch(`/api/exceptions/${exceptionId}?action=resolve`, {
-      method: "POST",
-    });
-
-    if (result.success) {
-      await loadExceptionDetail();
-    } else {
-      alert(result.error?.message || "Failed to resolve exception");
-    }
-  };
-
-  const handleIgnore = async () => {
-    if (
-      window.confirm(
-        "Are you sure you want to ignore this exception? This action cannot be undone."
-      )
-    ) {
-      const result = await safeFetch(`/api/exceptions/${exceptionId}?action=ignore`, {
-        method: "POST",
-      });
-
-      if (result.success) {
-        await loadExceptionDetail();
-      } else {
-        alert(result.error?.message || "Failed to ignore exception");
-      }
-    }
-  };
-
-  const handleReopen = async () => {
-    const result = await safeFetch(`/api/exceptions/${exceptionId}?action=reopen`, {
-      method: "POST",
-    });
-
-    if (result.success) {
-      await loadExceptionDetail();
-    } else {
-      alert(result.error?.message || "Failed to reopen exception");
-    }
-  };
-
-  const getStatusIcon = (status: ExceptionDetail["status"]) => {
-    switch (status) {
-      case "resolved":
-        return CheckCircle2;
-      case "ignored":
-        return XCircle;
-      case "investigating":
-        return RefreshCw;
-      default:
-        return Clock;
-    }
-  };
-
-  const getStatusColor = (status: ExceptionDetail["status"]) => {
-    switch (status) {
-      case "resolved":
-        return "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300";
-      case "ignored":
-        return "bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground";
-      case "investigating":
-        return "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300";
-      default:
-        return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300";
-    }
-  };
-
-  const getSeverityColor = (severity: ExceptionDetail["severity"]) => {
-    switch (severity) {
-      case "critical":
-        return "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300";
-      case "high":
-        return "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300";
-      case "medium":
-        return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300";
-      default:
-        return "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300";
-    }
-  };
-
-  if (loading && !exception) {
+  if (isLoading) {
     return (
       <div className="p-6 space-y-6">
         <Skeleton className="h-12 w-64" />
         <Skeleton className="h-64" />
+      </div>
+    );
+  }
+
+  if (error?.message === "Exception not found") {
+    return (
+      <div className="p-6">
+        <EmptyState
+          title="Exception not found"
+          description="This exception no longer exists or you do not have access."
+          action={{
+            label: "Go to Exceptions List",
+            onClick: () => (window.location.href = "/console/exceptions"),
+          }}
+        />
       </div>
     );
   }
@@ -194,8 +398,8 @@ export default function ExceptionDetailPage() {
       <div className="p-6">
         <ErrorState
           title="Failed to load exception"
-          message={error}
-          onRetry={loadExceptionDetail}
+          message={error.message}
+          onRetry={() => void refetch()}
         />
       </div>
     );
@@ -206,7 +410,7 @@ export default function ExceptionDetailPage() {
       <div className="p-6">
         <EmptyState
           title="Exception not found"
-          description="The exception you're looking for doesn't exist or you don't have access"
+          description="This exception no longer exists or you do not have access."
           action={{
             label: "Go to Exceptions List",
             onClick: () => (window.location.href = "/console/exceptions"),
@@ -216,189 +420,202 @@ export default function ExceptionDetailPage() {
     );
   }
 
-  const StatusIcon = getStatusIcon(exception.status);
-
   return (
     <div className="p-6 space-y-6">
-      <div className="flex items-center justify-between">
+      {/* ── Header ── */}
+      <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold text-foreground dark:text-white">Exception Detail</h1>
-          <p className="text-muted-foreground dark:text-muted-foreground mt-1">
-            Exception ID:{" "}
-            <code className="bg-muted/40 dark:bg-card px-2 py-1 rounded">{exception.id}</code>
+          <div className="flex items-center gap-3 flex-wrap mb-2">
+            <SeverityBadge severity={exception.severity} />
+            <StatusBadge status={exception.status} />
+            {exception.confidenceScore !== undefined && (
+              <Badge className="bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground">
+                Confidence: {Math.round(exception.confidenceScore * 100)}%
+              </Badge>
+            )}
+          </div>
+          <h1 className="text-2xl font-bold text-foreground dark:text-white">
+            {exception.description}
+          </h1>
+          <p className="text-xs text-muted-foreground mt-1">
+            ID:{" "}
+            <code className="bg-muted/40 dark:bg-card px-1.5 py-0.5 rounded font-mono">
+              {exception.id}
+            </code>
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={loadExceptionDetail}>
-            <RefreshCw className={`w-4 h-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+        <div className="flex items-center gap-2 shrink-0">
+          <Button variant="outline" size="sm" onClick={() => void refetch()} disabled={isFetching}>
+            <RefreshCw className={`w-4 h-4 mr-2 ${isFetching ? "animate-spin" : ""}`} />
             Refresh
           </Button>
           <Link
             href="/console/exceptions"
-            className="text-sm text-muted-foreground dark:text-muted-foreground hover:underline"
+            className="text-sm text-muted-foreground hover:underline"
           >
             ← Back to List
           </Link>
         </div>
       </div>
 
-      {/* Status and Severity Badges */}
-      <div className="flex items-center gap-4 mb-6">
-        <Badge className={getStatusColor(exception.status)}>
-          <StatusIcon className="w-4 h-4 mr-1" />
-          {exception.status.charAt(0).toUpperCase() + exception.status.slice(1)}
-        </Badge>
-        <Badge className={getSeverityColor(exception.severity)}>
-          {exception.severity.charAt(0).toUpperCase() + exception.severity.slice(1)}
-        </Badge>
-        {exception.confidenceScore !== undefined && (
-          <Badge className="bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground">
-            Confidence: {Math.round(exception.confidenceScore * 100)}%
-          </Badge>
-        )}
-      </div>
+      {/* ── Status detail banner ── */}
+      {exception.statusDetail && (
+        <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm text-foreground dark:border-border dark:bg-background/60 dark:text-muted-foreground">
+          {exception.statusDetail}
+        </div>
+      )}
 
-      {/* Exception Info Card */}
+      {/* ── Summary strip ── */}
       <Card>
-        <CardHeader>
-          <CardTitle>Exception Information</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {exception.statusDetail && (
-              <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm text-foreground dark:border-border dark:bg-background/60 dark:text-muted-foreground">
-                {exception.statusDetail}
+        <CardContent className="py-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-sm">
+            <div>
+              <span className="text-xs text-muted-foreground block">Type</span>
+              <span className="font-medium font-mono">
+                {exception.type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+              </span>
+            </div>
+            {exception.amount !== undefined && exception.currency && (
+              <div>
+                <span className="text-xs text-muted-foreground block">Amount</span>
+                <span className="font-medium font-mono">
+                  {exception.currency} {exception.amount.toLocaleString()}
+                </span>
               </div>
             )}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <span className="text-xs text-muted-foreground block">Detected</span>
+              <span>{new Date(exception.detectedAt).toLocaleString()}</span>
+            </div>
+            {exception.fieldPath && (
               <div>
-                <h3 className="font-medium text-foreground dark:text-white">Type</h3>
-                <p className="text-muted-foreground dark:text-muted-foreground">
-                  {exception.type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
-                </p>
+                <span className="text-xs text-muted-foreground block">Field</span>
+                <span className="font-mono text-xs">{exception.fieldPath}</span>
               </div>
-              {exception.reasonTags && exception.reasonTags.length > 0 && (
-                <div>
-                  <h3 className="font-medium text-foreground dark:text-white">Decision Drivers</h3>
-                  <div className="mt-1 flex flex-wrap gap-1.5">
-                    {exception.reasonTags.map((tag) => (
-                      <Badge key={`${exception.id}-${tag}`} variant="outline">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Provenance / lineage ── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Provenance &amp; Origin</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-0">
+            {/* Run link */}
+            <div className="flex items-start gap-2 py-1.5 border-b border-border">
+              <span className="text-xs text-muted-foreground w-40 shrink-0">
+                Reconciliation run
+              </span>
+              {exception.runId ? (
+                <Link
+                  href={`/console/runs/${exception.runId}`}
+                  className="flex items-center gap-1 text-xs text-blue-600 hover:underline dark:text-blue-400 font-mono"
+                >
+                  {exception.runId}
+                  <ExternalLink className="w-3 h-3" />
+                </Link>
+              ) : (
+                <span className="text-xs text-muted-foreground italic">unavailable</span>
               )}
-              <div>
-                <h3 className="font-medium text-foreground dark:text-white">Description</h3>
-                <p className="text-muted-foreground dark:text-muted-foreground">{exception.description}</p>
-              </div>
-              <div>
-                <h3 className="font-medium text-foreground dark:text-white">Detected</h3>
-                <p className="text-muted-foreground dark:text-muted-foreground">
-                  {new Date(exception.detectedAt).toLocaleString()}
-                </p>
-              </div>
-              {exception.runId && (
-                <div>
-                  <h3 className="font-medium text-foreground dark:text-white">Run</h3>
-                  <Link
-                    href={`/console/runs/${exception.runId}`}
-                    className="text-sm text-blue-600 hover:underline dark:text-blue-400"
-                  >
-                    {exception.runId}
-                  </Link>
-                </div>
+            </div>
+
+            {/* Source system */}
+            <div className="flex items-start gap-2 py-1.5 border-b border-border">
+              <span className="text-xs text-muted-foreground w-40 shrink-0">Source system</span>
+              {exception.sourceSystem ? (
+                <span className="text-xs text-foreground">{exception.sourceSystem}</span>
+              ) : (
+                <span className="text-xs text-muted-foreground italic">unavailable</span>
               )}
-              {exception.fieldPath && (
-                <div>
-                  <h3 className="font-medium text-foreground dark:text-white">Field</h3>
-                  <p className="text-muted-foreground dark:text-muted-foreground font-mono">
-                    {exception.fieldPath}
-                  </p>
-                </div>
+            </div>
+
+            {/* Target system */}
+            <div className="flex items-start gap-2 py-1.5 border-b border-border">
+              <span className="text-xs text-muted-foreground w-40 shrink-0">Target system</span>
+              {exception.targetSystem ? (
+                <span className="text-xs text-foreground">{exception.targetSystem}</span>
+              ) : (
+                <span className="text-xs text-muted-foreground italic">unavailable</span>
               )}
-              {exception.amount && exception.currency && (
-                <div>
-                  <h3 className="font-medium text-foreground dark:text-white">Amount</h3>
-                  <p className="text-muted-foreground dark:text-muted-foreground font-mono">
-                    {exception.currency} {exception.amount.toLocaleString()}
-                  </p>
-                </div>
+            </div>
+
+            {/* Source transaction */}
+            <div className="flex items-start gap-2 py-1.5 border-b border-border">
+              <span className="text-xs text-muted-foreground w-40 shrink-0">
+                Source transaction
+              </span>
+              {exception.sourceTransactionId ? (
+                <CopyableId value={exception.sourceTransactionId} label="source transaction ID" />
+              ) : (
+                <span className="text-xs text-muted-foreground italic">
+                  No source transaction attached
+                </span>
               )}
-              {exception.sourceTransactionId && (
-                <div>
-                  <h3 className="font-medium text-foreground dark:text-white">Source Transaction</h3>
-                  <p className="text-muted-foreground dark:text-muted-foreground font-mono">
-                    {exception.sourceTransactionId}
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        navigator.clipboard.writeText(exception.sourceTransactionId || "")
-                      }
-                      title="Copy to clipboard"
-                    >
-                      <Copy className="w-3 h-3 ml-1" />
-                    </Button>
-                  </p>
-                </div>
-              )}
-              {exception.targetTransactionId && (
-                <div>
-                  <h3 className="font-medium text-foreground dark:text-white">Target Transaction</h3>
-                  <p className="text-muted-foreground dark:text-muted-foreground font-mono">
-                    {exception.targetTransactionId}
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        navigator.clipboard.writeText(exception.targetTransactionId || "")
-                      }
-                      title="Copy to clipboard"
-                    >
-                      <Copy className="w-3 h-3 ml-1" />
-                    </Button>
-                  </p>
-                </div>
-              )}
-              {exception.sourceSystem && (
-                <div>
-                  <h3 className="font-medium text-foreground dark:text-white">Source System</h3>
-                  <p className="text-muted-foreground dark:text-muted-foreground">{exception.sourceSystem}</p>
-                </div>
-              )}
-              {exception.targetSystem && (
-                <div>
-                  <h3 className="font-medium text-foreground dark:text-white">Target System</h3>
-                  <p className="text-muted-foreground dark:text-muted-foreground">{exception.targetSystem}</p>
-                </div>
+            </div>
+
+            {/* Target transaction */}
+            <div className="flex items-start gap-2 py-1.5">
+              <span className="text-xs text-muted-foreground w-40 shrink-0">
+                Target transaction
+              </span>
+              {exception.targetTransactionId ? (
+                <CopyableId value={exception.targetTransactionId} label="target transaction ID" />
+              ) : (
+                <span className="text-xs text-muted-foreground italic">
+                  No target transaction attached
+                </span>
               )}
             </div>
           </div>
         </CardContent>
       </Card>
 
+      {/* ── Decision drivers (reason tags) ── */}
+      {exception.reasonTags && exception.reasonTags.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Decision Drivers</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-1.5">
+              {exception.reasonTags.map((tag) => (
+                <Badge
+                  key={`${exception.id}-${tag}`}
+                  variant="outline"
+                  className="font-mono text-xs"
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Evidence comparison ── */}
       {(exception.expectedValue !== undefined || exception.actualValue !== undefined) && (
         <Card>
           <CardHeader>
-            <CardTitle>Observed Difference</CardTitle>
+            <CardTitle className="text-base">Observed Difference</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="grid gap-4 md:grid-cols-2">
               <div className="rounded-lg border border-border bg-muted/20 p-4 dark:border-border dark:bg-background/60">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground dark:text-muted-foreground">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
                   Expected
                 </p>
-                <pre className="mt-2 whitespace-pre-wrap break-words text-sm text-foreground dark:text-muted-foreground">
+                <pre className="whitespace-pre-wrap break-words text-sm text-foreground dark:text-muted-foreground">
                   {JSON.stringify(exception.expectedValue ?? null, null, 2)}
                 </pre>
               </div>
               <div className="rounded-lg border border-border bg-muted/20 p-4 dark:border-border dark:bg-background/60">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground dark:text-muted-foreground">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
                   Actual
                 </p>
-                <pre className="mt-2 whitespace-pre-wrap break-words text-sm text-foreground dark:text-muted-foreground">
+                <pre className="whitespace-pre-wrap break-words text-sm text-foreground dark:text-muted-foreground">
                   {JSON.stringify(exception.actualValue ?? null, null, 2)}
                 </pre>
               </div>
@@ -407,12 +624,50 @@ export default function ExceptionDetailPage() {
         </Card>
       )}
 
+      {/* ── Suggested next steps ── */}
+      {exception.suggestedActions && exception.suggestedActions.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Suggested Next Steps</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {exception.suggestedActions.map((action, index) => (
+                <li
+                  key={index}
+                  className="flex items-start gap-2 text-sm text-muted-foreground dark:text-muted-foreground"
+                >
+                  <span className="text-muted-foreground mt-0.5 shrink-0">•</span>
+                  {action}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Operator action bar ── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Operator Actions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ActionBar
+            exception={exception}
+            isFrozen={isFrozen}
+            freezeReason={governanceState?.freeze_reason}
+            onActionComplete={handleActionComplete}
+          />
+        </CardContent>
+      </Card>
+
+      {/* ── Decision record ── */}
       {(exception.resolution || exception.resolvedAt || exception.ignoredAt) && (
         <Card>
           <CardHeader>
-            <CardTitle>Decision Record</CardTitle>
+            <CardTitle className="text-base">Decision Record</CardTitle>
           </CardHeader>
-          <CardContent className="space-y-2 text-sm text-muted-foreground dark:text-muted-foreground">
+          <CardContent className="space-y-1.5 text-sm text-muted-foreground dark:text-muted-foreground">
             {exception.resolution && <p>{exception.resolution}</p>}
             {exception.resolvedAt && (
               <p>Resolved at {new Date(exception.resolvedAt).toLocaleString()}</p>
@@ -427,91 +682,37 @@ export default function ExceptionDetailPage() {
         </Card>
       )}
 
-      {exception.suggestedActions?.length ? (
-        <Card>
-          <CardHeader>
-            <CardTitle>Suggested Actions</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="list-disc list-inside space-y-2 text-muted-foreground dark:text-muted-foreground">
-              {exception.suggestedActions.map((action, index) => (
-                <li key={index}>{action}</li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {/* Playbook Applied */}
+      {/* ── Applied playbook ── */}
       {exception.playbookApplied && (
         <Card>
           <CardHeader>
-            <CardTitle>Applied Playbook</CardTitle>
+            <CardTitle className="text-base">Applied Playbook</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-muted-foreground dark:text-muted-foreground">{exception.playbookApplied}</p>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground">
+              {exception.playbookApplied}
+            </p>
           </CardContent>
         </Card>
       )}
 
-      {/* Action Buttons */}
-      {(exception.status === "pending" || exception.status === "investigating") && (
-        <div className="flex flex-wrap gap-4">
-          <FreezeBlockedButton
-            onClick={handleResolve}
-            className="bg-green-600 hover:bg-green-700"
-            isFrozen={isFrozen}
-            freezeReason={governanceState?.freeze_reason}
-            frozenMessage="Exception resolution blocked by tenant freeze"
-          >
-            <CheckCircle2 className="mr-2" />
-            Mark Resolved
-          </FreezeBlockedButton>
-          <FreezeBlockedButton
-            onClick={handleIgnore}
-            className="bg-slate-600 hover:bg-muted"
-            isFrozen={isFrozen}
-            freezeReason={governanceState?.freeze_reason}
-            frozenMessage="Ignoring exceptions is blocked by tenant freeze"
-          >
-            <XCircle className="mr-2" />
-            Ignore Exception
-          </FreezeBlockedButton>
-        </div>
-      )}
-
-      {(exception.status === "resolved" || exception.status === "ignored") && (
-        <div className="flex flex-wrap gap-4">
-          <FreezeBlockedButton
-            onClick={handleReopen}
-            className="bg-yellow-600 hover:bg-yellow-700"
-            isFrozen={isFrozen}
-            freezeReason={governanceState?.freeze_reason}
-            frozenMessage="Reopening exceptions is blocked by tenant freeze"
-          >
-            <AlertCircle className="mr-2" />
-            Reopen Exception
-          </FreezeBlockedButton>
-        </div>
-      )}
-
-      {/* Audit Trail */}
+      {/* ── Audit trail ── */}
       {exception.auditTrail.length > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle>Audit Trail</CardTitle>
+            <CardTitle className="text-base">Activity &amp; Audit Trail</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
               {exception.auditTrail.map((entry, index) => (
                 <div key={index} className="border-l-2 border-border dark:border-border pl-4">
                   <div className="flex items-start gap-3">
-                    <div className="flex-shrink-0 text-xs text-muted-foreground dark:text-muted-foreground">
-                      {new Date(entry.timestamp).toLocaleTimeString()}
+                    <div className="shrink-0 text-xs text-muted-foreground dark:text-muted-foreground">
+                      {new Date(entry.timestamp).toLocaleString()}
                     </div>
                     <div className="flex-1">
-                      <div className="flex items-start gap-2">
-                        <span className="font-medium text-foreground dark:text-white">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-sm text-foreground dark:text-white">
                           {entry.action}
                         </span>
                         <span className="text-xs text-muted-foreground dark:text-muted-foreground">
@@ -519,13 +720,28 @@ export default function ExceptionDetailPage() {
                         </span>
                       </div>
                       {entry.details && (
-                        <p className="text-muted-foreground dark:text-muted-foreground mt-1">{entry.details}</p>
+                        <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-0.5">
+                          {entry.details}
+                        </p>
                       )}
                     </div>
                   </div>
                 </div>
               ))}
             </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Raw evidence (collapsible) ── */}
+      {(exception.expectedValue !== undefined || exception.actualValue !== undefined) && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Evidence Payload</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <CollapsibleJson label="Expected value (raw)" value={exception.expectedValue ?? null} />
+            <CollapsibleJson label="Actual value (raw)" value={exception.actualValue ?? null} />
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
Root causes closed:
- Admin detail page was fetching up to 1000 exceptions and filtering
  client-side to find one. Replaced with a dedicated
  GET /api/admin/exceptions/[id] route using findUnique.
- Mock AI recommendation import removed from admin detail page.
- Console detail page used alert() for action errors and had no
  pending state on buttons while actions were in-flight.
- Neither page showed real provenance (run, adapter, rule, field).

Changes:
- NEW: packages/web/src/app/api/admin/exceptions/[id]/route.ts
  Dedicated super-admin GET route. Returns id, tenantId, source,
  severity, status (derived from acknowledged + metadata.resolution),
  evidence, and a provenance block covering runId, fieldPath, ruleId,
  detectorId, sourceAdapter, targetAdapter, transaction IDs, ingestionId,
  matchReason, and confidenceScore. Gracefully nulls missing fields.
  No hard-500: falls through to structured error response.

- MODIFIED: packages/web/src/app/admin/exceptions/[id]/page.tsx
  Full rewrite. Uses useQuery hitting the new dedicated API.
  Severity badge (CRITICAL/WARN/INFO) visible in header.
  Provenance card shows every provenance field with explicit
  "unavailable" label when data is absent. Evidence comparison.
  Action bar wired to /api/admin/exceptions/[id]/resolve.
  Pending state disables buttons while action is in-flight.
  Post-action: invalidates query + refetches. No mock AI.

- MODIFIED: packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
  Replaced useState/useEffect data fetching with useQuery.
  Severity badge (CRITICAL/HIGH/MEDIUM/LOW) in header.
  alert() calls replaced with inline error state in ActionBar.
  Buttons disabled and relabelled while pending.
  Added Provenance & Origin card: run link, source/target system,
  source/target transaction IDs with copy buttons.
  Decision drivers (reason tags) promoted to their own card.
  Audit trail kept; suggested next steps retained.
  Auto-polls on active statuses via refetchInterval.

- NEW: packages/web/src/__tests__/api/admin-exception-detail.test.ts
  17 focused tests covering: 403/400/404/200 paths, findUnique
  invariant, status derivation from all three state combos,
  provenance extraction from metadata, null-field graceful
  degradation, severity/source fallbacks, reviewedBy/reviewedAt.

Verification:
  pnpm test --testPathPattern=admin-exception-detail  → 17/17 pass
  pnpm test --testPathPattern=exceptions-runtime-integrity → 5/5 pass
  pnpm test --testPathPattern=job-exceptions-ownership → 3/3 pass
  pnpm exec eslint [touched files] → 0 errors, 0 warnings

https://claude.ai/code/session_01KyjAf2mtW4JiCXhGXFxzwD