### PR TITLE
UX polish: marketing primitives, console list shell, CLI logger adoption

### DIFF
--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -11,6 +11,8 @@ import { Command } from "commander";
 import Settler from "@settler/sdk";
 import type { ApiKey, UsageSummary } from "@settler/sdk";
 
+import { createCliLogger, resolveJsonFallbackFromEnv } from "../lib/cli-logger";
+
 export const consoleCommand = new Command("console").description("Manage Console resources");
 
 // API Keys subcommand
@@ -20,13 +22,15 @@ apiKeysCommand
   .command("list" as const)
   .description("List all API keys")
   .action(async (options: { parent?: { apiKey?: string; baseUrl?: string } }) => {
+    const json = resolveJsonFallbackFromEnv();
+    const log = createCliLogger({ isJSONFallback: json });
     const parentApiKey = options.parent?.apiKey;
     const parentBaseUrl = options.parent?.baseUrl;
     const apiKey = process.env.SETTLER_API_KEY || parentApiKey || "";
     const baseUrl = parentBaseUrl || process.env.SETTLER_BASE_URL || "https://api.settler.io";
 
     if (!apiKey) {
-      console.error(chalk.red("Error: SETTLER_API_KEY environment variable not set"));
+      log.error("SETTLER_API_KEY environment variable not set");
       process.exit(1);
     }
 
@@ -40,29 +44,46 @@ apiKeysCommand
       const keys = response.data || [];
 
       if (keys.length === 0) {
-        console.log(chalk.yellow("No API keys found."));
+        log.warning("No API keys found.");
         return;
       }
 
-      console.log(chalk.bold("\nAPI Keys:"));
-      console.log("─".repeat(80));
+      log.section("API keys");
       keys.forEach((key: ApiKey) => {
-        console.log(chalk.cyan(`\nID: ${key.id}`));
-        if (key.name) console.log(`Name: ${key.name}`);
-        console.log(`Prefix: ${key.keyPrefix}`);
-        console.log(`Created: ${new Date(key.createdAt).toLocaleString()}`);
-        if (key.lastUsedAt) {
-          console.log(`Last Used: ${new Date(key.lastUsedAt).toLocaleString()}`);
+        if (json) {
+          log.detail(`ID: ${key.id}`);
+          if (key.name) {
+            log.detail(`Name: ${key.name}`);
+          }
+          log.detail(`Prefix: ${key.keyPrefix}`);
+          log.detail(`Created: ${new Date(key.createdAt).toLocaleString()}`);
+          if (key.lastUsedAt) {
+            log.detail(`Last Used: ${new Date(key.lastUsedAt).toLocaleString()}`);
+          }
+          if (key.revokedAt) {
+            log.detail(`Revoked: ${new Date(key.revokedAt).toLocaleString()}`);
+          }
+          log.detail(`Scopes: ${key.scopes.join(", ")}`);
+          log.detail("");
+        } else {
+          log.rawLine("");
+          log.rawLine(chalk.cyan(`ID: ${key.id}`));
+          if (key.name) {
+            log.rawLine(`Name: ${key.name}`);
+          }
+          log.rawLine(`Prefix: ${key.keyPrefix}`);
+          log.rawLine(`Created: ${new Date(key.createdAt).toLocaleString()}`);
+          if (key.lastUsedAt) {
+            log.rawLine(`Last Used: ${new Date(key.lastUsedAt).toLocaleString()}`);
+          }
+          if (key.revokedAt) {
+            log.rawLine(chalk.red(`Revoked: ${new Date(key.revokedAt).toLocaleString()}`));
+          }
+          log.rawLine(`Scopes: ${key.scopes.join(", ")}`);
         }
-        if (key.revokedAt) {
-          console.log(chalk.red(`Revoked: ${new Date(key.revokedAt).toLocaleString()}`));
-        }
-        console.log(`Scopes: ${key.scopes.join(", ")}`);
       });
     } catch (error) {
-      console.error(
-        chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
-      );
+      log.error(error instanceof Error ? error.message : "Unknown error");
       process.exit(1);
     }
   });
@@ -78,12 +99,13 @@ apiKeysCommand
       scopes?: string;
       parent?: { apiKey?: string; baseUrl?: string };
     }) => {
+      const log = createCliLogger({ isJSONFallback: resolveJsonFallbackFromEnv() });
       const apiKey = process.env.SETTLER_API_KEY || options.parent?.apiKey || "";
       const baseUrl =
         options.parent?.baseUrl || process.env.SETTLER_BASE_URL || "https://api.settler.io";
 
       if (!apiKey) {
-        console.error(chalk.red("Error: SETTLER_API_KEY environment variable not set"));
+        log.error("SETTLER_API_KEY environment variable not set");
         process.exit(1);
       }
 
@@ -100,18 +122,16 @@ apiKeysCommand
           scopes: scopes,
         });
 
