### PR TITLE
Normalize run-list query semantics across API and console

### DIFF
--- a/packages/web/src/__tests__/api/console-reconciliation-list-route.contract.test.ts
+++ b/packages/web/src/__tests__/api/console-reconciliation-list-route.contract.test.ts
@@ -1,0 +1,132 @@
+/** @jest-environment node */
+
+import { GET as getConsoleReconciliationList } from "@/app/api/console/reconciliation/route";
+
+const requireAuthMock = jest.fn();
+const resolveTenantMembershipScopeMock = jest.fn();
+const fetchMergedReconciliationRunsPageMock = jest.fn();
+const decodeMergedRunsCursorMock = jest.fn();
+const buildConsoleReconciliationListBodyMock = jest.fn();
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+jest.mock("@/middleware/billing-gate-universal", () => ({
+  withUniversalBillingGate: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/api/unified-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+
+jest.mock("@/lib/supabase/tenant-membership", () => ({
+  resolveTenantMembershipScope: (...args: unknown[]) => resolveTenantMembershipScopeMock(...args),
+  assertTenantMembership: jest.fn(),
+  resolveTenantForMutation: jest.fn(() => "tenant-1"),
+  TenantMembershipError: class TenantMembershipError extends Error {},
+}));
+
+jest.mock("@settler/reconciliation-core", () => {
+  const actual = jest.requireActual("@settler/reconciliation-core") as Record<string, unknown>;
+  return {
+    ...actual,
+    fetchMergedReconciliationRunsPage: (...args: unknown[]) =>
+      fetchMergedReconciliationRunsPageMock(...args),
+    decodeMergedRunsCursor: (...args: unknown[]) => decodeMergedRunsCursorMock(...args),
+    buildConsoleReconciliationListBody: (...args: unknown[]) =>
+      buildConsoleReconciliationListBodyMock(...args),
+  };
+});
+
+jest.mock("@/shared/db/prismaClient", () => ({
+  prisma: {},
+}));
+
+jest.mock("@/lib/server/settler/reconciliation", () => ({
+  getReconciliationSummary: jest.fn(),
+  listReconciliationItems: jest.fn(),
+}));
+
+jest.mock("@/lib/server/internal-api", () => ({
+  triggerInternalReconciliationRun: jest.fn(),
+}));
+
+jest.mock("@/lib/utils/logger", () => ({
+  appLogger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+function req(url: string) {
+  return {
+    url,
+    method: "GET",
+    headers: new Headers(),
+    nextUrl: new URL(url),
+  } as any;
+}
+
+describe("GET /api/console/reconciliation", () => {
+  beforeEach(() => {
+    requireAuthMock.mockReset();
+    resolveTenantMembershipScopeMock.mockReset();
+    fetchMergedReconciliationRunsPageMock.mockReset();
+    decodeMergedRunsCursorMock.mockReset();
+    buildConsoleReconciliationListBodyMock.mockReset();
+
+    requireAuthMock.mockResolvedValue({ tenantId: "tenant-1", userId: "u1", type: "session" });
+    resolveTenantMembershipScopeMock.mockResolvedValue({ tenantIds: ["tenant-1"], userId: "u1" });
+
+    fetchMergedReconciliationRunsPageMock.mockResolvedValue({
+      runs: [],
+      next_cursor: null,
+      pagination: {
+        limit: 50,
+        returned: 0,
+        has_more: false,
+        job_stream_has_more: false,
+        ingestion_stream_has_more: false,
+        job_stream_exhausted: true,
+        ingestion_stream_exhausted: true,
+      },
+      response_meta: {
+        contract_version: 1,
+        included_run_kinds: ["recon_job", "ingestion_run"],
+        ordering: "test-order",
+        consistency: "read_committed",
+      },
+    });
+    buildConsoleReconciliationListBodyMock.mockReturnValue({ reconciliations: [] });
+  });
+
+  it("accepts runKind alias and case-insensitive value", async () => {
+    const res = await getConsoleReconciliationList(
+      req("http://localhost/api/console/reconciliation?runKind=INGESTION_RUN&limit=25"),
+      {} as any
+    );
+    expect(res.status).toBe(200);
+    expect(fetchMergedReconciliationRunsPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runKind: "ingestion_run", limit: 25 })
+    );
+  });
+
+  it("returns 400 for invalid run_kind", async () => {
+    const res = await getConsoleReconciliationList(
+      req("http://localhost/api/console/reconciliation?run_kind=nope"),
+      {} as any
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("RECONCILIATION_INVALID_RUN_KIND");
+  });
+
+  it("falls back to safe default limit when provided limit is invalid", async () => {
+    const res = await getConsoleReconciliationList(
+      req("http://localhost/api/console/reconciliation?limit=-10"),
+      {} as any
+    );
+    expect(res.status).toBe(200);
+    expect(fetchMergedReconciliationRunsPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 })
+    );
+  });
+});

--- a/packages/web/src/app/api/console/reconciliation/route.ts
+++ b/packages/web/src/app/api/console/reconciliation/route.ts
@@ -29,6 +29,7 @@ import {
   fetchMergedReconciliationRunsPage,
   MergedRunsCursorError,
 } from "@settler/reconciliation-core";
+import { parseRunKindParam, parseRunsLimit } from "@/lib/reconciliation/runs-query-params";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -203,12 +204,11 @@ export const GET = withSecurity(
         }
 
         const cursorParam = request.nextUrl.searchParams.get("cursor") ?? undefined;
-        const limit = Math.min(Number(request.nextUrl.searchParams.get("limit") || 50), 500);
-        const runKindRaw = (request.nextUrl.searchParams.get("run_kind") ?? "all").trim();
-        const runKind =
-          runKindRaw === "all" || runKindRaw === "recon_job" || runKindRaw === "ingestion_run"
-            ? runKindRaw
-            : "__invalid__";
+        const limit = parseRunsLimit(request.nextUrl.searchParams.get("limit"));
+        const runKind = parseRunKindParam(
+          request.nextUrl.searchParams.get("run_kind") ??
+            request.nextUrl.searchParams.get("runKind")
+        );
 
         if (runKind === "__invalid__") {
           return NextResponse.json(

--- a/packages/web/src/app/api/runs/route.ts
+++ b/packages/web/src/app/api/runs/route.ts
@@ -26,12 +26,14 @@ import {
   mapCanonicalListItemToApiRunsLegacyRow,
   MergedRunsCursorError,
   type MergedRunsCursorV1,
-  type ReconciliationRunKindFilter,
 } from "@settler/reconciliation-core";
+import {
+  parseRunKindParam,
+  parseRunsLimit,
+  RUN_KIND_VALUES,
+} from "@/lib/reconciliation/runs-query-params";
 
 export const runtime = "nodejs";
-
-const RUN_KIND_VALUES: ReconciliationRunKindFilter[] = ["all", "recon_job", "ingestion_run"];
 
 function resolveTenantIdForRuns(
   authContext: UnifiedAuthContext,
@@ -49,18 +51,7 @@ function resolveTenantIdForRuns(
   return resolveTenantForMutation(tenantIds);
 }
 
-function parseLimit(raw: string | null): number {
-  const n = Number(raw || 50);
-  if (!Number.isFinite(n) || n < 1) {
-    return 50;
-  }
-  return Math.min(Math.floor(n), 500);
-}
-
-function matchesStatusFilter(
-  statusFilter: string | undefined,
-  status: string
-): boolean {
+function matchesStatusFilter(statusFilter: string | undefined, status: string): boolean {
   if (!statusFilter) return true;
   return status.toLowerCase() === statusFilter;
 }
@@ -88,14 +79,9 @@ export const GET = withSecurity(
 
         const statusFilter = searchParams.get("status")?.trim().toLowerCase() || undefined;
         const searchFilter = searchParams.get("search")?.trim().toLowerCase() || undefined;
-        const runKindRaw = (searchParams.get("run_kind") ?? searchParams.get("runKind") ?? "all")
-          .trim()
-          .toLowerCase();
-        const runKind = (
-          RUN_KIND_VALUES.includes(runKindRaw as ReconciliationRunKindFilter)
-            ? runKindRaw
-            : "__invalid__"
-        ) as ReconciliationRunKindFilter | "__invalid__";
+        const runKind = parseRunKindParam(
+          searchParams.get("run_kind") ?? searchParams.get("runKind")
+        );
 
         if (runKind === "__invalid__") {
           return NextResponse.json(
@@ -108,7 +94,7 @@ export const GET = withSecurity(
           );
         }
 
-        const limit = parseLimit(searchParams.get("limit"));
+        const limit = parseRunsLimit(searchParams.get("limit"));
         const cursorParam = searchParams.get("cursor")?.trim() || undefined;
         const legacyPage = searchParams.get("page");
 
@@ -181,9 +167,9 @@ export const GET = withSecurity(
         let walkCursor: MergedRunsCursorV1 | null = null;
         const collected: ReturnType<typeof mapCanonicalListItemToApiRunsLegacyRow>[] = [];
         let pagesScanned = 0;
-        let lastPagePagination = null as Awaited<
-          ReturnType<typeof fetchMergedReconciliationRunsPage>
-        >["pagination"] | null;
+        let lastPagePagination = null as
+          | Awaited<ReturnType<typeof fetchMergedReconciliationRunsPage>>["pagination"]
+          | null;
         let truncated = false;
 
         while (collected.length < limit && pagesScanned < MAX_FILTER_SCAN_PAGES) {

--- a/packages/web/src/lib/reconciliation/runs-query-params.ts
+++ b/packages/web/src/lib/reconciliation/runs-query-params.ts
@@ -1,0 +1,19 @@
+import type { ReconciliationRunKindFilter } from "@settler/reconciliation-core";
+
+export const RUN_KIND_VALUES: ReconciliationRunKindFilter[] = ["all", "recon_job", "ingestion_run"];
+
+export function parseRunKindParam(
+  value: string | null | undefined
+): ReconciliationRunKindFilter | "__invalid__" {
+  const normalized = (value ?? "all").trim().toLowerCase();
+  if (RUN_KIND_VALUES.includes(normalized as ReconciliationRunKindFilter)) {
+    return normalized as ReconciliationRunKindFilter;
+  }
+  return "__invalid__";
+}
+
+export function parseRunsLimit(raw: string | null | undefined): number {
+  const n = Number(raw ?? 50);
+  if (!Number.isFinite(n) || n < 1) return 50;
+  return Math.min(Math.floor(n), 500);
+}


### PR DESCRIPTION
### Motivation
- Close a semantic drift between operator-facing run list endpoints so deep-links and filters behave identically across API and console surfaces. 
- Make `run_kind` / `runKind` parsing and `limit` coercion canonical and testable to reduce future drift and operator confusion.

### Description
- Add a shared query parser `packages/web/src/lib/reconciliation/runs-query-params.ts` that exposes `parseRunKindParam`, `parseRunsLimit`, and `RUN_KIND_VALUES` for canonical parsing. 
- Wire `GET /api/runs` (`packages/web/src/app/api/runs/route.ts`) to use `parseRunKindParam` and `parseRunsLimit`, removing duplicate parsing logic. 
- Update `GET /api/console/reconciliation` (`packages/web/src/app/api/console/reconciliation/route.ts`) to accept the `runKind` alias, normalize case-insensitively, and apply safe limit coercion via the shared parser. 
- Add a contract test `packages/web/src/__tests__/api/console-reconciliation-list-route.contract.test.ts` that verifies `runKind` alias/case-normalization, invalid `run_kind` handling, and invalid-limit fallback.

### Testing
- Ran the focused web tests with `pnpm --filter @settler/web test -- --runTestsByPath src/__tests__/api/api-runs-list-route.contract.test.ts src/__tests__/api/console-reconciliation-list-route.contract.test.ts` and both suites passed. 
- Ran `pnpm lint` and the monorepo lint step completed (warnings present, no blocking errors). 
- Ran `pnpm typecheck` and the workspace typecheck completed successfully. 
- `pnpm build` failed in this environment due to missing required build environment variables (e.g. `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, DB URL), which are unrelated to the parser change. 
- `pnpm verify:fast` failed in this environment during route verification because of missing runtime env and existing module-resolution/runtime issues not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a51c36f08328b2cdf6a4f1e7256e)