### PR TITLE
Canonicalize operator run semantics — expose runKind, sourceModel, and detailHref

### DIFF
--- a/packages/reconciliation-core/src/api-runs-list-adapter.test.ts
+++ b/packages/reconciliation-core/src/api-runs-list-adapter.test.ts
@@ -73,6 +73,8 @@ describe("mapCanonicalListItemToApiRunsLegacyRow", () => {
     };
     const legacy = mapCanonicalListItemToApiRunsLegacyRow(row);
     expect(legacy.runKind).toBe("recon_job");
+    expect(legacy.sourceModel).toBe("recon_jobs");
+    expect(legacy.detailHref).toBe("/console/runs/j1");
     expect(legacy.configDrift.adapter).toBe("source");
     expect(legacy.ingestionId).toBeNull();
   });

--- a/packages/reconciliation-core/src/api-runs-list-adapter.ts
+++ b/packages/reconciliation-core/src/api-runs-list-adapter.ts
@@ -6,7 +6,9 @@
 import type { CanonicalReconciliationListItem } from "./canonical-reconciliation.js";
 import type { AdapterDriftSignal } from "./canonical-run-result.js";
 
-function legacyAdapterDriftLabel(signal: AdapterDriftSignal): "source" | "target" | "both" | "none" {
+function legacyAdapterDriftLabel(
+  signal: AdapterDriftSignal
+): "source" | "target" | "both" | "none" {
   if (signal.sourceChanged && signal.targetChanged) return "both";
   if (signal.sourceChanged) return "source";
   if (signal.targetChanged) return "target";
@@ -15,7 +17,9 @@ function legacyAdapterDriftLabel(signal: AdapterDriftSignal): "source" | "target
 
 export type ApiRunsListLegacyItem = {
   runKind: "recon_job" | "ingestion_run";
+  sourceModel: "recon_jobs" | "reconciliation_runs";
   id: string;
+  detailHref: string;
   name: string;
   status: string;
   statusLabel: string;
@@ -57,11 +61,12 @@ export type ApiRunsListLegacyItem = {
 export function mapCanonicalListItemToApiRunsLegacyRow(
   r: CanonicalReconciliationListItem
 ): ApiRunsListLegacyItem {
-  const startedAt =
-    r.timestamps.startedAt ?? r.timestamps.createdAt ?? new Date().toISOString();
+  const startedAt = r.timestamps.startedAt ?? r.timestamps.createdAt ?? new Date().toISOString();
   return {
     runKind: r.runKind,
+    sourceModel: r.provenance.sourceModel,
     id: r.id,
+    detailHref: `/console/runs/${r.id}`,
     name: r.name,
     status: r.lifecycle.status,
     statusLabel: r.lifecycle.statusLabel,

--- a/packages/reconciliation-core/src/console-reconciliation-list.test.ts
+++ b/packages/reconciliation-core/src/console-reconciliation-list.test.ts
@@ -99,7 +99,20 @@ describe("buildConsoleReconciliationListBody", () => {
 
   it("run_kind=all includes runs and job-shaped reconciliations", () => {
     const body = buildConsoleReconciliationListBody(mockPage([job, ing]), "all");
-    expect(body.runs).toEqual([job, ing]);
+    expect(body.runs).toEqual([
+      expect.objectContaining({
+        id: "j1",
+        runKind: "recon_job",
+        sourceModel: "recon_jobs",
+        detailHref: "/console/runs/j1",
+      }),
+      expect.objectContaining({
+        id: "i1",
+        runKind: "ingestion_run",
+        sourceModel: "reconciliation_runs",
+        detailHref: "/console/runs/i1",
+      }),
+    ]);
     expect(Array.isArray(body.reconciliations)).toBe(true);
     expect((body.reconciliations as unknown[]).length).toBe(1);
     const recs = body.reconciliations as { id: string }[];
@@ -107,18 +120,19 @@ describe("buildConsoleReconciliationListBody", () => {
     expect(body.response_meta).toMatchObject({
       requested_run_kind: "all",
       default_run_kind: "all",
+      legacy_reconciliations_field_scope: "recon_job_only",
     });
   });
 
-  it("run_kind=recon_job omits runs key", () => {
+  it("run_kind=recon_job still returns canonical runs list", () => {
     const body = buildConsoleReconciliationListBody(mockPage([job, ing]), "recon_job");
-    expect(body.runs).toBeUndefined();
+    expect((body.runs as unknown[]).length).toBe(2);
     expect((body.reconciliations as unknown[]).length).toBe(1);
   });
 
-  it("run_kind=ingestion_run yields empty reconciliations and omits runs", () => {
+  it("run_kind=ingestion_run keeps runs while reconciliations remains legacy-empty", () => {
     const body = buildConsoleReconciliationListBody(mockPage([ing]), "ingestion_run");
-    expect(body.runs).toBeUndefined();
+    expect((body.runs as unknown[]).length).toBe(1);
     expect(body.reconciliations).toEqual([]);
   });
 });

--- a/packages/reconciliation-core/src/console-reconciliation-list.ts
+++ b/packages/reconciliation-core/src/console-reconciliation-list.ts
@@ -45,25 +45,28 @@ export function buildConsoleReconciliationListBody(
   page: MergedReconciliationListResponse,
   runKind: ConsoleReconciliationRunKindParam
 ): Record<string, unknown> {
+  const runs = page.runs.map((r) => ({
+    ...r,
+    sourceModel: r.provenance.sourceModel,
+    detailHref: `/console/runs/${r.id}`,
+  }));
   const reconciliations =
     runKind === "ingestion_run"
       ? []
-      : page.runs.filter((r) => r.runKind === "recon_job").map(toLegacyReconciliation);
+      : runs.filter((r) => r.runKind === "recon_job").map(toLegacyReconciliation);
 
   const body: Record<string, unknown> = {
     contract_version: 1,
+    runs,
     next_cursor: page.next_cursor,
     pagination: page.pagination,
     response_meta: {
       ...page.response_meta,
       default_run_kind: "all",
       requested_run_kind: runKind,
+      legacy_reconciliations_field_scope: "recon_job_only",
     },
   };
-
-  if (runKind === "all") {
-    body.runs = page.runs;
-  }
 
   body.reconciliations = reconciliations;
   return body;

--- a/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
+++ b/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
@@ -22,8 +22,7 @@ jest.mock("@/lib/api/unified-auth", () => ({
 }));
 
 jest.mock("@/lib/supabase/tenant-membership", () => ({
-  resolveTenantMembershipScope: (...args: unknown[]) =>
-    resolveTenantMembershipScopeMock(...args),
+  resolveTenantMembershipScope: (...args: unknown[]) => resolveTenantMembershipScopeMock(...args),
   assertTenantMembership: jest.fn(),
   resolveTenantForMutation: jest.fn(() => "tenant-1"),
 }));
@@ -155,42 +154,46 @@ describe("GET /api/runs", () => {
       },
     });
 
-    mapCanonicalListItemToApiRunsLegacyRowMock.mockImplementation((row: CanonicalReconciliationListItem) => ({
-      runKind: row.runKind,
-      id: row.id,
-      name: row.name,
-      status: row.lifecycle.status,
-      statusLabel: row.lifecycle.statusLabel,
-      startedAt: row.timestamps.startedAt ?? row.timestamps.createdAt,
-      completedAt: row.timestamps.completedAt,
-      summary: {
-        total: row.summary.total,
-        sourceCount: row.summary.sourceCount,
-        targetCount: row.summary.targetCount,
-        matched: row.summary.matched,
-        unmatched: row.summary.unmatched,
-        unmatchedSourceCount: row.summary.unmatchedSourceCount,
-        unmatchedTargetCount: row.summary.unmatchedTargetCount,
-        conflicts: row.summary.conflicts,
-      },
-      summarySemantics: {
-        processed: row.summary.processed,
-        matchedWithTolerance: row.summary.matchedWithTolerance,
-        exceptioned: row.summary.exceptioned,
-        unresolved: row.summary.unresolved,
-        ignored: row.summary.ignored,
-        resolved: row.summary.resolved,
-      },
-      summaryState: row.summaryState,
-      progress: row.lifecycle.progressPercent,
-      progressState: row.lifecycle.progressState,
-      isTerminal: row.lifecycle.isTerminal,
-      provenance: {},
-      configDrift: { status: "none", adapter: "none" },
-      ingestionId: row.provenance.ingestionId,
-      sourceAdapter: row.adapters.sourceAdapter,
-      targetAdapter: row.adapters.targetAdapter,
-    }));
+    mapCanonicalListItemToApiRunsLegacyRowMock.mockImplementation(
+      (row: CanonicalReconciliationListItem) => ({
+        runKind: row.runKind,
+        sourceModel: row.provenance.sourceModel,
+        id: row.id,
+        detailHref: `/console/runs/${row.id}`,
+        name: row.name,
+        status: row.lifecycle.status,
+        statusLabel: row.lifecycle.statusLabel,
+        startedAt: row.timestamps.startedAt ?? row.timestamps.createdAt,
+        completedAt: row.timestamps.completedAt,
+        summary: {
+          total: row.summary.total,
+          sourceCount: row.summary.sourceCount,
+          targetCount: row.summary.targetCount,
+          matched: row.summary.matched,
+          unmatched: row.summary.unmatched,
+          unmatchedSourceCount: row.summary.unmatchedSourceCount,
+          unmatchedTargetCount: row.summary.unmatchedTargetCount,
+          conflicts: row.summary.conflicts,
+        },
+        summarySemantics: {
+          processed: row.summary.processed,
+          matchedWithTolerance: row.summary.matchedWithTolerance,
+          exceptioned: row.summary.exceptioned,
+          unresolved: row.summary.unresolved,
+          ignored: row.summary.ignored,
+          resolved: row.summary.resolved,
+        },
+        summaryState: row.summaryState,
+        progress: row.lifecycle.progressPercent,
+        progressState: row.lifecycle.progressState,
+        isTerminal: row.lifecycle.isTerminal,
+        provenance: {},
+        configDrift: { status: "none", adapter: "none" },
+        ingestionId: row.provenance.ingestionId,
+        sourceAdapter: row.adapters.sourceAdapter,
+        targetAdapter: row.adapters.targetAdapter,
+      })
+    );
   });
 
   it("returns 400 for invalid run_kind", async () => {
@@ -220,6 +223,9 @@ describe("GET /api/runs", () => {
     const body = await res.json();
     expect(body.items).toHaveLength(1);
     expect(body.items[0].id).toBe("job-1");
+    expect(body.items[0].runKind).toBe("recon_job");
+    expect(body.items[0].sourceModel).toBe("recon_jobs");
+    expect(body.items[0].detailHref).toBe("/console/runs/job-1");
     expect(body.next_cursor).toBe("next");
     expect(body.response_meta.pagination_mode).toBe("merged_cursor");
     expect(fetchMergedReconciliationRunsPageMock).toHaveBeenCalled();

--- a/packages/web/src/__tests__/api/console-reconciliation-list-route.contract.test.ts
+++ b/packages/web/src/__tests__/api/console-reconciliation-list-route.contract.test.ts
@@ -95,7 +95,17 @@ describe("GET /api/console/reconciliation", () => {
         consistency: "read_committed",
       },
     });
-    buildConsoleReconciliationListBodyMock.mockReturnValue({ reconciliations: [] });
+    buildConsoleReconciliationListBodyMock.mockReturnValue({
+      runs: [
+        {
+          id: "run-1",
+          runKind: "ingestion_run",
+          sourceModel: "reconciliation_runs",
+          detailHref: "/console/runs/run-1",
+        },
+      ],
+      reconciliations: [],
+    });
   });
 
   it("accepts runKind alias and case-insensitive value", async () => {
@@ -128,5 +138,23 @@ describe("GET /api/console/reconciliation", () => {
     expect(fetchMergedReconciliationRunsPageMock).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 50 })
     );
+  });
+
+  it("returns canonical runs list even when legacy reconciliations is empty", async () => {
+    const res = await getConsoleReconciliationList(
+      req("http://localhost/api/console/reconciliation?run_kind=ingestion_run"),
+      {} as any
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reconciliations).toEqual([]);
+    expect(body.runs).toEqual([
+      expect.objectContaining({
+        id: "run-1",
+        runKind: "ingestion_run",
+        sourceModel: "reconciliation_runs",
+        detailHref: "/console/runs/run-1",
+      }),
+    ]);
   });
 });

--- a/packages/web/src/__tests__/api/run-domain-trust-invariants.test.ts
+++ b/packages/web/src/__tests__/api/run-domain-trust-invariants.test.ts
@@ -324,6 +324,8 @@ describe("run domain trust invariants", () => {
     expect(response.status).toBe(200);
     const payload = await response.json();
     expect(payload.runKind).toBe("recon_job");
+    expect(payload.sourceModel).toBe("recon_jobs");
+    expect(payload.detailHref).toBe("/console/runs/run-a-1");
     expect(payload.config).toEqual(
       expect.objectContaining({
         sourceAdapter: "stripe",

--- a/packages/web/src/app/api/runs/[id]/route.ts
+++ b/packages/web/src/app/api/runs/[id]/route.ts
@@ -325,7 +325,9 @@ export const GET = withSecurity(
 
         return NextResponse.json({
           runKind: "recon_job" as const,
+          sourceModel: "recon_jobs" as const,
           id: run.id,
+          detailHref: `/console/runs/${run.id}`,
           name: contract.name,
           status: truth.status,
           statusLabel: truth.statusLabel,

--- a/packages/web/src/lib/reconciliation/build-ingestion-run-detail-json.ts
+++ b/packages/web/src/lib/reconciliation/build-ingestion-run-detail-json.ts
@@ -3,7 +3,9 @@ import type {
   CanonicalReconciliationRunDetail,
 } from "@settler/reconciliation-core";
 
-function legacyAdapterDriftLabel(signal: AdapterDriftSignal): "source" | "target" | "both" | "none" {
+function legacyAdapterDriftLabel(
+  signal: AdapterDriftSignal
+): "source" | "target" | "both" | "none" {
   if (signal.sourceChanged && signal.targetChanged) return "both";
   if (signal.sourceChanged) return "source";
   if (signal.targetChanged) return "target";
@@ -30,7 +32,9 @@ export function buildIngestionRunDetailJson(detail: CanonicalReconciliationRunDe
 
   return {
     runKind: "ingestion_run" as const,
+    sourceModel: detail.provenance.sourceModel,
     id: detail.id,
+    detailHref: `/console/runs/${detail.id}`,
     name: detail.name,
     status: lifecycle.status,
     statusLabel: lifecycle.statusLabel,
@@ -57,8 +61,7 @@ export function buildIngestionRunDetailJson(detail: CanonicalReconciliationRunDe
       unmatchedSourceCount: s.unmatchedSourceCount,
       unmatchedTargetCount: s.unmatchedTargetCount,
       conflictCount: s.conflicts,
-      note:
-        "Ingestion-backed run: counts come from reconciliation_runs; exception workflow and snapshot-backed config apply to recon job runs only.",
+      note: "Ingestion-backed run: counts come from reconciliation_runs; exception workflow and snapshot-backed config apply to recon job runs only.",
     },
     summarySemantics: {
       processed: s.processed,


### PR DESCRIPTION
### Motivation
- Close the operator-facing reality gap where console reconciliation list could present a placeholder `reconciliations: []` while canonical merged run data existed, by providing a single explicit canonical read surface for operator-visible runs.
- Make run-kind and source semantics explicit so consumers cannot incorrectly assume a single backing model or ambiguous ID-resolution behavior.
- Preserve backward compatibility for legacy `reconciliations` projection while removing its misleading empty-list semantics.

### Description
- Always include a canonical top-level `runs` array in the console reconciliation list and enrich each item with `runKind`, `sourceModel`, and stable deep link `detailHref` by updating `packages/reconciliation-core/src/console-reconciliation-list.ts` and related list adapter code.
- Add `sourceModel` and `detailHref` to the `GET /api/runs` legacy row projection by changing `packages/reconciliation-core/src/api-runs-list-adapter.ts` so list rows carry explicit provenance and detail links.
- Surface explicit `sourceModel` and `detailHref` in run detail responses for both recon-job and ingestion-run paths by updating `packages/web/src/app/api/runs/[id]/route.ts` and `packages/web/src/lib/reconciliation/build-ingestion-run-detail-json.ts`.
- Update and extend contract/unit tests to assert the new canonical `runs` shape and explicit fields, and mark the legacy `reconciliations` field scope in response metadata (tests in `packages/reconciliation-core` and `packages/web` were updated accordingly).

### Testing
- Ran reconciliation-core unit tests with `pnpm --filter @settler/reconciliation-core test -- console-reconciliation-list api-runs-list-adapter`, and both suites passed.
- Ran web contract/unit tests with `pnpm --filter @settler/web test -- api-runs-list-route.contract console-reconciliation-list-route.contract run-domain-trust-invariants`, and all targeted suites passed (3 test suites, 15 tests total passed).
- Ran repository checks: `pnpm lint` completed (lint reported existing warnings, no new errors) and `pnpm typecheck` completed successfully across packages.
- Attempted `pnpm build` but it failed in this environment due to missing required web build environment variables (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and DB URL), so full production build verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5aa4d10e88328af7b82ece8abccfb)