-        console.log(chalk.green("\n✅ API Key created successfully!\n"));
-        console.log(
-          chalk.yellow("⚠️  IMPORTANT: Save this key now. You won't be able to see it again.\n")
-        );
-        console.log(chalk.bold(`Key: ${data.key}`));
-        console.log(`ID: ${data.id}`);
-        if (data.name) console.log(`Name: ${data.name}`);
-        console.log(`Created: ${new Date(data.createdAt).toLocaleString()}\n`);
+        log.success("API key created successfully.");
+        log.warning("Save this key now. You will not be able to see it again.");
+        log.rawLine(chalk.bold(`Key: ${data.key}`));
+        log.detail(`ID: ${data.id}`);
+        if (data.name) {
+          log.detail(`Name: ${data.name}`);
+        }
+        log.detail(`Created: ${new Date(data.createdAt).toLocaleString()}`);
       } catch (error) {
-        console.error(
-          chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
-        );
+        log.error(error instanceof Error ? error.message : "Unknown error");
         process.exit(1);
       }
     }
@@ -121,17 +141,18 @@ apiKeysCommand
   .command("revoke <id>")
   .description("Revoke an API key")
   .action(async (id: string, options: { parent?: { apiKey?: string; baseUrl?: string } }) => {
+    const log = createCliLogger({ isJSONFallback: resolveJsonFallbackFromEnv() });
     const apiKey = process.env.SETTLER_API_KEY || options.parent?.apiKey || "";
     const baseUrl =
       options.parent?.baseUrl || process.env.SETTLER_BASE_URL || "https://api.settler.io";
 
     if (!apiKey) {
-      console.error(chalk.red("Error: SETTLER_API_KEY environment variable not set"));
+      log.error("SETTLER_API_KEY environment variable not set");
       process.exit(1);
     }
 
     if (!id) {
-      console.error(chalk.red("Error: API key ID required"));
+      log.error("API key ID required");
       process.exit(1);
     }
 
@@ -142,11 +163,9 @@ apiKeysCommand
       });
 
       await client.console.revokeApiKey(id);
-      console.log(chalk.green("✅ API key revoked successfully"));
+      log.success("API key revoked successfully.");
     } catch (error) {
-      console.error(
-        chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
-      );
+      log.error(error instanceof Error ? error.message : "Unknown error");
       process.exit(1);
     }
   });
@@ -159,12 +178,14 @@ usageCommand
   .description("Get usage summary")
   .option("-d, --days <days>", "Number of days", "7")
   .action(async (options: { days?: string; parent?: { apiKey?: string; baseUrl?: string } }) => {
+    const json = resolveJsonFallbackFromEnv();
+    const log = createCliLogger({ isJSONFallback: json });
     const apiKey = process.env.SETTLER_API_KEY || options.parent?.apiKey || "";
     const baseUrl =
       options.parent?.baseUrl || process.env.SETTLER_BASE_URL || "https://api.settler.io";
 
     if (!apiKey) {
-      console.error(chalk.red("Error: SETTLER_API_KEY environment variable not set"));
+      log.error("SETTLER_API_KEY environment variable not set");
       process.exit(1);
     }
 
@@ -187,25 +208,32 @@ usageCommand
         },
       };
 
-      console.log(chalk.bold(`\n📊 Usage Summary (Last ${days} days)`));
-      console.log("─".repeat(80));
-      console.log(`Total API Calls: ${chalk.cyan(summary.totalCalls?.toLocaleString() || 0)}`);
-      console.log(`Error Rate: ${chalk.yellow(((summary.errorRate || 0) * 100).toFixed(2))}%`);
-      console.log(`Active Services: ${chalk.cyan(Object.keys(summary.byService || {}).length)}`);
+      log.section(`Usage summary (last ${days} days)`);
+      if (json) {
+        log.detail(`Total API Calls: ${summary.totalCalls?.toLocaleString() ?? 0}`);
+        log.detail(`Error Rate: ${((summary.errorRate ?? 0) * 100).toFixed(2)}%`);
+        log.detail(`Active Services: ${Object.keys(summary.byService || {}).length}`);
+      } else {
+        log.rawLine(`Total API Calls: ${chalk.cyan(summary.totalCalls?.toLocaleString() ?? "0")}`);
+        log.rawLine(`Error Rate: ${chalk.yellow(((summary.errorRate ?? 0) * 100).toFixed(2))}%`);
+        log.rawLine(`Active Services: ${chalk.cyan(Object.keys(summary.byService || {}).length)}`);
+      }
 
       if (summary.byService && Object.keys(summary.byService).length > 0) {
-        console.log(chalk.bold("\nBy Service:"));
+        log.section("By service");
         const byServiceEntries = Object.entries(summary.byService) as Array<[string, number]>;
         byServiceEntries.forEach(([service, count]) => {
-          console.log(`  ${service}: ${chalk.cyan(count.toLocaleString())} calls`);
+          if (json) {
+            log.detail(`${service}: ${count.toLocaleString()} calls`);
+          } else {
+            log.rawLine(`  ${service}: ${chalk.cyan(count.toLocaleString())} calls`);
+          }
         });
       }
 
