### PR TITLE
Pre-go-live merged-runs simulation harness + docs

### DIFF
--- a/docs/ops/pre-go-live-simulation.md
+++ b/docs/ops/pre-go-live-simulation.md
@@ -1,0 +1,28 @@
+# Pre-go-live simulation (merged runs)
+
+This pass adds **executable, deterministic** coverage for the pure merge and cursor layer that backs merged reconciliation list APIs (`recon_jobs` + `reconciliation_runs`).
+
+## What is proven
+
+- **Concurrent overlapping reads**: Many parallel calls with the same candidate buffers return identical first pages (no race in pure merge).
+- **Tenant input isolation**: Independent buffers for two synthetic tenants do not share row payloads when merged separately.
+- **Cursor pagination contract**: Matches the dual-stream merge behavior documented in `merged-list-pagination` tests—after a page is emitted, the next page assumes buffers are refetched from the cursor (same pattern as existing pagination unit tests).
+- **Cursor encoding**: Base64url round-trip preserves merge semantics for page 2.
+- **Stream exhaustion metadata**: When one stream is empty, pagination flags reflect exhaustion.
+
+## What is not claimed
+
+- This does **not** prove database scale, network throughput, or full API integration. It proves the **merge + cursor mathematics** used by list endpoints.
+- For DB-backed guarantees (tenant-scoped SQL, merged list rows), use `RUN_RECON_MERGED_LIST_DB=1` with `packages/api` `test:recon-merged-db` when a matching schema is available.
+
+## How to rerun
+
+```bash
+pnpm run verify:pre-go-live-simulation
+```
+
+Or directly:
+
+```bash
+pnpm --filter @settler/reconciliation-core test -- pre-go-live-simulation.test.ts
+```

--- a/docs/ops/pre-go-live-simulation.md
+++ b/docs/ops/pre-go-live-simulation.md
@@ -4,7 +4,10 @@ This pass adds **executable, deterministic** coverage for the pure merge and cur
 
 ## What is proven
 
-- **Concurrent overlapping reads**: Many parallel calls with the same candidate buffers return identical first pages (no race in pure merge).
+- **Concurrent overlapping reads (merge layer)**: Many parallel calls with the same candidate buffers return identical first pages (no race in pure merge).
+- **Concurrent overlapping reads (HTTP contract)**: Parallel `GET /api/v1/reconciliation/runs` requests with the same tenant and query params return identical JSON when the data layer returns the same page (supertest + mocked `fetchMergedReconciliationRunsPage`).
+- **POST /run input hardening**: Non-string `ingestionId` is rejected with `VALIDATION_ERROR`; `jobId` / `templateId` are read as optional trimmed strings (no `any` on the request body).
+- **List telemetry**: Successful list responses emit structured `logInfo` with `event: reconciliation.runs_listed` and bounded fields (limit, run_kind, returned, has_more, cursor_present, tenantId, traceId).
 - **Tenant input isolation**: Independent buffers for two synthetic tenants do not share row payloads when merged separately.
 - **Cursor pagination contract**: Matches the dual-stream merge behavior documented in `merged-list-pagination` tests—after a page is emitted, the next page assumes buffers are refetched from the cursor (same pattern as existing pagination unit tests).
 - **Cursor encoding**: Base64url round-trip preserves merge semantics for page 2.
@@ -12,7 +15,8 @@ This pass adds **executable, deterministic** coverage for the pure merge and cur
 
 ## What is not claimed
 
-- This does **not** prove database scale, network throughput, or full API integration. It proves the **merge + cursor mathematics** used by list endpoints.
+- This does **not** prove database scale, network throughput, or live Prisma behavior under load. The API contract tests use **mocks** for `fetchMergedReconciliationRunsPage` and `runReconciliation`.
+- Merge-layer tests prove **merge + cursor mathematics**; they do not hit PostgreSQL.
 - For DB-backed guarantees (tenant-scoped SQL, merged list rows), use `RUN_RECON_MERGED_LIST_DB=1` with `packages/api` `test:recon-merged-db` when a matching schema is available.
 
 ## How to rerun

