### PR TITLE
fix(web): generate Prisma client before reconciliation-core on Vercel

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,7 +11,7 @@
     "clean:build": "rm -rf .next dist out .next/tsconfig.tsbuildinfo",
     "validate:api-routes": "test -f ../../scripts/validate-api-routes.ts && tsx ../../scripts/validate-api-routes.ts || echo '⚠️  API route validation skipped (script not found)'",
     "validate:boundary": "tsx ./scripts/check-public-route-boundary.ts",
-    "prebuild": "pnpm --filter @settler/reconciliation-core run build",
+    "prebuild": "cd ../.. && (pnpm run prisma:generate || pnpm exec prisma generate || echo 'Warning: Prisma generate may have failed') && pnpm --filter @settler/reconciliation-core run build",
     "build": "node ./scripts/assert-build-env.mjs && node ./scripts/assert-reconciliation-core-dist.mjs && next build --webpack",
     "build:vercel": "node ./scripts/assert-build-env.mjs && node ./scripts/assert-reconciliation-core-dist.mjs && next build --webpack",
     "postinstall": "export SENTRY_SKIP_AUTO_INSTALL=1 || set SENTRY_SKIP_AUTO_INSTALL=1 || true",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Vercel preview builds failed with:

`Module '"@prisma/client"' has no exported member 'PrismaClient'` in `@settler/reconciliation-core`.

## Root cause

1. `.vercelignore` excludes `/scripts/`, so the root `postinstall` never runs `vercel-prisma-postinstall.js` (the log showed "Skipping postinstall: script not found").
2. That script also skips `prisma generate` when `VERCEL=1`.
3. The web `prebuild` only ran `pnpm --filter @settler/reconciliation-core run build` without generating the Prisma client first, so TypeScript saw the stub `@prisma/client` package.

## Fix

Match `@settler/api`: run `pnpm run prisma:generate` (with fallbacks) from the repo root before building reconciliation-core in the web `prebuild` script.

## Verification

- `pnpm --filter @settler/web run prebuild` succeeds locally (prisma generate + reconciliation-core tsc).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f1dfb11-34b9-4f83-b962-0900a4598fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f1dfb11-34b9-4f83-b962-0900a4598fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

