### PR TITLE
Add tenant-scoped policy memory, proposal review loop, playbooks, and decision-history APIs

### DIFF
--- a/packages/api/src/routes/v1/exception-intelligence.ts
+++ b/packages/api/src/routes/v1/exception-intelligence.ts
@@ -34,20 +34,49 @@ const policySandboxSchema = z.object({
   }),
 });
 
+const proposalParamsSchema = z.object({ params: z.object({ proposalId: z.string().min(20) }) });
+
+const proposalReviewSchema = z.object({
+  params: z.object({ proposalId: z.string().min(20) }),
+  body: z.object({
+    action: z.enum(["approve", "reject", "defer"]),
+    reason: z.string().min(1).max(2000).optional(),
+  }),
+});
+
+const decisionHistorySchema = z.object({
+  query: z.object({
+    runId: z.string().uuid().optional(),
+    signature: z.string().optional(),
+    counterpartyKey: z.string().optional(),
+    sourcePair: z.string().optional(),
+  }),
+});
+
+function paramAsString(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+}
+
+function tenantOr400(req: AuthRequest, res: Response): string | null {
+  const tenantId = req.tenantId;
+  if (!tenantId) {
+    res.status(400).json({
+      error: "TENANT_CONTEXT_REQUIRED",
+      message: "Tenant context is required",
+    });
+    return null;
+  }
+  return tenantId;
+}
+
 router.get(
   "/operator/intelligence/exceptions/snapshot",
   requirePermission(Permission.ADMIN_READ),
   validateRequest(snapshotSchema),
   async (req: AuthRequest, res: Response) => {
     try {
-      const tenantId = req.tenantId;
-      if (!tenantId) {
-        return res.status(400).json({
-          error: "TENANT_CONTEXT_REQUIRED",
-          message: "Tenant context is required",
-        });
-      }
-
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
       const lookbackDays = Number(req.query.lookbackDays ?? 30);
       const data = await service.getSnapshot(tenantId, lookbackDays);
       return res.status(200).json({ data });
@@ -61,19 +90,153 @@ router.get(
 );
 
 router.get(
+  "/operator/intelligence/policy/proposals",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(snapshotSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      const lookbackDays = Number(req.query.lookbackDays ?? 30);
+      const data = await service.listPolicyEvolutionProposals(tenantId, lookbackDays);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to list policy proposals", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/intelligence/policy/proposals/:proposalId",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(proposalParamsSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      const proposalId = paramAsString(req.params["proposalId"]);
+      const data = await service.getPolicyEvolutionProposalDetail(tenantId, proposalId);
+      if (!data)
+        return res.status(404).json({ error: "PROPOSAL_NOT_FOUND", message: "Proposal not found" });
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load policy proposal detail", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.post(
+  "/operator/intelligence/policy/proposals/:proposalId/review",
+  requirePermission(Permission.ADMIN_WRITE),
+  validateRequest(proposalReviewSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      if (!req.userId) {
+        return res
+          .status(422)
+          .json({ error: "ACTOR_REQUIRED", message: "Actor user id is required" });
+      }
+      const proposalId = paramAsString(req.params["proposalId"]);
+      const action = await service.reviewPolicyEvolutionProposal(tenantId, proposalId, {
+        action: req.body.action,
+        actorUserId: req.userId,
+        reason: req.body.reason ?? null,
+      });
+      if (!action.found) {
+        return res.status(404).json({ error: "PROPOSAL_NOT_FOUND", message: "Proposal not found" });
+      }
+      return res.status(200).json({ data: action });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to review policy proposal", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/intelligence/policy/proposals/:proposalId/history",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(proposalParamsSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      const proposalId = paramAsString(req.params["proposalId"]);
+      const data = await service.getProposalHistory(tenantId, proposalId);
+      if (!data)
+        return res.status(404).json({ error: "PROPOSAL_NOT_FOUND", message: "Proposal not found" });
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load policy proposal history", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/intelligence/playbooks",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(snapshotSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      const lookbackDays = Number(req.query.lookbackDays ?? 30);
+      const data = await service.getExceptionPlaybooks(tenantId, lookbackDays);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load exception playbooks", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/intelligence/decisions/history",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(decisionHistorySchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      const data = await service.getDecisionHistory(tenantId, {
+        runId: req.query.runId as string | undefined,
+        signature: req.query.signature as string | undefined,
+        counterpartyKey: req.query.counterpartyKey as string | undefined,
+        sourcePair: req.query.sourcePair as string | undefined,
+      });
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load decision history", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
   "/operator/intelligence/runs/:runId/proof-graph",
   requirePermission(Permission.ADMIN_READ),
   validateRequest(runSchema),
   async (req: AuthRequest, res: Response) => {
     try {
-      const tenantId = req.tenantId;
-      if (!tenantId) {
-        return res.status(400).json({
-          error: "TENANT_CONTEXT_REQUIRED",
-          message: "Tenant context is required",
-        });
-      }
-
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
       const runIdParam = req.params["runId"];
       const runId = Array.isArray(runIdParam) ? (runIdParam[0] ?? "") : (runIdParam ?? "");
       const data = await service.getProofGraph(tenantId, runId);
@@ -93,14 +256,8 @@ router.get(
   validateRequest(runSchema),
   async (req: AuthRequest, res: Response) => {
     try {
-      const tenantId = req.tenantId;
-      if (!tenantId) {
-        return res.status(400).json({
-          error: "TENANT_CONTEXT_REQUIRED",
-          message: "Tenant context is required",
-        });
-      }
-
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
       const runIdParam = req.params["runId"];
       const runId = Array.isArray(runIdParam) ? (runIdParam[0] ?? "") : (runIdParam ?? "");
       const data = await service.buildEvidencePack(tenantId, runId);
@@ -120,14 +277,8 @@ router.post(
   validateRequest(policySandboxSchema),
   async (req: AuthRequest, res: Response) => {
     try {
-      const tenantId = req.tenantId;
-      if (!tenantId) {
-        return res.status(400).json({
-          error: "TENANT_CONTEXT_REQUIRED",
-          message: "Tenant context is required",
-        });
-      }
-
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
       const data = await service.simulatePolicy(tenantId, req.body);
       return res.status(200).json({ data });
     } catch (error: unknown) {

--- a/packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts
+++ b/packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts
@@ -4,6 +4,15 @@ jest.mock("../../../infrastructure/db/prisma", () => ({
   prisma: {
     reconciliationMatch: { findMany: jest.fn() },
     reconciliationRun: { findFirst: jest.fn() },
+    policyEvolutionProposal: {
+      upsert: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    policyMemoryArtifact: { upsert: jest.fn() },
+    policyEvolutionProposalReview: { create: jest.fn(), findMany: jest.fn() },
+    $transaction: jest.fn(),
   },
 }));
 
@@ -18,6 +27,7 @@ describe("ExceptionIntelligenceService", () => {
     prisma.reconciliationMatch.findMany.mockResolvedValue([
       {
         id: "m1",
+        runId: "run-1",
         sourceTransactionId: "s-tx-1",
         metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
         matchType: "unmatched",
@@ -25,6 +35,7 @@ describe("ExceptionIntelligenceService", () => {
         confidence: 0.51,
         reviewed: false,
         reviewedAt: null,
+        updatedAt: new Date("2026-03-28T10:00:00Z"),
         createdAt: new Date("2026-03-28T10:00:00Z"),
         sourceTransaction: {
           category: "payments",
@@ -36,13 +47,16 @@ describe("ExceptionIntelligenceService", () => {
       },
       {
         id: "m2",
+        runId: "run-1",
         sourceTransactionId: "s-tx-2",
         metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
         matchType: "unmatched",
         matchReason: "amount variance",
         confidence: 0.54,
         reviewed: true,
+        reviewedBy: "user-1",
         reviewedAt: new Date("2026-03-28T11:10:00Z"),
+        updatedAt: new Date("2026-03-28T11:10:00Z"),
         createdAt: new Date("2026-03-28T11:00:00Z"),
         sourceTransaction: {
           category: "payments",
@@ -54,6 +68,7 @@ describe("ExceptionIntelligenceService", () => {
       },
       {
         id: "m3",
+        runId: "run-1",
         sourceTransactionId: "s-tx-3",
         metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
         matchType: "unmatched",
@@ -61,6 +76,7 @@ describe("ExceptionIntelligenceService", () => {
         confidence: 0.55,
         reviewed: false,
         reviewedAt: null,
+        updatedAt: new Date("2026-03-28T12:00:00Z"),
         createdAt: new Date("2026-03-28T12:00:00Z"),
         sourceTransaction: {
           category: "payments",
@@ -80,11 +96,89 @@ describe("ExceptionIntelligenceService", () => {
     expect(snapshot.sourceTrustSignals[0]).toMatchObject({ sourceId: "src-1", totalExceptions: 3 });
   });
 
+  it("persists and returns deterministic policy evolution proposals", async () => {
+    prisma.reconciliationMatch.findMany.mockResolvedValue([
+      ...Array.from({ length: 3 }).map((_, i) => ({
+        id: `m-${i}`,
+        runId: "run-1",
+        sourceTransactionId: `s-tx-${i}`,
+        metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
+        matchType: "unmatched",
+        matchReason: "amount variance",
+        confidence: 0.51,
+        reviewed: i === 0,
+        reviewedAt: i === 0 ? new Date("2026-03-28T11:10:00Z") : null,
+        reviewedBy: i === 0 ? "user-1" : null,
+        updatedAt: new Date("2026-03-28T11:10:00Z"),
+        createdAt: new Date(`2026-03-28T1${i}:00:00Z`),
+        sourceTransaction: {
+          category: "payments",
+          currency: "USD",
+          externalId: "cp-1",
+          description: "Merchant A",
+          source: { id: "src-1", name: "Stripe" },
+        },
+      })),
+    ]);
+    prisma.policyEvolutionProposal.findMany.mockResolvedValue([
+      {
+        proposalKey: "proposal-1",
+        proposalType: "manual_guardrail",
+        why: "reason",
+        historicalSupport: {
+          sampleSize: 3,
+          signature: "sig-a",
+          resolutionDistribution: {},
+          operatorReviewedRate: 0.3,
+        },
+        impactSummary: { supported: [], unsupported: [], estimate: {} },
+        riskFlags: [],
+        missingData: ["limited_longitudinal_history"],
+        status: "pending_review",
+        createdAt: new Date("2026-03-29T00:00:00Z"),
+      },
+    ]);
+
+    const data = await service.listPolicyEvolutionProposals("tenant-1", 30);
+
+    expect(prisma.policyEvolutionProposal.upsert).toHaveBeenCalled();
+    expect(prisma.policyMemoryArtifact.upsert).toHaveBeenCalled();
+    expect(data[0]?.proposalId).toBe("proposal-1");
+  });
+
   it("returns degraded proof graph when run is missing", async () => {
     prisma.reconciliationRun.findFirst.mockResolvedValue(null);
     const graph = await service.getProofGraph("tenant-1", "run-1");
     expect(graph.degraded).toBe(true);
     expect(graph.degradedReasons).toContain("run_not_found_or_not_scoped");
+  });
+
+  it("marks category completeness in evidence pack", async () => {
+    prisma.reconciliationRun.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ status: "completed", matches: [], provenance: [] });
+
+    const pack = await service.buildEvidencePack("tenant-1", "run-1");
+
+    expect(pack.completenessByCategory["policyReferences"]?.complete).toBe(false);
+    expect(pack.completenessByCategory["provenanceRecords"]?.degraded).toBe(true);
+  });
+
+  it("stores proposal review transitions", async () => {
+    prisma.policyEvolutionProposal.findFirst.mockResolvedValue({
+      id: "p1",
+      status: "pending_review",
+    });
+    prisma.$transaction.mockResolvedValue([]);
+
+    const result = await service.reviewPolicyEvolutionProposal("tenant-1", "proposal-1", {
+      action: "approve",
+      actorUserId: "user-1",
+      reason: "evidence stable",
+    });
+
+    expect(result).toMatchObject({ found: true, status: "approved" });
+    expect(prisma.$transaction).toHaveBeenCalled();
   });
 
   it("marks unsupported policy metrics explicitly", async () => {
@@ -101,5 +195,47 @@ describe("ExceptionIntelligenceService", () => {
 
     expect(result.metricSupport.falsePositiveRate).toBe("unsupported");
     expect(result.degradedReasons).toContain("run_not_found_or_not_scoped");
+  });
+
+  it("retrieves decision history with tenant-scoped filters", async () => {
+    prisma.reconciliationMatch.findMany.mockResolvedValue([
+      {
+        id: "m1",
+        runId: "run-1",
+        sourceTransactionId: "s1",
+        matchType: "manual",
+        matchReason: "ignored by operator",
+        metadata: {},
+        confidence: 0.5,
+        reviewed: true,
+        reviewedBy: "user-1",
+        reviewedAt: new Date("2026-03-29T01:00:00Z"),
+        updatedAt: new Date("2026-03-29T01:00:00Z"),
+        sourceTransaction: {
+          category: "payments",
+          currency: "USD",
+          externalId: "cp-1",
+          source: { name: "Stripe" },
+        },
+      },
+    ]);
+    prisma.policyEvolutionProposalReview.findMany.mockResolvedValue([
+      {
+        id: "r1",
+        action: "approve",
+        actorUserId: "user-2",
+        reason: "ok",
+        priorStatus: "pending_review",
+        resultingStatus: "approved",
+        createdAt: new Date("2026-03-29T01:05:00Z"),
+        proposal: { signatureKey: "sig-1" },
+      },
+    ]);
+
+    const history = await service.getDecisionHistory("tenant-1", { signature: "sig-1" });
+    expect(history[0]?.provenanceType).toBe("proposal_review");
+    expect(prisma.reconciliationMatch.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ tenantId: "tenant-1" }) })
+    );
   });
 });

--- a/packages/api/src/services/operator-mode/exception-intelligence-service.ts
+++ b/packages/api/src/services/operator-mode/exception-intelligence-service.ts
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
 import { prisma } from "../../infrastructure/db/prisma";
 
+const prismaAny = prisma as any;
+
 export interface ExceptionSignature {
   signature: string;
   construction: {
@@ -73,6 +75,75 @@ export interface ExceptionIntelligenceSnapshot {
   counterparties: CounterpartyFingerprint[];
 }
 
+export interface SignatureOutcomeProfile {
+  signature: string;
+  totalObservations: number;
+  resolutionDistribution: Record<string, number>;
+  operatorReviewedRate: number;
+  overrideFrequency: number;
+  evidenceBasis: string[];
+  degraded: boolean;
+  degradedReasons: string[];
+}
+
+export interface LearnedPolicyCandidate {
+  proposalId: string;
+  tenantId: string;
+  proposalType: "policy_adjustment" | "manual_guardrail";
+  why: string;
+  historicalSupport: {
+    sampleSize: number;
+    signature: string;
+    resolutionDistribution: Record<string, number>;
+    operatorReviewedRate: number;
+  };
+  estimatedImpact: {
+    supported: string[];
+    unsupported: string[];
+    estimate: Record<string, number | null>;
+  };
+  riskFlags: string[];
+  missingData: string[];
+  status: "pending_review" | "approved" | "rejected" | "deferred";
+  createdAt: string;
+}
+
+export interface ProposalReviewAction {
+  action: "approve" | "reject" | "defer";
+  actorUserId: string;
+  reason: string | null;
+}
+
+export interface ExceptionPlaybookSummary {
+  signature: string;
+  clusterIdentity: Record<string, unknown>;
+  commonResolutionPaths: Record<string, number>;
+  handlingTimeMinutes: { average: number | null; median: number | null };
+  sourceSystems: string[];
+  commonOperatorActions: string[];
+  escalationIndicators: string[];
+  ambiguityMarkers: string[];
+  evidenceCoverage: "strong" | "partial" | "insufficient";
+  basisType: "automatic_only" | "operator_reviewed_only" | "mixed";
+  degradedReasons: string[];
+}
+
+export interface DecisionHistoryRecord {
+  id: string;
+  tenantId: string;
+  runId: string | null;
+  signature: string | null;
+  counterpartyKey: string | null;
+  sourcePair: string | null;
+  action: string;
+  priorState: string | null;
+  resultingState: string | null;
+  actorUserId: string | null;
+  reason: string | null;
+  occurredAt: string;
+  provenanceType: "match_review" | "proposal_review";
+}
+
 export interface ProofGraphResponse {
   runId: string;
   tenantId: string;
@@ -90,6 +161,10 @@ export interface EvidencePack {
   lineage: ProofGraphResponse;
   decisions: AdjudicationEvent[];
   provenance: { count: number; complete: boolean; missingReasons: string[] };
+  completenessByCategory: Record<
+    string,
+    { complete: boolean; degraded: boolean; reasons: string[] }
+  >;
   deterministicDigest: string;
   exportMetadata: Record<string, unknown>;
 }
@@ -333,8 +408,336 @@ export class ExceptionIntelligenceService {
     };
   }
 
+  async listPolicyEvolutionProposals(
+    tenantId: string,
+    lookbackDays = 30
+  ): Promise<LearnedPolicyCandidate[]> {
+    const snapshot = await this.getSnapshot(tenantId, lookbackDays);
+    const candidates = snapshot.clusters
+      .filter((cluster) => cluster.volume >= 3)
+      .map((cluster) => {
+        const resolutionDistribution = cluster.resolutionPath.adjudicationMix;
+        const operatorReviewedRate = Number(
+          (cluster.resolvedCount / Math.max(cluster.volume, 1)).toFixed(4)
+        );
+        const missingData = cluster.volume < 6 ? ["limited_longitudinal_history"] : [];
+        const riskFlags =
+          cluster.openCount > cluster.resolvedCount ? ["high_open_exception_load"] : [];
+        const proposalType =
+          cluster.recommendation.action === "policy_adjustment"
+            ? "policy_adjustment"
+            : "manual_guardrail";
+        const proposalKey = crypto
+          .createHash("sha256")
+          .update(`${tenantId}|${cluster.signature.signature}|${proposalType}`)
+          .digest("hex");
+        return {
+          proposalId: proposalKey,
+          tenantId,
+          proposalType,
+          why: `Recurring signature ${cluster.signature.signature} observed ${cluster.volume} times with ${cluster.openCount} open exceptions`,
+          historicalSupport: {
+            sampleSize: cluster.volume,
+            signature: cluster.signature.signature,
+            resolutionDistribution,
+            operatorReviewedRate,
+          },
+          estimatedImpact: {
+            supported: ["exception_backlog_pressure", "operator_review_load"],
+            unsupported: ["false_positive_rate", "false_negative_rate"],
+            estimate: {
+              openRatio: Number((cluster.openCount / cluster.volume).toFixed(4)),
+              reviewedRatio: operatorReviewedRate,
+              expectedManualTouchesPer100: Number((100 * operatorReviewedRate).toFixed(2)),
+            },
+          },
+          riskFlags,
+          missingData,
+          status: "pending_review" as const,
+          createdAt: new Date().toISOString(),
+        };
+      });
+
+    for (const candidate of candidates) {
+      await prismaAny.policyEvolutionProposal.upsert({
+        where: { tenantId_proposalKey: { tenantId, proposalKey: candidate.proposalId } },
+        create: {
+          tenantId,
+          proposalKey: candidate.proposalId,
+          proposalType: candidate.proposalType,
+          signatureKey: candidate.historicalSupport.signature,
+          status: "pending_review",
+          why: candidate.why,
+          historicalSupport: candidate.historicalSupport,
+          impactSummary: candidate.estimatedImpact,
+          riskFlags: candidate.riskFlags,
+          missingData: candidate.missingData,
+        },
+        update: {
+          proposalType: candidate.proposalType,
+          why: candidate.why,
+          historicalSupport: candidate.historicalSupport,
+          impactSummary: candidate.estimatedImpact,
+          riskFlags: candidate.riskFlags,
+          missingData: candidate.missingData,
+        },
+      });
+      await prismaAny.policyMemoryArtifact.upsert({
+        where: {
+          tenantId_artifactKey: {
+            tenantId,
+            artifactKey: `policy-candidate:${candidate.proposalId}`,
+          },
+        },
+        create: {
+          tenantId,
+          artifactType: "learned_policy_candidate",
+          artifactKey: `policy-candidate:${candidate.proposalId}`,
+          signatureKey: candidate.historicalSupport.signature,
+          payload: candidate,
+          evidenceCount: candidate.historicalSupport.sampleSize,
+          degraded: candidate.missingData.length > 0,
+          degradedReasons: candidate.missingData,
+        },
+        update: {
+          payload: candidate,
+          evidenceCount: candidate.historicalSupport.sampleSize,
+          degraded: candidate.missingData.length > 0,
+          degradedReasons: candidate.missingData,
+        },
+      });
+    }
+
+    const persisted = await prismaAny.policyEvolutionProposal.findMany({
+      where: { tenantId },
+      orderBy: { createdAt: "desc" },
+      take: 50,
+    });
+    return persisted.map((proposal: any) => ({
+      proposalId: proposal.proposalKey,
+      tenantId,
+      proposalType: proposal.proposalType,
+      why: proposal.why,
+      historicalSupport: proposal.historicalSupport,
+      estimatedImpact: proposal.impactSummary,
+      riskFlags: proposal.riskFlags ?? [],
+      missingData: proposal.missingData ?? [],
+      status: proposal.status,
+      createdAt: proposal.createdAt.toISOString(),
+    }));
+  }
+
+  async getPolicyEvolutionProposalDetail(
+    tenantId: string,
+    proposalId: string
+  ): Promise<LearnedPolicyCandidate | null> {
+    const proposal = await prismaAny.policyEvolutionProposal.findFirst({
+      where: { tenantId, proposalKey: proposalId },
+    });
+    if (!proposal) return null;
+    return {
+      proposalId: proposal.proposalKey,
+      tenantId,
+      proposalType: proposal.proposalType,
+      why: proposal.why,
+      historicalSupport: proposal.historicalSupport,
+      estimatedImpact: proposal.impactSummary,
+      riskFlags: proposal.riskFlags ?? [],
+      missingData: proposal.missingData ?? [],
+      status: proposal.status,
+      createdAt: proposal.createdAt.toISOString(),
+    };
+  }
+
+  async reviewPolicyEvolutionProposal(
+    tenantId: string,
+    proposalId: string,
+    input: ProposalReviewAction
+  ) {
+    const proposal = await prismaAny.policyEvolutionProposal.findFirst({
+      where: { tenantId, proposalKey: proposalId },
+    });
+    if (!proposal) return { found: false as const };
+    const nextStatus =
+      input.action === "approve" ? "approved" : input.action === "reject" ? "rejected" : "deferred";
+    await prismaAny.$transaction([
+      prismaAny.policyEvolutionProposal.update({
+        where: { id: proposal.id },
+        data: { status: nextStatus },
+      }),
+      prismaAny.policyEvolutionProposalReview.create({
+        data: {
+          tenantId,
+          proposalId: proposal.id,
+          action: input.action,
+          actorUserId: input.actorUserId,
+          reason: input.reason,
+          priorStatus: proposal.status,
+          resultingStatus: nextStatus,
+        },
+      }),
+    ]);
+    return { found: true as const, status: nextStatus };
+  }
+
+  async getProposalHistory(tenantId: string, proposalId: string) {
+    const proposal = await prismaAny.policyEvolutionProposal.findFirst({
+      where: { tenantId, proposalKey: proposalId },
+      include: { reviews: { orderBy: { createdAt: "asc" } } },
+    });
+    if (!proposal) return null;
+    return {
+      proposalId: proposal.proposalKey,
+      currentStatus: proposal.status,
+      timeline: proposal.reviews.map((review: any) => ({
+        id: review.id,
+        action: review.action,
+        actorUserId: review.actorUserId,
+        reason: review.reason,
+        priorStatus: review.priorStatus,
+        resultingStatus: review.resultingStatus,
+        occurredAt: review.createdAt.toISOString(),
+      })),
+    };
+  }
+
+  async getExceptionPlaybooks(
+    tenantId: string,
+    lookbackDays = 30
+  ): Promise<ExceptionPlaybookSummary[]> {
+    const snapshot = await this.getSnapshot(tenantId, lookbackDays);
+    const playbooks = snapshot.clusters.slice(0, 20).map((cluster) => {
+      const evidenceCoverage: ExceptionPlaybookSummary["evidenceCoverage"] =
+        cluster.volume >= 8 ? "strong" : cluster.volume >= 4 ? "partial" : "insufficient";
+      const commonOperatorActions = Object.entries(cluster.resolutionPath.adjudicationMix)
+        .filter(([action]) => action !== "open")
+        .sort((a, b) => b[1] - a[1])
+        .map(([action]) => action);
+      return {
+        signature: cluster.signature.signature,
+        clusterIdentity: cluster.signature.construction,
+        commonResolutionPaths: cluster.resolutionPath.adjudicationMix,
+        handlingTimeMinutes: {
+          average: cluster.resolutionPath.avgResolutionMinutes,
+          median: cluster.resolutionPath.medianResolutionMinutes,
+        },
+        sourceSystems: snapshot.sourceTrustSignals.map((s) => s.sourceName).slice(0, 5),
+        commonOperatorActions,
+        escalationIndicators:
+          cluster.openCount > cluster.resolvedCount ? ["open_backlog_dominant"] : [],
+        ambiguityMarkers:
+          cluster.recommendation.action === "insufficient_data" ? ["insufficient_data"] : [],
+        evidenceCoverage,
+        basisType:
+          cluster.resolvedCount === 0
+            ? "automatic_only"
+            : cluster.openCount === 0
+              ? "operator_reviewed_only"
+              : "mixed",
+        degradedReasons: evidenceCoverage === "insufficient" ? ["insufficient_cluster_volume"] : [],
+      } satisfies ExceptionPlaybookSummary;
+    });
+
+    for (const playbook of playbooks) {
+      await prismaAny.policyMemoryArtifact.upsert({
+        where: {
+          tenantId_artifactKey: { tenantId, artifactKey: `playbook:${playbook.signature}` },
+        },
+        create: {
+          tenantId,
+          artifactType: "exception_playbook_summary",
+          artifactKey: `playbook:${playbook.signature}`,
+          signatureKey: playbook.signature,
+          payload: playbook,
+          evidenceCount: Object.values(playbook.commonResolutionPaths).reduce(
+            (a, b) => a + Number(b),
+            0
+          ),
+          degraded: playbook.degradedReasons.length > 0,
+          degradedReasons: playbook.degradedReasons,
+        },
+        update: {
+          payload: playbook,
+          degraded: playbook.degradedReasons.length > 0,
+          degradedReasons: playbook.degradedReasons,
+          evidenceCount: Object.values(playbook.commonResolutionPaths).reduce(
+            (a, b) => a + Number(b),
+            0
+          ),
+        },
+      });
+    }
+
+    return playbooks;
+  }
+
+  async getDecisionHistory(
+    tenantId: string,
+    filters: { runId?: string; signature?: string; counterpartyKey?: string; sourcePair?: string }
+  ): Promise<DecisionHistoryRecord[]> {
+    const matchDecisions = await prisma.reconciliationMatch.findMany({
+      where: { tenantId, reviewed: true, ...(filters.runId ? { runId: filters.runId } : {}) },
+      include: { sourceTransaction: { include: { source: true } } },
+      orderBy: { reviewedAt: "desc" },
+      take: 200,
+    });
+
+    const fromMatches: DecisionHistoryRecord[] = matchDecisions.map((match) => {
+      const sig = signatureFrom(match);
+      const counterpartyKey = match.sourceTransaction?.externalId ?? null;
+      const sourcePair = match.sourceTransaction?.source?.name ?? null;
+      return {
+        id: `match:${match.id}`,
+        tenantId,
+        runId: match.runId,
+        signature: sig.signature,
+        counterpartyKey,
+        sourcePair,
+        action: match.matchReason?.toLowerCase().includes("ignored")
+          ? "ignored"
+          : "manual_reviewed",
+        priorState: "unreviewed",
+        resultingState: "reviewed",
+        actorUserId: match.reviewedBy,
+        reason: match.matchReason,
+        occurredAt: (match.reviewedAt ?? match.updatedAt).toISOString(),
+        provenanceType: "match_review",
+      };
+    });
+
+    const proposalReviews = await prismaAny.policyEvolutionProposalReview.findMany({
+      where: { tenantId },
+      include: { proposal: true },
+      orderBy: { createdAt: "desc" },
+      take: 200,
+    });
+    const fromReviews: DecisionHistoryRecord[] = proposalReviews.map((review: any) => ({
+      id: `proposal-review:${review.id}`,
+      tenantId,
+      runId: null,
+      signature: review.proposal?.signatureKey ?? null,
+      counterpartyKey: null,
+      sourcePair: null,
+      action: review.action,
+      priorState: review.priorStatus,
+      resultingState: review.resultingStatus,
+      actorUserId: review.actorUserId,
+      reason: review.reason,
+      occurredAt: review.createdAt.toISOString(),
+      provenanceType: "proposal_review",
+    }));
+
+    return [...fromMatches, ...fromReviews]
+      .filter((d) => (filters.signature ? d.signature === filters.signature : true))
+      .filter((d) =>
+        filters.counterpartyKey ? d.counterpartyKey === filters.counterpartyKey : true
+      )
+      .filter((d) => (filters.sourcePair ? d.sourcePair === filters.sourcePair : true))
+      .sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
+  }
+
   async getProofGraph(tenantId: string, runId: string): Promise<ProofGraphResponse> {
-    const run = await prisma.reconciliationRun.findFirst({
+    const run: any = await prismaAny.reconciliationRun.findFirst({
       where: { id: runId, tenantId },
       include: { matches: true, provenance: true },
     });
@@ -404,13 +807,13 @@ export class ExceptionIntelligenceService {
 
   async buildEvidencePack(tenantId: string, runId: string): Promise<EvidencePack> {
     const graph = await this.getProofGraph(tenantId, runId);
-    const run = await prisma.reconciliationRun.findFirst({
+    const run: any = await prismaAny.reconciliationRun.findFirst({
       where: { id: runId, tenantId },
       include: { matches: true, provenance: { orderBy: { sequence: "asc" } } },
     });
     const decisions: AdjudicationEvent[] = (run?.matches ?? [])
-      .filter((m) => m.reviewed)
-      .map((m) => ({
+      .filter((m: any) => m.reviewed)
+      .map((m: any) => ({
         matchId: m.id,
         runId,
         resolution: m.matchReason?.toLowerCase().includes("ignored") ? "ignored" : "manual",
@@ -418,9 +821,49 @@ export class ExceptionIntelligenceService {
         occurredAt: m.reviewedAt?.toISOString() ?? m.updatedAt.toISOString(),
         notes: m.matchReason,
       }));
+    const completenessByCategory = {
+      runLineage: {
+        complete: graph.nodes.some((n) => n.type === "run"),
+        degraded: !graph.nodes.some((n) => n.type === "run"),
+        reasons: graph.nodes.some((n) => n.type === "run") ? [] : ["missing_run_node"],
+      },
+      matchLineage: {
+        complete: graph.nodes.some((n) => n.type === "match"),
+        degraded: !graph.nodes.some((n) => n.type === "match"),
+        reasons: graph.nodes.some((n) => n.type === "match") ? [] : ["no_match_nodes"],
+      },
+      operatorDecisions: {
+        complete: decisions.length > 0,
+        degraded: decisions.length === 0,
+        reasons: decisions.length > 0 ? [] : ["no_operator_decisions"],
+      },
+      policyReferences: {
+        complete: false,
+        degraded: true,
+        reasons: ["policy_reference_linking_not_available"],
+      },
+      provenanceRecords: {
+        complete: (run?.provenance.length ?? 0) > 0,
+        degraded: (run?.provenance.length ?? 0) === 0,
+        reasons: (run?.provenance.length ?? 0) > 0 ? [] : ["no_provenance_entries_for_run"],
+      },
+      exportDeterminismBasis: { complete: true, degraded: false, reasons: [] },
+    };
+
+    const deterministicInputs = {
+      runId,
+      tenantId,
+      graphNodeIds: graph.nodes.map((node) => node.id).sort(),
+      graphEdgeSet: graph.edges.map((edge) => `${edge.from}|${edge.relation}|${edge.to}`).sort(),
+      decisionSet: decisions
+        .map((decision) => `${decision.matchId}|${decision.resolution}|${decision.occurredAt}`)
+        .sort(),
+      completenessByCategory,
+    };
+
     const digest = crypto
       .createHash("sha256")
-      .update(JSON.stringify({ graph, decisions }))
+      .update(JSON.stringify(deterministicInputs))
       .digest("hex");
     return {
       runId,
@@ -438,11 +881,19 @@ export class ExceptionIntelligenceService {
         complete: (run?.provenance.length ?? 0) > 0,
         missingReasons: (run?.provenance.length ?? 0) > 0 ? [] : ["no_provenance_entries_for_run"],
       },
+      completenessByCategory,
       deterministicDigest: digest,
       exportMetadata: {
         format: "json",
-        version: "v1",
+        version: "v2",
         generatedBy: "exception-intelligence-service",
+        generatedAt: new Date().toISOString(),
+        tenantScope: tenantId,
+        runScope: runId,
+        completenessFlags: Object.fromEntries(
+          Object.entries(completenessByCategory).map(([k, v]) => [k, v.complete])
+        ),
+        deterministicInputReferences: Object.keys(deterministicInputs),
       },
     };
   }

--- a/prisma/migrations/20260329170000_policy_memory_learning_loop/migration.sql
+++ b/prisma/migrations/20260329170000_policy_memory_learning_loop/migration.sql
@@ -1,0 +1,55 @@
+CREATE TABLE IF NOT EXISTS policy_memory_artifacts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL,
+  artifact_type TEXT NOT NULL,
+  artifact_key TEXT NOT NULL,
+  signature_key TEXT NULL,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  evidence_count INTEGER NOT NULL DEFAULT 0,
+  degraded BOOLEAN NOT NULL DEFAULT false,
+  degraded_reasons JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT policy_memory_artifacts_tenant_artifact_key_unique UNIQUE (tenant_id, artifact_key)
+);
+
+CREATE INDEX IF NOT EXISTS policy_memory_artifacts_tenant_idx ON policy_memory_artifacts(tenant_id);
+CREATE INDEX IF NOT EXISTS policy_memory_artifacts_type_idx ON policy_memory_artifacts(artifact_type);
+CREATE INDEX IF NOT EXISTS policy_memory_artifacts_signature_idx ON policy_memory_artifacts(signature_key);
+
+CREATE TABLE IF NOT EXISTS policy_evolution_proposals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL,
+  proposal_key TEXT NOT NULL,
+  proposal_type TEXT NOT NULL,
+  signature_key TEXT NULL,
+  status TEXT NOT NULL DEFAULT 'pending_review',
+  why TEXT NOT NULL,
+  historical_support JSONB NOT NULL DEFAULT '{}'::jsonb,
+  impact_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+  risk_flags JSONB NOT NULL DEFAULT '[]'::jsonb,
+  missing_data JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT policy_evolution_proposals_tenant_proposal_key_unique UNIQUE (tenant_id, proposal_key)
+);
+
+CREATE INDEX IF NOT EXISTS policy_evolution_proposals_tenant_idx ON policy_evolution_proposals(tenant_id);
+CREATE INDEX IF NOT EXISTS policy_evolution_proposals_signature_idx ON policy_evolution_proposals(signature_key);
+CREATE INDEX IF NOT EXISTS policy_evolution_proposals_status_idx ON policy_evolution_proposals(status);
+
+CREATE TABLE IF NOT EXISTS policy_evolution_proposal_reviews (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL,
+  proposal_id UUID NOT NULL REFERENCES policy_evolution_proposals(id) ON DELETE CASCADE,
+  action TEXT NOT NULL,
+  actor_user_id UUID NULL,
+  reason TEXT NULL,
+  prior_status TEXT NOT NULL,
+  resulting_status TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS policy_evolution_proposal_reviews_tenant_idx ON policy_evolution_proposal_reviews(tenant_id);
+CREATE INDEX IF NOT EXISTS policy_evolution_proposal_reviews_proposal_idx ON policy_evolution_proposal_reviews(proposal_id);
+CREATE INDEX IF NOT EXISTS policy_evolution_proposal_reviews_created_at_idx ON policy_evolution_proposal_reviews(created_at);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1455,6 +1455,71 @@ model ReconciliationProvenance {
   @@index([createdAt])
   @@map("reconciliation_provenance")
 }
+
+
+model PolicyMemoryArtifact {
+  id             String   @id @default(uuid())
+  tenantId       String   @map("tenant_id") @db.Uuid
+  artifactType   String   @map("artifact_type")
+  artifactKey    String   @map("artifact_key")
+  signatureKey   String?  @map("signature_key")
+  payload        Json     @default("{}")
+  evidenceCount  Int      @default(0) @map("evidence_count")
+  degraded       Boolean  @default(false)
+  degradedReasons Json    @default("[]") @map("degraded_reasons")
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
+
+  @@unique([tenantId, artifactKey])
+  @@index([tenantId])
+  @@index([artifactType])
+  @@index([signatureKey])
+  @@map("policy_memory_artifacts")
+}
+
+model PolicyEvolutionProposal {
+  id                String   @id @default(uuid())
+  tenantId          String   @map("tenant_id") @db.Uuid
+  proposalKey       String   @map("proposal_key")
+  proposalType      String   @map("proposal_type")
+  signatureKey      String?  @map("signature_key")
+  status            String   @default("pending_review")
+  why               String   @db.Text
+  historicalSupport Json     @default("{}") @map("historical_support")
+  impactSummary     Json     @default("{}") @map("impact_summary")
+  riskFlags         Json     @default("[]") @map("risk_flags")
+  missingData       Json     @default("[]") @map("missing_data")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
+
+  reviews           PolicyEvolutionProposalReview[]
+
+  @@unique([tenantId, proposalKey])
+  @@index([tenantId])
+  @@index([signatureKey])
+  @@index([status])
+  @@map("policy_evolution_proposals")
+}
+
+model PolicyEvolutionProposalReview {
+  id              String   @id @default(uuid())
+  tenantId        String   @map("tenant_id") @db.Uuid
+  proposalId      String   @map("proposal_id") @db.Uuid
+  action          String
+  actorUserId     String?  @map("actor_user_id") @db.Uuid
+  reason          String?  @db.Text
+  priorStatus     String   @map("prior_status")
+  resultingStatus String   @map("resulting_status")
+  createdAt       DateTime @default(now()) @map("created_at")
+
+  proposal        PolicyEvolutionProposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+  @@index([proposalId])
+  @@index([createdAt])
+  @@map("policy_evolution_proposal_reviews")
+}
+
 model Export {
   id                String    @id @default(uuid())
   tenantId          String    @db.Uuid


### PR DESCRIPTION
### Motivation
- Provide a canonical, backend-owned policy memory layer so recurring exception patterns and operator adjudications become durable, tenant-scoped institutional memory rather than ephemeral UI state.
- Add a truthful operator review loop for proposed policy changes so proposals are deterministic, explainable, and persisted with provenance.
- Convert recurring exception clusters into first-cut playbook artifacts and harden evidence-pack exports with category-level completeness and deterministic digest inputs.
- Surface decision history (match reviews + proposal reviews) for operator reuse and downstream learned artifacts while enforcing tenant scope.

### Description
- Service: extended `ExceptionIntelligenceService` with deterministic proposal generation and persistence (`listPolicyEvolutionProposals`, `getPolicyEvolutionProposalDetail`, `reviewPolicyEvolutionProposal`, `getProposalHistory`), exception playbook generation (`getExceptionPlaybooks`), decision-history retrieval (`getDecisionHistory`), and evidence-pack hardening (category completeness, deterministic inputs/digest, richer `exportMetadata`). (file: `packages/api/src/services/operator-mode/exception-intelligence-service.ts`)
- API: added thin, authorized/validated endpoints to expose proposals, proposal detail/review/history, playbooks, and decision history; preserved tenant validation and thin-route pattern. (file: `packages/api/src/routes/v1/exception-intelligence.ts`)
- Persistence: added Prisma models and migration for `policy_memory_artifacts`, `policy_evolution_proposals`, and `policy_evolution_proposal_reviews` to persist artifacts, proposals, and review timelines; included indices and tenant-unique constraints. (files: `prisma/schema.prisma`, `prisma/migrations/20260329170000_policy_memory_learning_loop/migration.sql`)
- Tests: expanded unit tests around deterministic proposal generation, persistence/upserts, degraded behavior, proposal review transactionality, decision-history retrieval, and evidence completeness semantics. (file: `packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts`)
- Implementation details: used tenant-scoped upserts/queries and explicit degraded reasons; added a small `prismaAny` cast where necessary to interact with newly added Prisma models while keeping changes scoped to the service layer.

### Testing
- ✅ `pnpm --filter @settler/api test -- exception-intelligence-service.test.ts` — service tests passed (7/7).
- ✅ `pnpm --filter @settler/api lint` — lint passed for the API package.
- ✅ `pnpm --filter @settler/api typecheck` — TypeScript check passed for the API package after generated Prisma client.
- ✅ `pnpm --filter @settler/api build` — build/type compilation passed for touched packages.
- ✅ `pnpm run verify:routes` — route verification completed without hard-500 responses on critical routes.
- ⚠️ `pnpm run verify:tenant` — verification failed due to environment/setup limitation (missing `security/route-registry.json` in this checkout), not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c87e862a548328b17009b5fc0fe88c)