### PR TITLE
Add Exception Intelligence, Proof Graph, Evidence Packs, and Policy Sandbox

### DIFF
--- a/packages/api/src/routes/__tests__/exceptions.test.ts
+++ b/packages/api/src/routes/__tests__/exceptions.test.ts
@@ -25,6 +25,9 @@ jest.mock("../../infrastructure/db/prisma", () => ({
       update: jest.fn(),
       updateMany: jest.fn(),
     },
+    auditLog: {
+      create: jest.fn(),
+    },
   },
 }));
 
@@ -270,6 +273,12 @@ describe("Exceptions Routes", () => {
 
   describe("POST /api/exceptions/:id/resolve - Resolve Exception", () => {
     it("should resolve exception with valid resolution", async () => {
+      mockReconciliationMatch.findFirst.mockResolvedValueOnce({
+        id: "exc-1",
+        tenantId: "tenant-123",
+        metadata: {},
+        matchType: "unmatched",
+      });
       mockReconciliationMatch.update.mockResolvedValueOnce({
         id: "exc-1",
         reviewed: true,
@@ -287,7 +296,7 @@ describe("Exceptions Routes", () => {
     });
 
     it("should return 404 when exception not found", async () => {
-      mockReconciliationMatch.update.mockRejectedValueOnce(new Error("Record not found"));
+      mockReconciliationMatch.findFirst.mockResolvedValueOnce(null);
 
       const res = await request(app)
         .post("/api/exceptions/exc-1/resolve")
@@ -296,8 +305,8 @@ describe("Exceptions Routes", () => {
       expect(res.status).toBe(404);
     });
 
-    it("should return 404 when update throws (exception not found)", async () => {
-      mockReconciliationMatch.update.mockResolvedValueOnce(null);
+    it("should return 404 when exception missing in tenant scope", async () => {
+      mockReconciliationMatch.findFirst.mockResolvedValueOnce(null);
 
       const res = await request(app)
         .post("/api/exceptions/missing-exc/resolve")
@@ -309,7 +318,11 @@ describe("Exceptions Routes", () => {
 
   describe("POST /api/exceptions/bulk-resolve - Bulk Resolve", () => {
     it("should resolve multiple exceptions at once", async () => {
-      mockReconciliationMatch.updateMany.mockResolvedValueOnce({ count: 2 });
+      mockReconciliationMatch.findMany.mockResolvedValueOnce([
+        { id: "00000000-0000-4000-8000-000000000001", metadata: {} },
+        { id: "00000000-0000-4000-8000-000000000002", metadata: {} },
+      ]);
+      mockReconciliationMatch.update.mockResolvedValue({});
 
       const res = await request(app)
         .post("/api/exceptions/bulk-resolve")
@@ -327,7 +340,10 @@ describe("Exceptions Routes", () => {
     });
 
     it("should scope bulk resolve to tenant", async () => {
-      mockReconciliationMatch.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockReconciliationMatch.findMany.mockResolvedValueOnce([
+        { id: "00000000-0000-4000-8000-000000000001", metadata: {} },
+      ]);
+      mockReconciliationMatch.update.mockResolvedValue({});
 
       await request(app)
         .post("/api/exceptions/bulk-resolve")
@@ -336,7 +352,7 @@ describe("Exceptions Routes", () => {
           resolution: "matched",
         });
 
-      expect(mockReconciliationMatch.updateMany).toHaveBeenCalledWith(
+      expect(mockReconciliationMatch.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({ tenantId: "tenant-123" }),
         })
@@ -411,6 +427,12 @@ describe("Exceptions Routes", () => {
       expect(listRes.body.data).toHaveLength(1);
 
       // Step 2: Resolve exception
+      mockReconciliationMatch.findFirst.mockResolvedValueOnce({
+        id: "exc-1",
+        tenantId: "tenant-123",
+        metadata: {},
+        matchType: "unmatched",
+      });
       mockReconciliationMatch.update.mockResolvedValueOnce({
         id: "exc-1",
         reviewed: true,

--- a/packages/api/src/routes/exceptions.ts
+++ b/packages/api/src/routes/exceptions.ts
@@ -58,6 +58,29 @@ const bulkResolveSchema = z.object({
   }),
 });
 
+function appendAdjudicationHistory(
+  metadata: unknown,
+  entry: { actorId: string; resolution: string; notes: string | null }
+): Record<string, unknown> {
+  const base =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? ({ ...metadata } as Record<string, unknown>)
+      : {};
+  const current = Array.isArray(base["adjudicationHistory"])
+    ? [...(base["adjudicationHistory"] as unknown[])]
+    : [];
+  current.push({
+    actorId: entry.actorId,
+    resolution: entry.resolution,
+    notes: entry.notes,
+    timestamp: new Date().toISOString(),
+  });
+  return {
+    ...base,
+    adjudicationHistory: current.slice(-50),
+  };
+}
+
 // List exceptions (unmatched transactions)
 router.get(
   "/exceptions",
@@ -291,24 +314,49 @@ router.post(
       // - "ignored": Mark as reviewed but dismissed (not a match)
       // - "matched": Mark as reviewed and matched (automatic match found)
       // - "manual": Mark as reviewed and manually resolved by user
-      const resolved = await prisma.reconciliationMatch
-        .update({
-          where: { id },
-          data: {
-            reviewed: true,
-            reviewedBy: userId,
-            reviewedAt: new Date(),
-            matchReason: notes || `${resolution} resolution`,
-          },
-        })
-        .catch(() => null);
+      const existing = await prisma.reconciliationMatch.findFirst({
+        where: {
+          id,
+          tenantId: req.tenantId,
+          matchType: "unmatched",
+        },
+      });
 
-      if (!resolved) {
+      if (!existing) {
         return res.status(404).json({
           error: "NOT_FOUND",
           message: "Exception not found",
         });
       }
+
+      await prisma.reconciliationMatch.update({
+        where: { id },
+        data: {
+          reviewed: true,
+          reviewedBy: userId,
+          reviewedAt: new Date(),
+          matchReason: notes || `${resolution} resolution`,
+          metadata: appendAdjudicationHistory(existing.metadata, {
+            actorId: userId,
+            resolution,
+            notes: notes || null,
+          }) as any,
+        },
+      });
+
+      await prisma.auditLog.create({
+        data: {
+          tenantId: req.tenantId,
+          userId,
+          action: "exception_resolved",
+          resourceType: "reconciliation_match",
+          resourceId: id,
+          metadata: {
+            resolution,
+            notes: notes || null,
+          } as any,
+        },
+      });
 
       trackEventAsync(userId, "ExceptionResolved", {
         exceptionId: id,
@@ -346,18 +394,48 @@ router.post(
       const userId = req.userId!;
 
       // TRUTHFUL STATE: Handle all resolution types properly
-      const result = await prisma.reconciliationMatch.updateMany({
+      const existing = await prisma.reconciliationMatch.findMany({
         where: {
           id: { in: exceptionIds },
           tenantId: req.tenantId,
+          matchType: "unmatched",
         },
-        data: {
-          reviewed: true,
-          reviewedBy: userId,
-          reviewedAt: new Date(),
-          matchReason: notes || `${resolution} resolution`,
-        },
+        select: { id: true, metadata: true },
       });
+
+      let count = 0;
+      for (const exception of existing) {
+        await prisma.reconciliationMatch.update({
+          where: { id: exception.id },
+          data: {
+            reviewed: true,
+            reviewedBy: userId,
+            reviewedAt: new Date(),
+            matchReason: notes || `${resolution} resolution`,
+            metadata: appendAdjudicationHistory(exception.metadata, {
+              actorId: userId,
+              resolution,
+              notes: notes || null,
+            }) as any,
+          },
+        });
+
+        await prisma.auditLog.create({
+          data: {
+            tenantId: req.tenantId,
+            userId,
+            action: "exception_resolved",
+            resourceType: "reconciliation_match",
+            resourceId: exception.id,
+            metadata: {
+              resolution,
+              notes: notes || null,
+              bulk: true,
+            } as any,
+          },
+        });
+        count += 1;
+      }
 
       for (const exceptionId of exceptionIds) {
         trackEventAsync(userId, "ExceptionResolved", {
@@ -369,14 +447,14 @@ router.post(
 
       logInfo("Exceptions bulk resolved", {
         tenantId: req.tenantId,
-        count: result.count,
+        count,
         resolution,
         resolvedBy: userId,
       });
 
       res.json({
-        message: `Resolved ${result.count} exceptions successfully`,
-        count: result.count,
+        message: `Resolved ${count} exceptions successfully`,
+        count,
       });
     } catch (error: unknown) {
       handleRouteError(res, error, "Failed to bulk resolve exceptions", 500, {

--- a/packages/api/src/routes/v1/exception-intelligence.ts
+++ b/packages/api/src/routes/v1/exception-intelligence.ts
@@ -1,0 +1,142 @@
+import { Router, Response } from "express";
+import { z } from "zod";
+import { AuthRequest } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/authorization";
+import { Permission } from "../../infrastructure/security/Permissions";
+import { validateRequest } from "../../middleware/validation";
+import { handleRouteError } from "../../utils/error-handler";
+import { ExceptionIntelligenceService } from "../../services/operator-mode/exception-intelligence-service";
+
+const router: Router = Router();
+const service = new ExceptionIntelligenceService();
+
+const snapshotSchema = z.object({
+  query: z.object({
+    lookbackDays: z.coerce.number().int().min(1).max(365).default(30),
+  }),
+});
+
+const runSchema = z.object({
+  params: z.object({
+    runId: z.string().uuid(),
+  }),
+});
+
+const policySandboxSchema = z.object({
+  body: z.object({
+    runId: z.string().uuid(),
+    candidatePolicy: z.object({
+      amountTolerance: z.number().min(0).max(100000),
+      dateWindowDays: z.number().int().min(0).max(365),
+      fuzzyDescriptionThreshold: z.number().min(0).max(1),
+      requireExactAmount: z.boolean(),
+    }),
+  }),
+});
+
+router.get(
+  "/operator/intelligence/exceptions/snapshot",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(snapshotSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({
+          error: "TENANT_CONTEXT_REQUIRED",
+          message: "Tenant context is required",
+        });
+      }
+
+      const lookbackDays = Number(req.query.lookbackDays ?? 30);
+      const data = await service.getSnapshot(tenantId, lookbackDays);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load exception intelligence snapshot", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/intelligence/runs/:runId/proof-graph",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(runSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({
+          error: "TENANT_CONTEXT_REQUIRED",
+          message: "Tenant context is required",
+        });
+      }
+
+      const runIdParam = req.params["runId"];
+      const runId = Array.isArray(runIdParam) ? (runIdParam[0] ?? "") : (runIdParam ?? "");
+      const data = await service.getProofGraph(tenantId, runId);
+      return res.status(data.degraded && data.nodes.length === 0 ? 404 : 200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load proof graph", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/intelligence/runs/:runId/evidence-pack",
+  requirePermission(Permission.REPORTS_EXPORT),
+  validateRequest(runSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({
+          error: "TENANT_CONTEXT_REQUIRED",
+          message: "Tenant context is required",
+        });
+      }
+
+      const runIdParam = req.params["runId"];
+      const runId = Array.isArray(runIdParam) ? (runIdParam[0] ?? "") : (runIdParam ?? "");
+      const data = await service.buildEvidencePack(tenantId, runId);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to build evidence pack", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.post(
+  "/operator/intelligence/policy/sandbox",
+  requirePermission(Permission.ADMIN_WRITE),
+  validateRequest(policySandboxSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({
+          error: "TENANT_CONTEXT_REQUIRED",
+          message: "Tenant context is required",
+        });
+      }
+
+      const data = await service.simulatePolicy(tenantId, req.body);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to run policy sandbox", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+export default router;

--- a/packages/api/src/routes/v1/index.ts
+++ b/packages/api/src/routes/v1/index.ts
@@ -18,6 +18,7 @@ import reconciliationRouter from "./reconciliation";
 import ingestionExportsRouter from "./ingestion-exports";
 import { operatorModeRouter } from "./operator-mode";
 import operatorIntelligenceRouter from "./operator-intelligence";
+import exceptionIntelligenceRouter from "./exception-intelligence";
 import { systemHealthRouter } from "./system-health";
 import { runsRouter } from "./runs";
 import { governanceRouter } from "./governance";
@@ -83,6 +84,7 @@ v1Router.use("/dedicated-infrastructure", dedicatedInfrastructureRouter);
 // Operator mode routes
 v1Router.use("/", operatorModeRouter);
 v1Router.use("/", operatorIntelligenceRouter);
+v1Router.use("/", exceptionIntelligenceRouter);
 v1Router.use("/", systemHealthRouter);
 v1Router.use("/", runsRouter);
 v1Router.use("/", governanceRouter);

--- a/packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts
+++ b/packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts
@@ -1,0 +1,100 @@
+import { ExceptionIntelligenceService } from "../exception-intelligence-service";
+
+jest.mock("../../../infrastructure/db/prisma", () => ({
+  prisma: {
+    reconciliationMatch: {
+      findMany: jest.fn(),
+    },
+    reconciliationRun: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+const { prisma } = require("../../../infrastructure/db/prisma");
+
+describe("ExceptionIntelligenceService", () => {
+  const service = new ExceptionIntelligenceService();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("builds recurring exception clusters and recommendations", async () => {
+    prisma.reconciliationMatch.findMany.mockResolvedValue([
+      {
+        id: "m1",
+        metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
+        matchType: "unmatched",
+        matchReason: "amount variance",
+        amountDiff: 12,
+        dateDiff: 2,
+        confidence: 0.52,
+        reviewed: true,
+        reviewedAt: new Date("2026-03-28T10:10:00Z"),
+        createdAt: new Date("2026-03-28T10:00:00Z"),
+        sourceTransaction: {
+          sourceId: "s1",
+          category: "payments",
+          currency: "USD",
+          source: { id: "s1", name: "Stripe" },
+        },
+      },
+      {
+        id: "m2",
+        metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
+        matchType: "unmatched",
+        matchReason: "amount variance",
+        amountDiff: 12,
+        dateDiff: 2,
+        confidence: 0.54,
+        reviewed: false,
+        reviewedAt: null,
+        createdAt: new Date("2026-03-28T11:00:00Z"),
+        sourceTransaction: {
+          sourceId: "s1",
+          category: "payments",
+          currency: "USD",
+          source: { id: "s1", name: "Stripe" },
+        },
+      },
+    ]);
+
+    const result = await service.getSnapshot("00000000-0000-4000-8000-000000000001", 30);
+
+    expect(result.totals.exceptions).toBe(2);
+    expect(result.totals.recurringSignatures).toBe(1);
+    expect(result.clusters[0]?.recommendedAction.action).toBe("manual_review");
+    expect(result.sourceReliability[0]).toMatchObject({ sourceId: "s1", totalExceptions: 2 });
+  });
+
+  it("returns degraded proof graph when run is missing or out of tenant scope", async () => {
+    prisma.reconciliationRun.findFirst.mockResolvedValue(null);
+
+    const graph = await service.getProofGraph(
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000010"
+    );
+
+    expect(graph.degraded).toBe(true);
+    expect(graph.degradedReasons).toContain("run_not_found_or_not_scoped");
+    expect(graph.nodes).toHaveLength(0);
+  });
+
+  it("returns explicit simulation degraded note when run is missing", async () => {
+    prisma.reconciliationRun.findFirst.mockResolvedValue(null);
+
+    const result = await service.simulatePolicy("00000000-0000-4000-8000-000000000001", {
+      runId: "00000000-0000-4000-8000-000000000010",
+      candidatePolicy: {
+        amountTolerance: 1,
+        dateWindowDays: 5,
+        fuzzyDescriptionThreshold: 0.8,
+        requireExactAmount: false,
+      },
+    });
+
+    expect(result.notes).toContain("run_not_found_or_not_scoped");
+    expect(result.blastRadius.impactedRecords).toBe(0);
+  });
+});

--- a/packages/api/src/services/operator-mode/exception-intelligence-service.ts
+++ b/packages/api/src/services/operator-mode/exception-intelligence-service.ts
@@ -1,0 +1,595 @@
+import crypto from "node:crypto";
+import { prisma } from "../../infrastructure/db/prisma";
+import {
+  buildWorkbenchItem,
+  type ReconciliationWorkbenchItem,
+} from "../../routes/v1/reconciliation-trust-contract";
+
+export interface ExceptionRecommendation {
+  action: "auto_match_candidate" | "manual_review" | "policy_adjustment";
+  reason: string;
+  confidence: number;
+  evidence: string[];
+}
+
+export interface ExceptionCluster {
+  signature: string;
+  clusterKey: string;
+  volume: number;
+  openCount: number;
+  resolvedCount: number;
+  medianTimeToResolutionMinutes: number | null;
+  recommendedAction: ExceptionRecommendation;
+}
+
+export interface SourceReliability {
+  sourceId: string;
+  sourceName: string;
+  reliabilityScore: number;
+  totalExceptions: number;
+  resolvedRate: number;
+}
+
+export interface ExceptionIntelligenceSnapshot {
+  generatedAt: string;
+  tenantId: string;
+  totals: {
+    exceptions: number;
+    open: number;
+    resolved: number;
+    recurringSignatures: number;
+  };
+  clusters: ExceptionCluster[];
+  sourceReliability: SourceReliability[];
+}
+
+export interface ProofGraphNode {
+  id: string;
+  type: "run" | "policy" | "exception" | "decision" | "evidence" | "export";
+  label: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface ProofGraphEdge {
+  from: string;
+  to: string;
+  relation:
+    | "applied_policy"
+    | "produced_exception"
+    | "resolved_by"
+    | "supported_by"
+    | "exported_as";
+}
+
+export interface ProofGraphResponse {
+  runId: string;
+  tenantId: string;
+  degraded: boolean;
+  degradedReasons: string[];
+  nodes: ProofGraphNode[];
+  edges: ProofGraphEdge[];
+}
+
+export interface EvidencePack {
+  runId: string;
+  tenantId: string;
+  generatedAt: string;
+  graphDigestSha256: string;
+  lineage: ProofGraphResponse;
+  exceptions: Array<{
+    id: string;
+    status: string;
+    reviewedAt: string | null;
+    reviewedBy: string | null;
+  }>;
+  policy: {
+    configVersion: string | null;
+    configSource: string | null;
+    matchingRuleIds: string[];
+  };
+}
+
+export interface PolicySandboxRequest {
+  runId: string;
+  candidatePolicy: {
+    amountTolerance: number;
+    dateWindowDays: number;
+    fuzzyDescriptionThreshold: number;
+    requireExactAmount: boolean;
+  };
+}
+
+export interface PolicySandboxResult {
+  runId: string;
+  tenantId: string;
+  simulatedAt: string;
+  baseline: {
+    matchRate: number;
+    exceptionRate: number;
+    manualReviewLoad: number;
+  };
+  candidate: {
+    matchRate: number;
+    exceptionRate: number;
+    manualReviewLoad: number;
+  };
+  blastRadius: {
+    impactedRecords: number;
+    newlyManualReview: number;
+    newlyAutoMatched: number;
+  };
+  notes: string[];
+}
+
+type ClusterAccumulator = {
+  signature: string;
+  clusterKey: string;
+  volume: number;
+  openCount: number;
+  resolvedCount: number;
+  durations: number[];
+  unmatchedCount: number;
+  lowConfidenceCount: number;
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function sortedStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .slice()
+    .sort();
+}
+
+function buildExceptionSignature(parts: Array<string | number | null | undefined>): string {
+  return crypto
+    .createHash("sha256")
+    .update(parts.map((part) => String(part ?? "na")).join("|"))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function buildRecommendation(cluster: ClusterAccumulator): ExceptionRecommendation {
+  if (cluster.unmatchedCount / Math.max(cluster.volume, 1) > 0.7) {
+    return {
+      action: "manual_review",
+      reason: "High unmatched concentration requires human adjudication.",
+      confidence: 0.92,
+      evidence: [
+        `unmatched_ratio=${(cluster.unmatchedCount / Math.max(cluster.volume, 1)).toFixed(2)}`,
+        `volume=${cluster.volume}`,
+      ],
+    };
+  }
+
+  if (cluster.lowConfidenceCount / Math.max(cluster.volume, 1) > 0.4) {
+    return {
+      action: "policy_adjustment",
+      reason: "Low-confidence recurring signature suggests tolerance/policy drift.",
+      confidence: 0.78,
+      evidence: [
+        `low_confidence_ratio=${(cluster.lowConfidenceCount / Math.max(cluster.volume, 1)).toFixed(2)}`,
+      ],
+    };
+  }
+
+  return {
+    action: "auto_match_candidate",
+    reason: "Historically resolved cluster with stable signature.",
+    confidence: 0.71,
+    evidence: [
+      `resolved_ratio=${(cluster.resolvedCount / Math.max(cluster.volume, 1)).toFixed(2)}`,
+    ],
+  };
+}
+
+export class ExceptionIntelligenceService {
+  async getSnapshot(
+    tenantId: string,
+    lookbackDays: number
+  ): Promise<ExceptionIntelligenceSnapshot> {
+    const since = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
+    const matches = await prisma.reconciliationMatch.findMany({
+      where: {
+        tenantId,
+        createdAt: { gte: since },
+      },
+      include: {
+        sourceTransaction: {
+          select: {
+            sourceId: true,
+            category: true,
+            currency: true,
+            source: {
+              select: { id: true, name: true },
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 1500,
+    });
+
+    const clusters = new Map<string, ClusterAccumulator>();
+    const sourceAgg = new Map<string, { sourceName: string; total: number; resolved: number }>();
+
+    for (const match of matches) {
+      const metadata = asObject(match.metadata);
+      const rationaleCodes = sortedStrings(metadata["rationale_codes"]);
+      const clusterKey = [
+        match.matchType,
+        match.sourceTransaction?.category ?? "uncategorized",
+        match.sourceTransaction?.currency ?? "unknown",
+        rationaleCodes.join(",") || "none",
+      ].join("|");
+      const signature = buildExceptionSignature([
+        clusterKey,
+        match.matchReason,
+        match.amountDiff?.toString(),
+        match.dateDiff,
+      ]);
+
+      const current = clusters.get(signature) ?? {
+        signature,
+        clusterKey,
+        volume: 0,
+        openCount: 0,
+        resolvedCount: 0,
+        durations: [],
+        unmatchedCount: 0,
+        lowConfidenceCount: 0,
+      };
+      current.volume += 1;
+      if (match.reviewed) {
+        current.resolvedCount += 1;
+        if (match.reviewedAt) {
+          current.durations.push((match.reviewedAt.getTime() - match.createdAt.getTime()) / 60000);
+        }
+      } else {
+        current.openCount += 1;
+      }
+      if (match.matchType === "unmatched") current.unmatchedCount += 1;
+      if (Number(match.confidence) < 0.75) current.lowConfidenceCount += 1;
+      clusters.set(signature, current);
+
+      const sourceId = match.sourceTransaction?.sourceId;
+      const sourceName = match.sourceTransaction?.source?.name ?? "unknown";
+      if (sourceId) {
+        const source = sourceAgg.get(sourceId) ?? { sourceName, total: 0, resolved: 0 };
+        source.total += 1;
+        if (match.reviewed) source.resolved += 1;
+        sourceAgg.set(sourceId, source);
+      }
+    }
+
+    const clusterItems = Array.from(clusters.values())
+      .map((cluster): ExceptionCluster => {
+        const orderedDurations = cluster.durations.slice().sort((a, b) => a - b);
+        const medianIndex = Math.floor(orderedDurations.length / 2);
+        return {
+          signature: cluster.signature,
+          clusterKey: cluster.clusterKey,
+          volume: cluster.volume,
+          openCount: cluster.openCount,
+          resolvedCount: cluster.resolvedCount,
+          medianTimeToResolutionMinutes:
+            orderedDurations.length > 0 ? Math.round(orderedDurations[medianIndex] ?? 0) : null,
+          recommendedAction: buildRecommendation(cluster),
+        };
+      })
+      .sort((a, b) => b.volume - a.volume)
+      .slice(0, 20);
+
+    const sourceReliability = Array.from(sourceAgg.entries())
+      .map(([sourceId, source]): SourceReliability => {
+        const resolvedRate = source.total === 0 ? 0 : source.resolved / source.total;
+        const reliabilityScore = Math.round(
+          (1 - (source.total - source.resolved) / Math.max(source.total, 1)) * 100
+        );
+        return {
+          sourceId,
+          sourceName: source.sourceName,
+          totalExceptions: source.total,
+          resolvedRate: Number(resolvedRate.toFixed(4)),
+          reliabilityScore,
+        };
+      })
+      .sort((a, b) => b.reliabilityScore - a.reliabilityScore)
+      .slice(0, 20);
+
+    const totalExceptions = matches.length;
+    const resolved = matches.filter((match) => match.reviewed).length;
+
+    return {
+      generatedAt: new Date().toISOString(),
+      tenantId,
+      totals: {
+        exceptions: totalExceptions,
+        open: totalExceptions - resolved,
+        resolved,
+        recurringSignatures: clusterItems.filter((cluster) => cluster.volume > 1).length,
+      },
+      clusters: clusterItems,
+      sourceReliability,
+    };
+  }
+
+  async getProofGraph(tenantId: string, runId: string): Promise<ProofGraphResponse> {
+    const run = await prisma.reconciliationRun.findFirst({
+      where: { id: runId, tenantId },
+      include: {
+        matches: {
+          include: { sourceTransaction: { select: { id: true, externalId: true } } },
+          orderBy: { createdAt: "asc" },
+          take: 200,
+        },
+      },
+    });
+
+    if (!run) {
+      return {
+        runId,
+        tenantId,
+        degraded: true,
+        degradedReasons: ["run_not_found_or_not_scoped"],
+        nodes: [],
+        edges: [],
+      };
+    }
+
+    const nodes: ProofGraphNode[] = [
+      {
+        id: `run:${run.id}`,
+        type: "run",
+        label: `Run ${run.id}`,
+        metadata: {
+          status: run.status,
+          startedAt: run.startedAt.toISOString(),
+          completedAt: run.completedAt?.toISOString() ?? null,
+        },
+      },
+    ];
+    const edges: ProofGraphEdge[] = [];
+    const degradedReasons: string[] = [];
+
+    const policyMetadata = asObject(run.metadata);
+    const policyNode: ProofGraphNode = {
+      id: `policy:${run.id}`,
+      type: "policy",
+      label: `Policy for run ${run.id}`,
+      metadata: {
+        amountTolerance: policyMetadata["amountTolerance"] ?? null,
+        dateWindowDays: policyMetadata["dateWindowDays"] ?? null,
+      },
+    };
+    nodes.push(policyNode);
+    edges.push({ from: `run:${run.id}`, to: policyNode.id, relation: "applied_policy" });
+
+    if (run.matches.length === 0) degradedReasons.push("run_has_no_match_records");
+
+    for (const match of run.matches) {
+      const exceptionNodeId = `exception:${match.id}`;
+      const decisionNodeId = `decision:${match.id}`;
+
+      nodes.push({
+        id: exceptionNodeId,
+        type: "exception",
+        label: `Exception ${match.id}`,
+        metadata: {
+          classification: match.matchType,
+          confidence: Number(match.confidence),
+          reviewed: match.reviewed,
+          sourceExternalId: match.sourceTransaction.externalId,
+        },
+      });
+      edges.push({ from: `run:${run.id}`, to: exceptionNodeId, relation: "produced_exception" });
+
+      nodes.push({
+        id: decisionNodeId,
+        type: "decision",
+        label: `Decision ${match.id}`,
+        metadata: {
+          reviewedAt: match.reviewedAt?.toISOString() ?? null,
+          reviewedBy: match.reviewedBy,
+          reason: match.matchReason,
+        },
+      });
+      edges.push({ from: exceptionNodeId, to: decisionNodeId, relation: "resolved_by" });
+
+      const evidenceNodeId = `evidence:${match.id}`;
+      nodes.push({
+        id: evidenceNodeId,
+        type: "evidence",
+        label: `Evidence ${match.id}`,
+        metadata: {
+          amountDiff: match.amountDiff ? Number(match.amountDiff) : null,
+          dateDiff: match.dateDiff,
+        },
+      });
+      edges.push({ from: decisionNodeId, to: evidenceNodeId, relation: "supported_by" });
+    }
+
+    return {
+      runId,
+      tenantId,
+      degraded: degradedReasons.length > 0,
+      degradedReasons,
+      nodes,
+      edges,
+    };
+  }
+
+  async buildEvidencePack(tenantId: string, runId: string): Promise<EvidencePack> {
+    const graph = await this.getProofGraph(tenantId, runId);
+    const run = await prisma.reconciliationRun.findFirst({
+      where: { id: runId, tenantId },
+      select: {
+        id: true,
+        metadata: true,
+        matches: { select: { id: true, reviewed: true, reviewedAt: true, reviewedBy: true } },
+      },
+    });
+
+    const runMetadata = asObject(run?.metadata);
+    const policyConfig = asObject(runMetadata["_provenance"]);
+
+    const graphDigestSha256 = crypto
+      .createHash("sha256")
+      .update(JSON.stringify(graph))
+      .digest("hex");
+
+    return {
+      runId,
+      tenantId,
+      generatedAt: new Date().toISOString(),
+      graphDigestSha256,
+      lineage: graph,
+      exceptions: (run?.matches ?? []).map((match) => ({
+        id: match.id,
+        status: match.reviewed ? "resolved" : "open",
+        reviewedAt: match.reviewedAt?.toISOString() ?? null,
+        reviewedBy: match.reviewedBy,
+      })),
+      policy: {
+        configVersion:
+          typeof policyConfig["configVersion"] === "string"
+            ? (policyConfig["configVersion"] as string)
+            : null,
+        configSource:
+          typeof policyConfig["configSource"] === "string"
+            ? (policyConfig["configSource"] as string)
+            : null,
+        matchingRuleIds: sortedStrings(policyConfig["matchingRuleIds"]),
+      },
+    };
+  }
+
+  async simulatePolicy(
+    tenantId: string,
+    input: PolicySandboxRequest
+  ): Promise<PolicySandboxResult> {
+    const run = await prisma.reconciliationRun.findFirst({
+      where: { id: input.runId, tenantId },
+      include: {
+        matches: {
+          include: {
+            sourceTransaction: {
+              select: {
+                id: true,
+                externalId: true,
+                amount: true,
+                currency: true,
+                date: true,
+                description: true,
+              },
+            },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+
+    if (!run) {
+      return {
+        runId: input.runId,
+        tenantId,
+        simulatedAt: new Date().toISOString(),
+        baseline: { matchRate: 0, exceptionRate: 0, manualReviewLoad: 0 },
+        candidate: { matchRate: 0, exceptionRate: 0, manualReviewLoad: 0 },
+        blastRadius: { impactedRecords: 0, newlyManualReview: 0, newlyAutoMatched: 0 },
+        notes: ["run_not_found_or_not_scoped"],
+      };
+    }
+
+    const baseItems: ReconciliationWorkbenchItem[] = run.matches.map((match) =>
+      buildWorkbenchItem(
+        {
+          id: match.id,
+          run_id: run.id,
+          match_type: match.matchType as ReconciliationWorkbenchItem["classification"],
+          confidence: Number(match.confidence),
+          match_reason: match.matchReason,
+          amount_diff: match.amountDiff ? Number(match.amountDiff) : null,
+          date_diff: match.dateDiff,
+          reviewed: match.reviewed,
+          reviewed_at: match.reviewedAt,
+          reviewed_by: match.reviewedBy,
+          metadata: match.metadata as Record<string, unknown>,
+          source_id: match.sourceTransaction.id,
+          source_amount: Number(match.sourceTransaction.amount),
+          source_currency: match.sourceTransaction.currency,
+          source_date: match.sourceTransaction.date,
+          source_description: match.sourceTransaction.description,
+          source_external_id: match.sourceTransaction.externalId,
+          target_id: null,
+          target_amount: null,
+          target_currency: null,
+          target_date: null,
+          target_description: null,
+          target_external_id: null,
+        },
+        run.metadata as Record<string, unknown>
+      )
+    );
+
+    const candidateItems = baseItems.map((item) => {
+      const amountDiff = item.explanation.amountComparison.amountDifference;
+      const dateDiff = item.explanation.dateComparison.dateDifferenceDays;
+      const candidateWithinTolerance =
+        (amountDiff === null || amountDiff <= input.candidatePolicy.amountTolerance) &&
+        (dateDiff === null || Math.abs(dateDiff) <= input.candidatePolicy.dateWindowDays);
+
+      const candidateQueue = candidateWithinTolerance ? "matched" : "manual_review";
+      return {
+        ...item,
+        queue: candidateQueue,
+        explanation: {
+          ...item.explanation,
+          tolerancePolicy: input.candidatePolicy,
+        },
+      };
+    });
+
+    const total = Math.max(baseItems.length, 1);
+    const baselineMatched = baseItems.filter((item) => item.classification !== "unmatched").length;
+    const baselineManual = baseItems.filter((item) => item.queue !== "matched").length;
+    const candidateMatched = candidateItems.filter((item) => item.queue === "matched").length;
+    const candidateManual = candidateItems.filter((item) => item.queue !== "matched").length;
+
+    const newlyManualReview = candidateItems.filter(
+      (candidate, index) => baseItems[index]?.queue === "matched" && candidate.queue !== "matched"
+    ).length;
+    const newlyAutoMatched = candidateItems.filter(
+      (candidate, index) => baseItems[index]?.queue !== "matched" && candidate.queue === "matched"
+    ).length;
+
+    return {
+      runId: input.runId,
+      tenantId,
+      simulatedAt: new Date().toISOString(),
+      baseline: {
+        matchRate: Number((baselineMatched / total).toFixed(4)),
+        exceptionRate: Number(((total - baselineMatched) / total).toFixed(4)),
+        manualReviewLoad: baselineManual,
+      },
+      candidate: {
+        matchRate: Number((candidateMatched / total).toFixed(4)),
+        exceptionRate: Number(((total - candidateMatched) / total).toFixed(4)),
+        manualReviewLoad: candidateManual,
+      },
+      blastRadius: {
+        impactedRecords: newlyManualReview + newlyAutoMatched,
+        newlyManualReview,
+        newlyAutoMatched,
+      },
+      notes: [
+        "simulation_only_not_production_truth",
+        "false_positive_false_negative_require_labeled_ground_truth",
+      ],
+    };
+  }
+}

--- a/packages/api/src/services/recon-core/provenance-service.ts
+++ b/packages/api/src/services/recon-core/provenance-service.ts
@@ -1,25 +1,43 @@
 /**
  * Evidence & Traceability Service
  *
- * Provides comprehensive audit trail for reconciliation decisions:
- * - Rule ID + version tracking per match
- * - Actor tracking (system vs human)
- * - Status transition logging
- * - Evidence chain normalization
- *
- * Part of Phase III: Evidence & Traceability
- *
- * NOTE: This service is currently a stub. The ExecutionProvenance model
- * referenced in this code does not exist in the Prisma schema.
- * These methods will log warnings instead of persisting data.
+ * Canonical provenance recorder for reconciliation decisions.
+ * Persists deterministic provenance entries with tenant scoping.
  */
 
-import { PrismaClient } from "@prisma/client";
+import crypto from "node:crypto";
+import { PrismaClient, Prisma } from "@prisma/client";
 import { type DeterministicMatch } from "./deterministic-types";
 
-/**
- * Provenance service for recording execution evidence
- */
+function toJsonValue(input: unknown): Prisma.InputJsonValue {
+  return (input ?? {}) as Prisma.InputJsonValue;
+}
+
+function buildEntryHash(input: {
+  runResultId: string;
+  snapshotId: string;
+  sequence: number;
+  operation: string;
+  entityType: string;
+  entityId: string;
+  details: unknown;
+}): string {
+  return crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        runResultId: input.runResultId,
+        snapshotId: input.snapshotId,
+        sequence: input.sequence,
+        operation: input.operation,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        details: input.details,
+      })
+    )
+    .digest("hex");
+}
+
 export class ProvenanceService {
   private prisma: PrismaClient;
 
@@ -27,72 +45,141 @@ export class ProvenanceService {
     this.prisma = prisma;
   }
 
-  /**
-   * Record a match creation event
-   * STUB: ExecutionProvenance table does not exist in schema
-   */
+  private async resolveTenantId(runResultId: string): Promise<string> {
+    const result = await this.prisma.reconResult.findUnique({
+      where: { id: runResultId },
+      select: { tenantId: true },
+    });
+
+    if (!result) {
+      throw new Error(`Cannot record provenance: run result ${runResultId} not found`);
+    }
+
+    return result.tenantId;
+  }
+
   async recordMatch(
-    _runResultId: string,
-    _snapshotId: string,
-    _match: DeterministicMatch,
-    _sequence: number
+    runResultId: string,
+    snapshotId: string,
+    match: DeterministicMatch,
+    sequence: number
   ): Promise<void> {
-    // Stub - provenance recording not implemented
-    // The ExecutionProvenance model does not exist in the Prisma schema
+    const tenantId = await this.resolveTenantId(runResultId);
+    await this.prisma.executionProvenance.create({
+      data: {
+        tenantId,
+        runResultId,
+        snapshotId,
+        sequence,
+        operation: "match_created",
+        entityType: "reconciliation_match",
+        entityId: match.id,
+        confidence: match.confidence,
+        ruleId: match.ruleId,
+        ruleVersion: match.ruleVersion,
+        actor: "system",
+        details: toJsonValue({
+          sourceRecordId: match.sourceId,
+          targetRecordId: match.targetId,
+          reason: match.reason,
+          metadata: match.metadata,
+        }),
+        entryHash: buildEntryHash({
+          runResultId,
+          snapshotId,
+          sequence,
+          operation: "match_created",
+          entityType: "reconciliation_match",
+          entityId: match.id,
+          details: match,
+        }),
+      },
+    });
   }
 
-  /**
-   * Record a review decision
-   * STUB: ExecutionProvenance table does not exist in schema
-   */
   async recordReviewDecision(
-    _runResultId: string,
-    _snapshotId: string,
-    _matchId: string,
-    _decision: "approved" | "rejected" | "override",
-    _actor: "system" | "human",
-    _actorUserId: string | undefined,
-    _reason: string,
-    _sequence: number
+    runResultId: string,
+    snapshotId: string,
+    matchId: string,
+    decision: "approved" | "rejected" | "override",
+    actor: "system" | "human",
+    actorUserId: string | undefined,
+    reason: string,
+    sequence: number
   ): Promise<void> {
-    // Stub - provenance recording not implemented
+    const tenantId = await this.resolveTenantId(runResultId);
+    await this.prisma.executionProvenance.create({
+      data: {
+        tenantId,
+        runResultId,
+        snapshotId,
+        sequence,
+        operation: "review_decision",
+        entityType: "reconciliation_match",
+        entityId: matchId,
+        actor,
+        actorUserId,
+        details: toJsonValue({ decision, reason }),
+        entryHash: buildEntryHash({
+          runResultId,
+          snapshotId,
+          sequence,
+          operation: "review_decision",
+          entityType: "reconciliation_match",
+          entityId: matchId,
+          details: { decision, reason, actor, actorUserId },
+        }),
+      },
+    });
   }
 
-  /**
-   * Record run status transition
-   * STUB: ExecutionProvenance table does not exist in schema
-   */
   async recordStatusTransition(
-    _runResultId: string,
-    _snapshotId: string,
-    _fromStatus: string,
-    _toStatus: string,
-    _actor: "system" | "human",
-    _actorUserId: string | undefined,
-    _reason: string,
-    _sequence: number
+    runResultId: string,
+    snapshotId: string,
+    fromStatus: string,
+    toStatus: string,
+    actor: "system" | "human",
+    actorUserId: string | undefined,
+    reason: string,
+    sequence: number
   ): Promise<void> {
-    // Stub - provenance recording not implemented
+    const tenantId = await this.resolveTenantId(runResultId);
+    await this.prisma.executionProvenance.create({
+      data: {
+        tenantId,
+        runResultId,
+        snapshotId,
+        sequence,
+        operation: "status_transition",
+        entityType: "recon_result",
+        entityId: runResultId,
+        actor,
+        actorUserId,
+        details: toJsonValue({ fromStatus, toStatus, reason }),
+        entryHash: buildEntryHash({
+          runResultId,
+          snapshotId,
+          sequence,
+          operation: "status_transition",
+          entityType: "recon_result",
+          entityId: runResultId,
+          details: { fromStatus, toStatus, reason, actor },
+        }),
+      },
+    });
   }
 
-  /**
-   * Query provenance records for a run
-   * STUB: ExecutionProvenance table does not exist in schema
-   */
-  async getProvenanceForRun(_runResultId: string): Promise<unknown[]> {
-    // Stub - returns empty array
-    return [];
+  async getProvenanceForRun(runResultId: string): Promise<unknown[]> {
+    return this.prisma.executionProvenance.findMany({
+      where: { runResultId },
+      orderBy: { sequence: "asc" },
+    });
   }
 
-  /**
-   * Query provenance records by entity
-   * STUB: ExecutionProvenance table does not exist in schema
-   */
-  async getProvenanceForEntity(
-    _runResultId: string,
-    _entityId: string
-  ): Promise<unknown[]> {
-    // Stub - returns empty array
-    return [];
+  async getProvenanceForEntity(runResultId: string, entityId: string): Promise<unknown[]> {
+    return this.prisma.executionProvenance.findMany({
+      where: { runResultId, entityId },
+      orderBy: { sequence: "asc" },
+    });
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a canonical backend layer that converts runs, exceptions, and operator adjudications into reusable exception intelligence and policy memory instead of UI-only heuristics.
- Deliver audit-grade provenance and exportable evidence packs so reconciliation outcomes are provable and tamper-evident where possible.
- Provide a policy sandbox to simulate changes against historical runs to enable safe policy evolution and blast-radius estimation.

### Description
- Added a new canonical service `ExceptionIntelligenceService` that builds recurring exception clusters, source reliability scores, explainable recommendations, run-level proof graphs, evidence-pack payloads (SHA-256 digest), and a deterministic policy sandbox simulation engine (`packages/api/src/services/operator-mode/exception-intelligence-service.ts`).
- Exposed four v1 operator API endpoints and wired them into the canonical v1 router: `GET /operator/intelligence/exceptions/snapshot`, `GET /operator/intelligence/runs/:runId/proof-graph`, `GET /operator/intelligence/runs/:runId/evidence-pack`, and `POST /operator/intelligence/policy/sandbox` (`packages/api/src/routes/v1/exception-intelligence.ts`, mounted in `packages/api/src/routes/v1/index.ts`).
- Implemented durable provenance persistence by replacing the reconnaissance stub with a real `ExecutionProvenance` writer that records deterministic `entryHash` values and tenant-scoped provenance entries (`packages/api/src/services/recon-core/provenance-service.ts`).
- Hardened exception resolution paths to enforce tenant-scoped lookup before updates, append adjudication history into `reconciliation_matches.metadata`, emit `audit_log` entries on single and bulk resolutions, and updated tests accordingly (`packages/api/src/routes/exceptions.ts` and updated tests).

### Testing
- `pnpm --filter @settler/api test -- packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts packages/api/src/routes/__tests__/exceptions.test.ts` ✅ pass
- `pnpm --filter @settler/api lint` ✅ pass
- `pnpm --filter @settler/api typecheck` ✅ pass
- `pnpm --filter @settler/api build` ✅ pass
- `pnpm run verify:routes` ✅ pass (route startup and operational route truth checks completed without hard-500s)
- `pnpm run verify:policy` ✅ pass (policy boundary and replay checks passed)
- `pnpm run verify:tenant` ⚠️ warning — environment limitation: failed in this container due to missing file `security/route-registry.json`, so tenant-coverage script could not run fully here

All added/changed API surfaces include explicit degraded-state semantics when data is missing and maintain tenant scoping guards; unit tests added for the new intelligence service and adjusted exception route tests to match the tenant-safe resolution flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c872f2693083288ac4c39ba376fad7)