### PR TITLE
AAA visual polish: marketing motion, dense tables, token toasts, CLI logger

### DIFF
--- a/packages/cli/src/commands/jobs.ts
+++ b/packages/cli/src/commands/jobs.ts
@@ -3,6 +3,8 @@ import { Command } from "commander";
 
 import Settler from "@settler/sdk";
 import type { ReconciliationJob } from "@settler/sdk";
+import { createCliLogger, resolveJsonFallbackFromEnv } from "../lib/cli-logger";
+import { withIndeterminateProgress } from "../lib/cli-progress";
 import { createTraceContext, withTraceHeaders } from "../lib/http";
 
 interface CommandParentOptions {
@@ -23,10 +25,11 @@ jobsCommand
   .command("list")
   .description("List all reconciliation jobs")
   .action(async (options: CommandOptions) => {
+    const log = createCliLogger({ isJSONFallback: resolveJsonFallbackFromEnv() });
     try {
       const apiKey = process.env.SETTLER_API_KEY || options.parent?.apiKey;
       if (!apiKey) {
-        console.error(chalk.red("Error: API key required. Set SETTLER_API_KEY or use --api-key"));
+        log.error("API key required. Set SETTLER_API_KEY or use --api-key");
         process.exit(1);
       }
 
@@ -35,25 +38,28 @@ jobsCommand
         ...(options.parent?.baseUrl ? { baseUrl: options.parent.baseUrl } : {}),
       });
 
-      const response = await client.jobs.list();
+      const response = await withIndeterminateProgress(
+        "Fetching jobs…",
+        resolveJsonFallbackFromEnv(),
+        () => client.jobs.list()
+      );
 
       if (response.data.length === 0) {
-        console.log(chalk.yellow("No jobs found."));
+        log.warning("No jobs found.");
         return;
       }
 
-      console.log(chalk.bold("\nReconciliation Jobs:\n"));
+      log.rawLine("");
+      log.rawLine(chalk.bold("Reconciliation Jobs:"));
       response.data.forEach((job: ReconciliationJob) => {
-        console.log(chalk.cyan(`  ${job.id}`));
-        console.log(`    Name: ${job.name}`);
-        console.log(`    Status: ${job.status}`);
-        console.log(`    Created: ${new Date(job.createdAt).toLocaleString()}`);
-        console.log();
+        log.rawLine(chalk.cyan(`  ${job.id}`));
+        log.rawLine(`    Name: ${job.name}`);
+        log.rawLine(`    Status: ${job.status}`);
+        log.rawLine(`    Created: ${new Date(job.createdAt).toLocaleString()}`);
+        log.rawLine("");
       });
     } catch (error) {
-      console.error(
-        chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
-      );
+      log.error(error instanceof Error ? error.message : "Unknown error");
       process.exit(1);
     }
   });
@@ -71,16 +77,16 @@ jobsCommand
       target?: string;
       parent?: CommandParentOptions;
     }) => {
+      const log = createCliLogger({ isJSONFallback: resolveJsonFallbackFromEnv() });
       try {
         const apiKey = process.env.SETTLER_API_KEY || options.parent?.parent?.apiKey;
         if (!apiKey) {
-          console.error(chalk.red("Error: API key required"));
+          log.error("API key required");
           process.exit(1);
         }
 
-        // In a real CLI, you'd use inquirer for interactive prompts
-        console.log(chalk.yellow("Creating job..."));
-        console.log(chalk.gray("Note: Use the web UI or API for full configuration"));
+        log.warning("Creating job…");
+        log.detail("Note: Use the web UI or API for full configuration");
 
         const client = new Settler({
           apiKey,
@@ -89,30 +95,33 @@ jobsCommand
 
         // Example job creation
         const emptyConfig: Record<string, unknown> = {};
-        const response = await client.jobs.create({
-          name: options.name || "New Reconciliation Job",
-          source: {
-            adapter: options.source || "shopify",
-            config: emptyConfig,
-          },
-          target: {
-            adapter: options.target || "stripe",
-            config: emptyConfig,
-          },
-          rules: {
-            matching: [
-              { field: "order_id" as const, type: "exact" as const },
-              { field: "amount" as const, type: "exact" as const, tolerance: 0.01 },
-            ],
-          },
-        });
-
-        console.log(chalk.green(`\n✓ Job created: ${response.data.id}`));
-        console.log(chalk.gray(`  Name: ${response.data.name}`));
-      } catch (error) {
-        console.error(
-          chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
+        const response = await withIndeterminateProgress(
+          "Submitting job…",
+          resolveJsonFallbackFromEnv(),
+          () =>
+            client.jobs.create({
+              name: options.name || "New Reconciliation Job",
+              source: {
+                adapter: options.source || "shopify",
+                config: emptyConfig,
+              },
+              target: {
+                adapter: options.target || "stripe",
+                config: emptyConfig,
+              },
+              rules: {
+                matching: [
+                  { field: "order_id" as const, type: "exact" as const },
+                  { field: "amount" as const, type: "exact" as const, tolerance: 0.01 },
+                ],
+              },
+            })
         );
+
+        log.success(`Job created: ${response.data.id}`);
+        log.detail(`Name: ${response.data.name}`);
+      } catch (error) {
+        log.error(error instanceof Error ? error.message : "Unknown error");
         process.exit(1);
       }
     }
@@ -123,10 +132,11 @@ jobsCommand
   .description("Run a reconciliation job")
   .option("--wait", "Wait for job completion")
   .action(async (id: string, options: { wait?: boolean; parent?: CommandParentOptions }) => {
+    const log = createCliLogger({ isJSONFallback: resolveJsonFallbackFromEnv() });
     try {
       const apiKey = process.env.SETTLER_API_KEY || options.parent?.apiKey;
       if (!apiKey) {
-        console.error(chalk.red("Error: API key required"));
+        log.error("API key required");
         process.exit(1);
       }
 
@@ -138,11 +148,15 @@ jobsCommand
         baseUrl,
       });
 
-      const response = await client.jobs.run(id);
-      console.log(chalk.green(`\n✓ Job execution started: ${response.data.id}`));
+      const response = await withIndeterminateProgress(
+        "Starting job run…",
+        resolveJsonFallbackFromEnv(),
+        () => client.jobs.run(id)
+      );
+      log.success(`Job execution started: ${response.data.id}`);
 
       if (options.wait) {
-        console.log(chalk.blue("Waiting for completion..."));
+        log.info("Waiting for completion…");
         // Poll for completion
         let completed = false;
         let attempts = 0;
@@ -159,7 +173,7 @@ jobsCommand
               endDate: new Date().toISOString(),
             });
             completed = true;
-            console.log(chalk.green("✓ Job execution completed"));
+            log.success("Job execution completed");
           } catch {
             // Execution might still be running, continue polling
           }
@@ -167,13 +181,11 @@ jobsCommand
         }
 
         if (!completed) {
-          console.log(chalk.yellow("⚠ Job still running after 5 minutes"));
+          log.warning("Job still running after 5 minutes");
         }
       }
     } catch (error) {
-      console.error(
-        chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
-      );
+      log.error(error instanceof Error ? error.message : "Unknown error");
       process.exit(1);
     }
   });

