### PR TITLE
Unify console GET /api/runs on merged reconciliation list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- `GET /api/console/reconciliation` list: default `run_kind=recon_job` preserves legacy `reconciliations[]` shape; `run_kind=all` adds canonical `runs` plus real `next_cursor` (dual-stream).
+- `GET /api/console/reconciliation` list: default `run_kind=all` for merged dual-stream listing; invalid `run_kind` returns **400**; `run_kind=recon_job` omits top-level `runs` (legacy `reconciliations[]` only); `run_kind=all` includes canonical `runs` plus real `next_cursor`.
+- `GET /api/runs` returns merged recon jobs + ingestion runs via `fetchMergedReconciliationRunsPage` with explicit `runKind` on each item; `GET /api/runs/:id` resolves ingestion runs with `runKind: ingestion_run` and typed collision **409** when both tables share a UUID.
 - Workbench-style v1 routes return **409** `RECONCILIATION_WRONG_RUN_KIND` when the id resolves to a `recon_job` instead of `reconciliation_runs`.
 - `ReconciliationMatches` prefetches canonical run detail when `run_kind` is unknown, uses `capabilitiesForRunKind` to skip matches for `recon_job`, and surfaces typed collision/not-found states instead of a generic failure.
 - Root `pnpm.overrides` pins `@types/pg` to **8.18.0**; API `pretypecheck`/`prebuild` builds `@settler/reconciliation-core` so workspace typecheck resolves the package; Turbo `typecheck` depends on `^build` so dependent `dist` exists before consumer `tsc`.

--- a/docs/api/families/runs.md
+++ b/docs/api/families/runs.md
@@ -1,8 +1,9 @@
 # API Family: runs
 
-Generated from route inventory. Routes: **2**.
+Console run surfaces (list + detail) use `@settler/reconciliation-core` merged pagination and cross-table resolution so **recon jobs** and **ingestion reconciliation runs** stay aligned with `/api/console/reconciliation` and Express v1 reconciliation reads.
 
 | Method | Path | Criticality | Auth | Tenant | Test | Source |
 | --- | --- | --- | --- | --- | --- | --- |
-| GET | `/api/runs/[runId]` | medium | yes | no | missing | `packages/web/src/app/api/runs/[runId]/route.ts` |
+| GET | `/api/runs` | medium | yes | yes | partial | `packages/web/src/app/api/runs/route.ts` |
+| GET | `/api/runs/[id]` | medium | yes | yes | partial | `packages/web/src/app/api/runs/[id]/route.ts` |
 | POST | `/api/runs/create` | medium | yes | yes | missing | `packages/web/src/app/api/runs/create/route.ts` |

--- a/docs/architecture/reconciliation-read-contract.md
+++ b/docs/architecture/reconciliation-read-contract.md
@@ -47,11 +47,19 @@ If the same UUID exists in **both** `recon_jobs` and `reconciliation_runs` for a
 
 ## Next console: `GET /api/console/reconciliation`
 
-- **Default** `run_kind=recon_job` preserves historical “jobs only” `reconciliations[]` shape for list calls without query params.
+- **Default** `run_kind=all` returns the merged dual-stream page (same semantics as `fetchMergedReconciliationRunsPage`). Invalid `run_kind` values return **400** with `RECONCILIATION_INVALID_RUN_KIND` (no silent fallback to recon-job-only).
 - **`run_kind=all`**: response includes `runs` (canonical merged list) plus `reconciliations` (job-shaped projection for backward compatibility) and real `next_cursor`.
+- **`run_kind=recon_job`**: job stream only; omits top-level `runs` key (legacy shape).
 - **`run_kind=ingestion_run`**: only ingestion stream; `reconciliations` is `[]`.
 
 List JSON (no `id` query) is built via **`buildConsoleReconciliationListBody`** in `@settler/reconciliation-core` so Next and any other consumer stay aligned with the same `runs` / `reconciliations` projection rules.
+
+## Next console: `GET /api/runs`
+
+- **Merged by default**: uses **`fetchMergedReconciliationRunsPage`** with `run_kind=all` unless overridden.
+- **Envelope**: `{ items[], next_cursor, pagination, response_meta }`. Each `items[]` entry includes **`runKind`** (`recon_job` | `ingestion_run`) plus the legacy summary fields the console already consumed.
+- **Query**: `run_kind`, `limit` (1–500), `cursor` (opaque merged cursor), optional `status` / `search`. **Do not** combine `cursor` with `status` or `search` (returns **400** `RUNS_CURSOR_WITH_FILTERS_UNSUPPORTED`). Filtered mode scans up to a bounded number of merged pages server-side; see `response_meta.pagination_mode` and `pagination.filter_truncation_possible`.
+- **Detail**: `GET /api/runs/:id` resolves via **`resolveReconciliationRunForTenants`**; ingestion runs return `runKind: ingestion_run` with explicit degraded fields where recon-job-only data does not exist. UUID collision returns **409** `RUN_ID_COLLISION`.
 
 ### DB-backed integration tests (optional)
 

--- a/packages/reconciliation-core/src/api-runs-list-adapter.test.ts
+++ b/packages/reconciliation-core/src/api-runs-list-adapter.test.ts
@@ -1,0 +1,79 @@
+import { mapCanonicalListItemToApiRunsLegacyRow } from "./api-runs-list-adapter.js";
+import type { CanonicalReconciliationListItem } from "./canonical-reconciliation.js";
+
+const baseConfigDrift = {
+  status: "none" as const,
+  strategyChanged: false,
+  templateChanged: false,
+  validationRulesChanged: false,
+  adapter: {
+    status: "none" as const,
+    comparisonMode: "unavailable" as const,
+    sourceChanged: null as boolean | null,
+    targetChanged: null as boolean | null,
+    sourceHashPresent: false,
+    targetHashPresent: false,
+  },
+  notes: [] as string[],
+};
+
+describe("mapCanonicalListItemToApiRunsLegacyRow", () => {
+  it("maps recon_job row with legacy configDrift adapter label", () => {
+    const row: CanonicalReconciliationListItem = {
+      runKind: "recon_job",
+      id: "j1",
+      tenantId: "t1",
+      name: "Job",
+      reconResultId: "r1",
+      configDrift: {
+        ...baseConfigDrift,
+        adapter: {
+          ...baseConfigDrift.adapter,
+          sourceChanged: true,
+          targetChanged: false,
+        },
+      },
+      lifecycle: {
+        status: "completed",
+        statusLabel: "Completed",
+        isTerminal: true,
+        progressPercent: 100,
+        progressState: "completed",
+      },
+      summaryState: "success",
+      summary: {
+        total: 2,
+        sourceCount: 1,
+        targetCount: 1,
+        processed: 2,
+        matched: 1,
+        matchedWithTolerance: 0,
+        unmatched: 0,
+        unmatchedSourceCount: 0,
+        unmatchedTargetCount: 0,
+        conflicts: 0,
+        exceptioned: 0,
+        unresolved: 0,
+        ignored: 0,
+        resolved: 0,
+      },
+      provenance: {
+        sourceModel: "recon_jobs",
+        runKind: "recon_job",
+        ingestionId: null,
+        reconJobId: "j1",
+      },
+      adapters: { sourceAdapter: "s", targetAdapter: "t" },
+      timestamps: {
+        createdAt: "2024-01-01T00:00:00.000Z",
+        startedAt: "2024-01-01T00:00:01.000Z",
+        completedAt: "2024-01-01T00:00:02.000Z",
+        updatedAt: "2024-01-01T00:00:02.000Z",
+      },
+    };
+    const legacy = mapCanonicalListItemToApiRunsLegacyRow(row);
+    expect(legacy.runKind).toBe("recon_job");
+    expect(legacy.configDrift.adapter).toBe("source");
+    expect(legacy.ingestionId).toBeNull();
+  });
+});

