### PR TITLE
Exception detail: ReconciliationRun provenance join

### DIFF
--- a/packages/web/src/__tests__/api/console-exception-detail.test.ts
+++ b/packages/web/src/__tests__/api/console-exception-detail.test.ts
@@ -25,7 +25,9 @@ const resolveTenantForMutationMock = jest.fn();
 const getTraceIdMock = jest.fn();
 const driftEventFindFirstMock = jest.fn();
 const driftEventUpdateMock = jest.fn();
+const reconJobFindFirstMock = jest.fn();
 const reconciliationRunFindFirstMock = jest.fn();
+const reconResultFindFirstMock = jest.fn();
 
 jest.mock("@/lib/middleware/api-security", () => ({
   withSecurity: (handler: unknown) => handler,
@@ -63,8 +65,14 @@ jest.mock("@/shared/db/prismaClient", () => ({
       findFirst: (...args: unknown[]) => driftEventFindFirstMock(...args),
       update: (...args: unknown[]) => driftEventUpdateMock(...args),
     },
+    reconJob: {
+      findFirst: (...args: unknown[]) => reconJobFindFirstMock(...args),
+    },
     reconciliationRun: {
       findFirst: (...args: unknown[]) => reconciliationRunFindFirstMock(...args),
+    },
+    reconResult: {
+      findFirst: (...args: unknown[]) => reconResultFindFirstMock(...args),
     },
   },
 }));
@@ -132,7 +140,9 @@ beforeEach(() => {
   getTraceIdMock.mockReset();
   driftEventFindFirstMock.mockReset();
   driftEventUpdateMock.mockReset();
+  reconJobFindFirstMock.mockReset();
   reconciliationRunFindFirstMock.mockReset();
+  reconResultFindFirstMock.mockReset();
 
   resolveTenantMembershipScopeMock.mockResolvedValue({
     tenantIds: [TENANT_UUID],
@@ -142,15 +152,29 @@ beforeEach(() => {
   resolveTenantForMutationMock.mockReturnValue(TENANT_UUID);
   getTraceIdMock.mockResolvedValue("trace-test-001");
 
+  reconJobFindFirstMock.mockResolvedValue(null);
   reconciliationRunFindFirstMock.mockResolvedValue({
     id: RUN_UUID,
+    tenantId: TENANT_UUID,
+    userId: "88888888-8888-4888-8888-888888888888",
     name: "Test reconciliation run",
     status: "completed",
     createdAt: new Date("2026-02-01T08:00:00.000Z"),
     startedAt: new Date("2026-02-01T08:05:00.000Z"),
     completedAt: new Date("2026-02-01T08:10:00.000Z"),
+    sourceCount: 0,
+    targetCount: 0,
+    matchedCount: 0,
+    unmatchedSourceCount: 0,
+    unmatchedTargetCount: 0,
+    confidenceAvg: null,
+    errorMessage: null,
+    traceId: null,
+    metadata: {},
+    updatedAt: new Date("2026-02-01T08:10:00.000Z"),
     ingestionId: "99999999-aaaa-4bbb-8ccc-dddddddddddd",
   });
+  reconResultFindFirstMock.mockResolvedValue(null);
 });
 
 // ─── GET tests ────────────────────────────────────────────────────────────────
@@ -221,11 +245,16 @@ describe("GET /api/exceptions/[exceptionId]", () => {
     expect(payload.provenance.runId).toBe(RUN_UUID);
     expect(payload.provenance.run).toMatchObject({
       id: RUN_UUID,
+      runKind: "ingestion_run",
+      sourceModel: "reconciliation_runs",
       name: "Test reconciliation run",
-      status: "completed",
+      normalizedStatus: "completed",
+      statusLabel: "Completed",
       recordFound: true,
       href: `/console/runs/${RUN_UUID}`,
       ingestionId: "99999999-aaaa-4bbb-8ccc-dddddddddddd",
+      reconJobId: null,
+      uuidCollision: false,
     });
     expect(payload.provenance.run.createdAt).toBe("2026-02-01T08:00:00.000Z");
     expect(payload.provenance.run.startedAt).toBe("2026-02-01T08:05:00.000Z");
@@ -430,11 +459,13 @@ describe("GET /api/exceptions/[exceptionId]", () => {
     expect(payload.provenance.fieldPath).toBeNull();
     expect(payload.runId).toBeNull();
     expect(reconciliationRunFindFirstMock).not.toHaveBeenCalled();
+    expect(reconJobFindFirstMock).not.toHaveBeenCalled();
   });
 
   test("joins ReconciliationRun with tenantId — same id in another tenant does not leak", async () => {
     driftEventFindFirstMock.mockResolvedValue(makeException());
     reconciliationRunFindFirstMock.mockResolvedValue(null);
+    reconJobFindFirstMock.mockResolvedValue(null);
 
     const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
     const payload = await res.json();
@@ -443,12 +474,17 @@ describe("GET /api/exceptions/[exceptionId]", () => {
     const runCall = reconciliationRunFindFirstMock.mock.calls[0]?.[0];
     expect(runCall?.where?.id).toBe(RUN_UUID);
     expect(runCall?.where?.tenantId).toBe(TENANT_UUID);
+    expect(reconJobFindFirstMock).toHaveBeenCalledTimes(1);
+    const jobCall = reconJobFindFirstMock.mock.calls[0]?.[0];
+    expect(jobCall?.where?.id).toBe(RUN_UUID);
+    expect(jobCall?.where?.tenantId).toBe(TENANT_UUID);
 
     expect(payload.provenance.run).toMatchObject({
       id: RUN_UUID,
       recordFound: false,
       name: null,
-      status: null,
+      normalizedStatus: "unknown",
+      statusLabel: "Not found",
     });
   });
 
@@ -456,19 +492,85 @@ describe("GET /api/exceptions/[exceptionId]", () => {
     driftEventFindFirstMock.mockResolvedValue(makeException());
     reconciliationRunFindFirstMock.mockResolvedValue({
       id: RUN_UUID,
+      tenantId: TENANT_UUID,
+      userId: "88888888-8888-4888-8888-888888888888",
       name: null,
-      status: "cancelled",
+      status: "weird_status_xyz",
       createdAt: new Date("2026-02-01T08:00:00.000Z"),
       startedAt: new Date("2026-02-01T08:05:00.000Z"),
       completedAt: null,
+      sourceCount: 0,
+      targetCount: 0,
+      matchedCount: 0,
+      unmatchedSourceCount: 0,
+      unmatchedTargetCount: 0,
+      confidenceAvg: null,
+      errorMessage: null,
+      traceId: null,
+      metadata: {},
+      updatedAt: new Date("2026-02-01T08:05:00.000Z"),
       ingestionId: null,
     });
 
     const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
     expect(res.status).toBe(200);
     const payload = await res.json();
-    expect(payload.provenance.run?.status).toBe("cancelled");
+    expect(payload.provenance.run?.normalizedStatus).toBe("unknown");
+    expect(payload.provenance.run?.statusLabel).toMatch(/unknown/i);
     expect(payload.provenance.run?.recordFound).toBe(true);
+  });
+
+  test("resolves recon_jobs id when no reconciliation_runs row exists", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException());
+    reconciliationRunFindFirstMock.mockResolvedValue(null);
+    reconJobFindFirstMock.mockResolvedValue({
+      id: RUN_UUID,
+      tenantId: TENANT_UUID,
+      name: "Stripe ↔ Ledger",
+      status: "active",
+      createdAt: new Date("2026-02-01T07:00:00.000Z"),
+      updatedAt: new Date("2026-02-01T07:00:00.000Z"),
+      sourceAdapter: "stripe",
+      targetAdapter: "ledger",
+      reconStrategy: "deterministic",
+      templateId: null,
+      validationRules: [],
+      sourceConfigEncrypted: "x",
+      targetConfigEncrypted: "y",
+      metadata: {},
+    });
+    reconResultFindFirstMock.mockResolvedValue({
+      id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      reconJobId: RUN_UUID,
+      status: "completed",
+      startedAt: new Date("2026-02-01T08:00:00.000Z"),
+      completedAt: new Date("2026-02-01T08:30:00.000Z"),
+      sourceCount: 10,
+      targetCount: 10,
+      matchedCount: 9,
+      unmatchedSourceCount: 1,
+      unmatchedTargetCount: 0,
+      conflictCount: 0,
+      errorMessage: null,
+      inputHash: null,
+      snapshotId: null,
+      summary: {},
+      metadata: {},
+    });
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(payload.provenance.run).toMatchObject({
+      id: RUN_UUID,
+      runKind: "recon_job",
+      sourceModel: "recon_jobs",
+      name: "Stripe ↔ Ledger",
+      reconJobId: RUN_UUID,
+      recordFound: true,
+      latestResultId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    });
+    expect(reconResultFindFirstMock).toHaveBeenCalled();
   });
 
   test("handles null expectedValue and actualValue without throwing", async () => {

--- a/packages/web/src/__tests__/api/console-exception-detail.test.ts
+++ b/packages/web/src/__tests__/api/console-exception-detail.test.ts
@@ -25,6 +25,7 @@ const resolveTenantForMutationMock = jest.fn();
 const getTraceIdMock = jest.fn();
 const driftEventFindFirstMock = jest.fn();
 const driftEventUpdateMock = jest.fn();
+const reconciliationRunFindFirstMock = jest.fn();
 
 jest.mock("@/lib/middleware/api-security", () => ({
   withSecurity: (handler: unknown) => handler,
@@ -61,6 +62,9 @@ jest.mock("@/shared/db/prismaClient", () => ({
     driftEvent: {
       findFirst: (...args: unknown[]) => driftEventFindFirstMock(...args),
       update: (...args: unknown[]) => driftEventUpdateMock(...args),
+    },
+    reconciliationRun: {
+      findFirst: (...args: unknown[]) => reconciliationRunFindFirstMock(...args),
     },
   },
 }));
@@ -128,6 +132,7 @@ beforeEach(() => {
   getTraceIdMock.mockReset();
   driftEventFindFirstMock.mockReset();
   driftEventUpdateMock.mockReset();
+  reconciliationRunFindFirstMock.mockReset();
 
   resolveTenantMembershipScopeMock.mockResolvedValue({
     tenantIds: [TENANT_UUID],
@@ -136,6 +141,16 @@ beforeEach(() => {
   });
   resolveTenantForMutationMock.mockReturnValue(TENANT_UUID);
   getTraceIdMock.mockResolvedValue("trace-test-001");
+
+  reconciliationRunFindFirstMock.mockResolvedValue({
+    id: RUN_UUID,
+    name: "Test reconciliation run",
+    status: "completed",
+    createdAt: new Date("2026-02-01T08:00:00.000Z"),
+    startedAt: new Date("2026-02-01T08:05:00.000Z"),
+    completedAt: new Date("2026-02-01T08:10:00.000Z"),
+    ingestionId: "99999999-aaaa-4bbb-8ccc-dddddddddddd",
+  });
 });
 
 // ─── GET tests ────────────────────────────────────────────────────────────────
@@ -204,6 +219,17 @@ describe("GET /api/exceptions/[exceptionId]", () => {
 
     expect(payload.provenance).toBeDefined();
     expect(payload.provenance.runId).toBe(RUN_UUID);
+    expect(payload.provenance.run).toMatchObject({
+      id: RUN_UUID,
+      name: "Test reconciliation run",
+      status: "completed",
+      recordFound: true,
+      href: `/console/runs/${RUN_UUID}`,
+      ingestionId: "99999999-aaaa-4bbb-8ccc-dddddddddddd",
+    });
+    expect(payload.provenance.run.createdAt).toBe("2026-02-01T08:00:00.000Z");
+    expect(payload.provenance.run.startedAt).toBe("2026-02-01T08:05:00.000Z");
+    expect(payload.provenance.run.completedAt).toBe("2026-02-01T08:10:00.000Z");
     expect(payload.provenance.fieldPath).toBe("amount");
     // These are null when absent — not fabricated
     expect(payload.provenance.ruleId).toBeNull();
@@ -400,8 +426,49 @@ describe("GET /api/exceptions/[exceptionId]", () => {
     const payload = await res.json();
 
     expect(payload.provenance.runId).toBeNull();
+    expect(payload.provenance.run).toBeNull();
     expect(payload.provenance.fieldPath).toBeNull();
     expect(payload.runId).toBeNull();
+    expect(reconciliationRunFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  test("joins ReconciliationRun with tenantId — same id in another tenant does not leak", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException());
+    reconciliationRunFindFirstMock.mockResolvedValue(null);
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    const payload = await res.json();
+
+    expect(reconciliationRunFindFirstMock).toHaveBeenCalledTimes(1);
+    const runCall = reconciliationRunFindFirstMock.mock.calls[0]?.[0];
+    expect(runCall?.where?.id).toBe(RUN_UUID);
+    expect(runCall?.where?.tenantId).toBe(TENANT_UUID);
+
+    expect(payload.provenance.run).toMatchObject({
+      id: RUN_UUID,
+      recordFound: false,
+      name: null,
+      status: null,
+    });
+  });
+
+  test("returns run context for unusual persisted run status without error", async () => {
+    driftEventFindFirstMock.mockResolvedValue(makeException());
+    reconciliationRunFindFirstMock.mockResolvedValue({
+      id: RUN_UUID,
+      name: null,
+      status: "cancelled",
+      createdAt: new Date("2026-02-01T08:00:00.000Z"),
+      startedAt: new Date("2026-02-01T08:05:00.000Z"),
+      completedAt: null,
+      ingestionId: null,
+    });
+
+    const res = await GET(makeRequest(EXCEPTION_UUID), makeParams(EXCEPTION_UUID) as any);
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.provenance.run?.status).toBe("cancelled");
+    expect(payload.provenance.run?.recordFound).toBe(true);
   });
 
   test("handles null expectedValue and actualValue without throwing", async () => {

--- a/packages/web/src/__tests__/components/ExceptionDetailRunContext.test.tsx
+++ b/packages/web/src/__tests__/components/ExceptionDetailRunContext.test.tsx
@@ -1,0 +1,56 @@
+/** @jest-environment jsdom */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { ExceptionDetailRunContext } from "@/components/console/ExceptionDetailRunContext";
+
+describe("ExceptionDetailRunContext", () => {
+  const baseRun = {
+    id: "66666666-7777-4888-8999-aaaaaaaaaaaa",
+    name: "Nightly Stripe ↔ Ledger",
+    status: "completed",
+    createdAt: "2026-02-01T08:00:00.000Z",
+    startedAt: "2026-02-01T08:05:00.000Z",
+    completedAt: "2026-02-01T08:10:00.000Z",
+    ingestionId: "ing-1",
+    href: "/console/runs/66666666-7777-4888-8999-aaaaaaaaaaaa",
+    recordFound: true,
+  };
+
+  test("renders run name, status, and drift actions are not part of this component", () => {
+    const html = renderToStaticMarkup(<ExceptionDetailRunContext run={baseRun} />);
+    expect(html).toContain("Nightly Stripe");
+    expect(html).toContain("66666666-7777-4888-8999-aaaaaaaaaaaa");
+    expect(html).toContain("completed");
+    expect(html).not.toMatch(/Mark Resolved|Ignore Exception|Reopen/);
+  });
+
+  test("renders explicit fallback when no run is linked", () => {
+    const html = renderToStaticMarkup(<ExceptionDetailRunContext run={null} />);
+    expect(html).toContain("Run context is unavailable");
+  });
+
+  test("renders honest message when run id present but row missing", () => {
+    const html = renderToStaticMarkup(
+      <ExceptionDetailRunContext
+        run={{
+          ...baseRun,
+          name: null,
+          status: null,
+          createdAt: null,
+          startedAt: null,
+          completedAt: null,
+          ingestionId: null,
+          recordFound: false,
+        }}
+      />
+    );
+    expect(html).toContain("Run record not found");
+  });
+
+  test("renders unusual run status without throwing", () => {
+    const html = renderToStaticMarkup(
+      <ExceptionDetailRunContext run={{ ...baseRun, status: "archived" }} />
+    );
+    expect(html).toContain("archived");
+  });
+});

--- a/packages/web/src/__tests__/components/ExceptionDetailRunContext.test.tsx
+++ b/packages/web/src/__tests__/components/ExceptionDetailRunContext.test.tsx
@@ -6,21 +6,28 @@ import { ExceptionDetailRunContext } from "@/components/console/ExceptionDetailR
 describe("ExceptionDetailRunContext", () => {
   const baseRun = {
     id: "66666666-7777-4888-8999-aaaaaaaaaaaa",
+    runKind: "ingestion_run" as const,
+    sourceModel: "reconciliation_runs" as const,
     name: "Nightly Stripe ↔ Ledger",
-    status: "completed",
+    normalizedStatus: "completed",
+    statusLabel: "Completed",
     createdAt: "2026-02-01T08:00:00.000Z",
     startedAt: "2026-02-01T08:05:00.000Z",
     completedAt: "2026-02-01T08:10:00.000Z",
     ingestionId: "ing-1",
+    reconJobId: null,
     href: "/console/runs/66666666-7777-4888-8999-aaaaaaaaaaaa",
     recordFound: true,
+    latestResultId: null,
+    uuidCollision: false,
   };
 
-  test("renders run name, status, and drift actions are not part of this component", () => {
+  test("renders run name, status label, and no drift action buttons", () => {
     const html = renderToStaticMarkup(<ExceptionDetailRunContext run={baseRun} />);
     expect(html).toContain("Nightly Stripe");
     expect(html).toContain("66666666-7777-4888-8999-aaaaaaaaaaaa");
-    expect(html).toContain("completed");
+    expect(html).toContain("Completed");
+    expect(html).toContain("reconciliation_runs");
     expect(html).not.toMatch(/Mark Resolved|Ignore Exception|Reopen/);
   });
 
@@ -35,22 +42,44 @@ describe("ExceptionDetailRunContext", () => {
         run={{
           ...baseRun,
           name: null,
-          status: null,
-          createdAt: null,
-          startedAt: null,
-          completedAt: null,
-          ingestionId: null,
           recordFound: false,
+          normalizedStatus: "unknown",
+          statusLabel: "Not found",
         }}
       />
     );
     expect(html).toContain("Run record not found");
   });
 
-  test("renders unusual run status without throwing", () => {
+  test("renders uuid collision warning with both ids", () => {
     const html = renderToStaticMarkup(
-      <ExceptionDetailRunContext run={{ ...baseRun, status: "archived" }} />
+      <ExceptionDetailRunContext
+        run={{
+          ...baseRun,
+          recordFound: false,
+          uuidCollision: true,
+          collision: {
+            reconJobId: "job-1",
+            reconciliationRunId: "run-1",
+          },
+        }}
+      />
     );
-    expect(html).toContain("archived");
+    expect(html).toContain("Ambiguous run id");
+    expect(html).toContain("job-1");
+    expect(html).toContain("run-1");
+  });
+
+  test("renders unknown normalized status without throwing", () => {
+    const html = renderToStaticMarkup(
+      <ExceptionDetailRunContext
+        run={{
+          ...baseRun,
+          normalizedStatus: "unknown",
+          statusLabel: "Unknown",
+        }}
+      />
+    );
+    expect(html).toContain("Unknown");
   });
 });

--- a/packages/web/src/__tests__/lib/run-display.test.ts
+++ b/packages/web/src/__tests__/lib/run-display.test.ts
@@ -1,0 +1,17 @@
+import { reconciliationRunStatusToBadgeType } from "@/lib/console/run-display";
+
+describe("reconciliationRunStatusToBadgeType", () => {
+  test("maps known reconciliation run statuses", () => {
+    expect(reconciliationRunStatusToBadgeType("completed")).toBe("completed");
+    expect(reconciliationRunStatusToBadgeType("FAILED")).toBe("failed");
+    expect(reconciliationRunStatusToBadgeType(" running ")).toBe("running");
+    expect(reconciliationRunStatusToBadgeType("pending")).toBe("pending");
+  });
+
+  test("maps unknown persisted values to unknown badge type", () => {
+    expect(reconciliationRunStatusToBadgeType("cancelled")).toBe("unknown");
+    expect(reconciliationRunStatusToBadgeType("")).toBe("unknown");
+    expect(reconciliationRunStatusToBadgeType(null)).toBe("unknown");
+    expect(reconciliationRunStatusToBadgeType(undefined)).toBe("unknown");
+  });
+});

--- a/packages/web/src/__tests__/lib/run-display.test.ts
+++ b/packages/web/src/__tests__/lib/run-display.test.ts
@@ -14,4 +14,9 @@ describe("reconciliationRunStatusToBadgeType", () => {
     expect(reconciliationRunStatusToBadgeType(null)).toBe("unknown");
     expect(reconciliationRunStatusToBadgeType(undefined)).toBe("unknown");
   });
+
+  test("maps extended aliases used by canonical status normalization", () => {
+    expect(reconciliationRunStatusToBadgeType("success")).toBe("completed");
+    expect(reconciliationRunStatusToBadgeType("queued")).toBe("pending");
+  });
 });

--- a/packages/web/src/app/api/exceptions/[exceptionId]/route.ts
+++ b/packages/web/src/app/api/exceptions/[exceptionId]/route.ts
@@ -78,7 +78,7 @@ export const GET = withSecurity(
           null;
         const tenantId = resolveTenantForMutation(tenantIds, requestedTenantId);
 
-        // Fetch exception - workspace scoped
+        // Fetch exception - workspace scoped (DriftEvent = console "exception")
         const exception = await prisma.driftEvent.findFirst({
           where: {
             id: exceptionId,
@@ -128,6 +128,66 @@ export const GET = withSecurity(
           acknowledgedBy: exception.acknowledgedBy,
           acknowledgedAt: exception.acknowledgedAt,
         });
+
+        /**
+         * DriftEvent.reconJobId is the UUID of the reconciliation run that produced this drift
+         * (ReconciliationRun.id). It is not a batch/workflow job id; match review uses a separate
+         * API and route model (ReconciliationMatch under /api/jobs/...).
+         */
+        let provenanceRun:
+          | {
+              id: string;
+              name: string | null;
+              status: string | null;
+              createdAt: string | null;
+              startedAt: string | null;
+              completedAt: string | null;
+              ingestionId: string | null;
+              href: string;
+              recordFound: boolean;
+            }
+          | null = null;
+
+        if (exception.reconJobId) {
+          const runRow = await prisma.reconciliationRun.findFirst({
+            where: { id: exception.reconJobId, tenantId },
+            select: {
+              id: true,
+              name: true,
+              status: true,
+              createdAt: true,
+              startedAt: true,
+              completedAt: true,
+              ingestionId: true,
+            },
+          });
+
+          if (runRow) {
+            provenanceRun = {
+              id: runRow.id,
+              name: runRow.name ?? null,
+              status: runRow.status ?? null,
+              createdAt: runRow.createdAt.toISOString(),
+              startedAt: runRow.startedAt.toISOString(),
+              completedAt: runRow.completedAt?.toISOString() ?? null,
+              ingestionId: runRow.ingestionId,
+              href: `/console/runs/${runRow.id}`,
+              recordFound: true,
+            };
+          } else {
+            provenanceRun = {
+              id: exception.reconJobId,
+              name: null,
+              status: null,
+              createdAt: null,
+              startedAt: null,
+              completedAt: null,
+              ingestionId: null,
+              href: `/console/runs/${exception.reconJobId}`,
+              recordFound: false,
+            };
+          }
+        }
         const suggestedActions = buildSuggestedActions({
           driftType: exception.driftType,
           fieldPath: exception.fieldPath,
@@ -152,6 +212,7 @@ export const GET = withSecurity(
         // Build structured provenance block — aligned with admin API contract
         const provenance = {
           runId: exception.reconJobId || null,
+          run: provenanceRun,
           fieldPath: exception.fieldPath || null,
           ruleId:
             (metadata.ruleId as string | undefined) ??

--- a/packages/web/src/app/api/exceptions/[exceptionId]/route.ts
+++ b/packages/web/src/app/api/exceptions/[exceptionId]/route.ts
@@ -24,6 +24,7 @@ import {
   buildSuggestedActions,
   getExceptionWorkflowState,
 } from "@/lib/exceptions/presentation";
+import { resolveExceptionProvenanceRun } from "@/lib/exceptions/resolve-exception-run-context";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
@@ -130,64 +131,17 @@ export const GET = withSecurity(
         });
 
         /**
-         * DriftEvent.reconJobId is the UUID of the reconciliation run that produced this drift
-         * (ReconciliationRun.id). It is not a batch/workflow job id; match review uses a separate
-         * API and route model (ReconciliationMatch under /api/jobs/...).
+         * DriftEvent.reconJobId is a run-scoped UUID used by the console. It may reference either:
+         * - ReconciliationRun (ingestion-backed execution), or
+         * - ReconJob (definition id — same UUID space; resolved via @settler/reconciliation-core).
+         * Match adjudication (ReconciliationMatch) uses /api/jobs/... and is separate from this
+         * drift workflow.
          */
-        let provenanceRun:
-          | {
-              id: string;
-              name: string | null;
-              status: string | null;
-              createdAt: string | null;
-              startedAt: string | null;
-              completedAt: string | null;
-              ingestionId: string | null;
-              href: string;
-              recordFound: boolean;
-            }
-          | null = null;
-
-        if (exception.reconJobId) {
-          const runRow = await prisma.reconciliationRun.findFirst({
-            where: { id: exception.reconJobId, tenantId },
-            select: {
-              id: true,
-              name: true,
-              status: true,
-              createdAt: true,
-              startedAt: true,
-              completedAt: true,
-              ingestionId: true,
-            },
-          });
-
-          if (runRow) {
-            provenanceRun = {
-              id: runRow.id,
-              name: runRow.name ?? null,
-              status: runRow.status ?? null,
-              createdAt: runRow.createdAt.toISOString(),
-              startedAt: runRow.startedAt.toISOString(),
-              completedAt: runRow.completedAt?.toISOString() ?? null,
-              ingestionId: runRow.ingestionId,
-              href: `/console/runs/${runRow.id}`,
-              recordFound: true,
-            };
-          } else {
-            provenanceRun = {
-              id: exception.reconJobId,
-              name: null,
-              status: null,
-              createdAt: null,
-              startedAt: null,
-              completedAt: null,
-              ingestionId: null,
-              href: `/console/runs/${exception.reconJobId}`,
-              recordFound: false,
-            };
-          }
-        }
+        const provenanceRun = await resolveExceptionProvenanceRun(
+          prisma,
+          tenantId,
+          exception.reconJobId
+        );
         const suggestedActions = buildSuggestedActions({
           driftType: exception.driftType,
           fieldPath: exception.fieldPath,

--- a/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
+++ b/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
@@ -25,11 +25,17 @@ import {
 import Link from "next/link";
 import { useGovernanceState } from "@/hooks/use-governance-state";
 import { FreezeBlockedButton } from "@/components/shared/FreezeBlockedButton";
+import {
+  ExceptionDetailRunContext,
+  type ExceptionDetailProvenanceRun,
+} from "@/components/console/ExceptionDetailRunContext";
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
 interface ExceptionProvenance {
   runId: string | null;
+  /** Canonical ReconciliationRun row for this drift exception, tenant-scoped; null when unlinked. */
+  run?: ExceptionDetailProvenanceRun | null;
   fieldPath: string | null;
   ruleId: string | null;
   detectorId: string | null;
@@ -557,11 +563,30 @@ export default function ExceptionDetailPage() {
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Provenance &amp; Origin</CardTitle>
+          <p className="text-xs text-muted-foreground font-normal mt-1 max-w-3xl">
+            This page is for drift exceptions (resolve, ignore, reopen). Match adjudication for
+            reconciliation pairs is handled under Jobs, not here.
+          </p>
         </CardHeader>
-        <CardContent className="space-y-0">
+        <CardContent className="space-y-4">
           {(() => {
             const prov = exception.provenance;
             const runId = prov?.runId ?? exception.runId ?? null;
+            const runContext: ExceptionDetailProvenanceRun | null =
+              prov?.run ??
+              (runId
+                ? {
+                    id: runId,
+                    name: null,
+                    status: null,
+                    createdAt: null,
+                    startedAt: null,
+                    completedAt: null,
+                    ingestionId: null,
+                    href: `/console/runs/${runId}`,
+                    recordFound: false,
+                  }
+                : null);
             const sourceAdapter = prov?.sourceAdapter ?? exception.sourceSystem ?? null;
             const targetAdapter = prov?.targetAdapter ?? exception.targetSystem ?? null;
             const srcTxn = prov?.sourceTransactionId ?? exception.sourceTransactionId ?? null;
@@ -569,12 +594,8 @@ export default function ExceptionDetailPage() {
 
             return (
               <>
-                <ProvenanceRow
-                  label="Reconciliation run"
-                  value={runId}
-                  mono
-                  link={runId ? `/console/runs/${runId}` : undefined}
-                />
+                <ExceptionDetailRunContext run={runContext} />
+                <div className="space-y-0 border-t border-border pt-2">
                 <ProvenanceRow label="Source adapter" value={sourceAdapter} />
                 <ProvenanceRow label="Target adapter" value={targetAdapter} />
                 <ProvenanceRow label="Source transaction" value={srcTxn} mono />
@@ -612,6 +633,7 @@ export default function ExceptionDetailPage() {
                     </div>
                   </div>
                 )}
+                </div>
               </>
             );
           })()}

--- a/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
+++ b/packages/web/src/app/console/exceptions/[exceptionId]/page.tsx
@@ -34,7 +34,7 @@ import {
 
 interface ExceptionProvenance {
   runId: string | null;
-  /** Canonical ReconciliationRun row for this drift exception, tenant-scoped; null when unlinked. */
+  /** Resolved run context (recon job and/or ingestion run); null when unlinked. */
   run?: ExceptionDetailProvenanceRun | null;
   fieldPath: string | null;
   ruleId: string | null;
@@ -577,14 +577,20 @@ export default function ExceptionDetailPage() {
               (runId
                 ? {
                     id: runId,
+                    runKind: "ingestion_run",
+                    sourceModel: "reconciliation_runs",
                     name: null,
-                    status: null,
+                    normalizedStatus: "unknown",
+                    statusLabel: "Unavailable",
                     createdAt: null,
                     startedAt: null,
                     completedAt: null,
                     ingestionId: null,
+                    reconJobId: null,
                     href: `/console/runs/${runId}`,
                     recordFound: false,
+                    latestResultId: null,
+                    uuidCollision: false,
                   }
                 : null);
             const sourceAdapter = prov?.sourceAdapter ?? exception.sourceSystem ?? null;

--- a/packages/web/src/components/console/ExceptionDetailRunContext.tsx
+++ b/packages/web/src/components/console/ExceptionDetailRunContext.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * Reconciliation run context for a DriftEvent (console exception detail).
+ *
+ * DriftEvent.reconJobId references ReconciliationRun.id — it is the run UUID, not a
+ * batch/workflow job id. Match adjudication lives on /jobs/.../exceptions/... and
+ * must not be conflated with this drift workflow surface.
+ */
+
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { reconciliationRunStatusToBadgeType } from "@/lib/console/run-display";
+
+export interface ExceptionDetailProvenanceRun {
+  id: string;
+  name: string | null;
+  status: string | null;
+  createdAt: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  ingestionId: string | null;
+  href: string;
+  /** False when DriftEvent.reconJobId is set but no ReconciliationRun row exists for this tenant. */
+  recordFound: boolean;
+}
+
+function formatTs(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d.toLocaleString();
+}
+
+export function ExceptionDetailRunContext({ run }: { run: ExceptionDetailProvenanceRun | null }) {
+  if (!run) {
+    return (
+      <div className="rounded-md border border-border bg-muted/15 px-3 py-3 text-sm text-muted-foreground">
+        <p className="font-medium text-foreground">Reconciliation run</p>
+        <p className="mt-1 text-xs">
+          No reconciliation run is linked to this drift exception. Run context is unavailable.
+        </p>
+      </div>
+    );
+  }
+
+  const badgeType = reconciliationRunStatusToBadgeType(run.status ?? undefined);
+
+  return (
+    <div className="rounded-md border border-border bg-muted/15 px-3 py-3 space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="space-y-1 min-w-0">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Reconciliation run (source of exception)
+          </p>
+          {run.recordFound ? (
+            <>
+              <p className="text-sm font-semibold text-foreground break-words">
+                {run.name?.trim() ? run.name.trim() : "Unnamed run"}
+              </p>
+              <div className="flex flex-wrap items-center gap-2 pt-0.5">
+                {run.status ? (
+                  <StatusBadge
+                    status={badgeType}
+                    label={run.status}
+                    size="sm"
+                    showIcon
+                  />
+                ) : (
+                  <Badge variant="outline" className="text-xs font-normal">
+                    Run status unavailable
+                  </Badge>
+                )}
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Run record not found for this workspace. The linked run id may be stale or was
+              removed.
+            </p>
+          )}
+        </div>
+        <Link
+          href={run.href}
+          className="shrink-0 inline-flex items-center gap-1 text-xs text-blue-600 hover:underline dark:text-blue-400"
+        >
+          Open run
+          <ExternalLink className="w-3 h-3" />
+        </Link>
+      </div>
+
+      <div className="text-xs text-muted-foreground space-y-1 border-t border-border pt-2">
+        <div className="flex flex-wrap gap-x-4 gap-y-1">
+          <span>
+            Run id:{" "}
+            <code className="bg-muted/50 px-1 py-0.5 rounded font-mono text-[11px]">{run.id}</code>
+          </span>
+        </div>
+        {run.recordFound &&
+          (formatTs(run.startedAt) || formatTs(run.completedAt) || formatTs(run.createdAt)) && (
+            <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
+              {formatTs(run.createdAt) && <span>Created: {formatTs(run.createdAt)}</span>}
+              {formatTs(run.startedAt) && <span>Started: {formatTs(run.startedAt)}</span>}
+              {formatTs(run.completedAt) && <span>Completed: {formatTs(run.completedAt)}</span>}
+            </div>
+          )}
+        {run.recordFound && run.ingestionId && (
+          <p className="pt-1">
+            Ingestion id:{" "}
+            <code className="bg-muted/50 px-1 py-0.5 rounded font-mono text-[11px]">
+              {run.ingestionId}
+            </code>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/console/ExceptionDetailRunContext.tsx
+++ b/packages/web/src/components/console/ExceptionDetailRunContext.tsx
@@ -1,30 +1,35 @@
 "use client";
 
 /**
- * Reconciliation run context for a DriftEvent (console exception detail).
+ * Run / execution context for a DriftEvent on the console exception detail page.
  *
- * DriftEvent.reconJobId references ReconciliationRun.id — it is the run UUID, not a
- * batch/workflow job id. Match adjudication lives on /jobs/.../exceptions/... and
- * must not be conflated with this drift workflow surface.
+ * DriftEvent.reconJobId is resolved via the same dual-model path as the run list:
+ * ReconJob (recon_jobs) or ReconciliationRun (reconciliation_runs). This is not
+ * ReconciliationMatch adjudication (/jobs/.../exceptions/...).
  */
 
 import Link from "next/link";
 import { ExternalLink } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { reconciliationRunStatusToBadgeType } from "@/lib/console/run-display";
 
 export interface ExceptionDetailProvenanceRun {
   id: string;
+  runKind: "recon_job" | "ingestion_run";
+  sourceModel: "recon_jobs" | "reconciliation_runs";
   name: string | null;
-  status: string | null;
+  normalizedStatus: string;
+  statusLabel: string;
   createdAt: string | null;
   startedAt: string | null;
   completedAt: string | null;
   ingestionId: string | null;
+  reconJobId: string | null;
   href: string;
-  /** False when DriftEvent.reconJobId is set but no ReconciliationRun row exists for this tenant. */
   recordFound: boolean;
+  latestResultId: string | null;
+  uuidCollision: boolean;
+  collision?: { reconJobId: string; reconciliationRunId: string };
 }
 
 function formatTs(iso: string | null | undefined): string | null {
@@ -33,26 +38,46 @@ function formatTs(iso: string | null | undefined): string | null {
   return Number.isNaN(d.getTime()) ? null : d.toLocaleString();
 }
 
+function runKindLabel(kind: ExceptionDetailProvenanceRun["runKind"]): string {
+  return kind === "recon_job" ? "Reconciliation job" : "Ingestion reconciliation run";
+}
+
 export function ExceptionDetailRunContext({ run }: { run: ExceptionDetailProvenanceRun | null }) {
   if (!run) {
     return (
       <div className="rounded-md border border-border bg-muted/15 px-3 py-3 text-sm text-muted-foreground">
-        <p className="font-medium text-foreground">Reconciliation run</p>
+        <p className="font-medium text-foreground">Run context</p>
         <p className="mt-1 text-xs">
-          No reconciliation run is linked to this drift exception. Run context is unavailable.
+          No run is linked to this drift exception. Run context is unavailable.
         </p>
       </div>
     );
   }
 
-  const badgeType = reconciliationRunStatusToBadgeType(run.status ?? undefined);
+  if (run.uuidCollision && run.collision) {
+    return (
+      <div className="rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-3 text-sm">
+        <p className="font-medium text-foreground">Ambiguous run id</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          The same UUID exists as both a reconciliation job and an ingestion run in this workspace.
+          Open the correct record from Operations; do not assume a single run row.
+        </p>
+        <div className="mt-2 space-y-1 text-xs font-mono text-muted-foreground">
+          <p>recon_jobs.id: {run.collision.reconJobId}</p>
+          <p>reconciliation_runs.id: {run.collision.reconciliationRunId}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const badgeType = reconciliationRunStatusToBadgeType(run.normalizedStatus);
 
   return (
     <div className="rounded-md border border-border bg-muted/15 px-3 py-3 space-y-3">
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div className="space-y-1 min-w-0">
           <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Reconciliation run (source of exception)
+            {runKindLabel(run.runKind)} (source of exception)
           </p>
           {run.recordFound ? (
             <>
@@ -60,24 +85,18 @@ export function ExceptionDetailRunContext({ run }: { run: ExceptionDetailProvena
                 {run.name?.trim() ? run.name.trim() : "Unnamed run"}
               </p>
               <div className="flex flex-wrap items-center gap-2 pt-0.5">
-                {run.status ? (
-                  <StatusBadge
-                    status={badgeType}
-                    label={run.status}
-                    size="sm"
-                    showIcon
-                  />
-                ) : (
-                  <Badge variant="outline" className="text-xs font-normal">
-                    Run status unavailable
-                  </Badge>
-                )}
+                <StatusBadge status={badgeType} label={run.statusLabel} size="sm" showIcon />
               </div>
+              <p className="text-[11px] text-muted-foreground pt-0.5">
+                Model:{" "}
+                <span className="font-mono">
+                  {run.sourceModel === "recon_jobs" ? "recon_jobs" : "reconciliation_runs"}
+                </span>
+              </p>
             </>
           ) : (
             <p className="text-sm text-muted-foreground">
-              Run record not found for this workspace. The linked run id may be stale or was
-              removed.
+              Run record not found for this workspace. The linked id may be stale or was removed.
             </p>
           )}
         </div>
@@ -85,7 +104,7 @@ export function ExceptionDetailRunContext({ run }: { run: ExceptionDetailProvena
           href={run.href}
           className="shrink-0 inline-flex items-center gap-1 text-xs text-blue-600 hover:underline dark:text-blue-400"
         >
-          Open run
+          Open in console
           <ExternalLink className="w-3 h-3" />
         </Link>
       </div>
@@ -97,6 +116,14 @@ export function ExceptionDetailRunContext({ run }: { run: ExceptionDetailProvena
             <code className="bg-muted/50 px-1 py-0.5 rounded font-mono text-[11px]">{run.id}</code>
           </span>
         </div>
+        {run.recordFound && run.latestResultId && (
+          <p>
+            Latest result id:{" "}
+            <code className="bg-muted/50 px-1 py-0.5 rounded font-mono text-[11px]">
+              {run.latestResultId}
+            </code>
+          </p>
+        )}
         {run.recordFound &&
           (formatTs(run.startedAt) || formatTs(run.completedAt) || formatTs(run.createdAt)) && (
             <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
@@ -107,10 +134,13 @@ export function ExceptionDetailRunContext({ run }: { run: ExceptionDetailProvena
           )}
         {run.recordFound && run.ingestionId && (
           <p className="pt-1">
-            Ingestion id:{" "}
-            <code className="bg-muted/50 px-1 py-0.5 rounded font-mono text-[11px]">
+            Ingestion:{" "}
+            <Link
+              href={`/console/ingestion/${run.ingestionId}`}
+              className="text-blue-600 hover:underline dark:text-blue-400 font-mono text-[11px]"
+            >
               {run.ingestionId}
-            </code>
+            </Link>
           </p>
         )}
       </div>

--- a/packages/web/src/lib/console/run-display.ts
+++ b/packages/web/src/lib/console/run-display.ts
@@ -11,12 +11,18 @@ export function reconciliationRunStatusToBadgeType(status: string | null | undef
   const normalized = status.trim().toLowerCase();
   switch (normalized) {
     case "completed":
+    case "success":
       return "completed";
     case "failed":
+    case "error":
       return "failed";
     case "running":
+    case "processing":
+    case "in_progress":
       return "running";
     case "pending":
+    case "queued":
+    case "draft":
       return "pending";
     default:
       return "unknown";

--- a/packages/web/src/lib/console/run-display.ts
+++ b/packages/web/src/lib/console/run-display.ts
@@ -1,0 +1,24 @@
+import type { StatusType } from "@/components/ui/status-badge";
+
+/**
+ * Maps a reconciliation run's persisted `status` string to StatusBadge semantics.
+ * Unknown values map to "unknown" so operators still see the raw label from the API.
+ */
+export function reconciliationRunStatusToBadgeType(status: string | null | undefined): StatusType {
+  if (!status) {
+    return "unknown";
+  }
+  const normalized = status.trim().toLowerCase();
+  switch (normalized) {
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "running":
+      return "running";
+    case "pending":
+      return "pending";
+    default:
+      return "unknown";
+  }
+}

--- a/packages/web/src/lib/exceptions/resolve-exception-run-context.ts
+++ b/packages/web/src/lib/exceptions/resolve-exception-run-context.ts
@@ -1,0 +1,110 @@
+import type { CanonicalReconciliationRunDetail } from "@settler/reconciliation-core";
+import { resolveReconciliationRunForTenant } from "@settler/reconciliation-core";
+import type { PrismaClient } from "@prisma/client";
+
+export type ExceptionProvenanceRunDto = {
+  id: string;
+  /** Which persistence model backs this id for the workspace. */
+  runKind: "recon_job" | "ingestion_run";
+  sourceModel: "recon_jobs" | "reconciliation_runs";
+  name: string | null;
+  /** Normalized lifecycle status (shared with run list / canonical contract). */
+  normalizedStatus: string;
+  /** Operator-facing label from canonical reconciliation mapping. */
+  statusLabel: string;
+  createdAt: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  ingestionId: string | null;
+  /** When runKind is recon_job, same as id; otherwise null. */
+  reconJobId: string | null;
+  href: string;
+  recordFound: boolean;
+  /** Latest recon_result execution id when this is a recon_job run; null for ingestion-only. */
+  latestResultId: string | null;
+  /** UUID collision: same id exists in both recon_jobs and reconciliation_runs (extremely rare). */
+  uuidCollision: boolean;
+  collision?: { reconJobId: string; reconciliationRunId: string };
+};
+
+function mapDetailToDto(detail: CanonicalReconciliationRunDetail): ExceptionProvenanceRunDto {
+  return {
+    id: detail.id,
+    runKind: detail.runKind,
+    sourceModel: detail.provenance.sourceModel,
+    name: detail.name?.trim() ? detail.name : null,
+    normalizedStatus: detail.lifecycle.status,
+    statusLabel: detail.lifecycle.statusLabel,
+    createdAt: detail.timestamps.createdAt,
+    startedAt: detail.timestamps.startedAt,
+    completedAt: detail.timestamps.completedAt,
+    ingestionId: detail.provenance.ingestionId,
+    reconJobId: detail.provenance.reconJobId,
+    href: `/console/runs/${detail.id}`,
+    recordFound: true,
+    latestResultId: detail.latestResultId,
+    uuidCollision: false,
+  };
+}
+
+/**
+ * Resolves DriftEvent.reconJobId against both recon_jobs and reconciliation_runs (tenant-scoped),
+ * matching console run list semantics.
+ */
+export async function resolveExceptionProvenanceRun(
+  prisma: PrismaClient,
+  tenantId: string,
+  runId: string | null
+): Promise<ExceptionProvenanceRunDto | null> {
+  if (!runId) {
+    return null;
+  }
+
+  const resolution = await resolveReconciliationRunForTenant(prisma, tenantId, runId);
+
+  if (resolution.kind === "not_found") {
+    return {
+      id: runId,
+      runKind: "ingestion_run",
+      sourceModel: "reconciliation_runs",
+      name: null,
+      normalizedStatus: "unknown",
+      statusLabel: "Not found",
+      createdAt: null,
+      startedAt: null,
+      completedAt: null,
+      ingestionId: null,
+      reconJobId: null,
+      href: `/console/runs/${runId}`,
+      recordFound: false,
+      latestResultId: null,
+      uuidCollision: false,
+    };
+  }
+
+  if (resolution.kind === "ambiguous_uuid_collision") {
+    return {
+      id: runId,
+      runKind: "ingestion_run",
+      sourceModel: "reconciliation_runs",
+      name: null,
+      normalizedStatus: "unknown",
+      statusLabel: "Ambiguous id",
+      createdAt: null,
+      startedAt: null,
+      completedAt: null,
+      ingestionId: null,
+      reconJobId: null,
+      href: `/console/runs/${runId}`,
+      recordFound: false,
+      latestResultId: null,
+      uuidCollision: true,
+      collision: {
+        reconJobId: resolution.jobId,
+        reconciliationRunId: resolution.ingestionRunId,
+      },
+    };
+  }
+
+  return mapDetailToDto(resolution.detail);
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -546,6 +546,9 @@ model ContractVersion {
   @@map("contract_versions")
 }
 
+// reconJobId is a run-scoped UUID in the console: it may reference ReconciliationRun.id
+// (ingestion execution) or ReconJob.id (recon job definition). There is no single FK target,
+// so integrity is enforced in application code (tenant-scoped resolution).
 model DriftEvent {
   id                String    @id @default(uuid())
   tenantId          String    @db.Uuid


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enriches workspace exception detail (`GET /api/exceptions/[exceptionId]`) with **canonical dual-model run resolution** via `resolveReconciliationRunForTenant` (`@settler/reconciliation-core`): `DriftEvent.reconJobId` may reference **ReconJob** (`recon_jobs`) or **ReconciliationRun** (`reconciliation_runs`), matching how `/api/runs` works.

`provenance.run` now includes `runKind`, `sourceModel`, `normalizedStatus`, `statusLabel` (canonical labels), timestamps, `ingestionId`, `reconJobId`, `latestResultId` (when a `recon_results` row exists), `uuidCollision` + `collision` ids when both tables share the same UUID, and `recordFound` for missing rows.

Console exception detail shows model line (`recon_jobs` vs `reconciliation_runs`), **StatusBadge** from normalized status, optional latest result id, ingestion link to `/console/ingestion/[id]`, and collision warning when applicable.

Prisma: comment on `DriftEvent.reconJobId` explains **no single FK** (would be invalid for job ids).

## Tests

- `pnpm --filter @settler/web exec jest --testPathPattern="console-exception-detail|run-display|ExceptionDetailRunContext"`
- ESLint on touched files
- `pnpm --filter @settler/web exec tsc --noEmit`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59343691-b40f-4551-9dc9-60a8bc907205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59343691-b40f-4551-9dc9-60a8bc907205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

