### PR TITLE
api: add tenant-scoped policy evolution proposals, review workflow, and decision-history API

### DIFF
--- a/packages/api/src/routes/v1/exception-intelligence.ts
+++ b/packages/api/src/routes/v1/exception-intelligence.ts
@@ -34,6 +34,32 @@ const policySandboxSchema = z.object({
   }),
 });
 
+const policyProposalSchema = z.object({
+  query: z.object({
+    lookbackDays: z.coerce.number().int().min(1).max(365).default(30),
+  }),
+});
+
+const policyProposalReviewSchema = z.object({
+  params: z.object({
+    proposalId: z.string().min(8).max(64),
+  }),
+  body: z.object({
+    decision: z.enum(["approved", "rejected", "deferred"]),
+    reason: z.string().max(500).nullable().optional(),
+  }),
+});
+
+const decisionHistorySchema = z.object({
+  query: z.object({
+    runId: z.string().uuid().optional(),
+    sourceId: z.string().uuid().optional(),
+    counterpartyKey: z.string().min(1).max(255).optional(),
+    signature: z.string().min(20).max(20).optional(),
+    limit: z.coerce.number().int().min(1).max(500).default(100),
+  }),
+});
+
 router.get(
   "/operator/intelligence/exceptions/snapshot",
   requirePermission(Permission.ADMIN_READ),
@@ -132,6 +158,91 @@ router.post(
       return res.status(200).json({ data });
     } catch (error: unknown) {
       return handleRouteError(res, error, "Failed to run policy sandbox", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/intelligence/policy/proposals",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(policyProposalSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({
+          error: "TENANT_CONTEXT_REQUIRED",
+          message: "Tenant context is required",
+        });
+      }
+      const lookbackDays = Number(req.query.lookbackDays ?? 30);
+      const data = await service.listPolicyEvolutionProposals(tenantId, lookbackDays);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load policy evolution proposals", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.post(
+  "/operator/intelligence/policy/proposals/:proposalId/review",
+  requirePermission(Permission.ADMIN_WRITE),
+  validateRequest(policyProposalReviewSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({
+          error: "TENANT_CONTEXT_REQUIRED",
+          message: "Tenant context is required",
+        });
+      }
+      const proposalId = req.params["proposalId"] as string;
+      const data = await service.reviewPolicyEvolutionProposal(tenantId, {
+        proposalId,
+        decision: req.body.decision,
+        reviewerId: req.userId ?? null,
+        reason: req.body.reason ?? null,
+      });
+      return res.status(data.accepted ? 200 : 404).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to review policy evolution proposal", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/intelligence/decisions/history",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(decisionHistorySchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = req.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({
+          error: "TENANT_CONTEXT_REQUIRED",
+          message: "Tenant context is required",
+        });
+      }
+      const data = await service.getDecisionHistory(tenantId, {
+        runId: req.query.runId as string | undefined,
+        sourceId: req.query.sourceId as string | undefined,
+        counterpartyKey: req.query.counterpartyKey as string | undefined,
+        signature: req.query.signature as string | undefined,
+        limit: Number(req.query.limit ?? 100),
+      });
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load decision history", 500, {
         userId: req.userId,
         tenantId: req.tenantId,
       });

--- a/packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts
+++ b/packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts
@@ -4,6 +4,7 @@ jest.mock("../../../infrastructure/db/prisma", () => ({
   prisma: {
     reconciliationMatch: { findMany: jest.fn() },
     reconciliationRun: { findFirst: jest.fn() },
+    reconAudit: { findFirst: jest.fn(), findMany: jest.fn(), create: jest.fn() },
   },
 }));
 