--- a/packages/cli/src/lib/cli-logger.ts
+++ b/packages/cli/src/lib/cli-logger.ts
@@ -1,0 +1,89 @@
+import chalk from "chalk";
+
+export type CliLogLevel = "info" | "success" | "warning" | "error";
+
+export interface CliLoggerOptions {
+  /** When true, emit plain text / JSON-friendly lines without ANSI or decorative glyphs */
+  isJSONFallback?: boolean;
+}
+
+const LEVEL_LABEL: Record<CliLogLevel, string> = {
+  info: "info",
+  success: "success",
+  warning: "warning",
+  error: "error",
+};
+
+function formatPlainLine(level: CliLogLevel, message: string): string {
+  return `[${LEVEL_LABEL[level]}] ${message}`;
+}
+
+/**
+ * Structured CLI logger: strict levels, optional JSON/CI mode (no chalk, no icons).
+ */
+export function createCliLogger(options: CliLoggerOptions = {}) {
+  const json = options.isJSONFallback === true;
+
+  const log = (level: CliLogLevel, message: string): void => {
+    if (json) {
+      console.log(formatPlainLine(level, message));
+      return;
+    }
+    const styled =
+      level === "success"
+        ? chalk.green(message)
+        : level === "warning"
+          ? chalk.yellow(message)
+          : level === "error"
+            ? chalk.red(message)
+            : chalk.white(message);
+    const prefix =
+      level === "success"
+        ? chalk.green("✓")
+        : level === "warning"
+          ? chalk.yellow("!")
+          : level === "error"
+            ? chalk.red("✗")
+            : chalk.cyan("›");
+    console.log(`${prefix} ${styled}`);
+  };
+
+  return {
+    log,
+
+    info: (message: string): void => {
+      log("info", message);
+    },
+
+    success: (message: string): void => {
+      log("success", message);
+    },
+
+    warning: (message: string): void => {
+      log("warning", message);
+    },
+
+    error: (message: string): void => {
+      log("error", message);
+    },
+
+    /** Raw line without level prefix — use for tables or key=value output */
+    rawLine: (message: string): void => {
+      console.log(message);
+    },
+
+    /** Dim secondary detail */
+    detail: (message: string): void => {
+      if (json) {
+        console.log(message);
+        return;
+      }
+      console.log(chalk.gray(message));
+    },
+  };
+}
+
+export function resolveJsonFallbackFromEnv(): boolean {
+  const v = process.env.SETTLER_CLI_JSON;
+  return v === "1" || v === "true" || v === "yes";
+}

--- a/packages/cli/src/lib/cli-progress.ts
+++ b/packages/cli/src/lib/cli-progress.ts
@@ -1,0 +1,28 @@
+import chalk from "chalk";
+
+/**
+ * Indeterminate progress for long async work. Skips animation when JSON/CI mode is on.
+ */
+export async function withIndeterminateProgress<T>(
+  label: string,
+  isJSONFallback: boolean,
+  work: () => Promise<T>
+): Promise<T> {
+  if (isJSONFallback) {
+    return work();
+  }
+
+  const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+  let i = 0;
+  const id = setInterval(() => {
+    process.stdout.write(`\r${chalk.cyan(frames[i] ?? "⠋")} ${chalk.gray(label)}`);
+    i = (i + 1) % frames.length;
+  }, 90);
+
+  try {
+    return await work();
+  } finally {
+    clearInterval(id);
+    process.stdout.write("\r\x1b[K");
+  }
+}

