### PR TITLE
Systemize run-detail boundary (Express) + marketing/console/CLI polish

### DIFF
--- a/docs/api/families/runs.md
+++ b/docs/api/families/runs.md
@@ -6,6 +6,7 @@ Canonical contract notes:
 
 - `runs` is the canonical operator-truth surface (list + detail).
 - `/api/runs/[id]` delegates tenant-scoped resolution, enrichment (results, snapshots, audits, drift aggregates, deterministic previews), and serialization to `resolveOperatorRunDetailForTenants` in `@settler/reconciliation-core`, which emits `OperatorRunDetail` for both `recon_job` and `ingestion_run`.
+- Express `GET /api/runs/:runId` uses the same resolver and returns `{ data: OperatorRunDetail }` (Express envelope). It is not a separate serialized truth path.
 - Next.js `GET /api/v1/runs/[id]` is a **compatibility-only** v1 recon-job summary; it does not emit `OperatorRunDetail` and must not be treated as canonical operator detail.
 - Any `reconciliations` list exposure is compatibility-only and remains fenced to legacy scope metadata in console list responses.
 
@@ -13,4 +14,5 @@ Canonical contract notes:
 | ------ | ------------------ | ----------- | ---- | ------ | ------- | ----------------------------------------------- |
 | GET    | `/api/runs`        | medium      | yes  | yes    | partial | `packages/web/src/app/api/runs/route.ts`        |
 | GET    | `/api/runs/[id]`   | medium      | yes  | yes    | partial | `packages/web/src/app/api/runs/[id]/route.ts`   |
+| GET    | Express `/api/runs/:runId` | medium | yes | yes | partial | `packages/api/src/routes/runs.ts` |
 | POST   | `/api/runs/create` | medium      | yes  | yes    | missing | `packages/web/src/app/api/runs/create/route.ts` |

--- a/packages/api/src/routes/__tests__/runs.test.ts
+++ b/packages/api/src/routes/__tests__/runs.test.ts
@@ -26,6 +26,11 @@ jest.mock("../../infrastructure/db/prisma", () => ({
   },
 }));
 
+const mockResolveOperatorRunDetail = jest.fn();
+jest.mock("@settler/reconciliation-core", () => ({
+  resolveOperatorRunDetailForTenants: (...args: unknown[]) => mockResolveOperatorRunDetail(...args),
+}));
+
 // Access the mocked module after jest.mock is applied
 const { prisma: mockedPrisma } = require("../../infrastructure/db/prisma");
 const mockReconResult = mockedPrisma.reconResult;
