### PR TITLE
feat(exceptions): exception detail workbench — provenance block, richer UI, tests

### DIFF
--- a/packages/web/src/__tests__/api/console-exception-detail.test.ts
+++ b/packages/web/src/__tests__/api/console-exception-detail.test.ts
@@ -1,0 +1,558 @@
+/** @jest-environment node */
+
+/**
+ * Console exception detail API tests.
+ *
+ * Verifies:
+ * - GET returns expected shape including structured provenance block
+ * - 404 returned when exception does not exist
+ * - 400 returned for invalid UUID
+ * - Provenance fields extracted from metadata (ruleId, detectorId, ingestionId, matchReason)
+ * - Missing provenance fields returned as null, not fabricated
+ * - Status derivation: pending / investigating / resolved / ignored
+ * - No list-filter anti-pattern (findFirst with exact ID + tenant scope, not findMany + filter)
+ * - rationale_codes extracted and filtered to string values
+ * - confidenceScore resolved from driftMetrics then metadata fallback
+ * - POST resolve/ignore/reopen actions return success and call correct mutation
+ */
+
+import { GET, POST } from "@/app/api/exceptions/[exceptionId]/route";
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────────
+
+const resolveTenantMembershipScopeMock = jest.fn();
+const resolveTenantForMutationMock = jest.fn();
+const getTraceIdMock = jest.fn();
+const driftEventFindFirstMock = jest.fn();
+const driftEventUpdateMock = jest.fn();
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+jest.mock("@/middleware/billing-gate-universal", () => ({
+  withUniversalBillingGate: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/supabase/tenant-membership", () => {
+  class TenantMembershipError extends Error {
+    status: number;
+    code: string;
+    constructor(status: number, code: string, message: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  }
+
+  return {
+    resolveTenantMembershipScope: (...args: unknown[]) => resolveTenantMembershipScopeMock(...args),
+    resolveTenantForMutation: (...args: unknown[]) => resolveTenantForMutationMock(...args),
+    TenantMembershipError,
+  };
+});
+
+jest.mock("@/lib/observability/trace", () => ({
+  getTraceId: (...args: unknown[]) => getTraceIdMock(...args),
+}));
+
+jest.mock("@/shared/db/prismaClient", () => ({
+  prisma: {
+    driftEvent: {
+      findFirst: (...args: unknown[]) => driftEventFindFirstMock(...args),
+      update: (...args: unknown[]) => driftEventUpdateMock(...args),
+    },
+  },
+}));
+
+jest.mock("@/lib/utils/logger", () => ({
+  appLogger: { error: jest.fn(), info: jest.fn() },
+}));
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+const EXCEPTION_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const TENANT_UUID = "11111111-2222-4333-8444-555555555555";
+const RUN_UUID = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+
+function makeRequest(exceptionId: string, searchParams: Record<string, string> = {}) {
+  const url = new URL(`http://localhost/api/exceptions/${exceptionId}`);
+  for (const [k, v] of Object.entries(searchParams)) {
+    url.searchParams.set(k, v);
+  }
+  return {
+    url: url.toString(),
+    nextUrl: url,
+  } as unknown as import("next/server").NextRequest;
+}
+
+function makePostRequest(exceptionId: string, action: string, body: Record<string, unknown> = {}) {
+  const url = new URL(`http://localhost/api/exceptions/${exceptionId}?action=${action}`);
+  return {
+    url: url.toString(),
+    nextUrl: url,
+    json: () => Promise.resolve(body),
+  } as unknown as import("next/server").NextRequest;
+}
+
+function makeParams(exceptionId: string) {
+  return { params: Promise.resolve({ exceptionId }) };
+}
+
+function makeException(overrides: Record<string, unknown> = {}) {
+  return {
+    id: EXCEPTION_UUID,
+    tenantId: TENANT_UUID,
+    driftType: "amount_mismatch",
+    severity: "high",
+    acknowledged: false,
+    acknowledgedBy: null,
+    acknowledgedAt: null,
+    createdAt: new Date("2026-02-01T09:00:00.000Z"),
+    updatedAt: new Date("2026-02-01T09:00:00.000Z"),
+    reconJobId: RUN_UUID,
+    fieldPath: "amount",
+    expectedValue: "500.00",
+    actualValue: "510.00",
+    driftMetrics: null,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// ─── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resolveTenantMembershipScopeMock.mockReset();
+  resolveTenantForMutationMock.mockReset();
+  getTraceIdMock.mockReset();
+  driftEventFindFirstMock.mockReset();
+  driftEventUpdateMock.mockReset();
+
+  resolveTenantMembershipScopeMock.mockResolvedValue({
+    tenantIds: [TENANT_UUID],
+    userId: "user-test",
+    supabase: {},
+  });
+  resolveTenantForMutationMock.mockReturnValue(TENANT_UUID);
+  getTraceIdMock.mockResolvedValue("trace-test-001");
+});
+
+// ─── GET tests ────────────────────────────────────────────────────────────────
+
+describe("GET /api/exceptions/[exceptionId]", () => {
+  // ── Validation ──────────────────────────────────────────────────────────────
+
+  test("returns 400 for an invalid UUID", async () => {
+    const res = await GET(makeRequest("not-a-uuid"), makeParams("not-a-uuid") as any);
+
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toBe("Invalid exception ID");
+  });
+
+  // ── Not found ───────────────────────────────────────────────────────────────
+
+  test("returns 404 when exception does not exist", async () => {
+    driftEventFindFirstMock.mockResolvedValue(null);
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+
+    expect(res.status).toBe(404);
+    const payload = await res.json();
+    expect(payload.error).toBe("Exception not found");
+  });
+
+  // ── No list-filter anti-pattern ─────────────────────────────────────────────
+
+  test("queries with exact ID + tenantId via findFirst — not a list scan", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException());
+
+    await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+
+    expect(driftEventFindFirstMock).toHaveBeenCalledTimes(1);
+    const callArg = driftEventFindFirstMock.mock.calls[0]?.[0];
+    expect(callArg?.where?.id).toBe(EXCEPTION_UUID);
+    expect(callArg?.where?.tenantId).toBe(TENANT_UUID);
+  });
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  test("returns 200 with core fields for a valid exception", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException());
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+
+    expect(payload.id).toBe(EXCEPTION_UUID);
+    expect(payload.type).toBe("amount_mismatch");
+    expect(payload.severity).toBe("high");
+    expect(payload.status).toBe("pending");
+    expect(payload.runId).toBe(RUN_UUID);
+    expect(payload.trace_id).toBe("trace-test-001");
+  });
+
+  // ── Provenance block present ─────────────────────────────────────────────────
+
+  test("returns a provenance block with all fields declared", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException());
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.provenance).toBeDefined();
+    expect(payload.provenance.runId).toBe(RUN_UUID);
+    expect(payload.provenance.fieldPath).toBe("amount");
+    // These are null when absent — not fabricated
+    expect(payload.provenance.ruleId).toBeNull();
+    expect(payload.provenance.detectorId).toBeNull();
+    expect(payload.provenance.ingestionId).toBeNull();
+    expect(payload.provenance.matchReason).toBeNull();
+    expect(payload.provenance.sourceAdapter).toBeNull();
+    expect(payload.provenance.targetAdapter).toBeNull();
+    expect(payload.provenance.sourceTransactionId).toBeNull();
+    expect(payload.provenance.targetTransactionId).toBeNull();
+    expect(payload.provenance.confidenceScore).toBeNull();
+    expect(payload.provenance.rationale_codes).toBeNull();
+  });
+
+  // ── Provenance extraction from metadata ──────────────────────────────────────
+
+  test("extracts ruleId and detectorId from metadata (camelCase)", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({
+        metadata: {
+          ruleId: "rule_amount_tolerance_v3",
+          detectorId: "detector_007",
+          ingestionId: "ing_abc123",
+          matchReason: "Amount within 2% tolerance threshold",
+          sourceAdapter: "stripe",
+          targetAdapter: "netsuite",
+          sourceTransactionId: "txn_src_999",
+          targetTransactionId: "txn_tgt_888",
+        },
+      })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.provenance.ruleId).toBe("rule_amount_tolerance_v3");
+    expect(payload.provenance.detectorId).toBe("detector_007");
+    expect(payload.provenance.ingestionId).toBe("ing_abc123");
+    expect(payload.provenance.matchReason).toBe("Amount within 2% tolerance threshold");
+    expect(payload.provenance.sourceAdapter).toBe("stripe");
+    expect(payload.provenance.targetAdapter).toBe("netsuite");
+    expect(payload.provenance.sourceTransactionId).toBe("txn_src_999");
+    expect(payload.provenance.targetTransactionId).toBe("txn_tgt_888");
+  });
+
+  test("extracts ruleId from snake_case fallback (rule_id)", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({
+        metadata: {
+          rule_id: "rule_snake_case",
+          detector_id: "det_snake_case",
+        },
+      })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.provenance.ruleId).toBe("rule_snake_case");
+    expect(payload.provenance.detectorId).toBe("det_snake_case");
+  });
+
+  test("extracts matchReason from driftMetrics when not in metadata", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({
+        driftMetrics: { matchReason: "Reason from metrics", confidenceScore: 0.92 },
+        metadata: {},
+      })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.provenance.matchReason).toBe("Reason from metrics");
+    expect(payload.provenance.confidenceScore).toBeCloseTo(0.92);
+  });
+
+  test("extracts confidenceScore from metadata as fallback", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({
+        driftMetrics: null,
+        metadata: { confidenceScore: 0.75 },
+      })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.provenance.confidenceScore).toBeCloseTo(0.75);
+  });
+
+  test("extracts rationale_codes as string array, filtering non-strings", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({
+        metadata: { rationale_codes: ["tolerance_breach", "manual_flag", 42, null, "confirmed"] },
+      })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.provenance.rationale_codes).toEqual([
+      "tolerance_breach",
+      "manual_flag",
+      "confirmed",
+    ]);
+  });
+
+  test("returns rationale_codes as null when absent", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException({ metadata: {} }));
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.provenance.rationale_codes).toBeNull();
+  });
+
+  // ── Status derivation ────────────────────────────────────────────────────────
+
+  test("derives status=pending when acknowledged=false and no resolution", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException({ acknowledged: false, metadata: {} }));
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.status).toBe("pending");
+    expect(payload.exception.status).toBe("pending");
+  });
+
+  test("derives status=investigating when acknowledged=true and no resolution", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({
+        acknowledged: true,
+        acknowledgedBy: "user-x",
+        acknowledgedAt: new Date("2026-02-01T10:00:00.000Z"),
+        metadata: {},
+      })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.status).toBe("investigating");
+  });
+
+  test("derives status=resolved when metadata.resolution.status=resolved", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({
+        acknowledged: true,
+        metadata: {
+          resolution: {
+            status: "resolved",
+            resolvedBy: "user-x",
+            resolvedAt: "2026-02-01T11:00:00.000Z",
+          },
+        },
+      })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.status).toBe("resolved");
+  });
+
+  test("derives status=ignored when metadata.resolution.status=ignored", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({
+        acknowledged: true,
+        metadata: {
+          resolution: {
+            status: "ignored",
+            ignoredBy: "user-y",
+            ignoredAt: "2026-02-01T11:30:00.000Z",
+          },
+        },
+      })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.status).toBe("ignored");
+  });
+
+  // ── Graceful missing data ────────────────────────────────────────────────────
+
+  test("handles null reconJobId — provenance.runId=null, not fabricated", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({ reconJobId: null, fieldPath: null, metadata: {}, driftMetrics: null })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.provenance.runId).toBeNull();
+    expect(payload.provenance.fieldPath).toBeNull();
+    expect(payload.runId).toBeNull();
+  });
+
+  test("handles null expectedValue and actualValue without throwing", async () => {
+    driftEventFindFirstMock.mockResolvedValue(
+      makeException({ expectedValue: null, actualValue: null })
+    );
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.expectedValue).toBeNull();
+    expect(payload.actualValue).toBeNull();
+  });
+
+  test("falls back severity=low when severity is null", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException({ severity: null }));
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.severity).toBe("low");
+  });
+
+  test("falls back type=unknown when driftType is null", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException({ driftType: null }));
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.type).toBe("unknown");
+  });
+
+  // ── Audit trail ─────────────────────────────────────────────────────────────
+
+  test("includes audit trail with system Detected entry", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException());
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.exception.auditTrail).toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "Detected", user: "system" })])
+    );
+  });
+
+  // ── Both response shapes preserved for backward compat ──────────────────────
+
+  test("returns both top-level and exception-nested shapes", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException());
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    // Top-level fields (used by some clients)
+    expect(payload.id).toBe(EXCEPTION_UUID);
+    expect(payload.status).toBeDefined();
+    // Nested exception object
+    expect(payload.exception).toBeDefined();
+    expect(payload.exception.id).toBe(EXCEPTION_UUID);
+    // Provenance at top level
+    expect(payload.provenance).toBeDefined();
+  });
+});
+
+// ─── POST action tests ────────────────────────────────────────────────────────
+
+describe("POST /api/exceptions/[exceptionId] — actions", () => {
+  beforeEach(() => {
+    // For mutations, findFirst is called first (ownership check), then update
+    driftEventFindFirstMock.mockResolvedValue(makeException());
+    driftEventUpdateMock.mockResolvedValue({ id: EXCEPTION_UUID });
+  });
+
+  test("returns 400 for missing or invalid action param", async () => {
+    const url = new URL(`http://localhost/api/exceptions/${EXCEPTION_UUID}`);
+    const req = {
+      url: url.toString(),
+      nextUrl: url,
+      json: () => Promise.resolve({}),
+    } as unknown as import("next/server").NextRequest;
+
+    const res = await POST(req, makeParams(EXCEPTION_UUID) as any);
+
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.success).toBe(false);
+    expect(payload.error).toMatch(/action/i);
+  });
+
+  test("resolve action marks exception acknowledged with resolution.status=resolved", async () => {
+    const res = await POST(
+      makePostRequest(EXCEPTION_UUID, "resolve"),
+      makeParams(EXCEPTION_UUID) as any
+    );
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.success).toBe(true);
+
+    // Verify the update call was made with resolution.status=resolved
+    expect(driftEventUpdateMock).toHaveBeenCalledTimes(1);
+    const updateArg = driftEventUpdateMock.mock.calls[0]?.[0];
+    expect(updateArg?.where?.id).toBe(EXCEPTION_UUID);
+    expect(updateArg?.data?.acknowledged).toBe(true);
+    const metaAfter = updateArg?.data?.metadata as Record<string, unknown>;
+    expect((metaAfter?.resolution as Record<string, unknown>)?.status).toBe("resolved");
+  });
+
+  test("ignore action marks exception acknowledged with resolution.status=ignored", async () => {
+    const res = await POST(
+      makePostRequest(EXCEPTION_UUID, "ignore"),
+      makeParams(EXCEPTION_UUID) as any
+    );
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.success).toBe(true);
+
+    const updateArg = driftEventUpdateMock.mock.calls[0]?.[0];
+    const metaAfter = updateArg?.data?.metadata as Record<string, unknown>;
+    expect((metaAfter?.resolution as Record<string, unknown>)?.status).toBe("ignored");
+  });
+
+  test("reopen action clears acknowledgment and removes resolution", async () => {
+    const res = await POST(
+      makePostRequest(EXCEPTION_UUID, "reopen"),
+      makeParams(EXCEPTION_UUID) as any
+    );
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.success).toBe(true);
+
+    const updateArg = driftEventUpdateMock.mock.calls[0]?.[0];
+    expect(updateArg?.data?.acknowledged).toBe(false);
+    expect(updateArg?.data?.acknowledgedBy).toBeNull();
+    expect(updateArg?.data?.acknowledgedAt).toBeNull();
+    const metaAfter = updateArg?.data?.metadata as Record<string, unknown>;
+    expect(metaAfter?.resolution).toBeNull();
+  });
+
+  test("returns 404 when exception does not exist for action", async () => {
+    driftEventFindFirstMock.mockResolvedValue(null);
+
+    const res = await POST(
+      makePostRequest(EXCEPTION_UUID, "resolve"),
+      makeParams(EXCEPTION_UUID) as any
+    );
+
+    expect(res.status).toBe(404);
+    const payload = await res.json();
+    expect(payload.success).toBe(false);
+  });
+});