--- a/packages/web/src/app/console/runs/page.tsx
+++ b/packages/web/src/app/console/runs/page.tsx
@@ -254,26 +254,26 @@ export default function RunsPage() {
     return (
       <div className="space-y-6">
         <div className="space-y-2">
-          <Skeleton className="h-8 w-48" />
-          <Skeleton className="h-4 w-96" />
+          <Skeleton animation="wave" className="h-8 w-48" />
+          <Skeleton animation="wave" className="h-4 w-full max-w-md" />
         </div>
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {Array.from({ length: 4 }).map((_, index) => (
-            <Card key={index}>
+            <Card key={index} className="border-border/70 shadow-sm">
               <CardHeader className="pb-1 pt-5 px-5">
-                <Skeleton className="h-3 w-20" />
-                <Skeleton className="h-8 w-24 mt-1" />
+                <Skeleton animation="wave" className="h-3 w-20" />
+                <Skeleton animation="wave" className="mt-1 h-8 w-24" />
               </CardHeader>
               <CardContent className="px-5 pb-5">
-                <Skeleton className="h-3 w-40" />
+                <Skeleton animation="wave" className="h-3 w-40" />
               </CardContent>
             </Card>
           ))}
         </div>
-        <Card>
-          <CardContent className="py-6 space-y-4">
+        <Card className="border-border/70 shadow-sm">
+          <CardContent className="space-y-4 py-6">
             {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-36 w-full rounded-xl" />
+              <Skeleton key={i} animation="wave" className="h-36 w-full rounded-xl" />
             ))}
           </CardContent>
         </Card>
