### PR TITLE
Go-live closure: OperatorRunDetail typing, verify dist enforcement, canonical consumers

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -10,3 +10,7 @@ Settler ships an authenticated `/app` shell with tenant-aware navigation:
 - Settings
 
 The shell degrades safely when auth or required env variables are missing (no hard-500).
+
+## Canonical run detail
+
+Console run detail for merged runs is loaded from **GET `/api/runs/[id]`**, which returns the `OperatorRunDetail` DTO from `@settler/reconciliation-core` (`resolveOperatorRunDetailForTenants`). Compatibility-only v1 routes remain separate; do not treat them as the operator truth surface for full run detail.

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "verify:tenant-isolation": "node scripts/verify-tenant-isolation.mjs",
     "settler demo": "node scripts/settler-demo.mjs",
     "verify:root": "node scripts/verify-root-cleanliness.mjs",
+    "verify:reconciliation-core-dist": "node scripts/assert-reconciliation-core-dist-root.mjs",
     "demo": "tsx scripts/settler-demo.ts",
     "settler:replay": "tsx scripts/settler-replay.ts",
     "verify:policy": "tsx scripts/verify-policy.ts && tsx scripts/test-moat.ts && tsx scripts/settler-replay.ts examples/demo-output-fixtures/demo-run-1/evidence.json",

--- a/packages/reconciliation-core/src/operator-run-detail.ts
+++ b/packages/reconciliation-core/src/operator-run-detail.ts
@@ -8,6 +8,7 @@
  * remains compatibility scope only and must not become the source of truth.
  */
 
+import type { RunStatus } from "@settler/types";
 import type { CanonicalReconciliationRunDetail } from "./canonical-reconciliation.js";
 import type { AdapterDriftSignal } from "./canonical-run-result.js";
 