@@ -101,5 +102,149 @@ describe("ExceptionIntelligenceService", () => {
 
     expect(result.metricSupport.falsePositiveRate).toBe("unsupported");
     expect(result.degradedReasons).toContain("run_not_found_or_not_scoped");
+  });
+
+  it("generates deterministic policy proposals and avoids duplicate persistence", async () => {
+    prisma.reconciliationMatch.findMany.mockResolvedValue([
+      {
+        id: "m1",
+        runId: "run-1",
+        sourceTransactionId: "s-tx-1",
+        metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
+        matchType: "unmatched",
+        matchReason: "amount variance",
+        confidence: 0.51,
+        reviewed: false,
+        reviewedAt: null,
+        updatedAt: new Date("2026-03-28T10:00:00Z"),
+        createdAt: new Date("2026-03-28T10:00:00Z"),
+        sourceTransaction: {
+          sourceId: "src-1",
+          externalId: "cp-1",
+          category: "payments",
+          currency: "USD",
+          source: { id: "src-1" },
+        },
+      },
+      {
+        id: "m2",
+        runId: "run-1",
+        sourceTransactionId: "s-tx-2",
+        metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
+        matchType: "unmatched",
+        matchReason: "amount variance",
+        confidence: 0.54,
+        reviewed: true,
+        reviewedBy: "user-1",
+        reviewedAt: new Date("2026-03-28T11:10:00Z"),
+        updatedAt: new Date("2026-03-28T11:10:00Z"),
+        createdAt: new Date("2026-03-28T11:00:00Z"),
+        sourceTransaction: {
+          sourceId: "src-1",
+          externalId: "cp-1",
+          category: "payments",
+          currency: "USD",
+          source: { id: "src-1" },
+        },
+      },
+      {
+        id: "m3",
+        runId: "run-1",
+        sourceTransactionId: "s-tx-3",
+        metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
+        matchType: "unmatched",
+        matchReason: "amount variance",
+        confidence: 0.55,
+        reviewed: false,
+        reviewedAt: null,
+        updatedAt: new Date("2026-03-28T12:00:00Z"),
+        createdAt: new Date("2026-03-28T12:00:00Z"),
+        sourceTransaction: {
+          sourceId: "src-1",
+          externalId: "cp-1",
+          category: "payments",
+          currency: "USD",
+          source: { id: "src-1" },
+        },
+      },
+    ]);
+    prisma.reconAudit.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      entityId: "existing",
+    });
+
+    const first = await service.generatePolicyEvolutionProposals("tenant-1", 30);
+    const second = await service.generatePolicyEvolutionProposals("tenant-1", 30);
+
+    expect(first[0]?.proposalId).toBe(second[0]?.proposalId);
+    expect(prisma.reconAudit.create).toHaveBeenCalledTimes(1);
+    expect(first[0]?.unsupportedMetrics).toContain("false_positive_rate");
+  });
+
+  it("persists proposal review history and blocks missing proposal review", async () => {
+    prisma.reconAudit.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      entityId: "proposal-1",
+    });
+
+    const missing = await service.reviewPolicyEvolutionProposal("tenant-1", {
+      proposalId: "missing",
+      decision: "approved",
+      reviewerId: "user-1",
+      reason: "ok",
+    });
+    const accepted = await service.reviewPolicyEvolutionProposal("tenant-1", {
+      proposalId: "proposal-1",
+      decision: "deferred",
+      reviewerId: "user-2",
+      reason: "need more support",
+    });
+
+    expect(missing.accepted).toBe(false);
+    expect(missing.degradedReasons).toContain("proposal_not_found_or_not_scoped");
+    expect(accepted.accepted).toBe(true);
+    expect(prisma.reconAudit.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          entityType: "policy_proposal",
+          action: "proposal_reviewed",
+        }),
+      })
+    );
+  });
+
+  it("retrieves tenant-scoped decision history with explicit degraded state when sparse", async () => {
+    prisma.reconciliationMatch.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: "m4",
+        runId: "run-2",
+        sourceTransactionId: "s-tx-10",
+        metadata: { rationale_codes: ["AMBIGUOUS_REFERENCE"] },
+        matchType: "unmatched",
+        matchReason: "ignored by operator",
+        confidence: 0.41,
+        reviewed: true,
+        reviewedBy: "user-3",
+        reviewedAt: new Date("2026-03-29T12:00:00Z"),
+        updatedAt: new Date("2026-03-29T12:00:00Z"),
+        createdAt: new Date("2026-03-29T11:00:00Z"),
+        sourceTransaction: {
+          sourceId: "src-2",
+          externalId: "cp-9",
+          category: "fees",
+          currency: "USD",
+          source: { id: "src-2" },
+        },
+      },
+    ]);
+
+    const degraded = await service.getDecisionHistory("tenant-1", { runId: "run-2", limit: 10 });
+    const populated = await service.getDecisionHistory("tenant-1", { runId: "run-2", limit: 10 });
+
+    expect(degraded.degraded).toBe(true);
+    expect(degraded.degradedReasons).toContain("no_reviewed_decisions_in_scope");
+    expect(populated.decisions[0]).toMatchObject({
+      runId: "run-2",
+      resultingState: "reviewed",
+      decision: "ignored",
+    });
   });
 });