--- a/packages/reconciliation-core/src/api-runs-list-adapter.ts
+++ b/packages/reconciliation-core/src/api-runs-list-adapter.ts
@@ -1,0 +1,110 @@
+/**
+ * Maps {@link CanonicalReconciliationListItem} rows to the legacy console/API run list
+ * projection (same shape historically returned by GET /api/runs for recon_jobs).
+ */
+
+import type { CanonicalReconciliationListItem } from "./canonical-reconciliation.js";
+import type { AdapterDriftSignal } from "./canonical-run-result.js";
+
+function legacyAdapterDriftLabel(signal: AdapterDriftSignal): "source" | "target" | "both" | "none" {
+  if (signal.sourceChanged && signal.targetChanged) return "both";
+  if (signal.sourceChanged) return "source";
+  if (signal.targetChanged) return "target";
+  return "none";
+}
+
+export type ApiRunsListLegacyItem = {
+  runKind: "recon_job" | "ingestion_run";
+  id: string;
+  name: string;
+  status: string;
+  statusLabel: string;
+  startedAt: string;
+  completedAt: string | null;
+  summary: {
+    total: number;
+    sourceCount: number;
+    targetCount: number;
+    matched: number;
+    unmatched: number;
+    unmatchedSourceCount: number;
+    unmatchedTargetCount: number;
+    conflicts: number;
+  };
+  summarySemantics: {
+    processed: number;
+    matchedWithTolerance: number;
+    exceptioned: number;
+    unresolved: number;
+    ignored: number;
+    resolved: number;
+  };
+  summaryState: string;
+  progress: number;
+  progressState: string;
+  isTerminal: boolean;
+  provenance: Record<string, unknown>;
+  configDrift: {
+    status: "none" | "detected" | "indeterminate";
+    adapter: "source" | "target" | "both" | "none";
+  };
+  /** Ingestion-scoped execution id when runKind === ingestion_run */
+  ingestionId: string | null;
+  sourceAdapter: string | null;
+  targetAdapter: string | null;
+};
+
+export function mapCanonicalListItemToApiRunsLegacyRow(
+  r: CanonicalReconciliationListItem
+): ApiRunsListLegacyItem {
+  const startedAt =
+    r.timestamps.startedAt ?? r.timestamps.createdAt ?? new Date().toISOString();
+  return {
+    runKind: r.runKind,
+    id: r.id,
+    name: r.name,
+    status: r.lifecycle.status,
+    statusLabel: r.lifecycle.statusLabel,
+    startedAt,
+    completedAt: r.timestamps.completedAt,
+    summary: {
+      total: r.summary.total,
+      sourceCount: r.summary.sourceCount,
+      targetCount: r.summary.targetCount,
+      matched: r.summary.matched,
+      unmatched: r.summary.unmatched,
+      unmatchedSourceCount: r.summary.unmatchedSourceCount,
+      unmatchedTargetCount: r.summary.unmatchedTargetCount,
+      conflicts: r.summary.conflicts,
+    },
+    summarySemantics: {
+      processed: r.summary.processed,
+      matchedWithTolerance: r.summary.matchedWithTolerance,
+      exceptioned: r.summary.exceptioned,
+      unresolved: r.summary.unresolved,
+      ignored: r.summary.ignored,
+      resolved: r.summary.resolved,
+    },
+    summaryState: r.summaryState,
+    progress: r.lifecycle.progressPercent,
+    progressState: r.lifecycle.progressState,
+    isTerminal: r.lifecycle.isTerminal,
+    provenance: {
+      sourceModel: r.provenance.sourceModel,
+      runKind: r.provenance.runKind,
+      ingestionId: r.provenance.ingestionId,
+      reconJobId: r.provenance.reconJobId,
+      executedAt: startedAt,
+      completedAt: r.timestamps.completedAt,
+      sourceAdapter: r.adapters.sourceAdapter,
+      targetAdapter: r.adapters.targetAdapter,
+    },
+    configDrift: {
+      status: r.configDrift.status,
+      adapter: legacyAdapterDriftLabel(r.configDrift.adapter),
+    },
+    ingestionId: r.provenance.ingestionId,
+    sourceAdapter: r.adapters.sourceAdapter,
+    targetAdapter: r.adapters.targetAdapter,
+  };
+}

--- a/packages/reconciliation-core/src/canonical-reconciliation.ts
+++ b/packages/reconciliation-core/src/canonical-reconciliation.ts
@@ -16,6 +16,7 @@ import {
   getRunStatusLabel,
   getRunSummaryState,
   normalizeRunStatus,
+  type CanonicalConfigDrift,
   type ReconJobRecordLike,
   type ReconResultRecordLike,
 } from "./canonical-run-result.js";