@@ -71,6 +76,7 @@ describe("Runs Routes", () => {
 
     app.use("/api/runs", runsRouter);
     jest.clearAllMocks();
+    mockResolveOperatorRunDetail.mockReset();
   });
 
   describe("GET /api/runs", () => {
@@ -181,80 +187,81 @@ describe("Runs Routes", () => {
   });
 
   describe("GET /api/runs/:runId", () => {
-    it("should return run detail with stages and progress", async () => {
-      mockReconResult.findFirst.mockResolvedValueOnce({
-        id: "run-1",
-        reconJobId: "job-1",
-        reconJob: { name: "Daily Reconciliation" },
-        status: "completed",
-        startedAt: new Date("2026-03-17T10:00:00Z"),
-        completedAt: new Date("2026-03-17T10:05:00Z"),
-        summary: { total: 100, matched: 95, unmatched: 5, conflicts: 0 },
-        errorMessage: null,
+    const canonicalDetailSample = {
+      runKind: "recon_job" as const,
+      id: "run-1",
+      name: "Daily Reconciliation",
+      status: "completed",
+      progress: 100,
+      stages: [{ id: "audit-1", name: "Stage 1" }],
+    };
+
+    it("should return canonical operator detail from reconciliation-core", async () => {
+      mockResolveOperatorRunDetail.mockResolvedValueOnce({
+        kind: "ok",
+        detail: canonicalDetailSample,
       });
 
       const res = await request(app).get("/api/runs/run-1");
 
       expect(res.status).toBe(200);
-      expect(res.body.data).toMatchObject({
-        id: "run-1",
-        name: "Daily Reconciliation",
-        status: "completed",
-        progress: 100,
-        summary: { total: 100, matched: 95, unmatched: 5, conflicts: 0 },
-      });
-      expect(res.body.data.stages).toHaveLength(4);
-      expect(res.body.data.stages[0]).toMatchObject({
-        id: "1",
-        name: "Initialize",
-        status: "completed",
-      });
-
-      // Verify tenant isolation
-      expect(mockReconResult.findFirst).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({ tenantId: "tenant-123" }),
-        })
+      expect(res.body.data).toEqual(canonicalDetailSample);
+      expect(mockResolveOperatorRunDetail).toHaveBeenCalledWith(
+        expect.anything(),
+        ["tenant-123"],
+        "run-1"
       );
     });
 
-    it("should return null progress for running jobs", async () => {
-      mockReconResult.findFirst.mockResolvedValueOnce({
-        id: "run-2",
-        reconJobId: "job-2",
-        reconJob: { name: "Running Job" },
-        status: "running",
-        startedAt: new Date(),
-        completedAt: null,
-        summary: null,
-        errorMessage: null,
+    it("should surface in-progress runs via canonical detail.progress", async () => {
+      mockResolveOperatorRunDetail.mockResolvedValueOnce({
+        kind: "ok",
+        detail: {
+          ...canonicalDetailSample,
+          id: "run-2",
+          status: "running",
+          progress: 0,
+        },
       });
 
       const res = await request(app).get("/api/runs/run-2");
 
       expect(res.status).toBe(200);
-      // Route returns null for running status - no reliable estimate available
-      expect(res.body.data.progress).toBeNull();
+      expect(res.body.data.status).toBe("running");
+      expect(res.body.data.progress).toBe(0);
     });
 
     it("should return 404 when run not found", async () => {
-      mockReconResult.findFirst.mockResolvedValueOnce(null);
+      mockResolveOperatorRunDetail.mockResolvedValueOnce({ kind: "not_found" });
 
       const res = await request(app).get("/api/runs/nonexistent");
 
       expect(res.status).toBe(404);
     });
 
-    it("should enforce tenant isolation - reject cross-tenant access", async () => {
-      mockReconResult.findFirst.mockResolvedValueOnce(null);
+    it("should return 409 when UUID collision occurs", async () => {
+      mockResolveOperatorRunDetail.mockResolvedValueOnce({
+        kind: "ambiguous_uuid_collision",
+        jobId: "job-x",
+        ingestionRunId: "ing-x",
+      });
+
+      const res = await request(app).get("/api/runs/collision-id");
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe("CONFLICT");
+    });
+
+    it("should enforce tenant isolation via single-tenant resolver scope", async () => {
+      mockResolveOperatorRunDetail.mockResolvedValueOnce({ kind: "not_found" });
 
       const res = await request(app).get("/api/runs/other-tenant-run");
 
       expect(res.status).toBe(404);
-      expect(mockReconResult.findFirst).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({ tenantId: "tenant-123" }),
-        })
+      expect(mockResolveOperatorRunDetail).toHaveBeenCalledWith(
+        expect.anything(),
+        ["tenant-123"],
+        "other-tenant-run"
       );
     });
   });
@@ -290,22 +297,15 @@ describe("Runs Routes", () => {
   });
 
   describe("Data Integrity", () => {
-    it("should handle null summary gracefully", async () => {
-      mockReconResult.findFirst.mockResolvedValueOnce({
-        id: "run-3",
-        reconJobId: "job-3",
-        reconJob: { name: "Pending Run" },
-        status: "pending",
-        startedAt: new Date(),
-        completedAt: null,
-        summary: null,
-        errorMessage: null,
+    it("should return 500 when enrichment fails", async () => {
+      mockResolveOperatorRunDetail.mockResolvedValueOnce({
+        kind: "recon_enrichment_failed",
+        message: "snapshot read failed",
       });
 
       const res = await request(app).get("/api/runs/run-3");
 
-      expect(res.status).toBe(200);
-      expect(res.body.data.summary).toBeUndefined();
+      expect(res.status).toBe(500);
     });
   });
 

--- a/packages/api/src/routes/runs.ts
+++ b/packages/api/src/routes/runs.ts
@@ -4,11 +4,16 @@
  * Operator-facing route for reconciliation run history and detail.
  * Maps "runs" to executions with job context for clearer operator UX.
  *
+ * GET /api/runs/:runId returns canonical operator detail via
+ * `resolveOperatorRunDetailForTenants` (same read model as Next.js GET /api/runs/[id]),
+ * wrapped in `{ data: ... }` for this Express envelope. It is not a second truth source.
+ *
  * TENANT SAFETY: All queries scoped to req.tenantId
  * FREEZE AWARE: No mutations, read-only operator surface
  */
 
 import { Router, Response } from "express";
+import type { Prisma } from "@prisma/client";
 import { z } from "zod";
 import { validateRequest } from "../middleware/validation";
 import { AuthRequest } from "../middleware/auth";
@@ -16,9 +21,10 @@ import { requirePermission } from "../middleware/authorization";
 import { Permission } from "../infrastructure/security/Permissions";
 import { enforceFreezeState } from "../middleware/governance";
 
+import { resolveOperatorRunDetailForTenants } from "@settler/reconciliation-core";
 import { Run, RunSummary } from "@settler/types";
 import { handleRouteError } from "../utils/error-handler";
-import { NotFoundError, ValidationError } from "../utils/typed-errors";
+import { ConflictError, InternalServerError, NotFoundError, ValidationError } from "../utils/typed-errors";
 import { trackEventAsync } from "../utils/event-tracker";
 import { logInfo } from "../utils/logger";
 
@@ -58,7 +64,7 @@ router.get(
       const limit = Math.min(parseInt((req.query.limit as string) || "50"), 100);
       const offset = (page - 1) * limit;
 
-      const where: any = {
+      const where: Prisma.ReconResultWhereInput = {
         tenantId,
         ...(status && { status }),
         ...(search && {
@@ -122,7 +128,9 @@ router.get(
 
 /**
  * GET /api/runs/:runId
- * Get detailed run information including stages and progress
+ *
+ * Canonical operator run detail (OperatorRunDetail) from reconciliation-core, same resolver as
+ * Next GET /api/runs/[id]. Response is wrapped as `{ data: detail }` for the Express API envelope.
  */
 router.get(
   "/:runId",
@@ -134,104 +142,37 @@ router.get(
       const runId = Array.isArray(runIdParam) ? (runIdParam[0] ?? "") : (runIdParam ?? "");
       const tenantId = req.tenantId!;
 
-      // Get run with job context - tenant-scoped
-      const run = await prisma.reconResult.findFirst({
-        where: {
-          id: runId,
-          tenantId,
-        },
-        include: {
-          reconJob: {
-            select: {
-              name: true,
-            },
-          },
-        },
-      });
+      const outcome = await resolveOperatorRunDetailForTenants(prisma, [tenantId], runId);
 
-      if (!run) {
+      if (outcome.kind === "ambiguous_uuid_collision") {
+        throw new ConflictError("Ambiguous run identifier", {
+          code: "RUN_ID_COLLISION",
+          detail:
+            "The same UUID exists as both a recon job and an ingestion reconciliation run; disambiguate in the database or use tenant-scoped APIs that return a single kind.",
+          recon_job_id: outcome.jobId,
+          ingestion_run_id: outcome.ingestionRunId,
+        });
+      }
+
+      if (outcome.kind === "not_found") {
         throw new NotFoundError("Run not found or access denied", "run", runId);
       }
 
-      // TRUTHFUL STATE: Progress calculation
-      // - completed: 100%
-      // - failed: 0%
-      // - pending: null (not started)
-      // - running: null (no reliable estimate available - hardcoded estimate removed)
-      // Note: Real progress tracking requires job checkpoints or progress percentage stored in DB
-      let progress: number | null = null;
-      if (run.status === "completed") {
-        progress = 100;
-      } else if (run.status === "failed") {
-        progress = 0;
-      } else if (run.status === "pending") {
-        progress = null;
+      if (outcome.kind === "recon_enrichment_failed") {
+        throw new InternalServerError(outcome.message);
       }
-      // running status returns null - no reliable estimate available
 
-      // Build stage information (simplified for now - can be enhanced)
-      const stages = [
-        {
-          id: "1",
-          name: "Initialize",
-          status: run.status === "pending" ? "pending" : "completed",
-          startedAt: run.startedAt,
-          completedAt: run.status === "pending" ? undefined : run.startedAt,
-        },
-        {
-          id: "2",
-          name: "Extract Source Data",
-          status:
-            run.status === "pending"
-              ? "pending"
-              : run.status === "running"
-                ? "running"
-                : run.status === "failed"
-                  ? "failed"
-                  : "completed",
-          startedAt: run.status === "pending" ? undefined : run.startedAt,
-          completedAt: run.status === "completed" ? run.completedAt : undefined,
-          error: run.status === "failed" ? run.errorMessage : undefined,
-        },
-        {
-          id: "3",
-          name: "Match Records",
-          status: run.status === "completed" ? "completed" : "pending",
-          startedAt: run.status === "completed" ? run.startedAt : undefined,
-          completedAt: run.completedAt,
-        },
-        {
-          id: "4",
-          name: "Generate Results",
-          status: run.status === "completed" ? "completed" : "pending",
-          startedAt: run.status === "completed" ? run.startedAt : undefined,
-          completedAt: run.completedAt,
-        },
-      ];
-
-      const summary = (run.summary as RunSummary | null) || undefined;
+      const detail = outcome.detail;
 
       logInfo("Run detail fetched", {
         tenantId,
-        runId: run.id,
-        jobName: run.reconJob.name,
-        status: run.status,
-        hasError: !!run.errorMessage,
+        runId: detail.id,
+        jobName: detail.name,
+        status: detail.status,
+        hasError: !!detail.error,
       });
 
-      res.json({
-        data: {
-          id: run.id,
-          name: run.reconJob.name,
-          status: run.status as "pending" | "running" | "completed" | "failed" | "unknown",
-          progress,
-          startedAt: run.startedAt,
-          completedAt: run.completedAt,
-          error: run.errorMessage,
-          summary,
-          stages,
-        },
-      });
+      res.json({ data: detail });
     } catch (error: unknown) {
       handleRouteError(res, error, "Failed to fetch run detail", 500, {
         userId: req.userId,

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -9,24 +9,31 @@ import {
   listLedgerEntries,
   verifyLedgerEntry,
 } from "../lib/execution-ledger";
+import { createCliLogger, resolveJsonFallbackFromEnv } from "../lib/cli-logger";
 
 export const historyCommand = new Command("history")
   .description("Show execution ledger history")
   .option("--tenant <tenantId>", "Filter by tenant")
   .action(async (options: { tenant?: string }) => {
+    const json = resolveJsonFallbackFromEnv();
+    const log = createCliLogger({ isJSONFallback: json });
     const entries = await listLedgerEntries(options.tenant);
     if (entries.length === 0) {
-      console.log(chalk.yellow("No execution ledger entries found."));
+      log.warning("No execution ledger entries found.");
       return;
     }
 
+    log.section("Execution ledger");
     for (const entry of entries) {
-      console.log(
-        `${chalk.yellow(entry.execution_hash.slice(0, 12))} ${entry.status} ${entry.execution_id} (${entry.tenant_id}) ${entry.timestamp}`
-      );
-      console.log(
-        `  trace=${entry.trace_id} policy=${entry.policy_version} duration=${entry.duration}ms`
-      );
+      const line1 = `${entry.execution_hash.slice(0, 12)} ${entry.status} ${entry.execution_id} (${entry.tenant_id}) ${entry.timestamp}`;
+      const line2 = `  trace=${entry.trace_id} policy=${entry.policy_version} duration=${entry.duration}ms`;
+      if (json) {
+        log.detail(line1);
+        log.detail(line2);
+      } else {
+        log.rawLine(`${chalk.yellow(entry.execution_hash.slice(0, 12))} ${entry.status} ${entry.execution_id} (${entry.tenant_id}) ${entry.timestamp}`);
+        log.rawLine(line2);
+      }
     }
   });
 
@@ -48,23 +55,32 @@ export const diffCommand = new Command("diff")
   .argument("<execution_a>")
   .argument("<execution_b>")
   .action(async (executionA: string, executionB: string) => {
+    const json = resolveJsonFallbackFromEnv();
+    const log = createCliLogger({ isJSONFallback: json });
     const [a, b] = await Promise.all([getLedgerEntry(executionA), getLedgerEntry(executionB)]);
     if (!a || !b) {
-      console.error(chalk.red("Both execution IDs must exist in ledger."));
+      log.error("Both execution IDs must exist in ledger.");
       process.exit(1);
     }
 
     const diff = diffLedgerEntries(a, b);
     const keys = Object.keys(diff);
     if (keys.length === 0) {
-      console.log(chalk.green("No differences across tracked fields."));
+      log.success("No differences across tracked fields.");
       return;
     }
 
+    log.section("Diff");
     for (const key of keys) {
-      console.log(chalk.cyan(`${key}:`));
-      console.log(`  a: ${JSON.stringify(diff[key]?.a)}`);
-      console.log(`  b: ${JSON.stringify(diff[key]?.b)}`);
+      if (json) {
+        log.detail(`${key}:`);
+        log.detail(`  a: ${JSON.stringify(diff[key]?.a)}`);
+        log.detail(`  b: ${JSON.stringify(diff[key]?.b)}`);
+      } else {
+        log.rawLine(chalk.cyan(`${key}:`));
+        log.rawLine(`  a: ${JSON.stringify(diff[key]?.a)}`);
+        log.rawLine(`  b: ${JSON.stringify(diff[key]?.b)}`);
+      }
     }
   });
 
@@ -72,18 +88,27 @@ export const verifyExecutionCommand = new Command("verify-execution")
   .description("Verify deterministic receipt integrity for an execution")
   .argument("<execution_id>")
   .action(async (executionId: string) => {
+    const json = resolveJsonFallbackFromEnv();
+    const log = createCliLogger({ isJSONFallback: json });
     const report = await verifyLedgerEntry(executionId);
     if (!report) {
-      console.error(chalk.red(`Execution ${executionId} not found in ledger.`));
+      log.error(`Execution ${executionId} not found in ledger.`);
       process.exit(1);
     }
 
-    console.log(`execution=${report.executionId}`);
-    console.log(`receipt_integrity=${report.receiptIntegrity}`);
-    console.log(`hash_correct=${report.hashMatches}`);
-    console.log(`replay_compatible=${report.replayCompatible}`);
-    console.log(`expected_hash=${report.expectedHash}`);
-    console.log(`computed_hash=${report.computedHash}`);
+    const lines = [
+      `execution=${report.executionId}`,
+      `receipt_integrity=${report.receiptIntegrity}`,
+      `hash_correct=${report.hashMatches}`,
+      `replay_compatible=${report.replayCompatible}`,
+      `expected_hash=${report.expectedHash}`,
+      `computed_hash=${report.computedHash}`,
+    ];
+    if (json) {
+      lines.forEach((line) => log.detail(line));
+    } else {
+      lines.forEach((line) => log.rawLine(line));
+    }
 
     if (!report.receiptIntegrity || !report.hashMatches || !report.replayCompatible) {
       process.exit(1);
@@ -127,9 +152,11 @@ export const exportLedgerCommand = new Command("export-ledger")
       };
       await fs.writeFile(outPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
     } else {
-      console.error(chalk.red("Unsupported format. Use json|csv|signed."));
+      const log = createCliLogger({ isJSONFallback: resolveJsonFallbackFromEnv() });
+      log.error("Unsupported format. Use json|csv|signed.");
       process.exit(1);
     }
 
-    console.log(chalk.green(`Wrote ${entries.length} receipts to ${outPath}`));
+    const log = createCliLogger({ isJSONFallback: resolveJsonFallbackFromEnv() });
+    log.success(`Wrote ${entries.length} receipts to ${outPath}`);
   });

--- a/packages/web/src/app/console/runs/[runId]/page.tsx
+++ b/packages/web/src/app/console/runs/[runId]/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ConsolePageHeader } from "@/components/console/ConsolePageHeader";
 import { safeFetch } from "@/lib/safe-fetch";
 import {
   RefreshCw,
@@ -181,8 +182,13 @@ export default function RunPage() {
   if (loading && !run) {
     return (
       <div className="p-6 space-y-6">
-        <Skeleton className="h-12 w-64" />
-        <Skeleton className="h-64" />
+        <div className="space-y-3">
+          <Skeleton className="h-3 w-40" />
+          <Skeleton className="h-9 w-72 max-w-full" />
+          <Skeleton className="h-4 w-full max-w-xl" />
+        </div>
+        <Skeleton className="h-48 w-full rounded-lg" />
+        <Skeleton className="h-32 w-full rounded-lg" />
       </div>
     );
   }
@@ -215,50 +221,45 @@ export default function RunPage() {
 
   return (
     <div className="p-6 space-y-6">
-      {/* Breadcrumb navigation */}
-      <nav className="flex items-center text-sm text-muted-foreground dark:text-muted-foreground mb-4">
-        <Link href="/console" className="hover:text-foreground dark:hover:text-white">
-          Console
-        </Link>
-        <span className="mx-2">/</span>
-        <Link href="/console/runs" className="hover:text-foreground dark:hover:text-white">
-          Runs
-        </Link>
-        <span className="mx-2">/</span>
-        <span className="text-foreground dark:text-white">{run.name}</span>
-      </nav>
-
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link href="/console/runs">
-            <Button variant="outline" size="sm">
-              <ArrowLeft className="w-4 h-4 mr-2" />
-              Back to Runs
+      <ConsolePageHeader
+        title={run.name}
+        description={
+          <>
+            Run ID:{" "}
+            <code className="rounded bg-muted/40 px-1.5 py-0.5 font-mono text-xs break-all dark:bg-card">
+              {run.id}
+            </code>
+          </>
+        }
+        breadcrumbs={[
+          { label: "Console", href: "/console" },
+          { label: "Runs", href: "/console/runs" },
+          { label: run.name },
+        ]}
+        actions={
+          <div className="flex flex-wrap items-center gap-2">
+            <label className="flex items-center gap-2 text-sm text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={autoRefresh}
+                onChange={(e) => setAutoRefresh(e.target.checked)}
+                className="rounded"
+              />
+              Auto-refresh
+            </label>
+            <Button variant="outline" size="sm" onClick={loadRun}>
+              <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+              Refresh
             </Button>
-          </Link>
-          <div>
-            <h1 className="text-3xl font-bold text-foreground dark:text-white">{run.name}</h1>
-            <p className="text-muted-foreground dark:text-muted-foreground mt-1">
-              Run ID: <code className="bg-muted/40 dark:bg-card px-2 py-1 rounded">{run.id}</code>
-            </p>
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/console/runs">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back
+              </Link>
+            </Button>
           </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <label className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground">
-            <input
-              type="checkbox"
-              checked={autoRefresh}
-              onChange={(e) => setAutoRefresh(e.target.checked)}
-              className="rounded"
-            />
-            Auto-refresh
-          </label>
-          <Button variant="outline" size="sm" onClick={loadRun}>
-            <RefreshCw className={`w-4 h-4 mr-2 ${loading ? "animate-spin" : ""}`} />
-            Refresh
-          </Button>
-        </div>
-      </div>
+        }
+      />
 
       {isIngestionRun ? (
         <Card className="border-amber-200 bg-amber-50/50 dark:border-amber-900 dark:bg-amber-950/20">

--- a/packages/web/src/app/enterprise/page.tsx
+++ b/packages/web/src/app/enterprise/page.tsx
@@ -1,5 +1,6 @@
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
+import { MarketingSectionHeader } from "@/components/marketing/MarketingSectionHeader";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { SpotlightCard } from "@/components/ui/SpotlightCard";
@@ -161,14 +162,13 @@ export default function EnterprisePage() {
         aria-label="Enterprise capabilities"
       >
         <div className="max-w-7xl mx-auto">
-          <div className="text-center mb-12 md:mb-16">
-            <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-4 text-foreground dark:text-white tracking-tight">
-              Enterprise Capabilities
-            </h2>
-            <p className="text-lg text-muted-foreground dark:text-muted-foreground max-w-2xl mx-auto leading-relaxed">
-              Security, compliance, and governance controls built into the infrastructure layer.
-            </p>
-          </div>
+          <MarketingSectionHeader
+            align="center"
+            title="Enterprise Capabilities"
+            titleClassName="text-2xl md:text-3xl lg:text-4xl"
+            description="Security, compliance, and governance controls built into the infrastructure layer."
+            className="mb-12 md:mb-16"
+          />
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8">
             {enterpriseCapabilities.map((feature, index) => {
               const Icon = feature.icon;

--- a/packages/web/src/app/platform/page.tsx
+++ b/packages/web/src/app/platform/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
 import { Section } from "@/components/marketing/Section";
+import { MarketingSectionHeader } from "@/components/marketing/MarketingSectionHeader";
 import { Button } from "@/components/ui/button";
 import { UiLink } from "@/components/ui/link";
 import { Badge } from "@/components/ui/badge";
@@ -149,7 +150,10 @@ export default function PlatformPage() {
 
       {/* Platform layers */}
       <Section className="py-16" containerClassName="max-w-6xl">
-        <h2 className="text-2xl font-bold text-foreground mb-10">Platform Architecture</h2>
+        <MarketingSectionHeader
+          title="Platform Architecture"
+          description="Layers you operate: deterministic matching, review, governance, and replayable evidence—each inspectable end to end."
+        />
         <div className="grid gap-6 sm:grid-cols-2">
           {platformLayers.map((layer) => {
             const Icon = layer.icon;

--- a/packages/web/src/components/console/ConsolePageHeader.tsx
+++ b/packages/web/src/components/console/ConsolePageHeader.tsx
@@ -10,7 +10,7 @@ export interface BreadcrumbItem {
 
 interface ConsolePageHeaderProps {
   title: string;
-  description: string;
+  description: React.ReactNode;
   /** Only shown when scope is "admin" or "global" — tenant scope is the default and not labeled. */
   scope?: "tenant" | "global" | "admin";
   /** Breadcrumb trail above the title */

--- a/packages/web/src/components/marketing/MarketingSectionHeader.tsx
+++ b/packages/web/src/components/marketing/MarketingSectionHeader.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@/lib/utils";
+
+export interface MarketingSectionHeaderProps {
+  title: string;
+  eyebrow?: string;
+  description?: string;
+  /** Default start; center aligns title block for banded sections */
+  align?: "start" | "center";
+  /** Override default `text-2xl font-bold` on the heading when a page needs larger responsive type */
+  titleClassName?: string;
+  className?: string;
+}
+
+/**
+ * Shared marketing section title rhythm (eyebrow → heading → supporting copy).
+ * Does not wrap outer Section spacing — parent controls vertical padding.
+ */
+export function MarketingSectionHeader({
+  title,
+  eyebrow,
+  description,
+  align = "start",
+  titleClassName,
+  className,
+}: MarketingSectionHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "space-y-3 mb-10",
+        align === "center" && "text-center mx-auto max-w-2xl",
+        className
+      )}
+    >
+      {eyebrow ? (
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          {eyebrow}
+        </p>
+      ) : null}
+      <h2
+        className={cn(
+          "font-bold tracking-tight text-foreground",
+          titleClassName ?? "text-2xl"
+        )}
+      >
+        {title}
+      </h2>
+      {description ? (
+        <p
+          className={cn(
+            "text-muted-foreground leading-relaxed",
+            align === "center" ? "mx-auto" : "max-w-2xl"
+          )}
+        >
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Express `GET /api/runs/:runId`** now delegates to `resolveOperatorRunDetailForTenants` and returns `{ data: OperatorRunDetail }`, aligned with Next `GET /api/runs/[id]` (canonical resolver). Handles UUID collision (409), not found (404), enrichment failure (500). Replaces route-local stage fabrication.
- **Web**: `MarketingSectionHeader` for platform + enterprise section rhythm; run detail page uses `ConsolePageHeader` and a layout-faithful loading skeleton; `ConsolePageHeader` `description` accepts `ReactNode`.
- **CLI**: `history` subcommands use `createCliLogger` / `SETTLER_CLI_JSON` for consistent human vs plain output.
- **Docs**: `docs/api/families/runs.md` notes Express envelope vs Next canonical route.

## Validation

- `pnpm typecheck`
- `pnpm verify:fast`
- `pnpm --filter @settler/api exec jest src/routes/__tests__/runs.test.ts`
- ESLint on touched files

## Notes

Express list `GET /api/runs` remains recon-result pagination (unchanged); only detail was unified with core.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de2df822-ad8d-4763-9e73-b90298395b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de2df822-ad8d-4763-9e73-b90298395b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

