### PR TITLE
Harden runs retry path with duplicate-pressure guard and add pre-go-live simulation tests

### DIFF
--- a/packages/api/src/routes/__tests__/runs.pre-go-live-simulation.test.ts
+++ b/packages/api/src/routes/__tests__/runs.pre-go-live-simulation.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Pre-go-live simulation coverage for operator runs APIs.
+ *
+ * These scenarios intentionally exercise concurrent reads, degraded detail fetches,
+ * and retry-duplication pressure with tenant-safe assertions.
+ */
+
+import request from "supertest";
+import express from "express";
+import { runsRouter } from "../runs";
+import { AuthRequest } from "../../middleware/auth";
+
+jest.mock("../../infrastructure/db/prisma", () => ({
+  prisma: {
+    reconResult: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+
+const mockResolveOperatorRunDetail = jest.fn();
+jest.mock(
+  "@settler/reconciliation-core",
+  () => ({
+    resolveOperatorRunDetailForTenants: (...args: unknown[]) =>
+      mockResolveOperatorRunDetail(...args),
+  }),
+  { virtual: true }
+);
+
+const { prisma: mockedPrisma } = require("../../infrastructure/db/prisma");
+const mockReconResult = mockedPrisma.reconResult;
+
+jest.mock("../../middleware/governance", () => ({
+  enforceFreezeState: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+  bypassFreeze: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../../middleware/authorization", () => ({
+  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../../middleware/validation", () => ({
+  validateRequest: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../../utils/event-tracker", () => ({
+  trackEventAsync: jest.fn(),
+}));
+
+jest.mock("../../utils/logger", () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+  logWarn: jest.fn(),
+}));
+
+function buildApp(tenantId: string, userId = "operator-sim"): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as AuthRequest).tenantId = tenantId;
+    (req as AuthRequest).userId = userId;
+    next();
+  });
+  app.use("/api/runs", runsRouter);
+  return app;
+}
+
+describe("Runs pre-go-live simulation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveOperatorRunDetail.mockReset();
+  });
+
+  it("sustains bursty multi-tenant list/detail polling without tenant scope drift", async () => {
+    const appA = buildApp("tenant-A");
+    const appB = buildApp("tenant-B");
+
+    mockReconResult.findMany.mockImplementation(({ where }: { where: { tenantId: string } }) =>
+      Promise.resolve([
+        {
+          id: `${where.tenantId}-run-1`,
+          reconJobId: `${where.tenantId}-job-1`,
+          reconJob: { name: `Daily ${where.tenantId}` },
+          status: "running",
+          startedAt: new Date("2026-03-28T10:00:00Z"),
+          completedAt: null,
+          summary: { total: 10, matched: 8, unmatched: 2, conflicts: 0 },
+        },
+      ])
+    );
+    mockReconResult.count.mockResolvedValue(1);
+
+    mockResolveOperatorRunDetail.mockImplementation(
+      async (_prisma: unknown, tenantScope: string[], runId: string) => ({
+        kind: "ok",
+        detail: {
+          runKind: "recon_job" as const,
+          id: runId,
+          name: `Run ${runId}`,
+          status: "running",
+          progress: 50,
+          stages: [],
+          tenantScope,
+        },
+      })
+    );
+
+    const requests = Array.from({ length: 20 }).flatMap((_, idx) => [
+      request(appA).get(`/api/runs?page=${(idx % 3) + 1}&limit=10`),
+      request(appA).get(`/api/runs/tenant-A-run-${idx}`),
+      request(appB).get(`/api/runs?page=${(idx % 3) + 1}&limit=10`),
+      request(appB).get(`/api/runs/tenant-B-run-${idx}`),
+    ]);
+
+    const responses = await Promise.all(requests);
+    expect(responses.every((res) => res.status === 200)).toBe(true);
+
+    const listTenantIds = mockReconResult.findMany.mock.calls.map(
+      (call: [{ where: { tenantId: string } }]) => call[0].where.tenantId
+    );
+    expect(listTenantIds).toContain("tenant-A");
+    expect(listTenantIds).toContain("tenant-B");
+
+    const detailTenantScopes = mockResolveOperatorRunDetail.mock.calls.map(
+      (call: [unknown, string[], string]) => call[1][0]
+    );
+    expect(detailTenantScopes).toContain("tenant-A");
+    expect(detailTenantScopes).toContain("tenant-B");
+  });
+
+  it("keeps operator-visible truth explicit across mixed success/not-found/degraded detail responses", async () => {
+    const app = buildApp("tenant-sim");
+
+    mockResolveOperatorRunDetail
+      .mockResolvedValueOnce({
+        kind: "ok",
+        detail: { id: "run-ok", name: "ok", status: "running" },
+      })
+      .mockResolvedValueOnce({ kind: "not_found" })
+      .mockResolvedValueOnce({ kind: "recon_enrichment_failed", message: "snapshot timeout" });
+
+    const [ok, missing, degraded] = await Promise.all([
+      request(app).get("/api/runs/run-ok"),
+      request(app).get("/api/runs/run-missing"),
+      request(app).get("/api/runs/run-degraded"),
+    ]);
+
+    expect(ok.status).toBe(200);
+    expect(ok.body.data.status).toBe("running");
+
+    expect(missing.status).toBe(404);
+    expect(missing.body.error).toBe("NOT_FOUND");
+
+    expect(degraded.status).toBe(500);
+    expect(degraded.body.error).toBe("INTERNAL_SERVER_ERROR");
+  });
+
+  it("prevents duplicate retries during concurrent retry pressure on the same failed run", async () => {
+    const app = buildApp("tenant-retry", "operator-1");
+    let retryRunId: string | null = null;
+
+    mockReconResult.findFirst.mockImplementation(
+      async ({
+        where,
+      }: {
+        where: { id?: string; metadata?: { path: string[]; equals: string } };
+      }) => {
+        if (where.id) {
+          return {
+            id: where.id,
+            reconJobId: "job-1",
+            reconJob: { id: "job-1", name: "Daily Reconciliation" },
+            status: "failed",
+            tenantId: "tenant-retry",
+            startedAt: new Date(),
+            completedAt: new Date(),
+            summary: null,
+            errorMessage: "synthetic failure",
+          };
+        }
+
+        if (where.metadata?.equals && retryRunId) {
+          return { id: retryRunId };
+        }
+
+        return null;
+      }
+    );
+
+    mockReconResult.create.mockImplementation(async () => {
+      retryRunId = "retry-1";
+      return {
+        id: "retry-1",
+        reconJobId: "job-1",
+        status: "running",
+        startedAt: new Date(),
+      };
+    });
+
+    const [first, second] = await Promise.all([
+      request(app).post("/api/runs/run-failed/retry"),
+      request(app).post("/api/runs/run-failed/retry"),
+    ]);
+
+    const statuses = [first.status, second.status].sort((a, b) => a - b);
+    expect(statuses).toEqual([201, 409]);
+    expect(mockReconResult.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/routes/__tests__/runs.test.ts
+++ b/packages/api/src/routes/__tests__/runs.test.ts
@@ -27,9 +27,14 @@ jest.mock("../../infrastructure/db/prisma", () => ({
 }));
 
 const mockResolveOperatorRunDetail = jest.fn();
-jest.mock("@settler/reconciliation-core", () => ({
-  resolveOperatorRunDetailForTenants: (...args: unknown[]) => mockResolveOperatorRunDetail(...args),
-}));
+jest.mock(
+  "@settler/reconciliation-core",
+  () => ({
+    resolveOperatorRunDetailForTenants: (...args: unknown[]) =>
+      mockResolveOperatorRunDetail(...args),
+  }),
+  { virtual: true }
+);
 
 // Access the mocked module after jest.mock is applied
 const { prisma: mockedPrisma } = require("../../infrastructure/db/prisma");
@@ -322,6 +327,7 @@ describe("Runs Routes", () => {
         summary: null,
         errorMessage: "Previous failure",
       });
+      mockReconResult.findFirst.mockResolvedValueOnce(null);
       mockReconResult.create.mockResolvedValueOnce({
         id: "run-new",
         reconJobId: "job-1",
@@ -341,6 +347,27 @@ describe("Runs Routes", () => {
       const res = await request(app).post("/api/runs/run-1/retry");
 
       expect(res.status).toBe(404);
+    });
+
+    it("should return 409 if retry is already in progress", async () => {
+      mockReconResult.findFirst
+        .mockResolvedValueOnce({
+          id: "run-1",
+          reconJobId: "job-1",
+          reconJob: { id: "job-1", name: "Daily Reconciliation" },
+          status: "failed",
+          tenantId: "tenant-123",
+          startedAt: new Date(),
+          completedAt: new Date(),
+          summary: null,
+          errorMessage: "Previous failure",
+        })
+        .mockResolvedValueOnce({ id: "run-retry-existing" });
+
+      const res = await request(app).post("/api/runs/run-1/retry");
+
+      expect(res.status).toBe(409);
+      expect(mockReconResult.create).not.toHaveBeenCalled();
     });
 
     it("should block retry if run is not failed", async () => {

--- a/packages/api/src/routes/runs.ts
+++ b/packages/api/src/routes/runs.ts
@@ -24,7 +24,12 @@ import { enforceFreezeState } from "../middleware/governance";
 import { resolveOperatorRunDetailForTenants } from "@settler/reconciliation-core";
 import { Run, RunSummary } from "@settler/types";
 import { handleRouteError } from "../utils/error-handler";
-import { ConflictError, InternalServerError, NotFoundError, ValidationError } from "../utils/typed-errors";
+import {
+  ConflictError,
+  InternalServerError,
+  NotFoundError,
+  ValidationError,
+} from "../utils/typed-errors";
 import { trackEventAsync } from "../utils/event-tracker";
 import { logInfo } from "../utils/logger";
 
@@ -222,6 +227,29 @@ router.post(
         ]);
       }
 
+      const existingRetry = await prisma.reconResult.findFirst({
+        where: {
+          tenantId,
+          reconJobId: originalRun.reconJobId,
+          status: "running",
+          metadata: {
+            path: ["retryOfRunId"],
+            equals: runId2,
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      if (existingRetry) {
+        throw new ConflictError("Retry already in progress for this run", {
+          code: "RETRY_ALREADY_IN_PROGRESS",
+          runId: runId2,
+          retryRunId: existingRetry.id,
+        });
+      }
+
       const newRun = await prisma.reconResult.create({
         data: {
           reconJob: {
@@ -231,6 +259,11 @@ router.post(
           },
           tenantId,
           status: "running",
+          metadata: {
+            retryOfRunId: runId2,
+            retryTriggeredBy: userId,
+            retryTriggeredAt: new Date().toISOString(),
+          },
         },
       });
 


### PR DESCRIPTION
### Motivation

- Prevent duplicate in-flight retry executions when operators or automation concurrently retry the same failed run, which breaks operator truth and complicates triage.
- Provide reproducible, route-level pre-go-live simulation coverage (multi-tenant bursts, degraded reads, concurrent retries) to prove behavior under realistic operator pressure.

### Description

- Added an active retry guard in `POST /api/runs/:runId/retry` that checks for an existing running retry execution scoped to the same `tenantId` + `reconJobId` and `metadata.retryOfRunId === <originalRunId>`, returning a `409` `RETRY_ALREADY_IN_PROGRESS` if found.
- Persisted retry provenance into the new retry execution `metadata` with `retryOfRunId`, `retryTriggeredBy`, and `retryTriggeredAt` for deterministic linkage and operator/audit clarity.
- Extended `packages/api/src/routes/__tests__/runs.test.ts` to cover the `409` conflict scenario when a retry already exists and adjusted mocks accordingly.
- Added a new pre-go-live simulation test suite `packages/api/src/routes/__tests__/runs.pre-go-live-simulation.test.ts` that exercises bursty multi-tenant list/detail polling, mixed detail outcomes (`ok`/`not_found`/`recon_enrichment_failed`), and concurrent retry pressure asserting deterministic `[201, 409]` outcomes.

### Testing

- Ran the targeted API test suites with `pnpm --filter @settler/api test -- src/routes/__tests__/runs.test.ts src/routes/__tests__/runs.pre-go-live-simulation.test.ts` and both suites passed (all tests in scope succeeded).
- Performed full workspace type checking with `pnpm typecheck` and it completed successfully (note: engine warnings surfaced due to running on Node v22 in this environment while repo requests Node >=24, but typecheck itself passed).
- Ran package lint for the API with `pnpm --filter @settler/api lint`; lint completed with existing repository warnings unrelated to this change and no new errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c73f7ff9f483288391220a6b75d5f0)