@@ -494,29 +494,29 @@ export default function RunsPage() {
           hint={
             filters.status || filters.search || (filters.runKind && filters.runKind !== "all")
               ? undefined
-              : "Start by connecting an integration, or try the Playground to see reconciliation in action with sample data."
+              : "Next: connect Stripe (or another source) under Integrations, then trigger a recon job — or explore the Playground with sample data."
           }
           action={
             filters.status || filters.search || (filters.runKind && filters.runKind !== "all")
               ? { label: "Clear Filters", onClick: () => setFilters({ runKind: "all" }) }
-              : { label: "Open Reconciliations", href: "/console/reconciliations" }
+              : { label: "Connect integrations", href: "/dashboard/integrations" }
           }
           secondaryAction={
             filters.status || filters.search || (filters.runKind && filters.runKind !== "all")
               ? undefined
-              : { label: "Try Demo", href: "/demo/console" }
+              : { label: "Try demo console", href: "/demo/console", variant: "outline" }
           }
         />
       ) : (
-        <Card>
-          <CardHeader>
+        <Card className="border-border/70 shadow-sm">
+          <CardHeader className="sticky top-0 z-10 border-b border-border/40 bg-card/95 py-4 backdrop-blur-sm">
             <CardTitle>Run history</CardTitle>
             <CardDescription>
               Merged list: recon jobs and ingestion reconciliation runs. Detail pages differ by run
               kind where the data model does not yet offer parity.
             </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-3">
+          <CardContent className="space-y-3 pt-5">
             {listMeta?.pagination_mode === "filter_scan_first_page" &&
             listMeta.filters_applied &&
             (listMeta.filters_applied.status || listMeta.filters_applied.search) ? (
@@ -530,13 +530,13 @@ export default function RunsPage() {
             {runs.map((run) => (
                 <div
                   key={run.id}
-                  className="rounded-xl border border-border p-5 hover:border-border/80 transition-colors"
+                  className="rounded-xl border border-border/80 bg-card/50 p-5 shadow-sm transition-all hover:border-primary/25 hover:shadow-md"
                 >
                   <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
                     <div className="min-w-0 flex-1 space-y-4">
                       {/* Row 1: Name + status badges */}
                       <div className="flex flex-wrap items-center gap-2">
-                        <h2 className="truncate text-base font-semibold text-foreground">
+                        <h2 className="truncate text-base font-semibold text-foreground" title={run.name}>
                           {run.name}
                         </h2>
                         <Badge variant="outline" className="text-xs font-normal">
@@ -555,12 +555,20 @@ export default function RunsPage() {
                       <div className="grid gap-x-6 gap-y-1 text-sm md:grid-cols-4">
                         <div>
                           <span className="text-xs text-muted-foreground">Run ID</span>
-                          <div className="font-mono text-xs text-foreground truncate">{run.id}</div>
+                          <div
+                            className="truncate font-mono text-xs text-foreground"
+                            title={run.id}
+                          >
+                            {run.id}
+                          </div>
                         </div>
                         {run.ingestionId ? (
                           <div>
                             <span className="text-xs text-muted-foreground">Ingestion</span>
-                            <div className="font-mono text-xs text-foreground truncate">
+                            <div
+                              className="truncate font-mono text-xs text-foreground"
+                              title={run.ingestionId}
+                            >
                               {run.ingestionId}
                             </div>
                           </div>
@@ -596,19 +604,19 @@ export default function RunsPage() {
                       <div className="grid gap-2 sm:grid-cols-3 xl:grid-cols-6">
                         <div className="metric-chip">
                           <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Matched</div>
-                          <div className="mt-0.5 text-lg font-semibold text-green-600 dark:text-green-400 tabular-nums">
+                          <div className="mt-0.5 text-lg font-semibold text-success tabular-nums">
                             {formatCount(run.summary.matched)}
                           </div>
                         </div>
                         <div className="metric-chip">
                           <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Unmatched</div>
-                          <div className="mt-0.5 text-lg font-semibold text-amber-600 dark:text-amber-400 tabular-nums">
+                          <div className="mt-0.5 text-lg font-semibold text-warning tabular-nums">
                             {formatCount(run.summary.unmatched)}
                           </div>
                         </div>
                         <div className="metric-chip">
                           <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Conflicts</div>
-                          <div className="mt-0.5 text-lg font-semibold text-red-600 dark:text-red-400 tabular-nums">
+                          <div className="mt-0.5 text-lg font-semibold text-error tabular-nums">
                             {formatCount(run.summary.conflicts)}
                           </div>
                         </div>

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
   Section,
   SectionHeader,
 } from "@/components/site/primitives";
+import { MarketingIntentCard } from "@/components/site/marketing-motion-wrappers";
 import { Button } from "@/components/ui/button";
 import { UiLink } from "@/components/ui/link";
 
@@ -112,14 +113,15 @@ export default function HomePage() {
                 desc: "Interactive showcase console with realistic reconciliation scenarios.",
               },
             ].map((item) => (
-              <UiLink
-                key={item.role}
-                href={item.href}
-                className="rounded-xl border border-border bg-card p-5 hover:border-primary/50"
-              >
-                <h3 className="text-lg font-semibold text-foreground">{item.role}</h3>
-                <p className="mt-2 text-sm text-muted-foreground">{item.desc}</p>
-              </UiLink>
+              <MarketingIntentCard key={item.role}>
+                <UiLink
+                  href={item.href}
+                  className="block rounded-xl border border-border bg-card p-6 transition-colors hover:border-primary/45"
+                >
+                  <h3 className="text-lg font-semibold text-foreground">{item.role}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{item.desc}</p>
+                </UiLink>
+              </MarketingIntentCard>
             ))}
           </div>
         </Section>

--- a/packages/web/src/components/site/marketing-motion-wrappers.tsx
+++ b/packages/web/src/components/site/marketing-motion-wrappers.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Children, type ReactNode } from "react";
+import {
+  MotionFadeIn,
+  MotionHeroBlock,
+  MotionInteractive,
+  MotionSlideUp,
+} from "./marketing-motion";
+
+const easeSnappy = [0.22, 1, 0.36, 1] as const;
+
+export function MarketingHeroReveal({ children }: { children: ReactNode }) {
+  return <MotionHeroBlock>{children}</MotionHeroBlock>;
+}
+
+export function MarketingSectionFade({ children }: { children: ReactNode }) {
+  return <MotionFadeIn>{children}</MotionFadeIn>;
+}
+
+export function MarketingSlideUp({ children }: { children: ReactNode }) {
+  return <MotionSlideUp>{children}</MotionSlideUp>;
+}
+
+/** Wrap a full-width link/card; keeps existing border/bg on the child. */
+export function MarketingIntentCard({ children }: { children: ReactNode }) {
+  return <MotionInteractive className="block h-full">{children}</MotionInteractive>;
+}
+
+export function MarketingStaggeredFeatureGrid({ children }: { children: ReactNode }) {
+  return (
+    <motion.div
+      className="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
+      initial="hidden"
+      whileInView="show"
+      viewport={{ once: true, margin: "-48px" }}
+      variants={{
+        hidden: {},
+        show: {
+          transition: { staggerChildren: 0.06, delayChildren: 0.04 },
+        },
+      }}
+    >
+      {Children.map(children, (child, index) => (
+        <motion.div
+          key={index}
+          variants={{
+            hidden: { opacity: 0, y: 12 },
+            show: {
+              opacity: 1,
+              y: 0,
+              transition: { duration: 0.28, ease: easeSnappy },
+            },
+          }}
+        >
+          {child}
+        </motion.div>
+      ))}
+    </motion.div>
+  );
+}

--- a/packages/web/src/components/site/marketing-motion.tsx
+++ b/packages/web/src/components/site/marketing-motion.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { motion, type HTMLMotionProps } from "framer-motion";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+const easeSnappy = [0.22, 1, 0.36, 1] as const;
+
+const fadeInTransition = { duration: 0.28, ease: easeSnappy };
+
+const slideUpTransition = { duration: 0.32, ease: easeSnappy };
+
+export function MotionFadeIn({
+  className,
+  children,
+  ...rest
+}: HTMLMotionProps<"div"> & { children: ReactNode }) {
+  return (
+    <motion.div
+      className={cn("will-change-[opacity]", className)}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={fadeInTransition}
+      {...rest}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function MotionSlideUp({
+  className,
+  children,
+  ...rest
+}: HTMLMotionProps<"div"> & { children: ReactNode }) {
+  return (
+    <motion.div
+      className={cn("will-change-[transform,opacity]", className)}
+      initial={{ opacity: 0, y: 14 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={slideUpTransition}
+      {...rest}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+/** Hero / CTA — opacity + translateY, snappy spring alternative via cubic-bezier */
+export function MotionHeroBlock({
+  className,
+  children,
+  delay = 0,
+  ...rest
+}: HTMLMotionProps<"div"> & { children: ReactNode; delay?: number }) {
+  return (
+    <motion.div
+      className={cn("will-change-[transform,opacity]", className)}
+      initial={{ opacity: 0, y: 14 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ ...slideUpTransition, delay }}
+      {...rest}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+/** Subtle lift on hover for marketing cards / links */
+export function MotionInteractive({
+  className,
+  children,
+  ...rest
+}: HTMLMotionProps<"div"> & { children: ReactNode }) {
+  return (
+    <motion.div
+      className={cn(className)}
+      whileHover={{ y: -2 }}
+      whileTap={{ scale: 0.99 }}
+      transition={{ type: "spring", stiffness: 420, damping: 28 }}
+      {...rest}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/packages/web/src/components/site/primitives.tsx
+++ b/packages/web/src/components/site/primitives.tsx
@@ -4,6 +4,12 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { UiLink } from "@/components/ui/link";
 import { cn } from "@/lib/utils";
+import {
+  MarketingHeroReveal,
+  MarketingSectionFade,
+  MarketingSlideUp,
+  MarketingStaggeredFeatureGrid,
+} from "@/components/site/marketing-motion-wrappers";
 
 export function PublicPageShell({ children }: { children: ReactNode }) {
   return <div className="min-h-screen bg-background">{children}</div>;
@@ -11,7 +17,7 @@ export function PublicPageShell({ children }: { children: ReactNode }) {
 
 export function Section({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <section className={cn("px-4 py-20 sm:px-6 lg:px-8", className)}>
+    <section className={cn("px-4 py-24 sm:px-6 lg:px-8", className)}>
       <div className="mx-auto max-w-6xl">{children}</div>
     </section>
   );
@@ -29,36 +35,44 @@ export function PageHero({
   actions?: ReactNode;
 }) {
   return (
-    <Section className="border-b border-border/50 bg-muted/10 pt-24 pb-16">
-      {eyebrow ? (
-        <Badge variant="outline" className="mb-6 text-xs tracking-widest uppercase font-semibold">
-          {eyebrow}
-        </Badge>
-      ) : null}
-      <h1 className="max-w-4xl text-fluid-4xl font-bold tracking-tight text-foreground md:text-fluid-5xl leading-[1.15]">
-        {title}
-      </h1>
-      <p className="mt-6 max-w-3xl text-lg leading-relaxed text-muted-foreground">{description}</p>
-      {actions ? <div className="mt-10 flex flex-wrap gap-4">{actions}</div> : null}
+    <Section className="border-b border-border/50 bg-muted/10 pt-28 pb-20">
+      <MarketingHeroReveal>
+        {eyebrow ? (
+          <Badge variant="outline" className="mb-6 text-xs tracking-widest uppercase font-semibold">
+            {eyebrow}
+          </Badge>
+        ) : null}
+        <h1 className="max-w-4xl text-fluid-4xl font-bold tracking-tight text-foreground md:text-fluid-5xl leading-[1.12]">
+          {title}
+        </h1>
+        <p className="mt-7 max-w-3xl text-fluid-lg leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+        {actions ? (
+          <div className="mt-11 flex flex-wrap gap-4">{actions}</div>
+        ) : null}
+      </MarketingHeroReveal>
     </Section>
   );
 }
 
 export function SectionHeader({ title, description }: { title: string; description?: string }) {
   return (
-    <div className="mb-10 max-w-3xl">
-      <h2 className="text-fluid-2xl font-semibold tracking-tight text-foreground md:text-fluid-3xl">
-        {title}
-      </h2>
-      {description ? (
-        <p className="mt-4 text-muted-foreground leading-relaxed">{description}</p>
-      ) : null}
-    </div>
+    <MarketingSectionFade>
+      <div className="mb-12 max-w-3xl">
+        <h2 className="text-fluid-2xl font-semibold tracking-tight text-foreground md:text-fluid-3xl">
+          {title}
+        </h2>
+        {description ? (
+          <p className="mt-5 text-fluid-base text-muted-foreground leading-relaxed">{description}</p>
+        ) : null}
+      </div>
+    </MarketingSectionFade>
   );
 }
 
 export function FeatureGrid({ children }: { children: ReactNode }) {
-  return <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">{children}</div>;
+  return <MarketingStaggeredFeatureGrid>{children}</MarketingStaggeredFeatureGrid>;
 }
 
 export function FeatureCard({
@@ -71,10 +85,10 @@ export function FeatureCard({
   bullets?: string[];
 }) {
   return (
-    <Card className="h-full border-border/60 hover:border-border transition-colors duration-200">
+    <Card className="h-full border-border/60 shadow-sm transition-colors duration-200 hover:border-primary/35 hover:shadow-md">
       <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
+        <CardTitle className="text-fluid-lg">{title}</CardTitle>
+        <CardDescription className="text-fluid-sm leading-relaxed">{description}</CardDescription>
       </CardHeader>
       {bullets?.length ? (
         <CardContent>
@@ -108,19 +122,25 @@ export function CTASection({
   secondaryLabel?: string;
 }) {
   return (
-    <Section className="border-t border-border/50 bg-neutral-10 dark:bg-neutral-10 py-16 text-white">
-      <h2 className="text-fluid-2xl font-semibold tracking-tight md:text-fluid-3xl">{title}</h2>
-      <p className="mt-4 max-w-2xl text-neutral-200 leading-relaxed">{description}</p>
-      <div className="mt-8 flex flex-wrap gap-4">
-        <Button asChild>
-          <UiLink href={primaryHref}>{primaryLabel}</UiLink>
-        </Button>
-        {secondaryHref && secondaryLabel ? (
-          <Button variant="outline" asChild className="border-neutral-100/20 text-white hover:bg-white/10">
-            <UiLink href={secondaryHref}>{secondaryLabel}</UiLink>
+    <Section className="border-t border-border/60 bg-card py-20">
+      <MarketingSlideUp>
+        <h2 className="text-fluid-2xl font-semibold tracking-tight text-foreground md:text-fluid-3xl">
+          {title}
+        </h2>
+        <p className="mt-5 max-w-2xl text-fluid-base text-muted-foreground leading-relaxed">
+          {description}
+        </p>
+        <div className="mt-10 flex flex-wrap gap-4">
+          <Button asChild>
+            <UiLink href={primaryHref}>{primaryLabel}</UiLink>
           </Button>
-        ) : null}
-      </div>
+          {secondaryHref && secondaryLabel ? (
+            <Button variant="outline" asChild>
+              <UiLink href={secondaryHref}>{secondaryLabel}</UiLink>
+            </Button>
+          ) : null}
+        </div>
+      </MarketingSlideUp>
     </Section>
   );
 }

--- a/packages/web/src/components/ui/data-table.tsx
+++ b/packages/web/src/components/ui/data-table.tsx
@@ -20,7 +20,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { Search, ChevronLeft, ChevronRight, Loader2, AlertCircle, Inbox } from "lucide-react";
+import { Search, ChevronLeft, ChevronRight, AlertCircle, Inbox } from "lucide-react";
 import { Button } from "./button";
 import {
   Table,
@@ -116,10 +116,10 @@ function SkeletonRows({ columns, count = 5 }: { columns: number; count?: number 
       {Array.from({ length: count }).map((_, i) => (
         <TableRow key={i} className="border-b border-border/20">
           {Array.from({ length: columns }).map((_, j) => (
-            <TableCell key={j} className="py-3 px-4">
+            <TableCell key={j} className="px-3 py-2.5">
               <div
                 className={cn(
-                  "h-4 rounded bg-muted/60 animate-pulse",
+                  "h-3.5 rounded-md bg-gradient-to-r from-muted/80 via-primary/10 to-muted/80 bg-[length:200%_100%] animate-shimmer motion-reduce:animate-none",
                   j === 0 ? "w-24" : j === columns - 1 ? "w-12 ml-auto" : "w-full max-w-[180px]"
                 )}
               />
@@ -267,11 +267,14 @@ export function DataTable<TRow>({
 
       {/* Table */}
       <CardContent className="p-0">
-        <Table>
-          <TableHeader>
-            <TableRow className="bg-muted/20 hover:bg-muted/20 border-b border-border/40">
+        <Table stickyScroll>
+          <TableHeader sticky>
+            <TableRow className="border-b border-border/40 bg-muted/25 hover:bg-muted/25">
               {columns.map((col) => (
-                <TableHead key={col.key} className={col.headerClassName}>
+                <TableHead
+                  key={col.key}
+                  className={cn("h-9 py-2 text-[11px] font-semibold", col.headerClassName)}
+                >
                   {col.header}
                 </TableHead>
               ))}
@@ -291,11 +294,14 @@ export function DataTable<TRow>({
                   onClick={onRowClick ? () => onRowClick(row) : undefined}
                   className={cn(
                     "border-b border-border/20 last:border-0 transition-colors",
-                    onRowClick && "cursor-pointer hover:bg-muted/40"
+                    onRowClick && "cursor-pointer hover:bg-muted/50"
                   )}
                 >
                   {columns.map((col) => (
-                    <TableCell key={col.key} className={col.cellClassName}>
+                    <TableCell
+                      key={col.key}
+                      className={cn("py-2.5 text-[13px] leading-snug", col.cellClassName)}
+                    >
                       {col.cell(row)}
                     </TableCell>
                   ))}

--- a/packages/web/src/components/ui/error-boundary.tsx
+++ b/packages/web/src/components/ui/error-boundary.tsx
@@ -20,13 +20,23 @@ export interface ErrorFallbackProps {
 }
 
 const DefaultErrorFallback: React.FC<ErrorFallbackProps> = ({ error, resetError }) => {
+  const safeDetail =
+    process.env.NODE_ENV === "development" && error.message.trim().length > 0
+      ? error.message
+      : "We could not render this section. Your data is safe — try again, or refresh the page if the problem continues.";
+
   return (
     <EmptyState
       icon={AlertCircle}
       title="Something went wrong"
-      description={error.message || 'An unexpected error occurred. Please try again.'}
+      description={safeDetail}
+      hint={
+        process.env.NODE_ENV === "development"
+          ? undefined
+          : "If this keeps happening, contact support with what you were doing when it appeared."
+      }
       action={{
-        label: 'Try again',
+        label: "Try again",
         onClick: resetError,
       }}
     />

--- a/packages/web/src/components/ui/loading.tsx
+++ b/packages/web/src/components/ui/loading.tsx
@@ -50,7 +50,10 @@ const Loading = React.forwardRef<HTMLDivElement, LoadingProps>(
       >
         {showSpinner && (
           <Loader2
-            className={cn("animate-spin text-primary-600", sizeClasses[size])}
+            className={cn(
+              "animate-spin text-primary motion-reduce:animate-none",
+              sizeClasses[size]
+            )}
             aria-hidden="true"
           />
         )}

--- a/packages/web/src/components/ui/table.tsx
+++ b/packages/web/src/components/ui/table.tsx
@@ -19,12 +19,41 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
    * @default 'default'
    */
   size?: "sm" | "default" | "lg";
+
+  /**
+   * Enable vertical scroll + max height (use with sticky TableHeader for dense lists).
+   * @default false
+   */
+  stickyScroll?: boolean;
+
+  /**
+   * Max height class when stickyScroll is true
+   * @default 'max-h-[min(70vh,52rem)]'
+   */
+  scrollMaxHeightClassName?: string;
 }
 
 const Table = React.forwardRef<HTMLTableElement, TableProps>(
-  ({ className, striped = false, hover = false, size: _size = "default", ...props }, ref) => {
+  (
+    {
+      className,
+      striped = false,
+      hover = false,
+      size: _size = "default",
+      stickyScroll = false,
+      scrollMaxHeightClassName = "max-h-[min(70vh,52rem)]",
+      ...props
+    },
+    ref
+  ) => {
     return (
-      <div className="relative w-full overflow-auto">
+      <div
+        className={cn(
+          "relative w-full overflow-x-auto",
+          stickyScroll && "overflow-y-auto",
+          stickyScroll && scrollMaxHeightClassName
+        )}
+      >
         <table
           ref={ref}
           className={cn(
@@ -41,11 +70,23 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
 );
 Table.displayName = "Table";
 
-export type TableHeaderProps = React.HTMLAttributes<HTMLTableSectionElement>;
+export interface TableHeaderProps extends React.HTMLAttributes<HTMLTableSectionElement> {
+  /** Pin header while scrolling the table scroll container (pairs with overflow-auto wrapper). */
+  sticky?: boolean;
+}
 
 const TableHeader = React.forwardRef<HTMLTableSectionElement, TableHeaderProps>(
-  ({ className, ...props }, ref) => (
-    <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  ({ className, sticky, ...props }, ref) => (
+    <thead
+      ref={ref}
+      className={cn(
+        "[&_tr]:border-b",
+        sticky &&
+          "[&_th]:sticky [&_th]:top-0 [&_th]:z-[200] [&_th]:bg-card/95 [&_th]:backdrop-blur-sm [&_th]:shadow-[0_1px_0_0_var(--border)]",
+        className
+      )}
+      {...props}
+    />
   )
 );
 TableHeader.displayName = "TableHeader";

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -1,16 +1,14 @@
 /**
- * Toast Notification Component
- * 
- * Simple toast notification system for admin dashboard.
+ * Toast notification system — token-based surfaces for light/dark parity.
  */
 
-'use client';
+"use client";
 
-import { useState, useCallback } from 'react';
-import { X, CheckCircle2, AlertCircle, Info, AlertTriangle } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import React, { useState, useCallback } from "react";
+import { X, CheckCircle2, AlertCircle, Info, AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
 
-export type ToastType = 'success' | 'error' | 'info' | 'warning';
+export type ToastType = "success" | "error" | "info" | "warning";
 
 export interface Toast {
   id: string;
@@ -21,7 +19,7 @@ export interface Toast {
 
 interface ToastContextValue {
   toasts: Toast[];
-  addToast: (toast: Omit<Toast, 'id'>) => void;
+  addToast: (toast: Omit<Toast, "id">) => void;
   removeToast: (id: string) => void;
 }
 
@@ -30,20 +28,19 @@ const ToastContext = React.createContext<ToastContextValue | undefined>(undefine
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const addToast = useCallback((toast: Omit<Toast, 'id'>) => {
+  const addToast = useCallback((toast: Omit<Toast, "id">) => {
     const id = Math.random().toString(36).substring(7);
     const newToast = { ...toast, id };
-    setToasts(prev => [...prev, newToast]);
+    setToasts((prev) => [...prev, newToast]);
 
-    // Auto-remove after duration
     const duration = toast.duration ?? 5000;
     setTimeout(() => {
-      setToasts(prev => prev.filter(t => t.id !== id));
+      setToasts((prev) => prev.filter((t) => t.id !== id));
     }, duration);
   }, []);
 
   const removeToast = useCallback((id: string) => {
-    setToasts(prev => prev.filter(t => t.id !== id));
+    setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
   return (
@@ -57,15 +54,18 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
 export function useToast() {
   const context = React.useContext(ToastContext);
   if (!context) {
-    throw new Error('useToast must be used within ToastProvider');
+    throw new Error("useToast must be used within ToastProvider");
   }
   return context;
 }
 
 function ToastContainer({ toasts, onRemove }: { toasts: Toast[]; onRemove: (id: string) => void }) {
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
-      {toasts.map(toast => (
+    <div
+      className="fixed bottom-4 right-4 z-[var(--z-toast)] flex flex-col gap-2"
+      aria-live="polite"
+    >
+      {toasts.map((toast) => (
         <ToastItem key={toast.id} toast={toast} onRemove={onRemove} />
       ))}
     </div>
@@ -80,11 +80,21 @@ function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: (id: string) =
     warning: AlertTriangle,
   };
 
-  const colors = {
-    success: 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800 text-green-900 dark:text-green-300',
-    error: 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-900 dark:text-red-300',
-    info: 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800 text-blue-900 dark:text-blue-300',
-    warning: 'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800 text-yellow-900 dark:text-yellow-300',
+  const surface = {
+    success:
+      "border-success/35 bg-card text-foreground shadow-md ring-1 ring-inset ring-success/20 dark:bg-card dark:ring-success/25",
+    error:
+      "border-error/40 bg-card text-foreground shadow-md ring-1 ring-inset ring-error/25 dark:ring-error/30",
+    info: "border-border bg-card text-foreground shadow-md ring-1 ring-inset ring-border",
+    warning:
+      "border-warning/45 bg-card text-foreground shadow-md ring-1 ring-inset ring-warning/30 dark:ring-warning/35",
+  };
+
+  const iconClass = {
+    success: "text-success",
+    error: "text-error",
+    info: "text-highlight",
+    warning: "text-warning",
   };
 
   const Icon = icons[toast.type];
@@ -92,20 +102,21 @@ function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: (id: string) =
   return (
     <div
       className={cn(
-        'flex items-start gap-3 p-4 border rounded-lg shadow-lg min-w-[300px] max-w-[400px]',
-        colors[toast.type]
+        "flex min-w-[300px] max-w-[400px] items-start gap-3 rounded-[var(--ui-radius-md)] border p-4",
+        surface[toast.type]
       )}
+      role="status"
     >
-      <Icon className="w-5 h-5 flex-shrink-0 mt-0.5" />
-      <div className="flex-1 text-sm">{toast.message}</div>
+      <Icon className={cn("mt-0.5 h-5 w-5 flex-shrink-0", iconClass[toast.type])} aria-hidden="true" />
+      <div className="flex-1 text-sm leading-relaxed">{toast.message}</div>
       <button
+        type="button"
         onClick={() => onRemove(toast.id)}
-        className="flex-shrink-0 text-current opacity-70 hover:opacity-100"
+        className="flex-shrink-0 rounded-sm text-muted-foreground opacity-80 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring"
+        aria-label="Dismiss notification"
       >
-        <X className="w-4 h-4" />
+        <X className="h-4 w-4" />
       </button>
     </div>
   );
 }
-
-import React from 'react';

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -93,7 +93,7 @@ function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: (id: string) =
   const iconClass = {
     success: "text-success",
     error: "text-error",
-    info: "text-highlight",
+    info: "text-accent-highlight",
     warning: "text-warning",
   };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## Description

Presentation-only polish across marketing primitives, shared UI (tables, toasts, loading), console runs list, and the CLI jobs command.

- **Marketing:** Framer Motion wrappers (`fade` / `slideUp` / staggered grid) on `PageHero`, section headers, feature grid, and intent cards; increased vertical rhythm; CTA section uses semantic `bg-card` + token text (fixes harsh `neutral-10` + white text in light mode).
- **Console:** Branded shimmer skeletons, sticky "Run history" card header, denser run cards with hover depth, `title` on truncated IDs, token-based metric colors (`success` / `warning` / `error`), empty state primary action → **Connect integrations** (`/dashboard/integrations`).
- **Shared UI:** `Table` supports optional `stickyScroll` + sticky `TableHeader`; `DataTable` uses both with denser cells and improved skeleton rows; toasts use token borders/rings; info icon uses `text-accent-highlight`; default error boundary hides raw messages in production.
- **CLI:** New `createCliLogger` with strict levels and `SETTLER_CLI_JSON` for plain output; `withIndeterminateProgress` for network-heavy `jobs list` / `create` / `run`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] Security fix

## Testing

- `pnpm --filter @settler/web exec tsc --noEmit`
- `pnpm --filter @settler/cli exec tsc --noEmit`
- ESLint on touched files

## Environment

- **CLI:** `SETTLER_CLI_JSON=1` (or `true`/`yes`) disables ANSI prefixes for machine-readable logs.

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6f1f248-edcf-4c8d-b5db-5ef6118b9701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6f1f248-edcf-4c8d-b5db-5ef6118b9701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