-      console.log("");
+      log.detail("");
     } catch (error) {
-      console.error(
-        chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
-      );
+      log.error(error instanceof Error ? error.message : "Unknown error");
       process.exit(1);
     }
   });
@@ -214,12 +242,12 @@ usageCommand
 const healthCommand = new Command("health").description("Check Console health");
 
 healthCommand.action(async (options: { parent?: { baseUrl?: string } }) => {
+  const json = resolveJsonFallbackFromEnv();
+  const log = createCliLogger({ isJSONFallback: json });
   const baseUrl =
     options.parent?.baseUrl || process.env.SETTLER_BASE_URL || "https://api.settler.io";
 
   try {
-    // Health check doesn't require auth, but SDK needs an API key
-    // Use a dummy key for health checks
     const client = new Settler({
       apiKey: "health-check",
       baseUrl,
@@ -227,27 +255,34 @@ healthCommand.action(async (options: { parent?: { baseUrl?: string } }) => {
 
     const data = await client.console.health();
 
-    console.log(chalk.bold("\n🏥 Console Health Check"));
-    console.log("─".repeat(80));
-    console.log(
-      `Status: ${data.status === "healthy" ? chalk.green(data.status) : chalk.red(data.status)}`
-    );
-    console.log(
-      `Environment: ${data.checks.env.status === "ok" ? chalk.green(data.checks.env.status) : chalk.red(data.checks.env.status)}`
-    );
-    console.log(
-      `Supabase: ${data.checks.supabase.status === "ok" ? chalk.green(data.checks.supabase.status) : chalk.red(data.checks.supabase.status)}`
-    );
-    console.log(
-      `Auth: ${data.checks.auth.status === "ok" ? chalk.green(data.checks.auth.status) : chalk.yellow(data.checks.auth.status)}`
-    );
-    console.log(`Timestamp: ${new Date().toLocaleString()}\n`);
+    log.section("Console health");
+    if (json) {
+      log.detail(`Status: ${data.status}`);
+      log.detail(`Environment: ${data.checks.env.status}`);
+      log.detail(`Supabase: ${data.checks.supabase.status}`);
+      log.detail(`Auth: ${data.checks.auth.status}`);
+      log.detail(`Timestamp: ${new Date().toLocaleString()}`);
+    } else {
+      log.rawLine(
+        `Status: ${data.status === "healthy" ? chalk.green(data.status) : chalk.red(data.status)}`
+      );
+      log.rawLine(
+        `Environment: ${data.checks.env.status === "ok" ? chalk.green(data.checks.env.status) : chalk.red(data.checks.env.status)}`
+      );
+      log.rawLine(
+        `Supabase: ${data.checks.supabase.status === "ok" ? chalk.green(data.checks.supabase.status) : chalk.red(data.checks.supabase.status)}`
+      );
+      log.rawLine(
+        `Auth: ${data.checks.auth.status === "ok" ? chalk.green(data.checks.auth.status) : chalk.yellow(data.checks.auth.status)}`
+      );
+      log.rawLine(`Timestamp: ${new Date().toLocaleString()}`);
+    }
 
     if (data.status !== "healthy") {
       process.exit(1);
     }
   } catch {
-    console.error(chalk.red("❌ Health check failed:"), "Unknown error");
+    log.error("Health check failed.");
     process.exit(1);
   }
 });

--- a/packages/cli/src/commands/jobs.ts
+++ b/packages/cli/src/commands/jobs.ts
@@ -201,10 +201,11 @@ jobsCommand
       id: string,
       options: { tail?: boolean; since?: string; limit?: string; parent?: CommandParentOptions }
     ) => {
+      const log = createCliLogger({ isJSONFallback: resolveJsonFallbackFromEnv() });
       try {
         const apiKey = process.env.SETTLER_API_KEY || options.parent?.parent?.apiKey;
         if (!apiKey) {
-          console.error(chalk.red("Error: API key required"));
+          log.error("API key required. Set SETTLER_API_KEY or use --api-key");
           process.exit(1);
         }
 
@@ -231,7 +232,7 @@ jobsCommand
 
         if (!response.ok) {
           const error = (await response.json()) as { message?: string };
-          console.error(chalk.red(`Error: ${error?.message || "Failed to fetch logs"}`));
+          log.error(error?.message ?? "Failed to fetch logs");
           process.exit(1);
         }
 
@@ -245,14 +246,14 @@ jobsCommand
         };
 
         if (!logs.data || logs.data.length === 0) {
-          console.log(chalk.yellow("No logs found"));
+          log.warning("No logs found.");
           return;
         }
 
-        console.log(chalk.bold(`\nJob Logs (${logs.data.length} entries):\n`));
-        logs.data.forEach((log) => {
-          const timestamp = new Date(log.timestamp).toLocaleString();
-          const level = log.level.toUpperCase();
+        log.section(`Job logs (${logs.data.length} entries)`);
+        logs.data.forEach((entry) => {
+          const timestamp = new Date(entry.timestamp).toLocaleString();
+          const level = entry.level.toUpperCase();
           const levelColor =
             level === "ERROR"
               ? chalk.red
@@ -262,21 +263,18 @@ jobsCommand
                   ? chalk.blue
                   : chalk.gray;
 
-          console.log(`${chalk.gray(timestamp)} ${levelColor(level)} ${log.message}`);
-          if (log.metadata) {
-            console.log(chalk.gray(`  ${JSON.stringify(log.metadata, null, 2)}`));
+          log.rawLine(`${chalk.gray(timestamp)} ${levelColor(level)} ${entry.message}`);
+          if (entry.metadata) {
+            log.detail(JSON.stringify(entry.metadata, null, 2));
           }
         });
 
         if (options.tail) {
-          console.log(chalk.blue("\nFollowing logs... (Ctrl+C to stop)"));
-          // In a real implementation, you'd use WebSocket or Server-Sent Events
-          console.log(chalk.yellow("Note: Real-time tailing requires WebSocket support"));
+          log.info("Following logs... (Ctrl+C to stop)");
+          log.warning("Real-time tailing requires WebSocket support in this environment.");
         }
       } catch (error) {
-        console.error(
-          chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
-        );
+        log.error(error instanceof Error ? error.message : "Unknown error");
         process.exit(1);
       }
     }
@@ -298,10 +296,11 @@ jobsCommand
         parent?: CommandParentOptions;
       }
     ) => {
+      const log = createCliLogger({ isJSONFallback: resolveJsonFallbackFromEnv() });
       try {
         const apiKey = process.env.SETTLER_API_KEY || options.parent?.parent?.apiKey;
         if (!apiKey) {
-          console.error(chalk.red("Error: API key required"));
+          log.error("API key required. Set SETTLER_API_KEY or use --api-key");
           process.exit(1);
         }
 
@@ -319,7 +318,7 @@ jobsCommand
           body.eventId = options.eventId;
         }
 
-        console.log(chalk.blue("Replaying events..."));
+        log.info("Replaying events...");
 
         const trace = createTraceContext(undefined, id);
         const response = await fetch(`${baseUrl}/api/v1/jobs/${id}/replay`, {
@@ -336,7 +335,7 @@ jobsCommand
 
         if (!response.ok) {
           const error = (await response.json()) as { message?: string };
-          console.error(chalk.red(`Error: ${error.message || "Failed to replay events"}`));
+          log.error(error.message ?? "Failed to replay events");
           process.exit(1);
         }
 
@@ -346,17 +345,15 @@ jobsCommand
         };
 
         if (options.dryRun) {
-          console.log(chalk.yellow("Dry run mode - no events were actually replayed"));
+          log.warning("Dry run — no events were replayed.");
         } else {
-          console.log(chalk.green("✓ Events replayed successfully"));
+          log.success("Events replayed successfully.");
         }
 
-        console.log(chalk.gray(`   Events processed: ${result.eventsProcessed || 0}`));
-        console.log(chalk.gray(`   Events replayed: ${result.eventsReplayed || 0}`));
+        log.detail(`Events processed: ${result.eventsProcessed ?? 0}`);
+        log.detail(`Events replayed: ${result.eventsReplayed ?? 0}`);
       } catch (error) {
-        console.error(
-          chalk.red(`Error: ${error instanceof Error ? error.message : "Unknown error"}`)
-        );
+        log.error(error instanceof Error ? error.message : "Unknown error");
         process.exit(1);
       }
     }

--- a/packages/web/src/app/console/loading.tsx
+++ b/packages/web/src/app/console/loading.tsx
@@ -9,15 +9,17 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function ConsoleLoading() {
   return (
-    <div className="space-y-6">
-      {/* Page header skeleton */}
-      <div className="space-y-2">
-        <Skeleton className="h-8 w-64" />
-        <Skeleton className="h-4 w-96" />
+    <div className="space-y-6" aria-busy="true" aria-label="Loading console">
+      {/* Page header skeleton — matches ConsolePageHeader rhythm */}
+      <div className="space-y-3">
+        <Skeleton className="h-3 w-48 max-w-full" />
+        <Skeleton className="h-8 w-72 max-w-full sm:h-9" />
+        <Skeleton className="h-4 w-full max-w-xl" />
+        <Skeleton className="h-4 w-2/3 max-w-lg" />
       </div>
 
       {/* Stats cards skeleton */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
           <Card key={i}>
             <CardHeader className="pb-2">
@@ -34,11 +36,12 @@ export default function ConsoleLoading() {
       <Card>
         <CardHeader>
           <Skeleton className="h-6 w-40" />
+          <Skeleton className="mt-2 h-4 w-full max-w-md" />
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
             {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-12 w-full" />
+              <Skeleton key={i} className="h-12 w-full rounded-md" />
             ))}
           </div>
         </CardContent>

--- a/packages/web/src/app/console/reconciliations/page.tsx
+++ b/packages/web/src/app/console/reconciliations/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
+import { ConsoleListRow } from "@/components/console/console-list-row";
 import { ConsolePageHeader } from "@/components/console/ConsolePageHeader";
 import { ReconciliationView } from "@/components/console/ReconciliationView";
 import { safeFetch } from "@/lib/safe-fetch";
@@ -165,9 +166,23 @@ export default function ReconciliationsPage() {
         </CardHeader>
         <CardContent>
           {loading ? (
-            <div className="space-y-3">
+            <div className="space-y-4" aria-busy="true" aria-label="Loading recent runs">
               {Array.from({ length: 3 }).map((_, index) => (
-                <Skeleton key={index} className="h-20 w-full" />
+                <div
+                  key={index}
+                  className="rounded-xl border border-border bg-card/40 p-4 space-y-3"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Skeleton className="h-5 w-40" />
+                    <Skeleton className="h-5 w-20 rounded-full" />
+                    <Skeleton className="h-5 w-24 rounded-full" />
+                  </div>
+                  <Skeleton className="h-4 w-72 max-w-full" />
+                  <div className="flex flex-wrap gap-2 pt-1">
+                    <Skeleton className="h-9 w-32" />
+                    <Skeleton className="h-9 w-36" />
+                  </div>
+                </div>
               ))}
             </div>
           ) : error ? (
@@ -198,7 +213,7 @@ export default function ReconciliationsPage() {
                 const StatusIcon = getStatusIcon(run.status);
 
                 return (
-                  <div key={run.id} className="rounded-xl border border-border p-4">
+                  <ConsoleListRow key={run.id}>
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                       <div className="space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
@@ -222,10 +237,19 @@ export default function ReconciliationsPage() {
                           </Badge>
                         </div>
                         <p className="text-sm text-muted-foreground">
-                          Started {new Date(run.startedAt).toLocaleString()}
-                          {run.completedAt
-                            ? ` • Completed ${new Date(run.completedAt).toLocaleString()}`
-                            : ""}
+                          Started{" "}
+                          <time dateTime={run.startedAt}>
+                            {new Date(run.startedAt).toLocaleString()}
+                          </time>
+                          {run.completedAt ? (
+                            <>
+                              {" "}
+                              • Completed{" "}
+                              <time dateTime={run.completedAt}>
+                                {new Date(run.completedAt).toLocaleString()}
+                              </time>
+                            </>
+                          ) : null}
                         </p>
                         {run.summary && (
                           <p className="text-sm text-muted-foreground">
@@ -253,7 +277,7 @@ export default function ReconciliationsPage() {
                         ) : null}
                       </div>
                     </div>
-                  </div>
+                  </ConsoleListRow>
                 );
               })}
             </div>

--- a/packages/web/src/app/pricing/page.tsx
+++ b/packages/web/src/app/pricing/page.tsx
@@ -2,6 +2,7 @@ import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
 import { AnimatedHero } from "@/components/AnimatedHero";
 import { FeatureComparison } from "@/components/FeatureComparison";
+import { CTASection, Section, SectionHeader } from "@/components/site/primitives";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Check, ArrowRight, Zap, Shield, Globe } from "lucide-react";
@@ -79,12 +80,13 @@ export default function PricingPage() {
       />
 
       {/* Pricing Cards */}
-      <section className="py-20 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {plans.map((plan) => (
+      <Section className="py-16 sm:py-20">
+        <div className="mx-auto max-w-7xl">
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+            {plans.map((plan) => (
             <Card
               key={plan.name}
-              className={`relative flex flex-col h-full border-border/40 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 ${plan.popular ? "border-primary shadow-lg ring-1 ring-primary/20" : ""}`}
+              className={`relative flex h-full flex-col border-border/40 transition-all duration-300 hover:shadow-xl motion-reduce:transition-none motion-reduce:hover:translate-y-0 hover:-translate-y-1 ${plan.popular ? "border-primary shadow-lg ring-1 ring-primary/20" : ""}`}
             >
               {plan.popular && (
                 <div className="absolute top-0 right-1/2 translate-x-1/2 -translate-y-1/2 px-4 py-1.5 rounded-full bg-primary text-primary-foreground text-xs font-bold uppercase tracking-widest shadow-lg">
@@ -117,7 +119,7 @@ export default function PricingPage() {
                       <div className="mt-1 rounded-full bg-primary/10 p-1">
                         <Check className="h-3 w-3 text-primary" />
                       </div>
-                      <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                      <span className="text-sm font-medium text-foreground">
                         {feature}
                       </span>
                     </div>
@@ -136,68 +138,59 @@ export default function PricingPage() {
                 </Button>
               </CardContent>
             </Card>
-          ))}
+            ))}
+          </div>
         </div>
-      </section>
+      </Section>
 
       {/* Feature Comparison */}
       <FeatureComparison />
 
-      {/* Simple FAQ Section */}
-      <section className="py-24 px-4 sm:px-6 lg:px-8 max-w-4xl mx-auto border-t border-border/40">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl font-bold mb-4 italic tracking-tight">
-            Frequently Asked Questions
-          </h2>
-          <p className="text-muted-foreground font-medium">
-            Common inquiries regarding Settler deployment and scaling.
-          </p>
+      {/* FAQ */}
+      <Section className="border-t border-border/40 py-16 sm:py-20">
+        <div className="mx-auto max-w-3xl">
+          <SectionHeader
+            title="Frequently asked questions"
+            description="Common questions about deployment, plans, and reconciliation volume."
+          />
+          <div className="mt-10 space-y-10">
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-foreground">Can I switch plans later?</h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Absolutely. Our cloud infrastructure supports seamless migration between plans.
+                Downgrading from Commercial to OSS requires setting up your own hosting environment.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-foreground">
+                What constitutes a reconciliation run?
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                A run is any triggered execution that compares a source and target dataset. Our
+                pricing is based on volume and required data retention rather than just run counts.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-foreground">
+                Is the Enterprise plan available on-prem?
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Yes. For highly regulated industries, we provide a containerized version of the
+                Settler stack for air-gapped or VPC deployments.
+              </p>
+            </div>
+          </div>
         </div>
+      </Section>
 
-        <div className="space-y-12">
-          <div className="space-y-4">
-            <h3 className="text-lg font-bold">Can I switch plans later?</h3>
-            <p className="text-muted-foreground leading-relaxed">
-              Absolutely. Our cloud infrastructure supports seamless migration between plans.
-              Downgrading from Commercial to OSS requires setting up your own hosting environment.
-            </p>
-          </div>
-          <div className="space-y-4">
-            <h3 className="text-lg font-bold">What constitutes a 'Reconciliation Run'?</h3>
-            <p className="text-muted-foreground leading-relaxed">
-              A run is any triggered execution that compares a source and target dataset. Our
-              pricing is based on volume and required data retention rather than just run counts.
-            </p>
-          </div>
-          <div className="space-y-4">
-            <h3 className="text-lg font-bold">Is the Enterprise plan available on-prem?</h3>
-            <p className="text-muted-foreground leading-relaxed">
-              Yes. For highly regulated industries, we provide a containerized version of the
-              Settler stack for air-gapped or VPC deployments.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* Pre-footer CTA */}
-      <section className="py-24 bg-primary/5 border-y border-primary/10">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <h2 className="text-3xl md:text-5xl font-bold mb-6 tracking-tight italic">
-            Ready to Ensure Integrity?
-          </h2>
-          <p className="text-xl text-muted-foreground mb-10 leading-relaxed font-medium">
-            Join the teams building deterministic financial pipelines with Settler today.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button asChild size="lg" className="h-14 px-8 text-lg font-bold">
-              <Link href="/signup">Start Free Trial</Link>
-            </Button>
-            <Button asChild variant="outline" size="lg" className="h-14 px-8 text-lg font-bold">
-              <Link href="/docs">Read the Docs</Link>
-            </Button>
-          </div>
-        </div>
-      </section>
+      <CTASection
+        title="Ready to evaluate Settler?"
+        description="Start a trial or read the docs to see how deterministic runs and evidence fit your stack."
+        primaryHref="/signup"
+        primaryLabel="Start free trial"
+        secondaryHref="/docs"
+        secondaryLabel="Read documentation"
+      />
 
       <Footer />
     </div>

--- a/packages/web/src/app/product/page.tsx
+++ b/packages/web/src/app/product/page.tsx
@@ -8,6 +8,7 @@ import {
   PlatformOverviewDiagram,
   VisualProofCTA,
 } from "@/components/public-visual-proof";
+import { PageHero, PublicPageShell, Section } from "@/components/site/primitives";
 
 export const metadata: Metadata = {
   title: "Product — Settler",
@@ -17,30 +18,25 @@ export const metadata: Metadata = {
 
 export default function ProductPage() {
   return (
-    <>
+    <PublicPageShell>
       <Navigation />
-      <main
-        id="main-content"
-        className="min-h-screen bg-slate-50 px-4 pb-16 pt-24 dark:bg-slate-950 sm:px-6 lg:px-8"
-      >
-        <div className="mx-auto max-w-6xl space-y-8">
-          <section>
-            <h1 className="text-4xl font-bold text-slate-900 dark:text-slate-100">
-              Product architecture and capability proof
-            </h1>
-            <p className="mt-3 max-w-3xl text-slate-600 dark:text-slate-400">
-              A visual view of what is currently shipped: module boundaries, capability clusters,
-              integration points, and packaging boundaries.
-            </p>
-          </section>
-          <PlatformOverviewDiagram />
-          <CapabilityMap />
-          <IntegrationAndPackagingMap />
-          <VisualProofCTA />
-          <RealityEvidencePanel scope="architecture" title="Product proof references" />
-        </div>
+      <main id="main-content" className="pt-16">
+        <PageHero
+          eyebrow="Product"
+          title="Architecture and capability proof"
+          description="A visual view of what is currently shipped: module boundaries, capability clusters, integration points, and packaging boundaries."
+        />
+        <Section className="py-16 sm:py-20">
+          <div className="space-y-16">
+            <PlatformOverviewDiagram />
+            <CapabilityMap />
+            <IntegrationAndPackagingMap />
+            <VisualProofCTA />
+            <RealityEvidencePanel scope="architecture" title="Product proof references" />
+          </div>
+        </Section>
       </main>
       <Footer />
-    </>
+    </PublicPageShell>
   );
 }

--- a/packages/web/src/components/FeatureComparison.tsx
+++ b/packages/web/src/components/FeatureComparison.tsx
@@ -1,5 +1,6 @@
-import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { SectionHeader } from "@/components/site/primitives";
 
 interface Feature {
   name: string;
@@ -9,56 +10,64 @@ interface Feature {
 }
 
 const features: Feature[] = [
-  { name: 'Monthly Reconciliations', free: '1,000', commercial: '100,000', enterprise: 'Unlimited' },
-  { name: 'Platform Adapters', free: '2', commercial: 'Unlimited', enterprise: 'Unlimited' },
-  { name: 'Log Retention', free: '7 days', commercial: '30 days', enterprise: 'Unlimited' },
-  { name: 'Real-time Webhooks', free: false, commercial: true, enterprise: true },
-  { name: 'API Access', free: true, commercial: true, enterprise: true },
-  { name: 'Community Support', free: true, commercial: false, enterprise: false },
-  { name: 'Email Support', free: false, commercial: true, enterprise: false },
-  { name: 'Priority Support', free: false, commercial: false, enterprise: true },
-  { name: 'SSO / SAML', free: false, commercial: false, enterprise: true },
-  { name: 'RBAC', free: false, commercial: false, enterprise: true },
-  { name: 'White-label', free: false, commercial: false, enterprise: true },
-  { name: 'On-premise Deployment', free: false, commercial: false, enterprise: true },
+  { name: "Monthly Reconciliations", free: "1,000", commercial: "100,000", enterprise: "Unlimited" },
+  { name: "Platform Adapters", free: "2", commercial: "Unlimited", enterprise: "Unlimited" },
+  { name: "Log Retention", free: "7 days", commercial: "30 days", enterprise: "Unlimited" },
+  { name: "Real-time Webhooks", free: false, commercial: true, enterprise: true },
+  { name: "API Access", free: true, commercial: true, enterprise: true },
+  { name: "Community Support", free: true, commercial: false, enterprise: false },
+  { name: "Email Support", free: false, commercial: true, enterprise: false },
+  { name: "Priority Support", free: false, commercial: false, enterprise: true },
+  { name: "SSO / SAML", free: false, commercial: false, enterprise: true },
+  { name: "RBAC", free: false, commercial: false, enterprise: true },
+  { name: "White-label", free: false, commercial: false, enterprise: true },
+  { name: "On-premise Deployment", free: false, commercial: false, enterprise: true },
 ];
 
 export function FeatureComparison() {
   const renderValue = (value: boolean | string) => {
-    if (value === true) return <span className="text-green-600 dark:text-green-400">✓</span>;
-    if (value === false) return <span className="text-slate-400">—</span>;
-    return <span className="text-slate-700 dark:text-slate-300">{value}</span>;
+    if (value === true) {
+      return <span className="text-green-600 dark:text-green-400">✓</span>;
+    }
+    if (value === false) {
+      return <span className="text-muted-foreground">—</span>;
+    }
+    return <span className="text-foreground">{value}</span>;
   };
 
   return (
-    <div className="py-16 bg-white/50 dark:bg-slate-800/50">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-bold mb-4 text-slate-900 dark:text-white">
-            Compare Plans
-          </h2>
-          <p className="text-lg text-slate-600 dark:text-slate-300">
-            Choose the plan that fits your needs
-          </p>
-        </div>
-        <Card className="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800 overflow-x-auto">
+    <section className="border-t border-border/40 bg-muted/15 py-16 sm:py-20">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <SectionHeader
+          title="Compare plans"
+          description="Feature coverage across OSS, Commercial, and Enterprise."
+        />
+        <Card className="mt-10 overflow-x-auto border-border/60 bg-card">
           <CardContent className="p-0">
             <div className="overflow-x-auto" role="region" aria-label="Feature comparison table">
               <table className="w-full" role="table" aria-label="Pricing plan feature comparison">
                 <thead>
-                  <tr className="border-b border-slate-200 dark:border-slate-800">
-                    <th scope="col" className="text-left p-4 font-semibold text-slate-900 dark:text-white">Feature</th>
-                    <th scope="col" className="text-center p-4 font-semibold text-slate-900 dark:text-white">
+                  <tr className="border-b border-border">
+                    <th scope="col" className="p-4 text-left font-semibold text-foreground">
+                      Feature
+                    </th>
+                    <th scope="col" className="p-4 text-center font-semibold text-foreground">
                       <div>Free</div>
-                      <Badge className="mt-2 bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300">OSS</Badge>
+                      <Badge variant="secondary" className="mt-2">
+                        OSS
+                      </Badge>
                     </th>
-                    <th scope="col" className="text-center p-4 font-semibold text-slate-900 dark:text-white">
+                    <th scope="col" className="p-4 text-center font-semibold text-foreground">
                       <div>Commercial</div>
-                      <Badge className="mt-2 bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">$99/mo</Badge>
+                      <Badge variant="secondary" className="mt-2">
+                        $99/mo
+                      </Badge>
                     </th>
-                    <th scope="col" className="text-center p-4 font-semibold text-slate-900 dark:text-white">
+                    <th scope="col" className="p-4 text-center font-semibold text-foreground">
                       <div>Enterprise</div>
-                      <Badge className="mt-2 bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300">Custom</Badge>
+                      <Badge variant="secondary" className="mt-2">
+                        Custom
+                      </Badge>
                     </th>
                   </tr>
                 </thead>
@@ -66,9 +75,11 @@ export function FeatureComparison() {
                   {features.map((feature, index) => (
                     <tr
                       key={index}
-                      className="border-b border-slate-200 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors"
+                      className="border-b border-border transition-colors last:border-b-0 hover:bg-muted/40"
                     >
-                      <th scope="row" className="p-4 font-medium text-slate-900 dark:text-white">{feature.name}</th>
+                      <th scope="row" className="p-4 font-medium text-foreground">
+                        {feature.name}
+                      </th>
                       <td className="p-4 text-center">{renderValue(feature.free)}</td>
                       <td className="p-4 text-center">{renderValue(feature.commercial)}</td>
                       <td className="p-4 text-center">{renderValue(feature.enterprise)}</td>
@@ -80,6 +91,6 @@ export function FeatureComparison() {
           </CardContent>
         </Card>
       </div>
-    </div>
+    </section>
   );
 }

--- a/packages/web/src/components/console/console-list-row.tsx
+++ b/packages/web/src/components/console/console-list-row.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Dense console list row — shared border/hover/focus rhythm for operational lists.
+ */
+export function ConsoleListRow({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-card/40 p-4 transition-colors",
+        "hover:border-primary/30 hover:bg-muted/15",
+        "focus-within:border-primary/40 focus-within:ring-2 focus-within:ring-ring/40 focus-within:ring-offset-2 focus-within:ring-offset-background",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up UX completion pass focused on **shared marketing rhythm**, **operator list/dense surfaces**, and **CLI human-mode consistency** without changing business logic, routes, or API contracts.

### Web

- **Product (`/product`)**: Switched from ad hoc `slate-*` layout to `PublicPageShell`, `PageHero`, and `Section` from `@/components/site/primitives` so typography, spacing, and dark/light tokens match the rest of marketing.
- **Pricing (`/pricing`)**: Wrapped plan grid and FAQ in `Section` / `SectionHeader`; replaced bottom CTA block with shared `CTASection`; added `motion-reduce` guard on card hover lift; normalized feature list text to `text-foreground`.
- **Feature comparison**: Uses `SectionHeader`, semantic `border-border` / `bg-card` / `hover:bg-muted/40`, and `Badge variant="secondary"` for column labels (aligned with design tokens).
- **Console**: New `ConsoleListRow` for shared border/hover/focus rhythm on operational lists; applied on **Reconciliations** recent runs with `time` elements for ISO timestamps; **layout-faithful skeleton** for recent runs and improved **console `loading.tsx`** skeleton to mirror `ConsolePageHeader` + content.

### CLI

- **`console` command**: Routes through `createCliLogger` / `resolveJsonFallbackFromEnv`; JSON mode gets plain `[level]` lines and no decorative sections; human mode keeps structured sections and selective chalk for key material.
- **`jobs` (logs, replay)**: Uses shared logger for errors, empty, sections, and progress; metadata lines use `detail` in human mode.

### Validation

- `pnpm typecheck`
- `pnpm --filter @settler/web lint` and `pnpm --filter @settler/cli lint` (no new errors; pre-existing warnings in unrelated files)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac708b19-fdc9-4b26-bf4c-5d1a209c960b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac708b19-fdc9-4b26-bf4c-5d1a209c960b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