--- a/packages/api/src/services/operator-mode/exception-intelligence-service.ts
+++ b/packages/api/src/services/operator-mode/exception-intelligence-service.ts
@@ -94,6 +94,77 @@ export interface EvidencePack {
   exportMetadata: Record<string, unknown>;
 }
 
+export interface PolicyEvolutionProposal {
+  proposalId: string;
+  tenantId: string;
+  generatedAt: string;
+  signature: ExceptionSignature;
+  why: string;
+  historicalBasis: {
+    supportCount: number;
+    lookbackDays: number;
+    openCount: number;
+    resolvedCount: number;
+    lowConfidenceCount: number;
+    adjudicationMix: Record<string, number>;
+  };
+  affectedScope: {
+    sourceIds: string[];
+    counterpartyKeys: string[];
+  };
+  estimatedImpact: {
+    expectedManualReviewReduction: number | null;
+    expectedOpenExceptionChange: number | null;
+  };
+  unsupportedMetrics: string[];
+  riskFlags: string[];
+  dataSufficiency: "insufficient" | "limited" | "sufficient";
+  status: "pending_review" | "approved" | "rejected" | "deferred";
+  latestReview: {
+    decision: "approved" | "rejected" | "deferred";
+    reviewedBy: string | null;
+    reviewedAt: string;
+    reason: string | null;
+  } | null;
+}
+
+export interface DecisionHistoryEntry {
+  matchId: string;
+  runId: string;
+  tenantId: string;
+  signature: string;
+  sourceId: string | null;
+  counterpartyKey: string;
+  previousState: "pending_review";
+  resultingState: "reviewed";
+  decision: "manual" | "ignored";
+  actorId: string | null;
+  reason: string | null;
+  decidedAt: string;
+}
+
+export interface DecisionHistoryResponse {
+  tenantId: string;
+  generatedAt: string;
+  filters: {
+    runId?: string;
+    sourceId?: string;
+    counterpartyKey?: string;
+    signature?: string;
+    limit: number;
+  };
+  degraded: boolean;
+  degradedReasons: string[];
+  decisions: DecisionHistoryEntry[];
+}
+
+export interface PolicyProposalReviewInput {
+  proposalId: string;
+  decision: "approved" | "rejected" | "deferred";
+  reviewerId: string | null;
+  reason: string | null;
+}
+
 export interface PolicySandboxRequest {
   runId: string;
   candidatePolicy: {
@@ -196,6 +267,131 @@ function recommendationFor(cluster: {
     confidenceBasis: "Historically resolved signature with low open burden",
     reasons: [`resolved_ratio=${resolvedRatio.toFixed(2)}`],
     degraded: false,
+  };
+}
+
+function parseClusterFromProposalAudit(afterState: unknown): {
+  signature: ExceptionSignature;
+  volume: number;
+  openCount: number;
+  resolvedCount: number;
+  lowConfidenceCount: number;
+  adjudicationMix: Record<string, number>;
+  sourceIds: string[];
+  counterpartyKeys: string[];
+} | null {
+  const state = asRecord(afterState);
+  const signatureState = asRecord(state["signature"]);
+  const construction = asRecord(signatureState["construction"]);
+  const matchType = construction["matchType"];
+  const category = construction["category"];
+  const currency = construction["currency"];
+  const reason = construction["reason"];
+  if (
+    typeof signatureState["signature"] !== "string" ||
+    typeof matchType !== "string" ||
+    typeof category !== "string" ||
+    typeof currency !== "string" ||
+    typeof reason !== "string"
+  ) {
+    return null;
+  }
+  const rationaleCodes = Array.isArray(construction["rationaleCodes"])
+    ? (construction["rationaleCodes"] as unknown[]).filter(
+        (value): value is string => typeof value === "string"
+      )
+    : [];
+  const sourceIds = Array.isArray(state["sourceIds"])
+    ? (state["sourceIds"] as unknown[]).filter(
+        (value): value is string => typeof value === "string"
+      )
+    : [];
+  const counterpartyKeys = Array.isArray(state["counterpartyKeys"])
+    ? (state["counterpartyKeys"] as unknown[]).filter(
+        (value): value is string => typeof value === "string"
+      )
+    : [];
+  return {
+    signature: {
+      signature: signatureState["signature"],
+      construction: {
+        matchType,
+        category,
+        currency,
+        reason,
+        rationaleCodes,
+      },
+    },
+    volume: Number(state["volume"] ?? 0),
+    openCount: Number(state["openCount"] ?? 0),
+    resolvedCount: Number(state["resolvedCount"] ?? 0),
+    lowConfidenceCount: Number(state["lowConfidenceCount"] ?? 0),
+    adjudicationMix: asRecord(state["adjudicationMix"]) as Record<string, number>,
+    sourceIds,
+    counterpartyKeys,
+  };
+}
+
+function buildProposal(
+  tenantId: string,
+  generatedAt: Date,
+  lookbackDays: number,
+  cluster: {
+    signature: ExceptionSignature;
+    volume: number;
+    openCount: number;
+    resolvedCount: number;
+    lowConfidenceCount: number;
+    adjudicationMix: Record<string, number>;
+    sourceIds: string[];
+    counterpartyKeys: string[];
+  },
+  latestReview: PolicyEvolutionProposal["latestReview"]
+): PolicyEvolutionProposal {
+  const recommendation = recommendationFor(cluster);
+  const riskFlags: string[] = [];
+  if (cluster.openCount / Math.max(1, cluster.volume) > 0.6)
+    riskFlags.push("high_open_exception_concentration");
+  if (cluster.lowConfidenceCount / Math.max(1, cluster.volume) > 0.4)
+    riskFlags.push("high_low_confidence_concentration");
+  if (cluster.volume < 5) riskFlags.push("small_sample_size");
+
+  const dataSufficiency: PolicyEvolutionProposal["dataSufficiency"] =
+    cluster.volume >= 10 ? "sufficient" : cluster.volume >= 5 ? "limited" : "insufficient";
+
+  return {
+    proposalId: crypto
+      .createHash("sha256")
+      .update(`${tenantId}|${cluster.signature.signature}|${lookbackDays}`)
+      .digest("hex")
+      .slice(0, 24),
+    tenantId,
+    generatedAt: generatedAt.toISOString(),
+    signature: cluster.signature,
+    why: recommendation.confidenceBasis,
+    historicalBasis: {
+      supportCount: cluster.volume,
+      lookbackDays,
+      openCount: cluster.openCount,
+      resolvedCount: cluster.resolvedCount,
+      lowConfidenceCount: cluster.lowConfidenceCount,
+      adjudicationMix: cluster.adjudicationMix,
+    },
+    affectedScope: {
+      sourceIds: cluster.sourceIds,
+      counterpartyKeys: cluster.counterpartyKeys,
+    },
+    estimatedImpact: {
+      expectedManualReviewReduction:
+        cluster.volume > 0 ? Number((cluster.resolvedCount / cluster.volume).toFixed(4)) : null,
+      expectedOpenExceptionChange:
+        cluster.volume > 0 ? Number((-(cluster.openCount / cluster.volume)).toFixed(4)) : null,
+    },
+    unsupportedMetrics: ["false_positive_rate", "false_negative_rate", "causal_effect_size"],
+    riskFlags,
+    dataSufficiency,
+    status: latestReview?.decision ?? "pending_review",
+    latestReview,
   };
 }
 
@@ -330,6 +526,303 @@ export class ExceptionIntelligenceService {
         }))
         .sort((a, b) => b.exceptionCount - a.exceptionCount)
         .slice(0, 20),