--- a/packages/web/src/app/api/exceptions/[exceptionId]/route.ts
+++ b/packages/web/src/app/api/exceptions/[exceptionId]/route.ts
@@ -112,6 +112,7 @@ export const GET = withSecurity(
 
         // Transform to frontend format
         const metadata = (exception.metadata as Record<string, unknown>) || {};
+        const driftMetricsObj = (exception.driftMetrics as Record<string, unknown>) || {};
         const status = getExceptionWorkflowState({
           acknowledged: exception.acknowledged,
           metadata,
@@ -148,6 +149,46 @@ export const GET = withSecurity(
           timestamp: entry.timestamp,
         }));
 
+        // Build structured provenance block — aligned with admin API contract
+        const provenance = {
+          runId: exception.reconJobId || null,
+          fieldPath: exception.fieldPath || null,
+          ruleId:
+            (metadata.ruleId as string | undefined) ??
+            (metadata.rule_id as string | undefined) ??
+            null,
+          detectorId:
+            (metadata.detectorId as string | undefined) ??
+            (metadata.detector_id as string | undefined) ??
+            null,
+          sourceAdapter:
+            (metadata.sourceAdapter as string | undefined) ??
+            (metadata.sourceSystem as string | undefined) ??
+            null,
+          targetAdapter:
+            (metadata.targetAdapter as string | undefined) ??
+            (metadata.targetSystem as string | undefined) ??
+            null,
+          sourceTransactionId: (metadata.sourceTransactionId as string | undefined) ?? null,
+          targetTransactionId: (metadata.targetTransactionId as string | undefined) ?? null,
+          ingestionId: (metadata.ingestionId as string | undefined) ?? null,
+          matchReason:
+            (metadata.matchReason as string | undefined) ??
+            (driftMetricsObj.matchReason as string | undefined) ??
+            null,
+          confidenceScore:
+            typeof driftMetricsObj.confidenceScore === "number"
+              ? (driftMetricsObj.confidenceScore as number)
+              : typeof metadata.confidenceScore === "number"
+                ? (metadata.confidenceScore as number)
+                : null,
+          rationale_codes: Array.isArray(metadata.rationale_codes)
+            ? (metadata.rationale_codes as unknown[]).filter(
+                (c): c is string => typeof c === "string"
+              )
+            : null,
+        };
+
         const result = {
           id: exception.id,
           type: exception.driftType || "unknown",
@@ -168,14 +209,12 @@ export const GET = withSecurity(
           }),
           amount: metadata.amount as number | undefined,
           currency: metadata.currency as string | undefined,
-          sourceTransactionId: metadata.sourceTransactionId as string | undefined,
-          targetTransactionId: metadata.targetTransactionId as string | undefined,
-          sourceSystem:
-            (metadata.sourceSystem as string | undefined) ||
-            (metadata.sourceAdapter as string | undefined),
-          targetSystem:
-            (metadata.targetSystem as string | undefined) ||
-            (metadata.targetAdapter as string | undefined),
+          sourceTransactionId: provenance.sourceTransactionId ?? undefined,
+          targetTransactionId: provenance.targetTransactionId ?? undefined,
+          sourceSystem: provenance.sourceAdapter ?? undefined,
+          targetSystem: provenance.targetAdapter ?? undefined,
+          // Structured provenance block — all fields explicit, null when unavailable
+          provenance,
           // Additional details
           runId: exception.reconJobId,
           expectedValue: exception.expectedValue,
@@ -205,13 +244,7 @@ export const GET = withSecurity(
             status === "ignored" && typeof resolution.ignoredBy === "string"
               ? resolution.ignoredBy
               : undefined,
-          confidenceScore:
-            typeof (exception.driftMetrics as Record<string, unknown> | null)?.confidenceScore ===
-            "number"
-              ? ((exception.driftMetrics as Record<string, unknown>).confidenceScore as number)
-              : typeof metadata.confidenceScore === "number"
-                ? (metadata.confidenceScore as number)
-                : undefined,
+          confidenceScore: provenance.confidenceScore ?? undefined,
           suggestedActions,
           playbookApplied:
             typeof metadata.playbookApplied === "string"

--- a/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
+++ b/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
@@ -20,12 +20,28 @@ import {
   ChevronDown,
   ChevronUp,
   ExternalLink,
+  ArrowLeft,
 } from "lucide-react";
 import Link from "next/link";
 import { useGovernanceState } from "@/hooks/use-governance-state";
 import { FreezeBlockedButton } from "@/components/shared/FreezeBlockedButton";
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
+
+interface ExceptionProvenance {
+  runId: string | null;
+  fieldPath: string | null;
+  ruleId: string | null;
+  detectorId: string | null;
+  sourceAdapter: string | null;
+  targetAdapter: string | null;
+  sourceTransactionId: string | null;
+  targetTransactionId: string | null;
+  ingestionId: string | null;
+  matchReason: string | null;
+  confidenceScore: number | null;
+  rationale_codes: string[] | null;
+}
 
 interface ExceptionDetail {
   id: string;
@@ -53,6 +69,7 @@ interface ExceptionDetail {
   playbookApplied?: string;
   confidenceScore?: number;
   suggestedActions?: string[];
+  provenance?: ExceptionProvenance;
   auditTrail: {
     timestamp: string;
     action: string;
@@ -112,24 +129,6 @@ function StatusBadge({ status }: { status: ExceptionDetail["status"] }) {
   );
 }
 
-function CopyableId({ value, label }: { value: string; label: string }) {
-  return (
-    <div className="flex items-center gap-1.5">
-      <span className="font-mono text-xs break-all text-foreground dark:text-muted-foreground">
-        {value}
-      </span>
-      <button
-        type="button"
-        onClick={() => navigator.clipboard.writeText(value)}
-        className="shrink-0 p-0.5 rounded hover:bg-muted/60 text-muted-foreground hover:text-foreground"
-        title={`Copy ${label}`}
-      >
-        <Copy className="w-3 h-3" />
-      </button>
-    </div>
-  );
-}
-
 function CollapsibleJson({ label, value }: { label: string; value: unknown }) {
   const [open, setOpen] = useState(false);
 
@@ -178,6 +177,56 @@ function CollapsibleJson({ label, value }: { label: string; value: unknown }) {
           </pre>
         </div>
       )}
+    </div>
+  );
+}
+
+function ProvenanceRow({
+  label,
+  value,
+  mono = false,
+  link,
+}: {
+  label: string;
+  value: string | null | undefined;
+  mono?: boolean;
+  link?: string;
+}) {
+  if (!value) {
+    return (
+      <div className="flex items-start gap-2 py-1.5 border-b border-border last:border-0">
+        <span className="text-xs text-muted-foreground w-44 shrink-0">{label}</span>
+        <span className="text-xs text-muted-foreground italic">unavailable</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-2 py-1.5 border-b border-border last:border-0">
+      <span className="text-xs text-muted-foreground w-44 shrink-0">{label}</span>
+      <div className="flex items-center gap-1.5 min-w-0">
+        {link ? (
+          <Link
+            href={link}
+            className="text-xs text-blue-600 hover:underline dark:text-blue-400 font-mono break-all"
+          >
+            {value}
+            <ExternalLink className="inline w-3 h-3 ml-1" />
+          </Link>
+        ) : (
+          <span className={`text-xs text-foreground break-all ${mono ? "font-mono" : ""}`}>
+            {value}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => navigator.clipboard.writeText(value)}
+          className="shrink-0 p-0.5 rounded hover:bg-muted/60 text-muted-foreground hover:text-foreground"
+          title="Copy to clipboard"
+        >
+          <Copy className="w-3 h-3" />
+        </button>
+      </div>
     </div>
   );
 }
@@ -424,37 +473,44 @@ export default function ExceptionDetailPage() {
     <div className="p-6 space-y-6">
       {/* ── Header ── */}
       <div className="flex items-start justify-between gap-4">
-        <div>
-          <div className="flex items-center gap-3 flex-wrap mb-2">
-            <SeverityBadge severity={exception.severity} />
-            <StatusBadge status={exception.status} />
-            {exception.confidenceScore !== undefined && (
-              <Badge className="bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground">
-                Confidence: {Math.round(exception.confidenceScore * 100)}%
-              </Badge>
-            )}
+        <div className="flex items-start gap-3">
+          <Link href="/console/exceptions">
+            <Button variant="ghost" size="sm" className="mt-0.5">
+              <ArrowLeft className="w-4 h-4 mr-1" />
+              Back
+            </Button>
+          </Link>
+          <div>
+            <div className="flex items-center gap-3 flex-wrap mb-2">
+              <SeverityBadge severity={exception.severity} />
+              <StatusBadge status={exception.status} />
+              {(exception.provenance?.confidenceScore ?? exception.confidenceScore) !== undefined &&
+                (exception.provenance?.confidenceScore ?? exception.confidenceScore) !== null && (
+                  <Badge className="bg-muted/40 text-foreground dark:bg-background dark:text-muted-foreground">
+                    Confidence:{" "}
+                    {Math.round(
+                      (exception.provenance?.confidenceScore ?? exception.confidenceScore)! * 100
+                    )}
+                    %
+                  </Badge>
+                )}
+            </div>
+            <h1 className="text-2xl font-bold text-foreground dark:text-white">
+              {exception.description}
+            </h1>
+            <p className="text-xs text-muted-foreground mt-1">
+              Exception ID:{" "}
+              <code className="bg-muted/40 dark:bg-card px-1.5 py-0.5 rounded font-mono">
+                {exception.id}
+              </code>
+            </p>
           </div>
-          <h1 className="text-2xl font-bold text-foreground dark:text-white">
-            {exception.description}
-          </h1>
-          <p className="text-xs text-muted-foreground mt-1">
-            ID:{" "}
-            <code className="bg-muted/40 dark:bg-card px-1.5 py-0.5 rounded font-mono">
-              {exception.id}
-            </code>
-          </p>
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <Button variant="outline" size="sm" onClick={() => void refetch()} disabled={isFetching}>
             <RefreshCw className={`w-4 h-4 mr-2 ${isFetching ? "animate-spin" : ""}`} />
             Refresh
           </Button>
-          <Link
-            href="/console/exceptions"
-            className="text-sm text-muted-foreground hover:underline"
-          >
-            ← Back to List
-          </Link>
         </div>
       </div>
 
@@ -502,74 +558,63 @@ export default function ExceptionDetailPage() {
         <CardHeader>
           <CardTitle className="text-base">Provenance &amp; Origin</CardTitle>
         </CardHeader>
-        <CardContent>
-          <div className="space-y-0">
-            {/* Run link */}
-            <div className="flex items-start gap-2 py-1.5 border-b border-border">
-              <span className="text-xs text-muted-foreground w-40 shrink-0">
-                Reconciliation run
-              </span>
-              {exception.runId ? (
-                <Link
-                  href={`/console/runs/${exception.runId}`}
-                  className="flex items-center gap-1 text-xs text-blue-600 hover:underline dark:text-blue-400 font-mono"
-                >
-                  {exception.runId}
-                  <ExternalLink className="w-3 h-3" />
-                </Link>
-              ) : (
-                <span className="text-xs text-muted-foreground italic">unavailable</span>
-              )}
-            </div>
+        <CardContent className="space-y-0">
+          {(() => {
+            const prov = exception.provenance;
+            const runId = prov?.runId ?? exception.runId ?? null;
+            const sourceAdapter = prov?.sourceAdapter ?? exception.sourceSystem ?? null;
+            const targetAdapter = prov?.targetAdapter ?? exception.targetSystem ?? null;
+            const srcTxn = prov?.sourceTransactionId ?? exception.sourceTransactionId ?? null;
+            const tgtTxn = prov?.targetTransactionId ?? exception.targetTransactionId ?? null;
 
-            {/* Source system */}
-            <div className="flex items-start gap-2 py-1.5 border-b border-border">
-              <span className="text-xs text-muted-foreground w-40 shrink-0">Source system</span>
-              {exception.sourceSystem ? (
-                <span className="text-xs text-foreground">{exception.sourceSystem}</span>
-              ) : (
-                <span className="text-xs text-muted-foreground italic">unavailable</span>
-              )}
-            </div>
-
-            {/* Target system */}
-            <div className="flex items-start gap-2 py-1.5 border-b border-border">
-              <span className="text-xs text-muted-foreground w-40 shrink-0">Target system</span>
-              {exception.targetSystem ? (
-                <span className="text-xs text-foreground">{exception.targetSystem}</span>
-              ) : (
-                <span className="text-xs text-muted-foreground italic">unavailable</span>
-              )}
-            </div>
-
-            {/* Source transaction */}
-            <div className="flex items-start gap-2 py-1.5 border-b border-border">
-              <span className="text-xs text-muted-foreground w-40 shrink-0">
-                Source transaction
-              </span>
-              {exception.sourceTransactionId ? (
-                <CopyableId value={exception.sourceTransactionId} label="source transaction ID" />
-              ) : (
-                <span className="text-xs text-muted-foreground italic">
-                  No source transaction attached
-                </span>
-              )}
-            </div>
-
-            {/* Target transaction */}
-            <div className="flex items-start gap-2 py-1.5">
-              <span className="text-xs text-muted-foreground w-40 shrink-0">
-                Target transaction
-              </span>
-              {exception.targetTransactionId ? (
-                <CopyableId value={exception.targetTransactionId} label="target transaction ID" />
-              ) : (
-                <span className="text-xs text-muted-foreground italic">
-                  No target transaction attached
-                </span>
-              )}
-            </div>
-          </div>
+            return (
+              <>
+                <ProvenanceRow
+                  label="Reconciliation run"
+                  value={runId}
+                  mono
+                  link={runId ? `/console/runs/${runId}` : undefined}
+                />
+                <ProvenanceRow label="Source adapter" value={sourceAdapter} />
+                <ProvenanceRow label="Target adapter" value={targetAdapter} />
+                <ProvenanceRow label="Source transaction" value={srcTxn} mono />
+                <ProvenanceRow label="Target transaction" value={tgtTxn} mono />
+                <ProvenanceRow
+                  label="Field path"
+                  value={prov?.fieldPath ?? exception.fieldPath ?? null}
+                  mono
+                />
+                <ProvenanceRow label="Rule ID" value={prov?.ruleId ?? null} mono />
+                <ProvenanceRow label="Detector ID" value={prov?.detectorId ?? null} mono />
+                <ProvenanceRow label="Ingestion ID" value={prov?.ingestionId ?? null} mono />
+                <ProvenanceRow label="Match reason" value={prov?.matchReason ?? null} />
+                <ProvenanceRow
+                  label="Confidence"
+                  value={
+                    prov?.confidenceScore !== null && prov?.confidenceScore !== undefined
+                      ? `${(prov.confidenceScore * 100).toFixed(1)}%`
+                      : exception.confidenceScore !== undefined
+                        ? `${Math.round(exception.confidenceScore * 100)}%`
+                        : null
+                  }
+                />
+                {prov?.rationale_codes && prov.rationale_codes.length > 0 && (
+                  <div className="flex items-start gap-2 py-1.5 border-b border-border last:border-0">
+                    <span className="text-xs text-muted-foreground w-44 shrink-0">
+                      Rationale codes
+                    </span>
+                    <div className="flex flex-wrap gap-1">
+                      {prov.rationale_codes.map((code) => (
+                        <Badge key={code} variant="outline" className="font-mono text-xs">
+                          {code}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
+            );
+          })()}
         </CardContent>
       </Card>
 
@@ -655,7 +700,7 @@ export default function ExceptionDetailPage() {
           <ActionBar
             exception={exception}
             isFrozen={isFrozen}
-            freezeReason={governanceState?.freeze_reason}
+            freezeReason={governanceState?.freeze_reason ?? undefined}
             onActionComplete={handleActionComplete}
           />
         </CardContent>


### PR DESCRIPTION
Phase 1 — API contract (console detail route):
- Add structured `provenance` block to GET /api/exceptions/[exceptionId] response
- Extracts ruleId, detectorId (camelCase + snake_case fallback), ingestionId,
  matchReason (driftMetrics fallback), sourceAdapter, targetAdapter,
  sourceTransactionId, targetTransactionId, confidenceScore, rationale_codes
- All fields explicit and null when unavailable — no fabrication
- Deduplicates sourceSystem/targetSystem via provenance block
- Backward-compatible: top-level fields and exception-nested shape preserved

Phase 2 — Page rebuild (console detail page):
- Add ExceptionProvenance type aligned with admin API contract
- Replace inline provenance markup with ProvenanceRow component
  (label / value / mono / link / copy — same pattern as admin page)
- Surface ruleId, detectorId, ingestionId, matchReason, rationale_codes
  as first-class provenance rows with unavailable fallback
- Show rationale_codes as Badge list when present
- Improve header: ArrowLeft back button, structured layout
- Remove CopyableId (replaced by ProvenanceRow)
- Fix freeze_reason null→undefined type mismatch (TS strict)

Phase 3 — Tests (console-exception-detail.test.ts, 26 new cases):
- Owned exception returns full detail contract including provenance block
- Unknown exception returns 404
- Invalid UUID returns 400
- No list-filter anti-pattern: findFirst called with exact ID + tenantId
- ruleId/detectorId from camelCase and snake_case metadata
- matchReason from driftMetrics with metadata fallback
- confidenceScore from driftMetrics with metadata fallback
- rationale_codes extracted and filtered to strings only
- All provenance fields null when absent
- Status: pending / investigating / resolved / ignored derivation
- graceful null expectedValue/actualValue
- severity/type fallbacks when null
- audit trail includes Detected entry
- Both response shapes (top-level + nested) present
- POST resolve/ignore/reopen: correct mutation semantics verified
- POST: 404 for missing exception, 400 for missing action param

Verification: 51 tests pass (4 suites), tsc --noEmit clean, eslint --max-warnings=0 clean

https://claude.ai/code/session_01Ya5skpjLExNC8j4faw8qd5