### PR TITLE
UX polish: marketing motion, CTAs, console ergonomics, CLI section helper

### DIFF
--- a/packages/cli/src/lib/cli-logger.ts
+++ b/packages/cli/src/lib/cli-logger.ts
@@ -18,6 +18,15 @@ function formatPlainLine(level: CliLogLevel, message: string): string {
   return `[${LEVEL_LABEL[level]}] ${message}`;
 }
 
+/** Human-friendly section header (skipped in JSON/CI mode) */
+export function formatCliSection(title: string, json: boolean): string {
+  if (json) {
+    return "";
+  }
+  const line = "─".repeat(Math.min(48, Math.max(title.length + 4, 24)));
+  return `\n${line}\n${title}\n${line}\n`;
+}
+
 /**
  * Structured CLI logger: strict levels, optional JSON/CI mode (no chalk, no icons).
  */
@@ -79,6 +88,14 @@ export function createCliLogger(options: CliLoggerOptions = {}) {
         return;
       }
       console.log(chalk.gray(message));
+    },
+
+    /** Section header for long flows — no-op in JSON mode */
+    section: (title: string): void => {
+      const block = formatCliSection(title, json);
+      if (block) {
+        console.log(chalk.bold.cyan(block.trimEnd()));
+      }
     },
   };
 }

--- a/packages/web/src/app/(marketing)/home/page.tsx
+++ b/packages/web/src/app/(marketing)/home/page.tsx
@@ -156,7 +156,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
         {/* Hero Section */}
         <section
-          className="relative pt-16 sm:pt-20 lg:pt-28 pb-16 sm:pb-20 lg:pb-24 px-4 sm:px-6 lg:px-8 overflow-hidden"
+          className="relative pt-16 sm:pt-20 lg:pt-24 pb-16 sm:pb-20 lg:pb-24 px-4 sm:px-6 lg:px-8 overflow-hidden"
           aria-labelledby="hero-heading"
         >
           <ParallaxBackground>
@@ -184,15 +184,15 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                       as="h1"
                       id="hero-heading"
                       text="Reconcile Financial Data. Find Every Mismatch. Prove the Results."
-                      className="text-3xl sm:text-4xl md:text-5xl lg:text-[3.25rem] font-bold mb-4 sm:mb-6 text-foreground dark:text-foreground tracking-tight leading-[1.1]"
+                      className="text-3xl sm:text-4xl md:text-5xl lg:text-[3rem] font-bold mb-4 sm:mb-6 text-foreground dark:text-foreground tracking-tight leading-[1.12]"
                       delay={0}
                       staggerDelay={0.02}
                       splitBy="words"
                     />
                   </div>
 
-                  <div className="mb-10 sm:mb-12">
-                    <p className="text-lg sm:text-xl text-muted-foreground dark:text-muted-foreground leading-relaxed">
+                  <div className="mb-10 sm:mb-12 max-w-xl lg:max-w-2xl">
+                    <p className="text-base sm:text-lg text-muted-foreground dark:text-muted-foreground leading-relaxed">
                       Settler matches records across Stripe, banks, ERPs, and ledgers — then
                       surfaces every mismatch with full context. Every run produces verifiable
                       evidence. Every run can be replayed.
@@ -203,7 +203,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                     <Button
                       size="lg"
                       asChild
-                      className="w-full sm:w-auto bg-foreground hover:bg-foreground/90 text-background px-8 py-6 text-lg font-semibold shadow-xl transition-all duration-200"
+                      className="w-full sm:w-auto bg-foreground hover:bg-foreground/90 text-background px-8 py-6 text-base sm:text-lg font-semibold shadow-lg transition-all duration-200"
                     >
                       <Link
                         href="/docs/quickstart"
@@ -218,7 +218,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
                       size="lg"
                       variant="outline"
                       asChild
-                      className="w-full sm:w-auto px-8 py-6 text-lg border-2 border-border dark:border-border bg-card dark:bg-background hover:bg-background dark:hover:bg-card transition-all duration-200"
+                      className="w-full sm:w-auto px-8 py-6 text-base sm:text-lg border-2 border-border dark:border-border bg-card dark:bg-background hover:bg-background dark:hover:bg-card hover:border-primary/40 transition-all duration-200"
                     >
                       <Link href={repoUrl} className="flex items-center justify-center gap-3">
                         <span>View on GitHub</span>