+    };
+  }
+
+  async generatePolicyEvolutionProposals(
+    tenantId: string,
+    lookbackDays: number
+  ): Promise<PolicyEvolutionProposal[]> {
+    const since = new Date(Date.now() - lookbackDays * 86400000);
+    const matches = await prisma.reconciliationMatch.findMany({
+      where: { tenantId, createdAt: { gte: since } },
+      include: { sourceTransaction: { include: { source: { select: { id: true } } } } },
+      orderBy: { createdAt: "desc" },
+      take: 3000,
+    });
+
+    const clusters = new Map<
+      string,
+      {
+        signature: ExceptionSignature;
+        volume: number;
+        openCount: number;
+        resolvedCount: number;
+        lowConfidenceCount: number;
+        adjudicationMix: Record<string, number>;
+        sourceIds: Set<string>;
+        counterpartyKeys: Set<string>;
+      }
+    >();
+
+    for (const match of matches) {
+      const sig = signatureFrom(match);
+      const current = clusters.get(sig.signature) ?? {
+        signature: sig,
+        volume: 0,
+        openCount: 0,
+        resolvedCount: 0,
+        lowConfidenceCount: 0,
+        adjudicationMix: {},
+        sourceIds: new Set<string>(),
+        counterpartyKeys: new Set<string>(),
+      };
+      current.volume += 1;
+      if (match.reviewed) current.resolvedCount += 1;
+      else current.openCount += 1;
+      if (Number(match.confidence) < 0.75) current.lowConfidenceCount += 1;
+      const reasonKey = match.reviewed
+        ? match.matchReason?.toLowerCase().includes("ignored")
+          ? "ignored"
+          : "manual"
+        : "open";
+      current.adjudicationMix[reasonKey] = (current.adjudicationMix[reasonKey] ?? 0) + 1;
+      const sourceId = match.sourceTransaction?.source?.id;
+      if (sourceId) current.sourceIds.add(sourceId);
+      current.counterpartyKeys.add(
+        match.sourceTransaction?.externalId ?? `txn:${match.sourceTransactionId}`
+      );
+      clusters.set(sig.signature, current);
+    }
+
+    const generatedAt = new Date();
+    const candidateClusters = Array.from(clusters.values())
+      .filter((cluster) => cluster.volume >= 3)
+      .sort((a, b) => b.volume - a.volume)
+      .slice(0, 20);
+
+    const proposals: PolicyEvolutionProposal[] = [];
+    for (const cluster of candidateClusters) {
+      const proposal = buildProposal(
+        tenantId,
+        generatedAt,
+        lookbackDays,
+        {
+          signature: cluster.signature,
+          volume: cluster.volume,
+          openCount: cluster.openCount,
+          resolvedCount: cluster.resolvedCount,
+          lowConfidenceCount: cluster.lowConfidenceCount,
+          adjudicationMix: cluster.adjudicationMix,
+          sourceIds: Array.from(cluster.sourceIds.values()).sort(),
+          counterpartyKeys: Array.from(cluster.counterpartyKeys.values()).sort(),
+        },
+        null
+      );
+
+      const existing = await prisma.reconAudit.findFirst({
+        where: {
+          tenantId,
+          entityType: "policy_proposal",
+          entityId: proposal.proposalId,
+          action: "proposal_generated",
+        },
+        orderBy: { createdAt: "desc" },
+      });
+      if (!existing) {
+        await prisma.reconAudit.create({
+          data: {
+            tenantId,
+            reconJobId: null,
+            reconResultId: null,
+            userId: null,
+            auditType: "policy_evolution",
+            action: "proposal_generated",
+            entityType: "policy_proposal",
+            entityId: proposal.proposalId,
+            changes: {
+              lookbackDays,
+              generatedAt: proposal.generatedAt,
+            },
+            beforeState: {},
+            afterState: JSON.parse(
+              JSON.stringify({
+                signature: proposal.signature,
+                volume: proposal.historicalBasis.supportCount,
+                openCount: proposal.historicalBasis.openCount,
+                resolvedCount: proposal.historicalBasis.resolvedCount,
+                lowConfidenceCount: proposal.historicalBasis.lowConfidenceCount,
+                adjudicationMix: proposal.historicalBasis.adjudicationMix,
+                sourceIds: proposal.affectedScope.sourceIds,
+                counterpartyKeys: proposal.affectedScope.counterpartyKeys,
+              })
+            ),
+            metadata: {
+              unsupportedMetrics: proposal.unsupportedMetrics,
+              riskFlags: proposal.riskFlags,
+              dataSufficiency: proposal.dataSufficiency,
+            },
+          },
+        });
+      }
+      proposals.push(proposal);
+    }
+
+    return proposals;
+  }
+
+  async listPolicyEvolutionProposals(
+    tenantId: string,
+    lookbackDays: number
+  ): Promise<PolicyEvolutionProposal[]> {
+    await this.generatePolicyEvolutionProposals(tenantId, lookbackDays);
+    const generated = await prisma.reconAudit.findMany({
+      where: { tenantId, entityType: "policy_proposal", action: "proposal_generated" },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+    });
+    const reviews = await prisma.reconAudit.findMany({
+      where: { tenantId, entityType: "policy_proposal", action: "proposal_reviewed" },
+      orderBy: { createdAt: "desc" },
+      take: 500,
+    });
+    const latestReviewByProposal = new Map<string, PolicyEvolutionProposal["latestReview"]>();
+    for (const review of reviews) {
+      if (!review.entityId) continue;
+      if (latestReviewByProposal.has(review.entityId)) continue;
+      const changes = asRecord(review.changes);
+      const decision = changes["decision"];
+      if (decision !== "approved" && decision !== "rejected" && decision !== "deferred") continue;
+      latestReviewByProposal.set(review.entityId, {
+        decision,
+        reviewedBy: review.userId,
+        reviewedAt: review.createdAt.toISOString(),
+        reason: typeof changes["reason"] === "string" ? changes["reason"] : null,
+      });
+    }
+    return generated
+      .map((audit) => {
+        if (!audit.entityId) return null;
+        const cluster = parseClusterFromProposalAudit(audit.afterState);
+        if (!cluster) return null;
+        return buildProposal(
+          tenantId,
+          audit.createdAt,
+          lookbackDays,
+          cluster,
+          latestReviewByProposal.get(audit.entityId) ?? null
+        );
+      })
+      .filter((proposal): proposal is PolicyEvolutionProposal => Boolean(proposal));
+  }
+
+  async reviewPolicyEvolutionProposal(
+    tenantId: string,
+    input: PolicyProposalReviewInput
+  ): Promise<{ accepted: boolean; status: string; degraded: boolean; degradedReasons: string[] }> {
+    const proposal = await prisma.reconAudit.findFirst({
+      where: {
+        tenantId,
+        entityType: "policy_proposal",
+        entityId: input.proposalId,
+        action: "proposal_generated",
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    if (!proposal) {
+      return {
+        accepted: false,
+        status: "missing",
+        degraded: true,
+        degradedReasons: ["proposal_not_found_or_not_scoped"],
+      };
+    }
+
+    await prisma.reconAudit.create({
+      data: {
+        tenantId,
+        reconJobId: null,
+        reconResultId: null,
+        userId: input.reviewerId,
+        auditType: "policy_evolution",
+        action: "proposal_reviewed",
+        entityType: "policy_proposal",
+        entityId: input.proposalId,
+        changes: {
+          decision: input.decision,
+          reason: input.reason,
+        },
+        beforeState: {},
+        afterState: {
+          status: input.decision,
+        },
+        metadata: {
+          reviewedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    return {
+      accepted: true,
+      status: input.decision,
+      degraded: false,
+      degradedReasons: [],
+    };
+  }
+
+  async getDecisionHistory(
+    tenantId: string,
+    filters: {
+      runId?: string;
+      sourceId?: string;
+      counterpartyKey?: string;
+      signature?: string;
+      limit?: number;
+    }
+  ): Promise<DecisionHistoryResponse> {
+    const limit = Math.max(1, Math.min(filters.limit ?? 100, 500));
+    const matches = await prisma.reconciliationMatch.findMany({
+      where: {
+        tenantId,
+        reviewed: true,
+        ...(filters.runId ? { runId: filters.runId } : {}),
+        ...(filters.sourceId ? { sourceTransaction: { sourceId: filters.sourceId } } : {}),
+        ...(filters.counterpartyKey
+          ? { sourceTransaction: { externalId: filters.counterpartyKey } }
+          : {}),
+      },
+      include: { sourceTransaction: { include: { source: { select: { id: true } } } } },
+      orderBy: { reviewedAt: "desc" },
+      take: limit * 3,
+    });
+
+    const decisionsMapped = matches.map((match): DecisionHistoryEntry | null => {
+      const signature = signatureFrom(match).signature;
+      if (filters.signature && signature !== filters.signature) return null;
+      return {
+        matchId: match.id,
+        runId: match.runId,
+        tenantId,
+        signature,
+        sourceId: match.sourceTransaction?.source?.id ?? null,
+        counterpartyKey: match.sourceTransaction?.externalId ?? `txn:${match.sourceTransactionId}`,
+        previousState: "pending_review" as const,
+        resultingState: "reviewed" as const,
+        decision: (match.matchReason?.toLowerCase().includes("ignored") ? "ignored" : "manual") as
+          | "manual"
+          | "ignored",
+        actorId: match.reviewedBy,
+        reason: match.matchReason,
+        decidedAt: (match.reviewedAt ?? match.updatedAt).toISOString(),
+      };
+    });
+    const decisions = decisionsMapped
+      .filter((decision): decision is DecisionHistoryEntry => decision !== null)
+      .slice(0, limit);
+
+    return {
+      tenantId,
+      generatedAt: new Date().toISOString(),
+      filters: {
+        runId: filters.runId,
+        sourceId: filters.sourceId,
+        counterpartyKey: filters.counterpartyKey,
+        signature: filters.signature,
+        limit,
+      },
+      degraded: decisions.length === 0,
+      degradedReasons: decisions.length === 0 ? ["no_reviewed_decisions_in_scope"] : [],
+      decisions,
     };
   }
 


### PR DESCRIPTION
### Motivation
- Provide a canonical, backend-owned policy-memory loop so recurring exception signatures can be turned into reviewable policy evolution proposals instead of ephemeral UI-only suggestions. 
- Make operator decisions durable and queryable by run/source/counterparty/signature so operator judgment becomes reusable institutional memory rather than transient clicks. 
- Persist proposals and review actions in existing canonical audit storage to avoid shadow tables and preserve explainable, tenant-scoped history. 
- Surface explicit degraded-state semantics for sparse data and unsupported metrics to avoid confidence theater and silent fallbacks. 

### Description
- Added new types and service functions to `ExceptionIntelligenceService` including `PolicyEvolutionProposal`, `generatePolicyEvolutionProposals`, `listPolicyEvolutionProposals`, `reviewPolicyEvolutionProposal`, and decision-history retrieval `getDecisionHistory`. 
- Persisted proposal generation and review events to the canonical `reconAudit` audit table (`entityType = 'policy_proposal'`, actions `proposal_generated` / `proposal_reviewed`) and rehydrate latest review state from those audit records. 
- Implemented deterministic proposal construction and explicit fields for `why`, `historicalBasis`, `affectedScope`, `unsupportedMetrics`, `riskFlags`, `dataSufficiency`, `estimatedImpact`, and review metadata so proposals are replayable and explainable. 
- Exposed new v1 operator routes in `packages/api/src/routes/v1/exception-intelligence.ts`: `GET /operator/intelligence/policy/proposals`, `POST /operator/intelligence/policy/proposals/:proposalId/review`, and `GET /operator/intelligence/decisions/history`, all tenant-scoped and permission-checked. 
- Added and updated targeted unit tests in `packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts` to cover deterministic proposal generation (and dedupe), review persistence, and degraded decision-history behavior; no DB schema migration was added in this pass. 

### Testing
- `pnpm --filter @settler/api lint` ✅ (completed without errors) 
- `pnpm --filter @settler/api typecheck` ✅ (TS typecheck passed after fixes) 
- `pnpm --filter @settler/api test -- src/services/operator-mode/__tests__/exception-intelligence-service.test.ts` ✅ (service tests passed: 6/6) 
- `pnpm --filter @settler/api build` ✅ (package build succeeded) 
- `pnpm run verify:policy` ✅ (policy verification and replay checks passed) 
- `pnpm run verify:routes` ✅ (route verification ran and critical routes responded without hard-500s) 
- `pnpm run verify:surface-docs` ✅ (surface docs written and in sync) 
- `pnpm run verify:tenant` ⚠️ (environment limitation: failed with ENOENT for missing `security/route-registry.json` in this environment; tenant coverage check could not complete)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8814ea5c08328bf16e719804da4c7)