@@ -105,7 +106,8 @@ type OperatorKindDetail =
 export interface OperatorRunStageRow {
   id: string;
   name: string;
-  status: "pending" | "running" | "completed" | "failed";
+  /** Subset of {@link RunStatus} used for stage lifecycle in operator UI */
+  status: Extract<RunStatus, "pending" | "running" | "completed" | "failed">;
   startedAt?: string;
   completedAt?: string;
   error?: string;
@@ -117,7 +119,8 @@ export interface OperatorRunDetailBase {
   id: string;
   detailHref: string;
   name: string;
-  status: string;
+  /** Normalized lifecycle status (same contract as canonical reconciliation lifecycle) */
+  status: RunStatus;
   statusLabel: string;
   isTerminal: boolean;
   progress: number;
@@ -295,7 +298,7 @@ export function buildOperatorIngestionRunDetailJson(input: {
 
 export function buildOperatorReconRunDetailJson(input: {
   detail: CanonicalReconciliationRunDetail;
-  status: string;
+  status: RunStatus;
   startedAt: string;
   completedAt: string | null;
   errorMessage: string | null;

--- a/packages/reconciliation-core/src/recon-audit-stages.ts
+++ b/packages/reconciliation-core/src/recon-audit-stages.ts
@@ -2,6 +2,8 @@
  * Maps persisted recon audit rows to operator stage rows for run detail.
  */
 
+import type { OperatorRunStageRow } from "./operator-run-detail.js";
+
 export interface ReconAuditRow {
   id: string;
   audit_type: string | null;
@@ -10,14 +12,7 @@ export interface ReconAuditRow {
   created_at: string;
 }
 
-export function toStageRows(audits: ReconAuditRow[]): Array<{
-  id: string;
-  name: string;
-  status: "pending" | "running" | "completed" | "failed";
-  startedAt?: string;
-  completedAt?: string;
-  error?: string;
-}> {
+export function toStageRows(audits: ReconAuditRow[]): OperatorRunStageRow[] {
   return audits.map((audit) => {
     const auditType = audit.audit_type ?? "event";
     const action = (audit.action ?? "").toLowerCase();

--- a/packages/web/src/app/console/runs/[runId]/page.tsx
+++ b/packages/web/src/app/console/runs/[runId]/page.tsx
@@ -493,128 +493,126 @@ export default function RunPage() {
         </Card>
       )}
 
-      {/* Stages */}
-      {run.config && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Effective Configuration</CardTitle>
-            <CardDescription>
-              Configuration context used to interpret the latest persisted result.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div
-              className={`rounded-md border p-3 text-sm ${
-                run.config.configSource === "snapshot"
-                  ? "border-green-200 bg-green-50 text-green-900 dark:border-green-800 dark:bg-green-900/20 dark:text-green-200"
-                  : "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200"
-              }`}
-            >
-              {run.config.configSource === "snapshot"
-                ? "Snapshot-backed configuration: run decisions are tied to a captured snapshot."
-                : "Live-definition fallback: snapshot data was not available for this result."}
-              {run.config.configCapturedAt
-                ? ` Captured ${new Date(run.config.configCapturedAt).toLocaleString()}.`
-                : ""}
+      {/* Configuration + provenance timestamps (DTO-owned; same card for recon_job and ingestion_run) */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Effective Configuration</CardTitle>
+          <CardDescription>
+            Configuration context used to interpret the latest persisted result.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div
+            className={`rounded-md border p-3 text-sm ${
+              run.config.configSource === "snapshot"
+                ? "border-green-200 bg-green-50 text-green-900 dark:border-green-800 dark:bg-green-900/20 dark:text-green-200"
+                : "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200"
+            }`}
+          >
+            {run.config.configSource === "snapshot"
+              ? "Snapshot-backed configuration: run decisions are tied to a captured snapshot."
+              : "Live-definition fallback: snapshot data was not available for this result."}
+            {run.config.configCapturedAt
+              ? ` Captured ${new Date(run.config.configCapturedAt).toLocaleString()}.`
+              : ""}
+          </div>
+          {run.config.definitionDriftDetected && run.config.definitionDriftNotes.length > 0 && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+              <p className="font-medium">Current definition differs from captured snapshot:</p>
+              <ul className="mt-2 list-disc pl-5 space-y-1">
+                {run.config.definitionDriftNotes.map((note) => (
+                  <li key={note}>{note}</li>
+                ))}
+              </ul>
             </div>
-            {run.config.definitionDriftDetected && run.config.definitionDriftNotes.length > 0 && (
-              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
-                <p className="font-medium">Current definition differs from captured snapshot:</p>
-                <ul className="mt-2 list-disc pl-5 space-y-1">
-                  {run.config.definitionDriftNotes.map((note) => (
-                    <li key={note}>{note}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-              <div>
-                <p className="text-sm font-medium text-foreground dark:text-white">Adapters</p>
-                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-                  {[run.config.sourceAdapter, run.config.targetAdapter]
-                    .filter(Boolean)
-                    .join(" -> ") || "Not recorded"}
-                </p>
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground dark:text-white">Strategy</p>
-                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-                  {run.config.reconStrategy || "Not recorded"}
-                </p>
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground dark:text-white">Rules</p>
-                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-                  {run.config.validationRuleCount > 0
-                    ? `${run.config.validationRuleCount} rule${
-                        run.config.validationRuleCount === 1 ? "" : "s"
-                      } active`
-                    : "No validation rules recorded"}
-                </p>
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground dark:text-white">Rule Versions</p>
-                <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-                  {run.config.ruleVersionCount > 0
-                    ? `${run.config.ruleVersionCount} locked version${
-                        run.config.ruleVersionCount === 1 ? "" : "s"
-                      }`
-                    : "No rule-version lock recorded"}
-                </p>
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground dark:text-white">Snapshot</p>
-                <p className="text-sm text-muted-foreground dark:text-muted-foreground font-mono break-all">
-                  {run.config.snapshotId || "Not persisted"}
-                </p>
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground dark:text-white">Input Hash</p>
-                <p className="text-sm text-muted-foreground dark:text-muted-foreground font-mono break-all">
-                  {run.config.inputHash || "Not recorded"}
-                </p>
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground dark:text-white">Template</p>
-                <p className="text-sm text-muted-foreground dark:text-muted-foreground font-mono break-all">
-                  {run.config.templateId || "None"}
-                </p>
+          )}
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div>
+              <p className="text-sm font-medium text-foreground dark:text-white">Adapters</p>
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground">
+                {[run.config.sourceAdapter, run.config.targetAdapter]
+                  .filter(Boolean)
+                  .join(" -> ") || "Not recorded"}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground dark:text-white">Strategy</p>
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground">
+                {run.config.reconStrategy || "Not recorded"}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground dark:text-white">Rules</p>
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground">
+                {run.config.validationRuleCount > 0
+                  ? `${run.config.validationRuleCount} rule${
+                      run.config.validationRuleCount === 1 ? "" : "s"
+                    } active`
+                  : "No validation rules recorded"}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground dark:text-white">Rule Versions</p>
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground">
+                {run.config.ruleVersionCount > 0
+                  ? `${run.config.ruleVersionCount} locked version${
+                      run.config.ruleVersionCount === 1 ? "" : "s"
+                    }`
+                  : "No rule-version lock recorded"}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground dark:text-white">Snapshot</p>
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground font-mono break-all">
+                {run.config.snapshotId || "Not persisted"}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground dark:text-white">Input Hash</p>
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground font-mono break-all">
+                {run.config.inputHash || "Not recorded"}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground dark:text-white">Template</p>
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground font-mono break-all">
+                {run.config.templateId || "None"}
+              </p>
+            </div>
+          </div>
+          {run.config.validationRuleLabels.length > 0 && (
+            <div>
+              <p className="mb-2 text-sm font-medium text-foreground dark:text-white">
+                Recorded Rule Coverage
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {run.config.validationRuleLabels.map((label) => (
+                  <Badge key={label} variant="outline">
+                    {label}
+                  </Badge>
+                ))}
               </div>
             </div>
-            {run.config.validationRuleLabels.length > 0 && (
-              <div>
-                <p className="mb-2 text-sm font-medium text-foreground dark:text-white">
-                  Recorded Rule Coverage
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  {run.config.validationRuleLabels.map((label) => (
-                    <Badge key={label} variant="outline">
-                      {label}
-                    </Badge>
-                  ))}
-                </div>
+          )}
+          {run.config.ruleVersionLabels.length > 0 && (
+            <div>
+              <p className="mb-2 text-sm font-medium text-foreground dark:text-white">
+                Snapshot Rule Versions
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {run.config.ruleVersionLabels.map((label) => (
+                  <Badge key={label} variant="outline">
+                    {label}
+                  </Badge>
+                ))}
               </div>
-            )}
-            {run.config.ruleVersionLabels.length > 0 && (
-              <div>
-                <p className="mb-2 text-sm font-medium text-foreground dark:text-white">
-                  Snapshot Rule Versions
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  {run.config.ruleVersionLabels.map((label) => (
-                    <Badge key={label} variant="outline">
-                      {label}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-            <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-              {run.config.summaryBasis}
-            </p>
-          </CardContent>
-        </Card>
-      )}
+            </div>
+          )}
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground">
+            {run.config.summaryBasis}
+          </p>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>
@@ -623,6 +621,11 @@ export default function RunPage() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
+            {run.stages.length === 0 ? (
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground">
+                No stage events recorded for this run yet.
+              </p>
+            ) : null}
             {run.stages.map((stage) => {
               const StageIcon = getStatusIcon(stage.status);
               return (

--- a/packages/web/src/components/console/ReconciliationMatches.tsx
+++ b/packages/web/src/components/console/ReconciliationMatches.tsx
@@ -20,6 +20,7 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { AlertCircle, CheckCircle2, Info } from "lucide-react";
 import { capabilitiesForRunKind, type ReconciliationRunKind } from "@settler/reconciliation-core";
+import type { OperatorRunDetail } from "@/types/operator-run-detail";
 
 interface Match {
   id: string;
@@ -81,11 +82,7 @@ export function ReconciliationMatches({ runId, runKind: runKindProp }: Reconcili
 
       let runKind = resolvedRunKind;
       if (runKind == null) {
-        const detailRes = await fetch(`/api/v1/reconciliation/runs/${runId}`, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("apiKey")}`,
-          },
-        });
+        const detailRes = await fetch(`/api/runs/${runId}`);
 
         if (detailRes.status === 404) {
           setBlockReason({ kind: "not_found" });
@@ -97,39 +94,36 @@ export function ReconciliationMatches({ runId, runKind: runKindProp }: Reconcili
           const problem = (await detailRes.json().catch(() => ({}))) as {
             code?: string;
             detail?: string;
+            error?: string;
           };
-          if (problem.code === "RECONCILIATION_UUID_COLLISION") {
-            setBlockReason({
-              kind: "uuid_collision",
-              detail:
-                problem.detail ||
-                "This id exists as both a recon job and an ingestion reconciliation run.",
-            });
-          } else if (problem.code === "RECONCILIATION_WRONG_RUN_KIND") {
-            setBlockReason({ kind: "wrong_run_kind" });
-          } else {
-            setBlockReason({
-              kind: "other",
-              message: problem.detail || "Unable to resolve run for matches.",
-            });
-          }
+          setBlockReason({
+            kind: "uuid_collision",
+            detail:
+              problem.detail ||
+              problem.error ||
+              "This id exists as both a recon job and an ingestion reconciliation run.",
+          });
           setMatches([]);
           return;
         }
 
         if (!detailRes.ok) {
-          setBlockReason({ kind: "other", message: "Failed to load run detail for matches." });
+          setBlockReason({
+            kind: "other",
+            message: "Failed to load canonical run detail for matches.",
+          });
           setMatches([]);
           return;
         }
 
-        const detailBody = (await detailRes.json()) as { run_kind?: ReconciliationRunKind };
-        if (detailBody.run_kind !== "recon_job" && detailBody.run_kind !== "ingestion_run") {
-          setBlockReason({ kind: "other", message: "Unexpected run_kind in detail response." });
+        const detailBody = (await detailRes.json()) as OperatorRunDetail;
+        const k = detailBody.runKind;
+        if (k !== "recon_job" && k !== "ingestion_run") {
+          setBlockReason({ kind: "other", message: "Unexpected runKind in operator run detail." });
           setMatches([]);
           return;
         }
-        runKind = detailBody.run_kind;
+        runKind = k;
         setResolvedRunKind(runKind);
       }
 

--- a/scripts/__tests__/verify-fast-profile-contract.test.mjs
+++ b/scripts/__tests__/verify-fast-profile-contract.test.mjs
@@ -15,8 +15,16 @@ test("fast profile excludes linkIntegrity; fast-with-links includes it", () => {
   const fastMatch = src.match(/fast:\s*\[([\s\S]*?)\],/);
   assert.ok(fastMatch, "expected fast profile block");
   assert.ok(!fastMatch[1].includes("linkIntegrity"), "fast must not include linkIntegrity");
+  assert.ok(
+    fastMatch[1].includes("reconciliationCoreDist"),
+    "fast must include reconciliationCoreDist"
+  );
 
   const withLinks = src.match(/"fast-with-links":\s*\[([\s\S]*?)\],/);
   assert.ok(withLinks, "expected fast-with-links profile block");
   assert.ok(withLinks[1].includes("linkIntegrity"), "fast-with-links must include linkIntegrity");
+  assert.ok(
+    withLinks[1].includes("reconciliationCoreDist"),
+    "fast-with-links must include reconciliationCoreDist"
+  );
 });

--- a/scripts/assert-reconciliation-core-dist-root.mjs
+++ b/scripts/assert-reconciliation-core-dist-root.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Repo-root variant of `packages/web/scripts/assert-reconciliation-core-dist.mjs`.
+ * Used by `verify:fast` so CI catches stale `@settler/reconciliation-core` output without a web build.
+ */
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const coreRoot = join(repoRoot, "packages", "reconciliation-core");
+const distDir = join(coreRoot, "dist");
+const srcDir = join(coreRoot, "src");
+
+if (!existsSync(distDir)) {
+  console.error(
+    "❌ @settler/reconciliation-core dist/ is missing. Run: pnpm --filter @settler/reconciliation-core run build"
+  );
+  process.exit(1);
+}
+
+function newestMtimeMs(dir, exts) {
+  let max = 0;
+  const walk = (d) => {
+    for (const name of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, name.name);
+      if (name.isDirectory()) {
+        walk(p);
+      } else if (exts.some((e) => name.name.endsWith(e))) {
+        const t = statSync(p).mtimeMs;
+        if (t > max) max = t;
+      }
+    }
+  };
+  walk(dir);
+  return max;
+}
+
+const distNewest = newestMtimeMs(distDir, [".js", ".d.ts"]);
+const srcNewest = newestMtimeMs(srcDir, [".ts"]);
+
+if (srcNewest > distNewest) {
+  console.error(
+    "❌ @settler/reconciliation-core dist/ is older than src/. Rebuild: pnpm --filter @settler/reconciliation-core run build"
+  );
+  process.exit(1);
+}
+
+console.log("✅ reconciliation-core dist is present and not older than sources.");

--- a/scripts/assert-verify-fast-profile.mjs
+++ b/scripts/assert-verify-fast-profile.mjs
@@ -21,6 +21,12 @@ if (fastBody.includes("linkIntegrity")) {
   );
   process.exit(1);
 }
+if (!fastBody.includes("reconciliationCoreDist")) {
+  console.error(
+    "`fast` profile must include `reconciliationCoreDist` so stale `@settler/reconciliation-core` dist cannot pass CI silently."
+  );
+  process.exit(1);
+}
 
 const fastWithLinksMatch = src.match(/"fast-with-links":\s*\[([\s\S]*?)\],/);
 if (!fastWithLinksMatch) {

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -8,6 +8,11 @@ const defaultRunId = new Date().toISOString().replace(/[:.]/g, "-");
 
 const stageCatalog = {
   root: { label: "Root cleanliness", command: ["pnpm", ["run", "verify:root"]], timeoutMs: 60_000 },
+  reconciliationCoreDist: {
+    label: "Reconciliation core dist freshness",
+    command: ["pnpm", ["run", "verify:reconciliation-core-dist"]],
+    timeoutMs: 60_000,
+  },
   lint: { label: "Lint", command: ["pnpm", ["run", "lint"]], timeoutMs: 12 * 60_000 },
   typecheck: {
     label: "Typecheck",
@@ -74,10 +79,20 @@ const stageCatalog = {
 
 const profiles = {
   /** Release-critical code health; excludes internal marketing/docs link crawl (see `fast-with-links`). */
-  fast: ["root", "lint", "typecheck", "claims", "boundaries", "routes", "security"],
+  fast: [
+    "root",
+    "reconciliationCoreDist",
+    "lint",
+    "typecheck",
+    "claims",
+    "boundaries",
+    "routes",
+    "security",
+  ],
   /** Same as `fast` plus static internal link integrity (requires fresh `qa/route-registry.json` from `qa:routes`). */
   "fast-with-links": [
     "root",
+    "reconciliationCoreDist",
     "lint",
     "typecheck",
     "claims",
@@ -91,6 +106,7 @@ const profiles = {
   artifacts: ["launchManifest", "capture", "artifacts"],
   full: [
     "root",
+    "reconciliationCoreDist",
     "lint",
     "typecheck",
     "claims",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final-mile hardening for canonical run detail consumption, DTO typing, and release verification truth.

### Reconciliation core
- `OperatorRunDetail.status` is now `RunStatus` from `@settler/types` (aligned with canonical lifecycle).
- `OperatorRunStageRow.status` is explicitly tied to the `RunStatus` subset used for stages.
- `toStageRows` returns `OperatorRunStageRow[]` (single source of truth for stage shape).

### Verify / CI
- New `pnpm run verify:reconciliation-core-dist` (repo-root) — same mtime check as web `prebuild`, so stale `packages/reconciliation-core/dist` cannot pass `verify:fast` silently.
- `reconciliationCoreDist` stage added to `fast`, `fast-with-links`, and `full` profiles in `scripts/verify-release.mjs`.
- `assert-verify-fast-profile.mjs` and node contract test updated to require the new stage.

### Web / console
- Run detail: Effective Configuration card always rendered for ingestion runs (was hidden behind `run.config` truthiness).
- Stages: empty state when `stages.length === 0`.
- `ReconciliationMatches`: when `runKind` is unknown, resolve via **GET `/api/runs/:id`** (same `OperatorRunDetail` as canonical console detail) instead of v1 reconciliation run detail.

### Docs
- `docs/console.md`: short note on canonical GET `/api/runs/[id]` and compatibility boundaries.

## Validation

- `pnpm typecheck`
- `pnpm --filter @settler/reconciliation-core test`
- `pnpm run verify:fast`
- ESLint on touched web files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94aacd1f-5e89-46f3-8ee5-877131462572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94aacd1f-5e89-46f3-8ee5-877131462572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