@@ -636,7 +636,7 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
 
         {/* GitHub / Quickstart CTA */}
         <section
-          className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 bg-background "
+          className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 bg-background border-t border-border/60"
           aria-label="Get started"
         >
           <div className="max-w-3xl mx-auto text-center">
@@ -649,24 +649,22 @@ const mismatches = await client.reconciliations.getMismatches(reconciliation.id)
             <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-foreground tracking-tight mb-4">
               Start in Minutes
             </h2>
-            <p className="text-lg text-muted-foreground max-w-xl mx-auto leading-relaxed mb-10">
+            <p className="text-base sm:text-lg text-muted-foreground max-w-xl mx-auto leading-relaxed mb-10">
               One SDK install. Define your rules. Run reconciliation. Review the evidence.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-                href="/docs/quickstart"
-                className="inline-flex items-center justify-center gap-2 rounded-xl bg-card text-foreground hover:bg-muted/40 px-8 py-3.5 text-base font-semibold shadow-lg transition-all duration-200"
-              >
-                <BookOpen className="w-4 h-4" aria-hidden="true" />
-                Read the Quickstart
-              </Link>
-              <Link
-                href={repoUrl}
-                className="inline-flex items-center justify-center gap-2 rounded-xl border border-border bg-card text-foreground hover:bg-muted hover:border-border px-8 py-3.5 text-base font-medium transition-all duration-200"
-              >
-                <Github className="w-4 h-4" aria-hidden="true" />
-                View on GitHub
-              </Link>
+            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-stretch sm:items-center">
+              <Button size="lg" asChild className="shadow-md">
+                <Link href="/docs/quickstart" className="inline-flex items-center justify-center gap-2">
+                  <BookOpen className="w-4 h-4" aria-hidden="true" />
+                  Read the Quickstart
+                </Link>
+              </Button>
+              <Button size="lg" variant="outline" asChild>
+                <Link href={repoUrl} className="inline-flex items-center justify-center gap-2">
+                  <Github className="w-4 h-4" aria-hidden="true" />
+                  View on GitHub
+                </Link>
+              </Button>
             </div>
           </div>
         </section>