--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "test:reconciliation:e2e": "pnpm exec tsx packages/cli/src/index.ts foundry reconciliation-verify --seed 42 --profile smoke --strict",
     "verify:reconciliation-runtime": "pnpm exec tsx packages/cli/src/index.ts foundry reconciliation-verify --seed 42 --profile integration --strict",
     "verify:reconciliation:strict": "node scripts/verify-reconciliation-strict.mjs",
+    "verify:pre-go-live-simulation": "pnpm --filter @settler/reconciliation-core test -- pre-go-live-simulation.test.ts",
     "reconciliation:summary": "node scripts/reconciliation-run-tools.mjs summary test-data/exports/latest",
     "reconciliation:compare": "node scripts/reconciliation-run-tools.mjs compare test-data/exports/smoke-seed42 test-data/exports/latest",
     "verify:issue-templates": "node scripts/validate-issue-templates.mjs",

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "test:reconciliation:e2e": "pnpm exec tsx packages/cli/src/index.ts foundry reconciliation-verify --seed 42 --profile smoke --strict",
     "verify:reconciliation-runtime": "pnpm exec tsx packages/cli/src/index.ts foundry reconciliation-verify --seed 42 --profile integration --strict",
     "verify:reconciliation:strict": "node scripts/verify-reconciliation-strict.mjs",
-    "verify:pre-go-live-simulation": "pnpm --filter @settler/reconciliation-core test -- pre-go-live-simulation.test.ts",
+    "verify:pre-go-live-simulation": "pnpm --filter @settler/reconciliation-core test -- pre-go-live-simulation.test.ts && pnpm --filter @settler/api exec jest src/__tests__/routes/reconciliation-v1-contract.test.ts --runInBand --forceExit",
     "reconciliation:summary": "node scripts/reconciliation-run-tools.mjs summary test-data/exports/latest",
     "reconciliation:compare": "node scripts/reconciliation-run-tools.mjs compare test-data/exports/smoke-seed42 test-data/exports/latest",
     "verify:issue-templates": "node scripts/validate-issue-templates.mjs",