@@ -36,6 +37,7 @@ export interface CanonicalReconciliationListItem {
   id: string;
   tenantId: string;
   name: string;
+  configDrift: CanonicalConfigDrift;
   /** Latest persisted recon_results row for recon_job runs; null for ingestion runs or jobs without results */
   reconResultId: string | null;
   lifecycle: {
@@ -131,6 +133,7 @@ export function mapReconJobRowToCanonicalListItem(input: {
       completedAt: contract.provenance.completedAt,
       updatedAt: input.job.updatedAt.toISOString(),
     },
+    configDrift: contract.configDrift,
   };
 }
 
@@ -231,6 +234,21 @@ export function mapIngestionReconciliationRunToCanonicalDetail(row: {
       completedAt: row.completedAt?.toISOString() ?? null,
       updatedAt: row.updatedAt.toISOString(),
     },
+    configDrift: {
+      status: "none",
+      strategyChanged: false,
+      templateChanged: false,
+      validationRulesChanged: false,
+      adapter: {
+        status: "none",
+        comparisonMode: "unavailable",
+        sourceChanged: null,
+        targetChanged: null,
+        sourceHashPresent: false,
+        targetHashPresent: false,
+      },
+      notes: [],
+    },
     errorMessage: row.errorMessage,
     traceId: row.traceId,
     metadata: meta,
@@ -273,6 +291,7 @@ export function mapIngestionReconciliationRunToCanonicalListItem(row: {
     provenance: detail.provenance,
     adapters: detail.adapters,
     timestamps: detail.timestamps,
+    configDrift: detail.configDrift,
   };
 }
 

--- a/packages/reconciliation-core/src/console-reconciliation-list.test.ts
+++ b/packages/reconciliation-core/src/console-reconciliation-list.test.ts
@@ -68,6 +68,21 @@ describe("buildConsoleReconciliationListBody", () => {
       completedAt: null,
       updatedAt: "2024-01-01T00:00:00.000Z",
     },
+    configDrift: {
+      status: "none",
+      strategyChanged: false,
+      templateChanged: false,
+      validationRulesChanged: false,
+      adapter: {
+        status: "none",
+        comparisonMode: "unavailable",
+        sourceChanged: null,
+        targetChanged: null,
+        sourceHashPresent: false,
+        targetHashPresent: false,
+      },
+      notes: [],
+    },
   };
 
   const ing: CanonicalReconciliationListItem = {
@@ -91,7 +106,7 @@ describe("buildConsoleReconciliationListBody", () => {
     expect(recs[0]?.id).toBe("j1");
     expect(body.response_meta).toMatchObject({
       requested_run_kind: "all",
-      default_run_kind: "recon_job",
+      default_run_kind: "all",
     });
   });
 

--- a/packages/reconciliation-core/src/console-reconciliation-list.ts
+++ b/packages/reconciliation-core/src/console-reconciliation-list.ts
@@ -39,7 +39,7 @@ function toLegacyReconciliation(r: CanonicalReconciliationListItem) {
 
 /**
  * @param page — result of {@link fetchMergedReconciliationRunsPage}
- * @param runKind — validated `run_kind` query (`recon_job` default in route)
+ * @param runKind — validated `run_kind` query (`all` default in Next route)
  */
 export function buildConsoleReconciliationListBody(
   page: MergedReconciliationListResponse,
@@ -56,7 +56,7 @@ export function buildConsoleReconciliationListBody(
     pagination: page.pagination,
     response_meta: {
       ...page.response_meta,
-      default_run_kind: "recon_job",
+      default_run_kind: "all",
       requested_run_kind: runKind,
     },
   };

--- a/packages/reconciliation-core/src/index.ts
+++ b/packages/reconciliation-core/src/index.ts
@@ -7,3 +7,4 @@ export * from "./uuid-collision-log.js";
 export * from "./v1-serializer.js";
 export * from "./run-capabilities.js";
 export * from "./console-reconciliation-list.js";
+export * from "./api-runs-list-adapter.js";

--- a/packages/reconciliation-core/src/run-resolution.ts
+++ b/packages/reconciliation-core/src/run-resolution.ts
@@ -22,9 +22,43 @@ export async function resolveReconciliationRunForTenant(
   tenantId: string,
   runId: string
 ): Promise<ReconciliationRunResolution> {
+  const resolved = await resolveReconciliationRunForTenants(prisma, [tenantId], runId);
+  if (resolved.kind === "recon_job" || resolved.kind === "ingestion_run") {
+    return { kind: resolved.kind, detail: resolved.detail };
+  }
+  return resolved;
+}
+
+export type ResolvedReconciliationRunForTenants =
+  | {
+      kind: "recon_job";
+      tenantId: string;
+      detail: CanonicalReconciliationRunDetail;
+    }
+  | {
+      kind: "ingestion_run";
+      tenantId: string;
+      detail: CanonicalReconciliationRunDetail;
+    }
+  | { kind: "ambiguous_uuid_collision"; jobId: string; ingestionRunId: string }
+  | { kind: "not_found" };
+
+/**
+ * Resolve a run id when the caller has membership in multiple tenants (console scope).
+ * Uses at most one row per table across the allowed tenant set.
+ */
+export async function resolveReconciliationRunForTenants(
+  prisma: PrismaClient,
+  tenantIds: string[],
+  runId: string
+): Promise<ResolvedReconciliationRunForTenants> {
+  if (tenantIds.length === 0) {
+    return { kind: "not_found" };
+  }
+
   const [job, ingestionRun] = await Promise.all([
     prisma.reconJob.findFirst({
-      where: { id: runId, tenantId, deletedAt: null },
+      where: { id: runId, tenantId: { in: tenantIds }, deletedAt: null },
       select: {
         id: true,
         tenantId: true,
@@ -43,7 +77,7 @@ export async function resolveReconciliationRunForTenant(
       },
     }),
     prisma.reconciliationRun.findFirst({
-      where: { id: runId, tenantId },
+      where: { id: runId, tenantId: { in: tenantIds } },
       select: {
         id: true,
         tenantId: true,
@@ -70,7 +104,7 @@ export async function resolveReconciliationRunForTenant(
 
   if (job && ingestionRun) {
     await logConflict({
-      tenantId,
+      tenantId: job.tenantId,
       duplicateUuid: runId,
       reconJobId: job.id,
       reconciliationRunId: ingestionRun.id,
@@ -84,7 +118,7 @@ export async function resolveReconciliationRunForTenant(
 
   if (job) {
     const latestResult = await prisma.reconResult.findFirst({
-      where: { reconJobId: job.id, tenantId },
+      where: { reconJobId: job.id, tenantId: job.tenantId },
       orderBy: { startedAt: "desc" },
       select: {
         id: true,
@@ -129,6 +163,7 @@ export async function resolveReconciliationRunForTenant(
 
     return {
       kind: "recon_job",
+      tenantId: job.tenantId,
       detail: mapReconJobRowToCanonicalDetail({
         job: {
           id: job.id,
@@ -154,6 +189,7 @@ export async function resolveReconciliationRunForTenant(
   if (ingestionRun) {
     return {
       kind: "ingestion_run",
+      tenantId: ingestionRun.tenantId,
       detail: mapIngestionReconciliationRunToCanonicalDetail(ingestionRun),
     };
   }

--- a/packages/web/jest.config.js
+++ b/packages/web/jest.config.js
@@ -11,6 +11,7 @@ const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   testEnvironment: "jest-environment-jsdom",
   moduleNameMapper: {
+    "^@settler/reconciliation-core$": "<rootDir>/../reconciliation-core/src/index.ts",
     "^@/(.*)$": "<rootDir>/src/$1",
     // Strip .js extensions from relative imports so ts-jest can resolve .ts sources
     // in workspace packages (e.g. @settler/reconciliation-core uses ESM-style .js refs)

--- a/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
+++ b/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
@@ -1,0 +1,237 @@
+/** @jest-environment node */
+
+import { GET as getRunsList } from "@/app/api/runs/route";
+import type { CanonicalReconciliationListItem } from "@settler/reconciliation-core";
+
+const requireAuthMock = jest.fn();
+const resolveTenantMembershipScopeMock = jest.fn();
+const fetchMergedReconciliationRunsPageMock = jest.fn();
+const decodeMergedRunsCursorMock = jest.fn();
+const mapCanonicalListItemToApiRunsLegacyRowMock = jest.fn();
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+jest.mock("@/middleware/billing-gate-universal", () => ({
+  withUniversalBillingGate: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/api/unified-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+
+jest.mock("@/lib/supabase/tenant-membership", () => ({
+  resolveTenantMembershipScope: (...args: unknown[]) =>
+    resolveTenantMembershipScopeMock(...args),
+  assertTenantMembership: jest.fn(),
+  resolveTenantForMutation: jest.fn(() => "tenant-1"),
+}));
+
+jest.mock("@settler/reconciliation-core", () => {
+  const actual = jest.requireActual("@settler/reconciliation-core") as Record<string, unknown>;
+  return {
+    ...actual,
+    fetchMergedReconciliationRunsPage: (...args: unknown[]) =>
+      fetchMergedReconciliationRunsPageMock(...args),
+    decodeMergedRunsCursor: (...args: unknown[]) => decodeMergedRunsCursorMock(...args),
+    mapCanonicalListItemToApiRunsLegacyRow: (...args: unknown[]) =>
+      mapCanonicalListItemToApiRunsLegacyRowMock(...args),
+  };
+});
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+jest.mock("@/shared/db/prismaClient", () => ({
+  prisma: {},
+}));
+
+function req(url: string) {
+  return {
+    url,
+    method: "GET",
+    headers: new Headers(),
+    nextUrl: new URL(url),
+  } as any;
+}
+
+const baseListItem: CanonicalReconciliationListItem = {
+  runKind: "recon_job",
+  id: "job-1",
+  tenantId: "tenant-1",
+  name: "Test job",
+  reconResultId: null,
+  configDrift: {
+    status: "none",
+    strategyChanged: false,
+    templateChanged: false,
+    validationRulesChanged: false,
+    adapter: {
+      status: "none",
+      comparisonMode: "unavailable",
+      sourceChanged: null,
+      targetChanged: null,
+      sourceHashPresent: false,
+      targetHashPresent: false,
+    },
+    notes: [],
+  },
+  lifecycle: {
+    status: "completed",
+    statusLabel: "Completed",
+    isTerminal: true,
+    progressPercent: 100,
+    progressState: "completed",
+  },
+  summaryState: "success",
+  summary: {
+    total: 2,
+    sourceCount: 1,
+    targetCount: 1,
+    processed: 2,
+    matched: 1,
+    matchedWithTolerance: 0,
+    unmatched: 0,
+    unmatchedSourceCount: 0,
+    unmatchedTargetCount: 0,
+    conflicts: 0,
+    exceptioned: 0,
+    unresolved: 0,
+    ignored: 0,
+    resolved: 0,
+  },
+  provenance: {
+    sourceModel: "recon_jobs",
+    runKind: "recon_job",
+    ingestionId: null,
+    reconJobId: "job-1",
+  },
+  adapters: { sourceAdapter: "a", targetAdapter: "b" },
+  timestamps: {
+    createdAt: "2024-01-01T00:00:00.000Z",
+    startedAt: "2024-01-01T00:00:01.000Z",
+    completedAt: "2024-01-01T00:00:02.000Z",
+    updatedAt: "2024-01-01T00:00:02.000Z",
+  },
+};
+
+describe("GET /api/runs", () => {
+  beforeEach(() => {
+    requireAuthMock.mockReset();
+    resolveTenantMembershipScopeMock.mockReset();
+    fetchMergedReconciliationRunsPageMock.mockReset();
+    decodeMergedRunsCursorMock.mockReset();
+    mapCanonicalListItemToApiRunsLegacyRowMock.mockReset();
+
+    requireAuthMock.mockResolvedValue({ tenantId: "tenant-1", userId: "u1", type: "session" });
+    resolveTenantMembershipScopeMock.mockResolvedValue({
+      tenantIds: ["tenant-1"],
+      userId: "u1",
+    });
+
+    fetchMergedReconciliationRunsPageMock.mockResolvedValue({
+      runs: [baseListItem],
+      next_cursor: "next",
+      pagination: {
+        limit: 50,
+        returned: 1,
+        has_more: true,
+        job_stream_has_more: true,
+        ingestion_stream_has_more: false,
+        job_stream_exhausted: false,
+        ingestion_stream_exhausted: true,
+      },
+      response_meta: {
+        contract_version: 1,
+        included_run_kinds: ["recon_job", "ingestion_run"],
+        ordering: "test-ordering",
+        consistency: "read_committed",
+      },
+    });
+
+    mapCanonicalListItemToApiRunsLegacyRowMock.mockImplementation((row: CanonicalReconciliationListItem) => ({
+      runKind: row.runKind,
+      id: row.id,
+      name: row.name,
+      status: row.lifecycle.status,
+      statusLabel: row.lifecycle.statusLabel,
+      startedAt: row.timestamps.startedAt ?? row.timestamps.createdAt,
+      completedAt: row.timestamps.completedAt,
+      summary: {
+        total: row.summary.total,
+        sourceCount: row.summary.sourceCount,
+        targetCount: row.summary.targetCount,
+        matched: row.summary.matched,
+        unmatched: row.summary.unmatched,
+        unmatchedSourceCount: row.summary.unmatchedSourceCount,
+        unmatchedTargetCount: row.summary.unmatchedTargetCount,
+        conflicts: row.summary.conflicts,
+      },
+      summarySemantics: {
+        processed: row.summary.processed,
+        matchedWithTolerance: row.summary.matchedWithTolerance,
+        exceptioned: row.summary.exceptioned,
+        unresolved: row.summary.unresolved,
+        ignored: row.summary.ignored,
+        resolved: row.summary.resolved,
+      },
+      summaryState: row.summaryState,
+      progress: row.lifecycle.progressPercent,
+      progressState: row.lifecycle.progressState,
+      isTerminal: row.lifecycle.isTerminal,
+      provenance: {},
+      configDrift: { status: "none", adapter: "none" },
+      ingestionId: row.provenance.ingestionId,
+      sourceAdapter: row.adapters.sourceAdapter,
+      targetAdapter: row.adapters.targetAdapter,
+    }));
+  });
+
+  it("returns 400 for invalid run_kind", async () => {
+    const res = await getRunsList(req("http://localhost/api/runs?run_kind=nope"), {} as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("RUNS_INVALID_RUN_KIND");
+  });
+
+  it("returns 400 for invalid cursor", async () => {
+    decodeMergedRunsCursorMock.mockImplementation(() => {
+      const { MergedRunsCursorError } = jest.requireActual(
+        "@settler/reconciliation-core"
+      ) as typeof import("@settler/reconciliation-core");
+      throw new MergedRunsCursorError("bad");
+    });
+    const res = await getRunsList(req("http://localhost/api/runs?cursor=xx"), {} as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("RUNS_CURSOR_INVALID");
+  });
+
+  it("returns merged list envelope with next_cursor when no filters", async () => {
+    decodeMergedRunsCursorMock.mockReturnValue(null);
+    const res = await getRunsList(req("http://localhost/api/runs?run_kind=all"), {} as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].id).toBe("job-1");
+    expect(body.next_cursor).toBe("next");
+    expect(body.response_meta.pagination_mode).toBe("merged_cursor");
+    expect(fetchMergedReconciliationRunsPageMock).toHaveBeenCalled();
+  });
+
+  it("rejects cursor together with status filter", async () => {
+    const res = await getRunsList(
+      req("http://localhost/api/runs?cursor=abc&status=completed"),
+      {} as any
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("RUNS_CURSOR_WITH_FILTERS_UNSUPPORTED");
+  });
+});

--- a/packages/web/src/__tests__/api/run-domain-trust-invariants.test.ts
+++ b/packages/web/src/__tests__/api/run-domain-trust-invariants.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment node */
 
-import { GET as getRunDetail } from "@/app/api/runs/[runId]/route";
+import { GET as getRunDetail } from "@/app/api/runs/[id]/route";
 import { POST as createRun } from "@/app/api/runs/create/route";
 import { POST as runReconciliation } from "@/app/api/console/reconciliation/route";
 import { POST as postExceptionAction } from "@/app/api/exceptions/[exceptionId]/route";
@@ -14,6 +14,7 @@ const requireAuthMock = jest.fn();
 const authenticateApiKeyMock = jest.fn();
 const reconJobFindFirstMock = jest.fn();
 const reconResultFindFirstMock = jest.fn();
+const reconciliationRunFindFirstMock = jest.fn();
 const prismaQueryRawMock = jest.fn();
 
 jest.mock("@/lib/middleware/api-security", () => ({
@@ -47,6 +48,7 @@ jest.mock("@/shared/db/prismaClient", () => ({
     $queryRaw: (...args: unknown[]) => prismaQueryRawMock(...args),
     reconciliationRun: {
       count: jest.fn(async () => 0),
+      findFirst: (...args: unknown[]) => reconciliationRunFindFirstMock(...args),
     },
     reconJob: {
       findFirst: (...args: unknown[]) => reconJobFindFirstMock(...args),
@@ -119,6 +121,7 @@ describe("run domain trust invariants", () => {
     authenticateApiKeyMock.mockReset();
     reconJobFindFirstMock.mockReset();
     reconResultFindFirstMock.mockReset();
+    reconciliationRunFindFirstMock.mockReset();
     prismaQueryRawMock.mockReset();
     prismaQueryRawMock.mockResolvedValue([
       {
@@ -132,50 +135,17 @@ describe("run domain trust invariants", () => {
   });
 
   test("run detail read blocks cross-tenant access", async () => {
-    const runRow = {
-      id: "run-b-1",
-      name: "Tenant B Run",
-      status: "completed",
-      created_at: "2026-01-01T00:00:00.000Z",
-      updated_at: "2026-01-01T00:00:00.000Z",
-      tenant_id: "tenant-b",
-    };
-
-    const supabase = {
-      from: jest.fn((table: string) => {
-        if (table === "recon_jobs") {
-          return {
-            select: jest.fn(() => ({
-              eq: jest.fn((column: string, value: string) => ({
-                in: jest.fn((_tenantColumn: string, tenantIds: string[]) => ({
-                  single: jest.fn(async () => {
-                    if (
-                      column === "id" &&
-                      value === runRow.id &&
-                      tenantIds.includes(runRow.tenant_id)
-                    ) {
-                      return { data: runRow, error: null };
-                    }
-                    return { data: null, error: { message: "Not found" } };
-                  }),
-                })),
-              })),
-            })),
-          };
-        }
-
-        throw new Error(`Unexpected table access: ${table}`);
-      }),
-    };
+    reconJobFindFirstMock.mockResolvedValue(null);
+    reconciliationRunFindFirstMock.mockResolvedValue(null);
 
     resolveTenantMembershipScopeMock.mockResolvedValue({
-      supabase,
+      supabase: { from: jest.fn() },
       userId: "user-a",
       tenantIds: ["tenant-a"],
     });
 
     const response = await getRunDetail(req("http://localhost/api/runs/run-b-1"), {
-      params: { runId: "run-b-1" },
+      params: { id: "run-b-1" },
     } as any);
 
     expect(response.status).toBe(404);
@@ -201,6 +171,24 @@ describe("run domain trust invariants", () => {
       recon_strategy: "deterministic",
     };
 
+    reconJobFindFirstMock.mockResolvedValue({
+      id: runRow.id,
+      tenantId: "tenant-a",
+      name: runRow.name,
+      status: runRow.status,
+      createdAt: new Date(runRow.created_at),
+      updatedAt: new Date(runRow.updated_at),
+      sourceAdapter: "stripe",
+      targetAdapter: "netsuite",
+      reconStrategy: "deterministic",
+      templateId: "tpl-1",
+      validationRules: runRow.validation_rules,
+      sourceConfigEncrypted: "enc-src",
+      targetConfigEncrypted: "enc-tgt",
+      metadata: {},
+    });
+    reconciliationRunFindFirstMock.mockResolvedValue(null);
+
     const latestResult = {
       id: "result-a-1",
       recon_job_id: runRow.id,
@@ -219,13 +207,33 @@ describe("run domain trust invariants", () => {
       snapshot_id: "snapshot-1",
     };
 
+    reconResultFindFirstMock.mockResolvedValue({
+      id: latestResult.id,
+      reconJobId: runRow.id,
+      tenantId: "tenant-a",
+      status: latestResult.status,
+      startedAt: new Date(latestResult.started_at),
+      completedAt: new Date(latestResult.completed_at),
+      sourceCount: latestResult.source_count,
+      targetCount: latestResult.target_count,
+      matchedCount: latestResult.matched_count,
+      unmatchedSourceCount: latestResult.unmatched_source_count,
+      unmatchedTargetCount: latestResult.unmatched_target_count,
+      conflictCount: latestResult.conflict_count,
+      errorMessage: null,
+      inputHash: latestResult.input_hash,
+      snapshotId: latestResult.snapshot_id,
+      summary: null,
+      metadata: latestResult.metadata,
+    });
+
     const supabase = {
       from: jest.fn((table: string) => {
         if (table === "recon_jobs") {
           return {
             select: jest.fn(() => ({
               eq: jest.fn(() => ({
-                in: jest.fn(() => ({
+                eq: jest.fn(() => ({
                   single: jest.fn(async () => ({ data: runRow, error: null })),
                 })),
               })),
@@ -310,11 +318,12 @@ describe("run domain trust invariants", () => {
     });
 
     const response = await getRunDetail(req("http://localhost/api/runs/run-a-1"), {
-      params: { runId: "run-a-1" },
+      params: { id: "run-a-1" },
     } as any);
 
     expect(response.status).toBe(200);
     const payload = await response.json();
+    expect(payload.runKind).toBe("recon_job");
     expect(payload.config).toEqual(
       expect.objectContaining({
         sourceAdapter: "stripe",

--- a/packages/web/src/app/api/console/reconciliation/route.ts
+++ b/packages/web/src/app/api/console/reconciliation/route.ts
@@ -204,11 +204,22 @@ export const GET = withSecurity(
 
         const cursorParam = request.nextUrl.searchParams.get("cursor") ?? undefined;
         const limit = Math.min(Number(request.nextUrl.searchParams.get("limit") || 50), 500);
-        const runKindRaw = request.nextUrl.searchParams.get("run_kind") ?? "recon_job";
+        const runKindRaw = (request.nextUrl.searchParams.get("run_kind") ?? "all").trim();
         const runKind =
           runKindRaw === "all" || runKindRaw === "recon_job" || runKindRaw === "ingestion_run"
             ? runKindRaw
-            : "recon_job";
+            : "__invalid__";
+
+        if (runKind === "__invalid__") {
+          return NextResponse.json(
+            {
+              error: "Invalid run_kind",
+              code: "RECONCILIATION_INVALID_RUN_KIND",
+              detail: "run_kind must be one of: all, recon_job, ingestion_run",
+            },
+            { status: 400 }
+          );
+        }
 
         let cursorState = null;
         if (cursorParam) {

--- a/packages/web/src/app/api/runs/[id]/route.ts
+++ b/packages/web/src/app/api/runs/[id]/route.ts
@@ -30,7 +30,9 @@ import {
   type ReconResultRow,
 } from "@/lib/reconciliation/run-status";
 import { buildRunConfigurationSummary } from "@/lib/reconciliation/run-detail";
+import { buildIngestionRunDetailJson } from "@/lib/reconciliation/build-ingestion-run-detail-json";
 import { prisma } from "@/shared/db/prismaClient";
+import { resolveReconciliationRunForTenants } from "@settler/reconciliation-core";
 
 export const runtime = "nodejs";
 
@@ -42,13 +44,41 @@ export const GET = withSecurity(
       try {
         const { supabase, tenantIds: accessibleTenantIds } = await resolveTenantMembershipScope();
 
+        const resolved = await resolveReconciliationRunForTenants(
+          prisma,
+          accessibleTenantIds,
+          params.id
+        );
+
+        if (resolved.kind === "ambiguous_uuid_collision") {
+          return NextResponse.json(
+            {
+              error: "Ambiguous run identifier",
+              code: "RUN_ID_COLLISION",
+              detail:
+                "The same UUID exists as both a recon job and an ingestion reconciliation run; disambiguate in the database or use tenant-scoped APIs that return a single kind.",
+              recon_job_id: resolved.jobId,
+              ingestion_run_id: resolved.ingestionRunId,
+            },
+            { status: 409 }
+          );
+        }
+
+        if (resolved.kind === "not_found") {
+          return NextResponse.json({ error: "Run not found" }, { status: 404 });
+        }
+
+        if (resolved.kind === "ingestion_run") {
+          return NextResponse.json(buildIngestionRunDetailJson(resolved.detail));
+        }
+
         const { data: run, error: runError } = (await supabase
           .from("recon_jobs" as any)
           .select(
             "id, name, status, created_at, updated_at, tenant_id, template_id, source_adapter, target_adapter, source_config_encrypted, target_config_encrypted, validation_rules, recon_strategy"
           )
           .eq("id", params.id)
-          .in("tenant_id", accessibleTenantIds)
+          .eq("tenant_id", resolved.tenantId)
           .single()) as {
           data:
             | (ReconJobRow & {
@@ -294,6 +324,7 @@ export const GET = withSecurity(
         );
 
         return NextResponse.json({
+          runKind: "recon_job" as const,
           id: run.id,
           name: contract.name,
           status: truth.status,

--- a/packages/web/src/app/api/runs/route.ts
+++ b/packages/web/src/app/api/runs/route.ts
@@ -1,156 +1,268 @@
 /**
- * List Reconciliation Runs
+ * List reconciliation runs (merged canonical view)
  *
  * GET /api/runs
  *
- * Returns canonical run results using one shared run-result contract.
+ * Returns recon_jobs-backed runs and ingestion-backed reconciliation_runs in one list,
+ * using the same merge + cursor semantics as reconciliation-core.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { createLogger } from "@/lib/logger";
 import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
 import { withSecurity } from "@/lib/middleware/api-security";
+import { requireAuth, type UnifiedAuthContext } from "@/lib/api/unified-auth";
 import {
+  assertTenantMembership,
+  resolveTenantForMutation,
   resolveTenantMembershipScope,
   TenantMembershipError,
 } from "@/lib/supabase/tenant-membership";
+import { prisma } from "@/shared/db/prismaClient";
 import {
-  buildCanonicalRunResultContract,
-  type ReconJobRecordLike,
-  type ReconResultRecordLike,
-} from "@/lib/reconciliation/canonical-run-result";
+  decodeMergedRunsCursor,
+  encodeMergedRunsCursor,
+  fetchMergedReconciliationRunsPage,
+  mapCanonicalListItemToApiRunsLegacyRow,
+  MergedRunsCursorError,
+  type MergedRunsCursorV1,
+  type ReconciliationRunKindFilter,
+} from "@settler/reconciliation-core";
 
 export const runtime = "nodejs";
 
-type RunListJobRow = {
-  id: string;
-  name: string | null;
-  status: string | null;
-  tenant_id: string;
-  created_at: string;
-  updated_at?: string | null;
-  source_adapter?: string | null;
-  target_adapter?: string | null;
-  recon_strategy?: string | null;
-  template_id?: string | null;
-  validation_rules?: unknown;
-  source_config_encrypted?: string | null;
-  target_config_encrypted?: string | null;
-};
+const RUN_KIND_VALUES: ReconciliationRunKindFilter[] = ["all", "recon_job", "ingestion_run"];
 
-type RunListResultRow = ReconResultRecordLike & {
-  recon_job_id: string;
-};
+function resolveTenantIdForRuns(
+  authContext: UnifiedAuthContext,
+  tenantIds: string[],
+  tenantIdParam: string | null
+): string {
+  if (tenantIdParam) {
+    assertTenantMembership(tenantIds, tenantIdParam);
+    return tenantIdParam;
+  }
+  if (authContext.tenantId) {
+    assertTenantMembership(tenantIds, authContext.tenantId);
+    return authContext.tenantId;
+  }
+  return resolveTenantForMutation(tenantIds);
+}
+
+function parseLimit(raw: string | null): number {
+  const n = Number(raw || 50);
+  if (!Number.isFinite(n) || n < 1) {
+    return 50;
+  }
+  return Math.min(Math.floor(n), 500);
+}
+
+function matchesStatusFilter(
+  statusFilter: string | undefined,
+  status: string
+): boolean {
+  if (!statusFilter) return true;
+  return status.toLowerCase() === statusFilter;
+}
+
+function matchesSearchFilter(searchFilter: string | undefined, id: string, name: string): boolean {
+  if (!searchFilter) return true;
+  const haystack = `${id} ${name}`.toLowerCase();
+  return haystack.includes(searchFilter);
+}
+
+const MAX_FILTER_SCAN_PAGES = 30;
 
 export const GET = withSecurity(
   withUniversalBillingGate(
-    async function GET(_request: NextRequest, _params: unknown) {
+    async function GET(request: NextRequest) {
       const logger = createLogger({});
 
       try {
-        const { searchParams } = new URL(_request.url);
-        const statusFilter = searchParams.get("status")?.toLowerCase() || undefined;
+        const authContext = await requireAuth(request);
+        const { tenantIds } = await resolveTenantMembershipScope();
+
+        const { searchParams } = new URL(request.url);
+        const tenantIdParam = searchParams.get("tenant_id") ?? searchParams.get("workspace_id");
+        const tenantId = resolveTenantIdForRuns(authContext, tenantIds, tenantIdParam);
+
+        const statusFilter = searchParams.get("status")?.trim().toLowerCase() || undefined;
         const searchFilter = searchParams.get("search")?.trim().toLowerCase() || undefined;
+        const runKindRaw = (searchParams.get("run_kind") ?? searchParams.get("runKind") ?? "all")
+          .trim()
+          .toLowerCase();
+        const runKind = (
+          RUN_KIND_VALUES.includes(runKindRaw as ReconciliationRunKindFilter)
+            ? runKindRaw
+            : "__invalid__"
+        ) as ReconciliationRunKindFilter | "__invalid__";
 
-        const { supabase, tenantIds } = await resolveTenantMembershipScope();
-
-        const { data: latestResults, error: resultsError } = (await supabase
-          .from("recon_results" as any)
-          .select(
-            "id, recon_job_id, status, started_at, completed_at, source_count, target_count, matched_count, unmatched_source_count, unmatched_target_count, conflict_count, error_message, input_hash, snapshot_id, summary, metadata"
-          )
-          .in("tenant_id", tenantIds)
-          .order("started_at", { ascending: false })) as {
-          data: RunListResultRow[] | null;
-          error: { message?: string } | null;
-        };
-
-        if (resultsError) {
-          logger.error("Error fetching results", new Error(resultsError.message || "Unknown error"));
-          return NextResponse.json({ error: "Failed to fetch run results" }, { status: 500 });
+        if (runKind === "__invalid__") {
+          return NextResponse.json(
+            {
+              error: "Invalid run_kind",
+              code: "RUNS_INVALID_RUN_KIND",
+              detail: `run_kind must be one of: ${RUN_KIND_VALUES.join(", ")}`,
+            },
+            { status: 400 }
+          );
         }
 
-        const { data: runs, error: runsError } = (await supabase
-          .from("recon_jobs" as any)
-          .select(
-            "id, name, status, tenant_id, created_at, updated_at, source_adapter, target_adapter, recon_strategy, template_id, validation_rules, source_config_encrypted, target_config_encrypted"
-          )
-          .in("tenant_id", tenantIds)
-          .order("created_at", { ascending: false })
-          .limit(200)) as {
-          data: RunListJobRow[] | null;
-          error: { message?: string } | null;
-        };
+        const limit = parseLimit(searchParams.get("limit"));
+        const cursorParam = searchParams.get("cursor")?.trim() || undefined;
+        const legacyPage = searchParams.get("page");
 
-        if (runsError) {
-          logger.error("Error fetching runs", new Error(runsError.message || "Unknown error"));
-          return NextResponse.json({ error: "Failed to fetch runs" }, { status: 500 });
-        }
-
-        const latestResultByJobId = new Map<string, RunListResultRow>();
-        for (const result of latestResults || []) {
-          if (!latestResultByJobId.has(result.recon_job_id)) {
-            latestResultByJobId.set(result.recon_job_id, result);
+        let cursorState: MergedRunsCursorV1 | null = null;
+        if (cursorParam) {
+          try {
+            cursorState = decodeMergedRunsCursor(cursorParam);
+          } catch (e) {
+            logger.warn("[GET /api/runs] invalid cursor", {
+              code: "RUNS_CURSOR_INVALID",
+              detail: e instanceof MergedRunsCursorError ? e.message : "Invalid cursor",
+            });
+            return NextResponse.json(
+              {
+                error: "Invalid cursor",
+                code: "RUNS_CURSOR_INVALID",
+                detail: e instanceof MergedRunsCursorError ? e.message : "Invalid cursor",
+              },
+              { status: 400 }
+            );
           }
         }
 
-        const filteredRuns = (runs || [])
-          .map((run) => {
-            const latestResult = latestResultByJobId.get(run.id) ?? null;
-            const contract = buildCanonicalRunResultContract({
-              job: run as ReconJobRecordLike,
-              result: latestResult,
-            });
+        const filterActive = Boolean(statusFilter || searchFilter);
 
-            return {
-              id: run.id,
-              name: contract.name,
-              status: contract.lifecycle.status,
-              statusLabel: contract.lifecycle.statusLabel,
-              startedAt:
-                contract.provenance.executedAt || run.created_at || new Date().toISOString(),
-              completedAt: contract.provenance.completedAt,
-              summary: {
-                total: contract.summary.total,
-                sourceCount: contract.summary.sourceCount,
-                targetCount: contract.summary.targetCount,
-                matched: contract.summary.matched,
-                unmatched: contract.summary.unmatched,
-                unmatchedSourceCount: contract.summary.unmatchedSourceCount,
-                unmatchedTargetCount: contract.summary.unmatchedTargetCount,
-                conflicts: contract.summary.conflicts,
-              },
-              summarySemantics: {
-                processed: contract.summary.processed,
-                matchedWithTolerance: contract.summary.matchedWithTolerance,
-                exceptioned: contract.summary.exceptioned,
-                unresolved: contract.summary.unresolved,
-                ignored: contract.summary.ignored,
-                resolved: contract.summary.resolved,
-              },
-              summaryState: contract.summaryState,
-              progress: contract.lifecycle.progressPercent,
-              progressState: contract.lifecycle.progressState,
-              isTerminal: contract.lifecycle.isTerminal,
-              provenance: contract.provenance,
-              configDrift: {
-                status: contract.configDrift.status,
-                adapter: contract.configDrift.adapter,
-              },
-            };
-          })
-          .filter((run) => {
-            if (statusFilter && run.status !== statusFilter) {
-              return false;
-            }
-            if (searchFilter) {
-              const searchable = `${run.id} ${run.name}`.toLowerCase();
-              return searchable.includes(searchFilter);
-            }
-            return true;
+        if (!filterActive) {
+          const page = await fetchMergedReconciliationRunsPage({
+            prisma,
+            tenantId,
+            limit,
+            cursorState,
+            runKind,
+            encodeCursor: encodeMergedRunsCursor,
           });
 
-        return NextResponse.json(filteredRuns);
+          const items = page.runs.map(mapCanonicalListItemToApiRunsLegacyRow);
+
+          return NextResponse.json({
+            items,
+            next_cursor: page.next_cursor,
+            pagination: page.pagination,
+            response_meta: {
+              ...page.response_meta,
+              contract_version: 1,
+              api: "GET /api/runs",
+              tenant_id: tenantId,
+              requested_run_kind: runKind,
+              filters_applied: {
+                status: statusFilter ?? null,
+                search: searchFilter ?? null,
+              },
+              pagination_mode: "merged_cursor",
+              legacy_page_param_ignored: legacyPage ? true : false,
+            },
+          });
+        }
+
+        if (cursorParam) {
+          return NextResponse.json(
+            {
+              error: "Cursor pagination is not supported together with status or search filters",
+              code: "RUNS_CURSOR_WITH_FILTERS_UNSUPPORTED",
+              detail:
+                "Remove the cursor parameter or clear status/search to use keyset pagination; filtered mode returns the first page only.",
+            },
+            { status: 400 }
+          );
+        }
+
+        let walkCursor: MergedRunsCursorV1 | null = null;
+        const collected: ReturnType<typeof mapCanonicalListItemToApiRunsLegacyRow>[] = [];
+        let pagesScanned = 0;
+        let lastPagePagination = null as Awaited<
+          ReturnType<typeof fetchMergedReconciliationRunsPage>
+        >["pagination"] | null;
+        let truncated = false;
+
+        while (collected.length < limit && pagesScanned < MAX_FILTER_SCAN_PAGES) {
+          const page = await fetchMergedReconciliationRunsPage({
+            prisma,
+            tenantId,
+            limit,
+            cursorState: walkCursor,
+            runKind,
+            encodeCursor: encodeMergedRunsCursor,
+          });
+          pagesScanned += 1;
+          lastPagePagination = page.pagination;
+
+          for (const row of page.runs) {
+            const legacy = mapCanonicalListItemToApiRunsLegacyRow(row);
+            if (!matchesStatusFilter(statusFilter, legacy.status)) continue;
+            if (!matchesSearchFilter(searchFilter, legacy.id, legacy.name)) continue;
+            collected.push(legacy);
+            if (collected.length >= limit) break;
+          }
+
+          if (!page.next_cursor) {
+            break;
+          }
+          try {
+            walkCursor = decodeMergedRunsCursor(page.next_cursor);
+          } catch {
+            truncated = true;
+            break;
+          }
+          if (collected.length >= limit) {
+            truncated = Boolean(page.next_cursor);
+            break;
+          }
+        }
+
+        if (pagesScanned >= MAX_FILTER_SCAN_PAGES && lastPagePagination?.has_more) {
+          truncated = true;
+        }
+
+        const items = collected.slice(0, limit);
+
+        return NextResponse.json({
+          items,
+          next_cursor: null,
+          pagination: {
+            limit,
+            returned: items.length,
+            has_more: false,
+            job_stream_has_more: lastPagePagination?.job_stream_has_more ?? false,
+            ingestion_stream_has_more: lastPagePagination?.ingestion_stream_has_more ?? false,
+            job_stream_exhausted: lastPagePagination?.job_stream_exhausted ?? true,
+            ingestion_stream_exhausted: lastPagePagination?.ingestion_stream_exhausted ?? true,
+            filter_scan_pages: pagesScanned,
+            filter_truncation_possible: truncated,
+          },
+          response_meta: {
+            contract_version: 1,
+            included_run_kinds:
+              runKind === "all"
+                ? (["recon_job", "ingestion_run"] as const)
+                : runKind === "recon_job"
+                  ? (["recon_job"] as const)
+                  : (["ingestion_run"] as const),
+            ordering:
+              "merged: recon_jobs.created_at DESC,id DESC + reconciliation_runs GREATEST(started_at,created_at) DESC,id DESC; filtered mode scans pages until enough matches",
+            consistency: "read_committed",
+            api: "GET /api/runs",
+            tenant_id: tenantId,
+            requested_run_kind: runKind,
+            filters_applied: {
+              status: statusFilter ?? null,
+              search: searchFilter ?? null,
+            },
+            pagination_mode: "filter_scan_first_page",
+            legacy_page_param_ignored: legacyPage ? true : false,
+          },
+        });
       } catch (error) {
         if (error instanceof TenantMembershipError) {
           return NextResponse.json(

--- a/packages/web/src/app/console/reconciliations/page.tsx
+++ b/packages/web/src/app/console/reconciliations/page.tsx
@@ -14,6 +14,7 @@ import { ReconciliationView } from "@/components/console/ReconciliationView";
 import { safeFetch } from "@/lib/safe-fetch";
 
 interface RecentRun {
+  runKind?: "recon_job" | "ingestion_run";
   id: string;
   name: string;
   status: "pending" | "running" | "completed" | "failed" | "unknown";
@@ -74,14 +75,14 @@ export default function ReconciliationsPage() {
 
     async function loadRuns() {
       setLoading(true);
-      const result = await safeFetch<RecentRun[]>("/api/runs");
+      const result = await safeFetch<{ items: RecentRun[] }>("/api/runs?limit=6&run_kind=all");
 
       if (cancelled) {
         return;
       }
 
       if (result.success && result.data) {
-        setRuns(result.data.slice(0, 6));
+        setRuns((result.data.items ?? []).slice(0, 6));
         setError(null);
       } else {
         setRuns([]);
@@ -156,9 +157,10 @@ export default function ReconciliationsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Recent Runs</CardTitle>
+          <CardTitle>Recent runs</CardTitle>
           <CardDescription>
-            Open a completed run to review matched, unmatched, and conflict outcomes.
+            Mixed recon jobs and ingestion runs from the same merged list as Runs. Result inspection
+            is available for recon jobs; ingestion runs use run detail for now.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -201,6 +203,15 @@ export default function ReconciliationsPage() {
                       <div className="space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
                           <h3 className="font-semibold text-foreground">{run.name}</h3>
+                          {run.runKind === "ingestion_run" ? (
+                            <Badge variant="outline" className="text-xs font-normal">
+                              Ingestion run
+                            </Badge>
+                          ) : (
+                            <Badge variant="outline" className="text-xs font-normal">
+                              Recon job
+                            </Badge>
+                          )}
                           <Badge className={getStatusTone(run.status)}>
                             <StatusIcon
                               className={`mr-1 h-3.5 w-3.5 ${
@@ -233,7 +244,7 @@ export default function ReconciliationsPage() {
                         <Button asChild variant="outline">
                           <Link href={`/console/runs/${run.id}`}>Open Run Detail</Link>
                         </Button>
-                        {run.status === "completed" ? (
+                        {run.status === "completed" && run.runKind !== "ingestion_run" ? (
                           <Button asChild>
                             <Link href={`/console/reconciliations?runId=${run.id}`}>
                               Inspect Results

--- a/packages/web/src/app/console/runs/[runId]/page.tsx
+++ b/packages/web/src/app/console/runs/[runId]/page.tsx
@@ -31,6 +31,7 @@ interface RunStage {
 }
 
 interface Run {
+  runKind?: "recon_job" | "ingestion_run";
   id: string;
   name: string;
   status: "pending" | "running" | "completed" | "failed" | "unknown";
@@ -103,6 +104,9 @@ interface Run {
     ignored: number;
     reviewRequired: number;
   };
+  exceptionWorkflowNote?: string;
+  metadata?: Record<string, unknown>;
+  traceId?: string | null;
 }
 
 export default function RunPage() {
@@ -207,6 +211,7 @@ export default function RunPage() {
   }
 
   const StatusIcon = getStatusIcon(run.status);
+  const isIngestionRun = run.runKind === "ingestion_run";
 
   return (
     <div className="p-6 space-y-6">
@@ -254,6 +259,24 @@ export default function RunPage() {
           </Button>
         </div>
       </div>
+
+      {isIngestionRun ? (
+        <Card className="border-amber-200 bg-amber-50/50 dark:border-amber-900 dark:bg-amber-950/20">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Ingestion reconciliation run</CardTitle>
+            <CardDescription>
+              This run is stored in <code className="text-xs">reconciliation_runs</code>, not{" "}
+              <code className="text-xs">recon_jobs</code>. Counts and lifecycle here reflect that
+              row; snapshot-backed job config and drift-event scoping may differ from recon job runs.
+            </CardDescription>
+          </CardHeader>
+          {run.exceptionWorkflowNote ? (
+            <CardContent className="pt-0 text-sm text-muted-foreground">
+              {run.exceptionWorkflowNote}
+            </CardContent>
+          ) : null}
+        </Card>
+      ) : null}
 
       {/* Status Card */}
       <Card>
@@ -335,7 +358,7 @@ export default function RunPage() {
         </CardContent>
       </Card>
 
-      {run.resultContext && (
+      {run.resultContext && !isIngestionRun && (
         <Card>
           <CardHeader>
             <CardTitle>Result Provenance</CardTitle>
@@ -396,7 +419,7 @@ export default function RunPage() {
         </Card>
       )}
 
-      {run.exceptions && (
+      {run.exceptions && !isIngestionRun && (
         <Card>
           <CardHeader>
             <CardTitle>Exception Workflow</CardTitle>
@@ -459,7 +482,7 @@ export default function RunPage() {
       )}
 
       {/* Workflow Continuity - Next Actions */}
-      {run.status === "completed" && (
+      {run.status === "completed" && !isIngestionRun && (
         <Card>
           <CardHeader>
             <CardTitle>Next Steps</CardTitle>

--- a/packages/web/src/app/console/runs/page.tsx
+++ b/packages/web/src/app/console/runs/page.tsx
@@ -2,16 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  AlertCircle,
-  CheckCircle2,
-  Clock,
-  RefreshCw,
-  Search,
-  TimerReset,
-  XCircle,
-  Scale,
-} from "lucide-react";
+import { RefreshCw, Search, TimerReset, Scale } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -26,12 +17,16 @@ import { useGovernanceState } from "@/hooks/use-governance-state";
 import { shouldPollRuns } from "@/lib/console/polling";
 import { safeFetch } from "@/lib/safe-fetch";
 
+type RunKindFilter = "all" | "recon_job" | "ingestion_run";
+
 interface RunFilters {
   status?: string;
   search?: string;
+  runKind?: RunKindFilter;
 }
 
 interface RunListItem {
+  runKind: "recon_job" | "ingestion_run";
   id: string;
   name: string;
   status: "pending" | "running" | "completed" | "failed" | "unknown";
@@ -41,6 +36,9 @@ interface RunListItem {
   progress: number;
   progressState?: "not_started" | "in_progress" | "completed" | "failed" | "unknown";
   isTerminal: boolean;
+  ingestionId?: string | null;
+  sourceAdapter?: string | null;
+  targetAdapter?: string | null;
   summary: {
     total: number;
     sourceCount: number;
@@ -62,6 +60,23 @@ interface RunListItem {
   summaryState: "success" | "review_needed" | "in_progress" | "failed" | "empty" | "unknown";
   configDrift?: {
     status?: "none" | "detected" | "indeterminate";
+  };
+}
+
+interface RunsListApiResponse {
+  items: RunListItem[];
+  next_cursor: string | null;
+  pagination?: {
+    limit?: number;
+    returned?: number;
+    has_more?: boolean;
+    filter_scan_pages?: number;
+    filter_truncation_possible?: boolean;
+  };
+  response_meta?: {
+    pagination_mode?: string;
+    requested_run_kind?: RunKindFilter;
+    filters_applied?: { status: string | null; search: string | null };
   };
 }
 
@@ -118,9 +133,15 @@ function formatCount(value: number) {
 
 export default function RunsPage() {
   const [runs, setRuns] = useState<RunListItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [listMeta, setListMeta] = useState<RunsListApiResponse["response_meta"] | null>(null);
+  const [pagePagination, setPagePagination] = useState<RunsListApiResponse["pagination"] | null>(
+    null
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<RunFilters>({});
+  const [filters, setFilters] = useState<RunFilters>({ runKind: "all" });
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { isFrozen, governanceState } = useGovernanceState();
 
@@ -134,20 +155,29 @@ export default function RunsPage() {
     if (filters.search) {
       queryParams.set("search", filters.search);
     }
+    const runKind = filters.runKind ?? "all";
+    queryParams.set("run_kind", runKind);
+    queryParams.set("limit", "50");
 
     const query = queryParams.toString();
-    const result = await safeFetch<RunListItem[]>(query ? `/api/runs?${query}` : "/api/runs");
+    const result = await safeFetch<RunsListApiResponse>(`/api/runs?${query}`);
 
     if (result.success && result.data) {
-      setRuns(result.data);
+      setRuns(result.data.items ?? []);
+      setNextCursor(result.data.next_cursor ?? null);
+      setListMeta(result.data.response_meta ?? null);
+      setPagePagination(result.data.pagination ?? null);
       setError(null);
     } else {
       setRuns([]);
+      setNextCursor(null);
+      setListMeta(null);
+      setPagePagination(null);
       setError(result.error?.message || "Failed to load runs");
     }
 
     setLoading(false);
-  }, [filters.search, filters.status]);
+  }, [filters.search, filters.status, filters.runKind]);
 
   useEffect(() => {
     void loadRuns();
@@ -199,6 +229,24 @@ export default function RunsPage() {
   const handleRefresh = useCallback(async () => {
     await loadRuns();
   }, [loadRuns]);
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || filters.status || filters.search) {
+      return;
+    }
+    setLoadingMore(true);
+    const queryParams = new URLSearchParams();
+    const runKind = filters.runKind ?? "all";
+    queryParams.set("run_kind", runKind);
+    queryParams.set("limit", "50");
+    queryParams.set("cursor", nextCursor);
+    const result = await safeFetch<RunsListApiResponse>(`/api/runs?${queryParams.toString()}`);
+    if (result.success && result.data) {
+      setRuns((prev) => [...prev, ...(result.data!.items ?? [])]);
+      setNextCursor(result.data.next_cursor ?? null);
+    }
+    setLoadingMore(false);
+  }, [filters.runKind, filters.search, filters.status, nextCursor]);
 
   const showFreezeBanner = isFrozen && governanceState;
 
@@ -268,7 +316,7 @@ export default function RunsPage() {
 
       <ConsolePageHeader
         title="Runs"
-        description="Track reconciliation execution state, compare outcomes, and drill into the exception queue."
+        description="Merged reconciliation activity: scheduled recon jobs and ingestion-triggered reconciliation runs share one list. Use the run kind filter to narrow the stream."
         breadcrumbs={[
           { label: "Console", href: "/console" },
           { label: "Runs" },
@@ -309,7 +357,7 @@ export default function RunsPage() {
           <StatCard
             label="Visible runs"
             value={formatCount(totals.totalRuns)}
-            description="Tenant-scoped run history after filters."
+            description="Rows on this page after filters (merged recon jobs + ingestion runs)."
           />
           <StatCard
             label="Matched rows"
@@ -338,7 +386,30 @@ export default function RunsPage() {
 
       <Card>
         <CardContent className="py-5">
-          <div className="grid gap-4 md:grid-cols-[200px_minmax(0,1fr)_auto]">
+          <div className="grid gap-4 md:grid-cols-[minmax(0,160px)_200px_minmax(0,1fr)_auto]">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="run-kind-filter"
+                className="block text-xs font-medium text-muted-foreground"
+              >
+                Run kind
+              </label>
+              <select
+                id="run-kind-filter"
+                value={filters.runKind ?? "all"}
+                onChange={(event) =>
+                  setFilters((current) => ({
+                    ...current,
+                    runKind: (event.target.value as RunKindFilter) || "all",
+                  }))
+                }
+                className="input-field"
+              >
+                <option value="all">All kinds</option>
+                <option value="recon_job">Recon job</option>
+                <option value="ingestion_run">Ingestion run</option>
+              </select>
+            </div>
             <div className="space-y-1.5">
               <label
                 htmlFor="status-filter"
@@ -392,8 +463,12 @@ export default function RunsPage() {
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => setFilters({})}
-                disabled={!filters.search && !filters.status}
+                onClick={() => setFilters({ runKind: "all" })}
+                disabled={
+                  !filters.search &&
+                  !filters.status &&
+                  (!filters.runKind || filters.runKind === "all")
+                }
               >
                 <TimerReset className="mr-1.5 h-3.5 w-3.5" />
                 Clear
@@ -407,27 +482,27 @@ export default function RunsPage() {
         <EmptyState
           icon={Scale}
           title={
-            filters.status || filters.search
+            filters.status || filters.search || (filters.runKind && filters.runKind !== "all")
               ? "No runs match your filters"
               : "No reconciliation runs yet"
           }
           description={
-            filters.status || filters.search
-              ? "Try widening the lifecycle filter or clearing your search to review the full tenant run history."
-              : "Reconciliation runs appear here once you connect data sources and execute your first match. Each run compares records from a source system (e.g., Stripe) against a target system (e.g., your bank), identifies matches, flags mismatches, and produces an auditable result."
+            filters.status || filters.search || (filters.runKind && filters.runKind !== "all")
+              ? "Try widening filters: clear run kind, lifecycle status, or search to see the full merged tenant history."
+              : "Reconciliation runs appear here from recon jobs and from ingestion-triggered reconciliation. Each row shows execution state and summary counts for that run kind."
           }
           hint={
-            filters.status || filters.search
+            filters.status || filters.search || (filters.runKind && filters.runKind !== "all")
               ? undefined
               : "Start by connecting an integration, or try the Playground to see reconciliation in action with sample data."
           }
           action={
-            filters.status || filters.search
-              ? { label: "Clear Filters", onClick: () => setFilters({}) }
+            filters.status || filters.search || (filters.runKind && filters.runKind !== "all")
+              ? { label: "Clear Filters", onClick: () => setFilters({ runKind: "all" }) }
               : { label: "Open Reconciliations", href: "/console/reconciliations" }
           }
           secondaryAction={
-            filters.status || filters.search
+            filters.status || filters.search || (filters.runKind && filters.runKind !== "all")
               ? undefined
               : { label: "Try Demo", href: "/demo/console" }
           }
@@ -437,10 +512,21 @@ export default function RunsPage() {
           <CardHeader>
             <CardTitle>Run history</CardTitle>
             <CardDescription>
-              Every row uses the same lifecycle and summary semantics surfaced on run detail.
+              Merged list: recon jobs and ingestion reconciliation runs. Detail pages differ by run
+              kind where the data model does not yet offer parity.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
+            {listMeta?.pagination_mode === "filter_scan_first_page" &&
+            listMeta.filters_applied &&
+            (listMeta.filters_applied.status || listMeta.filters_applied.search) ? (
+              <p className="text-sm text-muted-foreground rounded-lg border border-border px-3 py-2">
+                Status and search use a bounded scan of merged pages;{" "}
+                {pagePagination?.filter_truncation_possible
+                  ? "results may be incomplete if more matches exist beyond the scan limit—narrow filters or use run kind + pagination without status/search."
+                  : "pagination cursor is disabled until those filters are cleared."}
+              </p>
+            ) : null}
             {runs.map((run) => (
                 <div
                   key={run.id}
@@ -453,6 +539,9 @@ export default function RunsPage() {
                         <h2 className="truncate text-base font-semibold text-foreground">
                           {run.name}
                         </h2>
+                        <Badge variant="outline" className="text-xs font-normal">
+                          {run.runKind === "ingestion_run" ? "Ingestion run" : "Recon job"}
+                        </Badge>
                         <StatusBadge
                           status={toStatusType(run.status)}
                           label={run.statusLabel || undefined}
@@ -468,6 +557,23 @@ export default function RunsPage() {
                           <span className="text-xs text-muted-foreground">Run ID</span>
                           <div className="font-mono text-xs text-foreground truncate">{run.id}</div>
                         </div>
+                        {run.ingestionId ? (
+                          <div>
+                            <span className="text-xs text-muted-foreground">Ingestion</span>
+                            <div className="font-mono text-xs text-foreground truncate">
+                              {run.ingestionId}
+                            </div>
+                          </div>
+                        ) : null}
+                        {(run.sourceAdapter || run.targetAdapter) && (
+                          <div className="md:col-span-2">
+                            <span className="text-xs text-muted-foreground">Adapters</span>
+                            <div className="text-sm text-foreground">
+                              {[run.sourceAdapter, run.targetAdapter].filter(Boolean).join(" → ") ||
+                                "—"}
+                            </div>
+                          </div>
+                        )}
                         <div>
                           <span className="text-xs text-muted-foreground">Started</span>
                           <div className="text-foreground">{new Date(run.startedAt).toLocaleString()}</div>
@@ -547,18 +653,39 @@ export default function RunsPage() {
                       <Button asChild size="sm">
                         <Link href={`/console/runs/${run.id}`}>Open detail</Link>
                       </Button>
-                      <Button asChild variant="outline" size="sm">
-                        <Link href={`/console/reconciliations?runId=${run.id}`}>
-                          Reconciliation
-                        </Link>
-                      </Button>
-                      <Button asChild variant="ghost" size="sm">
-                        <Link href={`/console/exceptions?runId=${run.id}`}>Exceptions</Link>
-                      </Button>
+                      {run.runKind === "recon_job" ? (
+                        <>
+                          <Button asChild variant="outline" size="sm">
+                            <Link href={`/console/reconciliations?runId=${run.id}`}>
+                              Reconciliation
+                            </Link>
+                          </Button>
+                          <Button asChild variant="ghost" size="sm">
+                            <Link href={`/console/exceptions?runId=${run.id}`}>Exceptions</Link>
+                          </Button>
+                        </>
+                      ) : (
+                        <p className="text-xs text-muted-foreground xl:px-1">
+                          Results and exceptions UIs are recon-job keyed today; open detail for
+                          ingestion run truth.
+                        </p>
+                      )}
                     </div>
                   </div>
                 </div>
               ))}
+            {!filters.status && !filters.search && nextCursor ? (
+              <div className="flex justify-center pt-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void loadMore()}
+                  disabled={loadingMore}
+                >
+                  {loadingMore ? "Loading…" : "Load more"}
+                </Button>
+              </div>
+            ) : null}
           </CardContent>
         </Card>
       )}

--- a/packages/web/src/lib/reconciliation/build-ingestion-run-detail-json.ts
+++ b/packages/web/src/lib/reconciliation/build-ingestion-run-detail-json.ts
@@ -1,0 +1,141 @@
+import type {
+  AdapterDriftSignal,
+  CanonicalReconciliationRunDetail,
+} from "@settler/reconciliation-core";
+
+function legacyAdapterDriftLabel(signal: AdapterDriftSignal): "source" | "target" | "both" | "none" {
+  if (signal.sourceChanged && signal.targetChanged) return "both";
+  if (signal.sourceChanged) return "source";
+  if (signal.targetChanged) return "target";
+  return "none";
+}
+
+/**
+ * JSON body for GET /api/runs/[id] when the resolved entity is a `reconciliation_runs` row.
+ * Intentionally narrower than recon_job detail (no snapshot, audits, drift_events FK, etc.).
+ */
+export function buildIngestionRunDetailJson(detail: CanonicalReconciliationRunDetail) {
+  const s = detail.summary;
+  const lifecycle = detail.lifecycle;
+  const startedAt = detail.timestamps.startedAt ?? detail.timestamps.createdAt;
+
+  const stageStatus: "pending" | "running" | "completed" | "failed" =
+    lifecycle.status === "completed"
+      ? "completed"
+      : lifecycle.status === "failed"
+        ? "failed"
+        : lifecycle.status === "running"
+          ? "running"
+          : "pending";
+
+  return {
+    runKind: "ingestion_run" as const,
+    id: detail.id,
+    name: detail.name,
+    status: lifecycle.status,
+    statusLabel: lifecycle.statusLabel,
+    isTerminal: lifecycle.isTerminal,
+    progress: lifecycle.progressPercent,
+    progressState: lifecycle.progressState,
+    startedAt,
+    completedAt: detail.timestamps.completedAt,
+    ...(detail.errorMessage ? { error: detail.errorMessage } : {}),
+    summary: {
+      total: s.total,
+      sourceCount: s.sourceCount,
+      targetCount: s.targetCount,
+      matched: s.matched,
+      unmatched: s.unmatched,
+      unmatchedSourceCount: s.unmatchedSourceCount,
+      unmatchedTargetCount: s.unmatchedTargetCount,
+      conflicts: s.conflicts,
+    },
+    summaryMath: {
+      sourceCount: s.sourceCount,
+      targetCount: s.targetCount,
+      matchedCount: s.matched,
+      unmatchedSourceCount: s.unmatchedSourceCount,
+      unmatchedTargetCount: s.unmatchedTargetCount,
+      conflictCount: s.conflicts,
+      note:
+        "Ingestion-backed run: counts come from reconciliation_runs; exception workflow and snapshot-backed config apply to recon job runs only.",
+    },
+    summarySemantics: {
+      processed: s.processed,
+      matchedWithTolerance: s.matchedWithTolerance,
+      exceptioned: s.exceptioned,
+      unresolved: s.unresolved,
+      ignored: s.ignored,
+      resolved: s.resolved,
+    },
+    summaryState: detail.summaryState,
+    provenance: {
+      sourceModel: detail.provenance.sourceModel,
+      runKind: detail.provenance.runKind,
+      ingestionId: detail.provenance.ingestionId,
+      reconJobId: detail.provenance.reconJobId,
+      executedAt: startedAt,
+      completedAt: detail.timestamps.completedAt,
+      sourceAdapter: detail.adapters.sourceAdapter,
+      targetAdapter: detail.adapters.targetAdapter,
+    },
+    resultContext: {
+      latestResultId: null,
+      latestResultStatus: lifecycle.status,
+      latestResultStartedAt: startedAt,
+      latestResultCompletedAt: detail.timestamps.completedAt,
+      persistedResultCount: 0,
+      comparison: null,
+      note: "This run is stored in reconciliation_runs (ingestion path), not recon_jobs + recon_results.",
+    },
+    config: {
+      sourceAdapter: detail.adapters.sourceAdapter,
+      targetAdapter: detail.adapters.targetAdapter,
+      reconStrategy: null,
+      templateId: null,
+      validationRuleCount: 0,
+      validationRuleLabels: [] as string[],
+      ruleVersionCount: 0,
+      ruleVersionLabels: [] as string[],
+      snapshotId: null,
+      inputHash: null,
+      configSource: "job_definition" as const,
+      configCapturedAt: null,
+      definitionDriftDetected: false,
+      definitionDriftNotes: [] as string[],
+      summaryBasis: "Ingestion run row only; no job snapshot.",
+    },
+    configDrift: {
+      status: detail.configDrift.status,
+      adapter: legacyAdapterDriftLabel(detail.configDrift.adapter),
+    },
+    exceptions: {
+      total: 0,
+      pending: 0,
+      investigating: 0,
+      resolved: 0,
+      ignored: 0,
+      reviewRequired: 0,
+    },
+    exceptionWorkflowNote:
+      "Drift events are keyed to recon_job_id today; ingestion-backed runs may not appear in exception lists filtered by this run id.",
+    rowRationale: {
+      available: false,
+      rowCount: 0,
+      codes: [] as string[],
+    },
+    rowResultsPreview: [] as unknown[],
+    stages: [
+      {
+        id: "ingestion-reconciliation",
+        name: "Ingestion reconciliation",
+        status: stageStatus,
+        startedAt,
+        completedAt: detail.timestamps.completedAt ?? undefined,
+        ...(detail.errorMessage ? { error: detail.errorMessage } : {}),
+      },
+    ],
+    metadata: detail.metadata,
+    traceId: detail.traceId,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves Next `GET /api/runs` onto `fetchMergedReconciliationRunsPage` with explicit `runKind` on each row, real merged cursor pagination, and truthful handling of filters. `GET /api/runs/:id` resolves across `recon_jobs` and `reconciliation_runs` (multi-tenant membership) and returns `runKind`-appropriate detail, including honest degraded fields for ingestion runs.

## Key changes

- **reconciliation-core**: `mapCanonicalListItemToApiRunsLegacyRow`, `configDrift` on `CanonicalReconciliationListItem`, `resolveReconciliationRunForTenants`, default `default_run_kind: all` in console list meta.
- **web**: New list envelope `{ items, next_cursor, pagination, response_meta }`; `run_kind` query; 400 for invalid cursor/kind and cursor+filter combo; console Runs + Reconciliations surfaces updated; ingestion run detail JSON builder.
- **tests**: Web contract tests for `/api/runs`; reconciliation-core adapter test; fixed run detail test import path and Prisma mocks.
- **docs**: `reconciliation-read-contract.md`, `docs/api/families/runs.md`, `CHANGELOG.md`.

## Backward compatibility

- **Breaking for raw array consumers** of `GET /api/runs`: response is now an object with `items`. Console and in-repo callers updated.
- **Explicit** `run_kind=recon_job` / `ingestion_run` / `all` (default **all**). Invalid values → 400.
- **`GET /api/console/reconciliation`**: default `run_kind` is now **all** (invalid values → 400); clients that relied on implicit recon-job-only listing must pass `run_kind=recon_job`.

## Honest limitations (not fixed here)

- Operator dashboard metrics in `runs-reader.ts` (`getDashboardStats`, etc.) remain recon-job-oriented; only primary runs/reconciliations surfaces in this PR were aligned.
- `drift_events.recon_job_id` polymorphism unchanged; ingestion detail explains exception UI limits.
- Reconciliation results view (`ReconciliationView`) remains recon-job keyed; ingestion rows no longer link to a misleading inspect-results path.

## Verification

- `pnpm --filter @settler/reconciliation-core exec tsc --noEmit`
- `pnpm --filter @settler/reconciliation-core exec jest --runInBand --forceExit`
- `pnpm --filter @settler/web run typecheck`
- `pnpm --filter @settler/web exec jest src/__tests__/api/api-runs-list-route.contract.test.ts src/__tests__/api/run-domain-trust-invariants.test.ts --runInBand`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc379098-7913-461a-823d-e563bddd2488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc379098-7913-461a-823d-e563bddd2488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