--- a/packages/web/src/app/console/runs/page.tsx
+++ b/packages/web/src/app/console/runs/page.tsx
@@ -530,7 +530,7 @@ export default function RunsPage() {
             {runs.map((run) => (
                 <div
                   key={run.id}
-                  className="rounded-xl border border-border/80 bg-card/50 p-5 shadow-sm transition-all hover:border-primary/25 hover:shadow-md"
+                  className="rounded-xl border border-border/80 bg-card/50 p-5 shadow-sm transition-colors hover:border-primary/30 hover:bg-card/80 hover:shadow-md"
                 >
                   <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
                     <div className="min-w-0 flex-1 space-y-4">

--- a/packages/web/src/components/console/ConsolePageHeader.tsx
+++ b/packages/web/src/components/console/ConsolePageHeader.tsx
@@ -40,7 +40,7 @@ export function ConsolePageHeader({
               {crumb.href ? (
                 <Link
                   href={crumb.href}
-                  className="hover:text-foreground transition-colors"
+                  className="rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 >
                   {crumb.label}
                 </Link>

--- a/packages/web/src/components/site/marketing-motion-wrappers.tsx
+++ b/packages/web/src/components/site/marketing-motion-wrappers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { Children, type ReactNode } from "react";
 import {
   MotionFadeIn,
@@ -29,6 +29,7 @@ export function MarketingIntentCard({ children }: { children: ReactNode }) {
 }
 
 export function MarketingStaggeredFeatureGrid({ children }: { children: ReactNode }) {
+  const reduceMotion = useReducedMotion();
   return (
     <motion.div
       className="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
@@ -38,7 +39,9 @@ export function MarketingStaggeredFeatureGrid({ children }: { children: ReactNod
       variants={{
         hidden: {},
         show: {
-          transition: { staggerChildren: 0.06, delayChildren: 0.04 },
+          transition: reduceMotion
+            ? { staggerChildren: 0, delayChildren: 0 }
+            : { staggerChildren: 0.06, delayChildren: 0.04 },
         },
       }}
     >
@@ -46,11 +49,11 @@ export function MarketingStaggeredFeatureGrid({ children }: { children: ReactNod
         <motion.div
           key={index}
           variants={{
-            hidden: { opacity: 0, y: 12 },
+            hidden: reduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 12 },
             show: {
               opacity: 1,
               y: 0,
-              transition: { duration: 0.28, ease: easeSnappy },
+              transition: { duration: reduceMotion ? 0 : 0.28, ease: easeSnappy },
             },
           }}
         >

--- a/packages/web/src/components/site/marketing-motion.tsx
+++ b/packages/web/src/components/site/marketing-motion.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, type HTMLMotionProps } from "framer-motion";
+import { motion, useReducedMotion, type HTMLMotionProps } from "framer-motion";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
@@ -15,12 +15,13 @@ export function MotionFadeIn({
   children,
   ...rest
 }: HTMLMotionProps<"div"> & { children: ReactNode }) {
+  const reduceMotion = useReducedMotion();
   return (
     <motion.div
       className={cn("will-change-[opacity]", className)}
-      initial={{ opacity: 0 }}
+      initial={reduceMotion ? false : { opacity: 0 }}
       animate={{ opacity: 1 }}
-      transition={fadeInTransition}
+      transition={reduceMotion ? { duration: 0 } : fadeInTransition}
       {...rest}
     >
       {children}
@@ -33,12 +34,13 @@ export function MotionSlideUp({
   children,
   ...rest
 }: HTMLMotionProps<"div"> & { children: ReactNode }) {
+  const reduceMotion = useReducedMotion();
   return (
     <motion.div
       className={cn("will-change-[transform,opacity]", className)}
-      initial={{ opacity: 0, y: 14 }}
+      initial={reduceMotion ? false : { opacity: 0, y: 14 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={slideUpTransition}
+      transition={reduceMotion ? { duration: 0 } : slideUpTransition}
       {...rest}
     >
       {children}
@@ -53,12 +55,13 @@ export function MotionHeroBlock({
   delay = 0,
   ...rest
 }: HTMLMotionProps<"div"> & { children: ReactNode; delay?: number }) {
+  const reduceMotion = useReducedMotion();
   return (
     <motion.div
       className={cn("will-change-[transform,opacity]", className)}
-      initial={{ opacity: 0, y: 14 }}
+      initial={reduceMotion ? false : { opacity: 0, y: 14 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ ...slideUpTransition, delay }}
+      transition={reduceMotion ? { duration: 0 } : { ...slideUpTransition, delay }}
       {...rest}
     >
       {children}
@@ -72,11 +75,12 @@ export function MotionInteractive({
   children,
   ...rest
 }: HTMLMotionProps<"div"> & { children: ReactNode }) {
+  const reduceMotion = useReducedMotion();
   return (
     <motion.div
       className={cn(className)}
-      whileHover={{ y: -2 }}
-      whileTap={{ scale: 0.99 }}
+      whileHover={reduceMotion ? undefined : { y: -2 }}
+      whileTap={reduceMotion ? undefined : { scale: 0.99 }}
       transition={{ type: "spring", stiffness: 420, damping: 28 }}
       {...rest}
     >

--- a/packages/web/src/components/site/primitives.tsx
+++ b/packages/web/src/components/site/primitives.tsx
@@ -17,7 +17,7 @@ export function PublicPageShell({ children }: { children: ReactNode }) {
 
 export function Section({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <section className={cn("px-4 py-24 sm:px-6 lg:px-8", className)}>
+    <section className={cn("px-4 py-20 sm:py-24 sm:px-6 lg:px-8", className)}>
       <div className="mx-auto max-w-6xl">{children}</div>
     </section>
   );
@@ -35,21 +35,21 @@ export function PageHero({
   actions?: ReactNode;
 }) {
   return (
-    <Section className="border-b border-border/50 bg-muted/10 pt-28 pb-20">
+    <Section className="border-b border-border/50 bg-muted/10 pt-24 pb-16 sm:pt-28 sm:pb-20">
       <MarketingHeroReveal>
         {eyebrow ? (
-          <Badge variant="outline" className="mb-6 text-xs tracking-widest uppercase font-semibold">
+          <Badge variant="outline" className="mb-5 text-xs tracking-widest uppercase font-semibold">
             {eyebrow}
           </Badge>
         ) : null}
-        <h1 className="max-w-4xl text-fluid-4xl font-bold tracking-tight text-foreground md:text-fluid-5xl leading-[1.12]">
+        <h1 className="max-w-4xl text-fluid-3xl font-bold tracking-tight text-foreground sm:text-fluid-4xl md:text-fluid-5xl leading-[1.12]">
           {title}
         </h1>
-        <p className="mt-7 max-w-3xl text-fluid-lg leading-relaxed text-muted-foreground">
+        <p className="mt-6 max-w-3xl text-fluid-base sm:text-fluid-lg leading-relaxed text-muted-foreground">
           {description}
         </p>
         {actions ? (
-          <div className="mt-11 flex flex-wrap gap-4">{actions}</div>
+          <div className="mt-9 flex flex-wrap gap-3 sm:gap-4">{actions}</div>
         ) : null}
       </MarketingHeroReveal>
     </Section>
@@ -59,12 +59,14 @@ export function PageHero({
 export function SectionHeader({ title, description }: { title: string; description?: string }) {
   return (
     <MarketingSectionFade>
-      <div className="mb-12 max-w-3xl">
+      <div className="mb-10 max-w-3xl">
         <h2 className="text-fluid-2xl font-semibold tracking-tight text-foreground md:text-fluid-3xl">
           {title}
         </h2>
         {description ? (
-          <p className="mt-5 text-fluid-base text-muted-foreground leading-relaxed">{description}</p>
+          <p className="mt-4 text-fluid-sm sm:text-fluid-base text-muted-foreground leading-relaxed">
+            {description}
+          </p>
         ) : null}
       </div>
     </MarketingSectionFade>
@@ -122,15 +124,15 @@ export function CTASection({
   secondaryLabel?: string;
 }) {
   return (
-    <Section className="border-t border-border/60 bg-card py-20">
+    <Section className="border-t border-border/60 bg-card py-16 sm:py-20">
       <MarketingSlideUp>
         <h2 className="text-fluid-2xl font-semibold tracking-tight text-foreground md:text-fluid-3xl">
           {title}
         </h2>
-        <p className="mt-5 max-w-2xl text-fluid-base text-muted-foreground leading-relaxed">
+        <p className="mt-4 max-w-2xl text-fluid-sm sm:text-fluid-base text-muted-foreground leading-relaxed">
           {description}
         </p>
-        <div className="mt-10 flex flex-wrap gap-4">
+        <div className="mt-9 flex flex-wrap gap-3 sm:gap-4">
           <Button asChild>
             <UiLink href={primaryHref}>{primaryLabel}</UiLink>
           </Button>

--- a/packages/web/src/components/ui/empty-state.tsx
+++ b/packages/web/src/components/ui/empty-state.tsx
@@ -67,11 +67,11 @@ export function EmptyState({
 
       <p className="text-sm text-muted-foreground mb-1 max-w-md leading-relaxed">{description}</p>
 
-      {hint && (
-        <p className="text-xs text-muted-foreground/70 mb-6 max-w-sm leading-relaxed">{hint}</p>
+      {hint ? (
+        <p className="text-xs text-muted-foreground/80 mb-6 max-w-sm leading-relaxed">{hint}</p>
+      ) : (
+        <div className="mb-6" aria-hidden="true" />
       )}
-
-      {!hint && <div className="mb-6" />}
 
       {(action || secondaryAction) && (
         <div className="flex flex-col sm:flex-row gap-3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Production-grade UX polish pass (presentation only; no business logic or API changes).

- **Marketing:** `prefers-reduced-motion` respected across shared Framer motion primitives; tighter hero/section rhythm on root marketing primitives; long-form `(marketing)/home` hero and bottom CTA aligned with design tokens (primary/outline `Button`), improved copy line length and section separation.
- **Console:** Breadcrumb links get visible focus rings; run list cards get clearer hover/background affordance for scanning dense rows.
- **Shared:** `EmptyState` spacing is consistent whether or not a `hint` is provided.
- **CLI:** `formatCliSection` and `createCliLogger().section()` for human-readable section headers; JSON/CI mode (`SETTLER_CLI_JSON`) unchanged—section is a no-op and still no ANSI in JSON mode.

## Type of Change

- [x] Performance improvement (reduced motion paths)
- [ ] (other items N/A)

## Testing

- `pnpm typecheck` (passed)
- `pnpm --filter @settler/web lint` (pre-existing warnings only; no new errors on touched files)

## Checklist

- [x] No API or data contract changes
- [x] No new theme or ad-hoc palette
- [x] Type-safe (`tsc` clean)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d2c9de9-1604-456b-8a09-c8af97a84164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d2c9de9-1604-456b-8a09-c8af97a84164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