--- a/packages/api/src/__tests__/routes/reconciliation-v1-contract.test.ts
+++ b/packages/api/src/__tests__/routes/reconciliation-v1-contract.test.ts
@@ -10,8 +10,10 @@ jest.mock("../../middleware/governance", () => ({
   enforceFreezeState: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+const mockRunReconciliation = jest.fn().mockResolvedValue("33333333-3333-4333-8333-333333333333");
+
 jest.mock("../../services/ingestion/reconciliation-matcher", () => ({
-  runReconciliation: jest.fn().mockResolvedValue("33333333-3333-4333-8333-333333333333"),
+  runReconciliation: (...args: unknown[]) => mockRunReconciliation(...args),
 }));
 
 jest.mock("../../infrastructure/db/prisma", () => ({
@@ -40,7 +42,6 @@ jest.mock("../../utils/logger", () => ({
 }));
 
 import { query } from "../../db";
-
 const tenantId = "11111111-1111-4111-8111-111111111111";
 
 describe("reconciliation v1 contract", () => {
@@ -80,6 +81,8 @@ describe("reconciliation v1 contract", () => {
     });
     (resolveReconciliationRunForTenant as jest.Mock).mockReset();
     (query as jest.Mock).mockReset();
+    mockRunReconciliation.mockClear();
+    mockRunReconciliation.mockResolvedValue("33333333-3333-4333-8333-333333333333");
   });
 
   test("GET /runs rejects malformed cursor with RECONCILIATION_CURSOR_INVALID", async () => {
@@ -122,6 +125,86 @@ describe("reconciliation v1 contract", () => {
     expect(res.body.code).toBe("RECONCILIATION_UUID_COLLISION");
     expect(res.body.recon_job_id).toBe("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
     expect(res.body.reconciliation_run_id).toBe("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+  });
+
+  test("GET /runs serves identical pages for concurrent pollers (same tenant, same params)", async () => {
+    const pagePayload = {
+      runs: [{ id: "run-1", runKind: "ingestion_run" } as never],
+      next_cursor: null,
+      pagination: {
+        limit: 10,
+        returned: 1,
+        has_more: false,
+        job_stream_has_more: false,
+        ingestion_stream_has_more: false,
+        job_stream_exhausted: true,
+        ingestion_stream_exhausted: true,
+      },
+      response_meta: {
+        contract_version: 1 as const,
+        included_run_kinds: ["recon_job", "ingestion_run"] as const,
+        ordering: "test",
+        consistency: "read_committed" as const,
+      },
+    };
+    (fetchMergedReconciliationRunsPage as jest.Mock).mockResolvedValue(pagePayload);
+
+    const concurrent = 24;
+    const responses = await Promise.all(
+      Array.from({ length: concurrent }, () =>
+        request(app).get("/api/v1/reconciliation/runs?limit=10&run_kind=all")
+      )
+    );
+
+    const expectedBody = {
+      contract_version: 1,
+      ...pagePayload,
+      traceId: "trace-contract",
+    };
+
+    for (const res of responses) {
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(expectedBody);
+    }
+
+    expect(fetchMergedReconciliationRunsPage).toHaveBeenCalledTimes(concurrent);
+    for (const [arg] of (fetchMergedReconciliationRunsPage as jest.Mock).mock.calls) {
+      expect(arg.tenantId).toBe(tenantId);
+      expect(arg.limit).toBe(10);
+      expect(arg.runKind).toBe("all");
+      expect(arg.cursorState).toBeNull();
+    }
+  });
+
+  test("POST /run rejects object ingestionId with validation error", async () => {
+    const res = await request(app)
+      .post("/api/v1/reconciliation/run")
+      .send({ ingestionId: { not: "valid" } })
+      .expect(400);
+
+    expect(res.headers["content-type"]).toMatch(/application\/problem\+json/);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+    expect(mockRunReconciliation).not.toHaveBeenCalled();
+  });
+
+  test("POST /run forwards trimmed jobId and templateId when strings", async () => {
+    await request(app)
+      .post("/api/v1/reconciliation/run")
+      .send({
+        ingestionId: "ing-1",
+        jobId: "  job-abc  ",
+        templateId: "tpl-1",
+      })
+      .expect(201);
+
+    expect(mockRunReconciliation).toHaveBeenCalledWith(
+      "ing-1",
+      tenantId,
+      "22222222-2222-4222-8222-222222222222",
+      "job-abc",
+      "tpl-1",
+      {}
+    );
   });
 
   test("GET /runs/:id/matches caps limit at 500", async () => {

--- a/packages/api/src/routes/v1/reconciliation.ts
+++ b/packages/api/src/routes/v1/reconciliation.ts
@@ -39,6 +39,32 @@ function paramString(value: string | string[] | undefined): string {
 const WRONG_RUN_KIND = "RECONCILIATION_WRONG_RUN_KIND";
 const CURSOR_INVALID = "RECONCILIATION_CURSOR_INVALID";
 
+/** POST /run JSON body (partial validation; config fields validated below). */
+type ReconciliationRunRequestBody = {
+  ingestionId?: unknown;
+  config?: unknown;
+  jobId?: unknown;
+  templateId?: unknown;
+};
+
+function optionalNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const t = value.trim();
+  return t === "" ? undefined : t;
+}
+
+/** Normalize ingestion id from JSON (string or finite number, matching typical clients). */
+function coerceIngestionId(value: unknown): string | null {
+  if (typeof value === "string") {
+    const t = value.trim();
+    return t === "" ? null : t;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
 type IngestionWorkbenchGate =
   | { ok: true }
   | { ok: false; problem: Parameters<typeof sendProblemJson>[2] }
@@ -116,22 +142,27 @@ function respondIngestionWorkbenchGate(
  */
 router.post("/run", enforceFreezeState(), async (req: AuthRequest, res: Response) => {
   try {
-    const { ingestionId, config } = req.body;
+    const body = req.body as ReconciliationRunRequestBody;
+    const config = body.config;
     const tenantId = req.tenantId!;
     const userId = req.userId!;
 
+    const ingestionId = coerceIngestionId(body.ingestionId);
     if (!ingestionId) {
       sendProblemJson(req, res, {
         status: 400,
         title: "Validation Error",
-        detail: "ingestionId is required",
+        detail: "ingestionId is required (non-empty string or number)",
         code: "VALIDATION_ERROR",
         extra: { field: "ingestionId" },
       });
       return;
     }
 
-    const rawConfig = (config ?? {}) as Record<string, unknown>;
+    const rawConfig =
+      config !== undefined && config !== null && typeof config === "object" && !Array.isArray(config)
+        ? (config as Record<string, unknown>)
+        : {};
     const reconciliationConfig: ReconciliationConfig = {};
     const invalidConfigFields: string[] = [];
 
@@ -195,18 +226,10 @@ router.post("/run", enforceFreezeState(), async (req: AuthRequest, res: Response
       return;
     }
 
-    // Extract jobId and templateId from request if available
-    const jobId = (req.body as any)?.jobId;
-    const templateId = (req.body as any)?.templateId;
+    const jobId = optionalNonEmptyString(body.jobId);
+    const templateId = optionalNonEmptyString(body.templateId);
 
-    const runId = await runReconciliation(
-      ingestionId,
-      tenantId,
-      userId,
-      jobId,
-      templateId,
-      reconciliationConfig
-    );
+    const runId = await runReconciliation(ingestionId, tenantId, userId, jobId, templateId, reconciliationConfig);
 
     logInfo("Reconciliation run started", { runId, ingestionId, traceId: req.traceId });
 
@@ -287,6 +310,17 @@ router.get("/runs", async (req: AuthRequest, res: Response) => {
       cursorState,
       runKind,
       encodeCursor: encodeMergedRunsCursor,
+    });
+
+    logInfo("Reconciliation runs listed", {
+      event: "reconciliation.runs_listed",
+      tenantId,
+      limit,
+      run_kind: runKind,
+      returned: page.pagination.returned,
+      has_more: page.pagination.has_more,
+      cursor_present: Boolean(cursorParam),
+      traceId: req.traceId,
     });
 
     return res.json({

--- a/packages/reconciliation-core/src/pre-go-live-simulation.test.ts
+++ b/packages/reconciliation-core/src/pre-go-live-simulation.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Executable pre-go-live simulation for merged reconciliation list behavior.
+ * Proves (without theatre): determinism under concurrent reads, stable ordering,
+ * cursor validity, and tenant-independent merge outcomes when inputs are isolated.
+ *
+ * This does not substitute for DB integration tests; it exercises the pure merge
+ * and cursor layers that back operator list APIs under overlapping poll pressure.
+ */
+
+import {
+  compareMergeCandidates,
+  decodeMergedRunsCursor,
+  encodeMergedRunsCursor,
+  mergeDualStreamPage,
+  type MergeCandidate,
+  type MergedRunsCursorV1,
+} from "./merged-list-pagination";
+
+type Tagged = { tenant: "A" | "B"; kind: "job" | "ing"; payload: string };
+
+function seededRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+/** Deterministic valid UUIDs for stable lexicographic tie-breaks in merge tests. */
+function uuidFromIndex(i: number, stream: "job" | "ing"): string {
+  const offset = stream === "job" ? 0 : 50_000;
+  const h = (i + offset).toString(16).padStart(12, "0");
+  return `00000000-0000-4000-8000-${h}`;
+}
+
+function buildCandidates(
+  tenant: "A" | "B",
+  jobCount: number,
+  ingCount: number,
+  random: () => number,
+  timeBase: number
+): {
+  job: MergeCandidate<string>[];
+  ing: MergeCandidate<string>[];
+} {
+  const jobs: MergeCandidate<string>[] = [];
+  for (let i = 0; i < jobCount; i += 1) {
+    const id = uuidFromIndex(i, "job");
+    const sortTimeMs = timeBase + Math.floor(random() * 86_400_000);
+    jobs.push({ row: `job-${tenant}-${i}`, sortTimeMs, id });
+  }
+  const ings: MergeCandidate<string>[] = [];
+  for (let i = 0; i < ingCount; i += 1) {
+    const id = uuidFromIndex(i, "ing");
+    const sortTimeMs = timeBase + Math.floor(random() * 86_400_000);
+    ings.push({ row: `ing-${tenant}-${i}`, sortTimeMs, id });
+  }
+  jobs.sort((a, b) => compareMergeCandidates(a, b));
+  ings.sort((a, b) => compareMergeCandidates(a, b));
+  return { job: jobs, ing: ings };
+}
+
+function mergePage(
+  job: MergeCandidate<string>[],
+  ing: MergeCandidate<string>[],
+  limit: number,
+  prev: MergedRunsCursorV1 | null
+) {
+  return mergeDualStreamPage({
+    limit,
+    jobCandidates: job,
+    ingestionCandidates: ing,
+    mapJob: (x) => x,
+    mapIngestion: (x) => x,
+    prev,
+  });
+}
+
+describe("pre-go-live simulation (merged runs)", () => {
+  it("produces identical pages under concurrent overlapping reads (operator poll storm)", () => {
+    const random = seededRng(42);
+    const { job, ing } = buildCandidates("A", 24, 18, random, Date.parse("2026-03-01T00:00:00.000Z"));
+    const limit = 12;
+    const expected = mergePage(job, ing, limit, null);
+
+    const concurrent = 64;
+    const runs = Array.from({ length: concurrent }, () => mergePage(job, ing, limit, null));
+
+    for (const r of runs) {
+      expect(r.items).toEqual(expected.items);
+      expect(r.nextCursor).toEqual(expected.nextCursor);
+      expect(r.pagination).toEqual(expected.pagination);
+    }
+  });
+
+  it("keeps independent tenant buffers from cross-merging (isolation of inputs)", () => {
+    const rA = seededRng(1);
+    const rB = seededRng(2);
+    const base = Date.parse("2026-03-15T00:00:00.000Z");
+    const a = buildCandidates("A", 8, 6, rA, base);
+    const b = buildCandidates("B", 8, 6, rB, base);
+
+    const pageA = mergePage(a.job, a.ing, 20, null);
+    const pageB = mergePage(b.job, b.ing, 20, null);
+
+    const rowsA = new Set(pageA.items.map((x) => String(x)));
+    const rowsB = new Set(pageB.items.map((x) => String(x)));
+    for (const row of rowsA) {
+      expect(rowsB.has(row)).toBe(false);
+    }
+  });
+
+  it("paginates across pages without duplicates when buffers refetch like the API (cursor follows last emitted per stream)", () => {
+    const t = Date.parse("2026-06-01T12:00:00.000Z");
+    const i1 = { row: "i1", sortTimeMs: t, id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc" };
+    const j1 = { row: "j1", sortTimeMs: t, id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" };
+    const j0 = { row: "j0", sortTimeMs: t, id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" };
+
+    const page1 = mergePage([j1, j0], [i1], 1, null);
+    expect(page1.items).toEqual(["i1"]);
+    expect(page1.nextCursor).not.toBeNull();
+
+    const page2 = mergePage([j1, j0], [], 1, page1.nextCursor);
+    expect(page2.items).toEqual(["j1"]);
+    expect(page2.nextCursor).not.toBeNull();
+
+    const page3 = mergePage([j0], [], 1, page2.nextCursor);
+    expect(page3.items).toEqual(["j0"]);
+    expect(page3.nextCursor).toBeNull();
+
+    const collected = [...page1.items, ...page2.items, ...page3.items];
+    expect(new Set(collected).size).toBe(3);
+  });
+
+  it("round-trips next_cursor through encode/decode without changing merge semantics on page 2", () => {
+    const t = Date.parse("2026-02-01T00:00:00.000Z");
+    const jobCandidates: MergeCandidate<string>[] = [
+      { row: "j0", sortTimeMs: t, id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" },
+      { row: "j1", sortTimeMs: t - 1000, id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaab" },
+    ];
+    const ingCandidates: MergeCandidate<string>[] = [
+      { row: "i0", sortTimeMs: t + 500, id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc" },
+    ];
+
+    const page1 = mergePage(jobCandidates, ingCandidates, 1, null);
+    expect(page1.nextCursor).not.toBeNull();
+    const encoded = encodeMergedRunsCursor(page1.nextCursor!);
+    const decoded = decodeMergedRunsCursor(encoded);
+    const page2 = mergePage(jobCandidates, [], 5, decoded);
+
+    const full = mergePage(jobCandidates, ingCandidates, 5, null);
+    expect([...page1.items, ...page2.items]).toEqual(full.items);
+  });
+
+  it("surfaces stream exhaustion flags consistently when one stream is empty", () => {
+    const t = Date.parse("2026-04-01T00:00:00.000Z");
+    const onlyJobs: MergeCandidate<string>[] = [
+      { row: "j0", sortTimeMs: t, id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd" },
+    ];
+    const merged = mergePage(onlyJobs, [], 10, null);
+    expect(merged.pagination.ingestion_stream_exhausted).toBe(true);
+    expect(merged.pagination.job_stream_exhausted).toBe(true);
+    expect(merged.items).toHaveLength(1);
+  });
+});
+
+describe("pre-go-live simulation (tagged interleave)", () => {
+  it("preserves total ordering when interleaving job and ingestion streams with shared clock", () => {
+    const t0 = Date.parse("2026-05-01T12:00:00.000Z");
+    const jobCandidates: MergeCandidate<Tagged>[] = [
+      { row: { tenant: "A", kind: "job", payload: "a" }, sortTimeMs: t0, id: "11111111-1111-4111-8111-111111111111" },
+      { row: { tenant: "A", kind: "job", payload: "b" }, sortTimeMs: t0 - 1, id: "11111111-1111-4111-8111-111111111112" },
+    ];
+    const ingCandidates: MergeCandidate<Tagged>[] = [
+      { row: { tenant: "A", kind: "ing", payload: "x" }, sortTimeMs: t0, id: "22222222-2222-4222-8222-222222222222" },
+    ];
+
+    const merged = mergeDualStreamPage({
+      limit: 10,
+      jobCandidates,
+      ingestionCandidates: ingCandidates,
+      mapJob: (r) => r,
+      mapIngestion: (r) => r,
+      prev: null,
+    });
+
+    const keys = merged.items.map((x) => (x as Tagged).payload);
+    expect(keys[0]).toBe("x");
+    expect(keys[1]).toBe("a");
+    expect(keys[2]).toBe("b");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **executable, deterministic** coverage for merged reconciliation list behavior **and** extends **API contract + input hardening** for `POST /api/v1/reconciliation/run` and `GET /api/v1/reconciliation/runs`.

## Changes

### Reconciliation core
- **`packages/reconciliation-core/src/pre-go-live-simulation.test.ts`**: Concurrent reads, tenant-isolated buffers, cursor pagination (API-shaped refetch), cursor round-trip, stream exhaustion, ordering.

### API
- **`packages/api/src/routes/v1/reconciliation.ts`**:
  - `ingestionId`: require non-empty **string** or **finite number** (reject object/array/null).
  - `jobId` / `templateId`: optional **trimmed strings** (no `any`).
  - **`logInfo`** on successful list: `event: reconciliation.runs_listed` with bounded meta (limit, run_kind, returned, has_more, cursor_present, tenantId, traceId).
- **`packages/api/src/__tests__/routes/reconciliation-v1-contract.test.ts`**: Parallel `GET /runs` identical responses; POST rejects bad `ingestionId`; POST forwards trimmed `jobId`/`templateId`.

### Tooling / docs
- **`verify:pre-go-live-simulation`**: Runs reconciliation-core simulation **and** API contract jest file.
- **`docs/ops/pre-go-live-simulation.md`**: Updated evidence scope and caveats.

## Validation

- `pnpm run verify:pre-go-live-simulation`
- `pnpm typecheck`
- `pnpm run verify:fast`

## Honest limits

- API tests use **mocks** for Prisma merge fetch and `runReconciliation`; they prove **routing + validation + response shape under concurrency**, not live DB load.
- DB-backed tenant isolation for merged lists remains opt-in (`RUN_RECON_MERGED_LIST_DB=1`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54bc9802-132d-4f3a-84df-e75c6b4b0c66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54bc9802-132d-4f3a-84df-e75c6b4b0c66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

