### PR TITLE
API: consolidate exception-intelligence routes and add tenant-scoped reconciliation memory graph

### DIFF
--- a/packages/api/src/routes/v1/exception-intelligence.ts
+++ b/packages/api/src/routes/v1/exception-intelligence.ts
@@ -22,6 +22,12 @@ const runSchema = z.object({
   }),
 });
 
+const proposalParamsSchema = z.object({
+  params: z.object({
+    proposalId: z.string().min(8).max(64),
+  }),
+});
+
 const policySandboxSchema = z.object({
   body: z.object({
     runId: z.string().uuid(),
@@ -31,12 +37,6 @@ const policySandboxSchema = z.object({
       fuzzyDescriptionThreshold: z.number().min(0).max(1),
       requireExactAmount: z.boolean(),
     }),
-  }),
-});
-
-const policyProposalSchema = z.object({
-  query: z.object({
-    lookbackDays: z.coerce.number().int().min(1).max(365).default(30),
   }),
 });
 
@@ -60,6 +60,17 @@ const decisionHistorySchema = z.object({
   }),
 });
 
+function tenantOr400(req: AuthRequest, res: Response): string | null {
+  if (!req.tenantId) {
+    res.status(400).json({
+      error: "TENANT_CONTEXT_REQUIRED",
+      message: "Tenant context is required",
+    });
+    return null;
+  }
+  return req.tenantId;
+}
+
 router.get(
   "/operator/intelligence/exceptions/snapshot",
   requirePermission(Permission.ADMIN_READ),
@@ -73,6 +84,26 @@ router.get(
       return res.status(200).json({ data });
     } catch (error: unknown) {
       return handleRouteError(res, error, "Failed to load exception intelligence snapshot", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/intelligence/memory-graph",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(snapshotSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      const lookbackDays = Number(req.query.lookbackDays ?? 30);
+      const data = await service.getReconciliationMemoryGraph(tenantId, lookbackDays);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load reconciliation memory graph", 500, {
         userId: req.userId,
         tenantId: req.tenantId,
       });
@@ -108,7 +139,7 @@ router.get(
     try {
       const tenantId = tenantOr400(req, res);
       if (!tenantId) return;
-      const proposalId = paramAsString(req.params["proposalId"]);
+      const proposalId = req.params["proposalId"] as string;
       const data = await service.getPolicyEvolutionProposalDetail(tenantId, proposalId);
       if (!data)
         return res.status(404).json({ error: "PROPOSAL_NOT_FOUND", message: "Proposal not found" });
@@ -125,26 +156,19 @@ router.get(
 router.post(
   "/operator/intelligence/policy/proposals/:proposalId/review",
   requirePermission(Permission.ADMIN_WRITE),
-  validateRequest(proposalReviewSchema),
+  validateRequest(policyProposalReviewSchema),
   async (req: AuthRequest, res: Response) => {
     try {
       const tenantId = tenantOr400(req, res);
       if (!tenantId) return;
-      if (!req.userId) {
-        return res
-          .status(422)
-          .json({ error: "ACTOR_REQUIRED", message: "Actor user id is required" });
-      }
-      const proposalId = paramAsString(req.params["proposalId"]);
-      const action = await service.reviewPolicyEvolutionProposal(tenantId, proposalId, {
-        action: req.body.action,
-        actorUserId: req.userId,
+      const proposalId = req.params["proposalId"] as string;
+      const data = await service.reviewPolicyEvolutionProposal(tenantId, {
+        proposalId,
+        decision: req.body.decision,
+        reviewerId: req.userId ?? null,
         reason: req.body.reason ?? null,
       });
-      if (!action.found) {
-        return res.status(404).json({ error: "PROPOSAL_NOT_FOUND", message: "Proposal not found" });
-      }
-      return res.status(200).json({ data: action });
+      return res.status(data.accepted ? 200 : 404).json({ data });
     } catch (error: unknown) {
       return handleRouteError(res, error, "Failed to review policy proposal", 500, {
         userId: req.userId,
@@ -162,7 +186,7 @@ router.get(
     try {
       const tenantId = tenantOr400(req, res);
       if (!tenantId) return;
-      const proposalId = paramAsString(req.params["proposalId"]);
+      const proposalId = req.params["proposalId"] as string;
       const data = await service.getProposalHistory(tenantId, proposalId);
       if (!data)
         return res.status(404).json({ error: "PROPOSAL_NOT_FOUND", message: "Proposal not found" });
@@ -206,9 +230,10 @@ router.get(
       if (!tenantId) return;
       const data = await service.getDecisionHistory(tenantId, {
         runId: req.query.runId as string | undefined,
-        signature: req.query.signature as string | undefined,
+        sourceId: req.query.sourceId as string | undefined,
         counterpartyKey: req.query.counterpartyKey as string | undefined,
-        sourcePair: req.query.sourcePair as string | undefined,
+        signature: req.query.signature as string | undefined,
+        limit: Number(req.query.limit ?? 100),
       });
       return res.status(200).json({ data });
     } catch (error: unknown) {
@@ -228,8 +253,7 @@ router.get(
     try {
       const tenantId = tenantOr400(req, res);
       if (!tenantId) return;
-      const runIdParam = req.params["runId"];
-      const runId = Array.isArray(runIdParam) ? (runIdParam[0] ?? "") : (runIdParam ?? "");
+      const runId = req.params["runId"] as string;
       const data = await service.getProofGraph(tenantId, runId);
       return res.status(data.degraded && data.nodes.length === 0 ? 404 : 200).json({ data });
     } catch (error: unknown) {
@@ -249,8 +273,7 @@ router.get(
     try {
       const tenantId = tenantOr400(req, res);
       if (!tenantId) return;
-      const runIdParam = req.params["runId"];
-      const runId = Array.isArray(runIdParam) ? (runIdParam[0] ?? "") : (runIdParam ?? "");
+      const runId = req.params["runId"] as string;
       const data = await service.buildEvidencePack(tenantId, runId);
       return res.status(200).json({ data });
     } catch (error: unknown) {
@@ -274,91 +297,6 @@ router.post(
       return res.status(200).json({ data });
     } catch (error: unknown) {
       return handleRouteError(res, error, "Failed to run policy sandbox", 500, {
-        userId: req.userId,
-        tenantId: req.tenantId,
-      });
-    }
-  }
-);
-
-router.get(
-  "/operator/intelligence/policy/proposals",
-  requirePermission(Permission.ADMIN_READ),
-  validateRequest(policyProposalSchema),
-  async (req: AuthRequest, res: Response) => {
-    try {
-      const tenantId = req.tenantId;
-      if (!tenantId) {
-        return res.status(400).json({
-          error: "TENANT_CONTEXT_REQUIRED",
-          message: "Tenant context is required",
-        });
-      }
-      const lookbackDays = Number(req.query.lookbackDays ?? 30);
-      const data = await service.listPolicyEvolutionProposals(tenantId, lookbackDays);
-      return res.status(200).json({ data });
-    } catch (error: unknown) {
-      return handleRouteError(res, error, "Failed to load policy evolution proposals", 500, {
-        userId: req.userId,
-        tenantId: req.tenantId,
-      });
-    }
-  }
-);
-
-router.post(
-  "/operator/intelligence/policy/proposals/:proposalId/review",
-  requirePermission(Permission.ADMIN_WRITE),
-  validateRequest(policyProposalReviewSchema),
-  async (req: AuthRequest, res: Response) => {
-    try {
-      const tenantId = req.tenantId;
-      if (!tenantId) {
-        return res.status(400).json({
-          error: "TENANT_CONTEXT_REQUIRED",
-          message: "Tenant context is required",
-        });
-      }
-      const proposalId = req.params["proposalId"] as string;
-      const data = await service.reviewPolicyEvolutionProposal(tenantId, {
-        proposalId,
-        decision: req.body.decision,
-        reviewerId: req.userId ?? null,
-        reason: req.body.reason ?? null,
-      });
-      return res.status(data.accepted ? 200 : 404).json({ data });
-    } catch (error: unknown) {
-      return handleRouteError(res, error, "Failed to review policy evolution proposal", 500, {
-        userId: req.userId,
-        tenantId: req.tenantId,
-      });
-    }
-  }
-);
-
-router.get(
-  "/operator/intelligence/decisions/history",
-  requirePermission(Permission.ADMIN_READ),
-  validateRequest(decisionHistorySchema),
-  async (req: AuthRequest, res: Response) => {
-    try {
-      const tenantId = req.tenantId;
-      if (!tenantId) {
-        return res.status(400).json({
-          error: "TENANT_CONTEXT_REQUIRED",
-          message: "Tenant context is required",
-        });
-      }
-      const data = await service.getDecisionHistory(tenantId, {
-        runId: req.query.runId as string | undefined,
-        sourceId: req.query.sourceId as string | undefined,
-        counterpartyKey: req.query.counterpartyKey as string | undefined,
-        signature: req.query.signature as string | undefined,
-        limit: Number(req.query.limit ?? 100),
-      });
-      return res.status(200).json({ data });
-    } catch (error: unknown) {
-      return handleRouteError(res, error, "Failed to load decision history", 500, {
         userId: req.userId,
         tenantId: req.tenantId,
       });

--- a/packages/api/src/services/operator-mode/__tests__/exception-intelligence-memory-graph.test.ts
+++ b/packages/api/src/services/operator-mode/__tests__/exception-intelligence-memory-graph.test.ts
@@ -1,0 +1,179 @@
+import { ExceptionIntelligenceService } from "../exception-intelligence-service";
+
+jest.mock("../../../infrastructure/db/prisma", () => ({
+  prisma: {
+    reconciliationMatch: { findMany: jest.fn() },
+    reconciliationRun: { findFirst: jest.fn() },
+    reconAudit: { findFirst: jest.fn(), findMany: jest.fn(), create: jest.fn() },
+  },
+}));
+
+const { prisma } = require("../../../infrastructure/db/prisma");
+
+describe("ExceptionIntelligenceService memory graph", () => {
+  const service = new ExceptionIntelligenceService();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("builds a tenant-scoped memory graph with proposal review lineage", async () => {
+    prisma.reconciliationMatch.findMany.mockResolvedValue([
+      {
+        id: "m-1",
+        runId: "run-1",
+        sourceTransactionId: "st-1",
+        metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
+        matchType: "unmatched",
+        matchReason: "amount variance",
+        confidence: 0.6,
+        reviewed: true,
+        reviewedBy: "user-1",
+        reviewedAt: new Date("2026-03-28T11:00:00Z"),
+        updatedAt: new Date("2026-03-28T11:00:00Z"),
+        createdAt: new Date("2026-03-28T10:00:00Z"),
+        sourceTransaction: {
+          sourceId: "src-1",
+          externalId: "cp-1",
+          category: "payments",
+          currency: "USD",
+          description: "Merchant A",
+          source: { id: "src-1", name: "Stripe" },
+        },
+      },
+      {
+        id: "m-2",
+        runId: "run-1",
+        sourceTransactionId: "st-2",
+        metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
+        matchType: "unmatched",
+        matchReason: "amount variance",
+        confidence: 0.61,
+        reviewed: false,
+        reviewedBy: null,
+        reviewedAt: null,
+        updatedAt: new Date("2026-03-28T12:00:00Z"),
+        createdAt: new Date("2026-03-28T12:00:00Z"),
+        sourceTransaction: {
+          sourceId: "src-1",
+          externalId: "cp-1",
+          category: "payments",
+          currency: "USD",
+          description: "Merchant A",
+          source: { id: "src-1", name: "Stripe" },
+        },
+      },
+      {
+        id: "m-3",
+        runId: "run-2",
+        sourceTransactionId: "st-3",
+        metadata: { rationale_codes: ["LOW_CONFIDENCE"] },
+        matchType: "unmatched",
+        matchReason: "amount variance",
+        confidence: 0.59,
+        reviewed: false,
+        reviewedBy: null,
+        reviewedAt: null,
+        updatedAt: new Date("2026-03-28T13:00:00Z"),
+        createdAt: new Date("2026-03-28T13:00:00Z"),
+        sourceTransaction: {
+          sourceId: "src-1",
+          externalId: "cp-1",
+          category: "payments",
+          currency: "USD",
+          description: "Merchant A",
+          source: { id: "src-1", name: "Stripe" },
+        },
+      },
+    ]);
+
+    prisma.reconAudit.findFirst.mockResolvedValue(null);
+    prisma.reconAudit.findMany
+      .mockResolvedValueOnce([
+        {
+          tenantId: "tenant-1",
+          entityId: "proposal-1",
+          action: "proposal_generated",
+          createdAt: new Date("2026-03-29T00:00:00Z"),
+          afterState: {
+            signature: {
+              signature: "09f0ef31ce6d2dc6b38d",
+              construction: {
+                matchType: "unmatched",
+                category: "payments",
+                currency: "USD",
+                reason: "amount variance",
+                rationaleCodes: ["LOW_CONFIDENCE"],
+              },
+            },
+            volume: 3,
+            openCount: 2,
+            resolvedCount: 1,
+            lowConfidenceCount: 3,
+            adjudicationMix: { open: 2, manual: 1 },
+            sourceIds: ["src-1"],
+            counterpartyKeys: ["cp-1"],
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          tenantId: "tenant-1",
+          entityId: "proposal-1",
+          action: "proposal_reviewed",
+          userId: "reviewer-1",
+          changes: { decision: "approved", reason: "strong repeated support" },
+          metadata: {},
+          createdAt: new Date("2026-03-29T01:00:00Z"),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          tenantId: "tenant-1",
+          entityId: "proposal-1",
+          action: "proposal_generated",
+          userId: null,
+          changes: {},
+          metadata: {},
+          createdAt: new Date("2026-03-29T00:00:00Z"),
+        },
+        {
+          tenantId: "tenant-1",
+          entityId: "proposal-1",
+          action: "proposal_reviewed",
+          userId: "reviewer-1",
+          changes: { decision: "approved", reason: "strong repeated support" },
+          metadata: {},
+          createdAt: new Date("2026-03-29T01:00:00Z"),
+        },
+      ]);
+
+    const graph = await service.getReconciliationMemoryGraph("tenant-1", 30);
+
+    expect(graph.tenantId).toBe("tenant-1");
+    expect(graph.nodes.some((node) => node.type === "proposal_review")).toBe(true);
+    expect(
+      graph.edges.some((edge) => edge.relation === "reviews" && edge.to.startsWith("proposal:"))
+    ).toBe(true);
+    expect(graph.degraded).toBe(false);
+  });
+
+  it("marks proposal history as degraded when review is missing", async () => {
+    prisma.reconAudit.findMany.mockResolvedValue([
+      {
+        tenantId: "tenant-1",
+        entityId: "proposal-1",
+        action: "proposal_generated",
+        userId: null,
+        changes: {},
+        metadata: {},
+        createdAt: new Date("2026-03-29T00:00:00Z"),
+      },
+    ]);
+
+    const history = await service.getProposalHistory("tenant-1", "proposal-1");
+
+    expect(history).not.toBeNull();
+    expect(history?.degraded).toBe(true);
+    expect(history?.degradedReasons).toContain("proposal_has_no_review_history");
+    expect(history?.latestStatus).toBe("pending_review");
+  });
+});

--- a/packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts
+++ b/packages/api/src/services/operator-mode/__tests__/exception-intelligence-service.test.ts
@@ -157,20 +157,17 @@ describe("ExceptionIntelligenceService", () => {
   });
 
   it("stores proposal review transitions", async () => {
-    prisma.policyEvolutionProposal.findFirst.mockResolvedValue({
-      id: "p1",
-      status: "pending_review",
-    });
-    prisma.$transaction.mockResolvedValue([]);
+    prisma.reconAudit.findFirst.mockResolvedValue({ entityId: "proposal-1" });
 
-    const result = await service.reviewPolicyEvolutionProposal("tenant-1", "proposal-1", {
-      action: "approve",
-      actorUserId: "user-1",
+    const result = await service.reviewPolicyEvolutionProposal("tenant-1", {
+      proposalId: "proposal-1",
+      decision: "approved",
+      reviewerId: "user-1",
       reason: "evidence stable",
     });
 
-    expect(result).toMatchObject({ found: true, status: "approved" });
-    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(result).toMatchObject({ accepted: true, status: "approved" });
+    expect(prisma.reconAudit.create).toHaveBeenCalled();
   });
 
   it("marks unsupported policy metrics explicitly", async () => {

--- a/packages/api/src/services/operator-mode/exception-intelligence-service.ts
+++ b/packages/api/src/services/operator-mode/exception-intelligence-service.ts
@@ -1063,6 +1063,317 @@ export class ExceptionIntelligenceService {
     };
   }
 
+  async getPolicyEvolutionProposalDetail(
+    tenantId: string,
+    proposalId: string
+  ): Promise<PolicyEvolutionProposal | null> {
+    const proposals = await this.listPolicyEvolutionProposals(tenantId, 30);
+    return proposals.find((proposal) => proposal.proposalId === proposalId) ?? null;
+  }
+
+  async getProposalHistory(
+    tenantId: string,
+    proposalId: string
+  ): Promise<{
+    proposalId: string;
+    tenantId: string;
+    generatedAt: string | null;
+    latestStatus: "pending_review" | "approved" | "rejected" | "deferred";
+    events: Array<{
+      action: string;
+      actorUserId: string | null;
+      occurredAt: string;
+      changes: Record<string, unknown>;
+      metadata: Record<string, unknown>;
+    }>;
+    degraded: boolean;
+    degradedReasons: string[];
+  } | null> {
+    const events = await prisma.reconAudit.findMany({
+      where: {
+        tenantId,
+        entityType: "policy_proposal",
+        entityId: proposalId,
+        action: { in: ["proposal_generated", "proposal_reviewed"] },
+      },
+      orderBy: { createdAt: "asc" },
+      take: 100,
+    });
+
+    if (events.length === 0) return null;
+
+    const generated = events.find((event) => event.action === "proposal_generated") ?? null;
+    const latestReview =
+      [...events].reverse().find((event) => event.action === "proposal_reviewed") ?? null;
+    const latestDecision = asRecord(latestReview?.changes ?? {})["decision"];
+
+    return {
+      proposalId,
+      tenantId,
+      generatedAt: generated?.createdAt.toISOString() ?? null,
+      latestStatus:
+        latestDecision === "approved" ||
+        latestDecision === "rejected" ||
+        latestDecision === "deferred"
+          ? latestDecision
+          : "pending_review",
+      events: events.map((event) => ({
+        action: event.action,
+        actorUserId: event.userId,
+        occurredAt: event.createdAt.toISOString(),
+        changes: asRecord(event.changes),
+        metadata: asRecord(event.metadata),
+      })),
+      degraded: events.every((event) => event.action !== "proposal_reviewed"),
+      degradedReasons: events.some((event) => event.action === "proposal_reviewed")
+        ? []
+        : ["proposal_has_no_review_history"],
+    };
+  }
+
+  async getExceptionPlaybooks(
+    tenantId: string,
+    lookbackDays: number
+  ): Promise<{
+    tenantId: string;
+    generatedAt: string;
+    lookbackDays: number;
+    playbooks: ExceptionPlaybookSummary[];
+    degraded: boolean;
+    degradedReasons: string[];
+  }> {
+    const snapshot = await this.getSnapshot(tenantId, lookbackDays);
+    const playbooks: ExceptionPlaybookSummary[] = snapshot.clusters.map((cluster) => {
+      const action = cluster.recommendation.action;
+      return {
+        signature: cluster.signature.signature,
+        clusterIdentity: cluster.signature.construction,
+        commonResolutionPaths: cluster.resolutionPath.adjudicationMix,
+        handlingTimeMinutes: {
+          average: cluster.resolutionPath.avgResolutionMinutes,
+          median: cluster.resolutionPath.medianResolutionMinutes,
+        },
+        sourceSystems: snapshot.sourceTrustSignals.map((signal) => signal.sourceName),
+        commonOperatorActions:
+          action === "manual_review"
+            ? ["manual_review"]
+            : action === "policy_adjustment"
+              ? ["policy_review"]
+              : action === "auto_match_candidate"
+                ? ["monitor_and_sample"]
+                : ["gather_more_evidence"],
+        escalationIndicators:
+          cluster.openCount > Math.max(2, Math.floor(cluster.volume * 0.6))
+            ? ["high_unresolved_concentration"]
+            : [],
+        ambiguityMarkers:
+          cluster.recommendation.degraded || cluster.recommendation.action === "insufficient_data"
+            ? ["insufficient_cluster_volume"]
+            : [],
+        evidenceCoverage:
+          cluster.volume >= 8 ? "strong" : cluster.volume >= 3 ? "partial" : "insufficient",
+        basisType: cluster.resolvedCount > 0 && cluster.openCount > 0 ? "mixed" : "automatic_only",
+        degradedReasons:
+          cluster.recommendation.degraded || cluster.volume < 3
+            ? ["limited_historical_support"]
+            : [],
+      };
+    });
+
+    return {
+      tenantId,
+      generatedAt: new Date().toISOString(),
+      lookbackDays,
+      playbooks,
+      degraded: snapshot.degraded,
+      degradedReasons: snapshot.degradedReasons,
+    };
+  }
+
+  async getReconciliationMemoryGraph(
+    tenantId: string,
+    lookbackDays: number
+  ): Promise<{
+    tenantId: string;
+    generatedAt: string;
+    lookbackDays: number;
+    degraded: boolean;
+    degradedReasons: string[];
+    nodes: Array<{ id: string; type: string; label: string; metadata: Record<string, unknown> }>;
+    edges: Array<{ from: string; to: string; relation: string }>;
+  }> {
+    const [snapshot, proposals, decisions] = await Promise.all([
+      this.getSnapshot(tenantId, lookbackDays),
+      this.listPolicyEvolutionProposals(tenantId, lookbackDays),
+      this.getDecisionHistory(tenantId, { limit: 300 }),
+    ]);
+
+    const proposalHistory = await Promise.all(
+      proposals.map(async (proposal) => ({
+        proposalId: proposal.proposalId,
+        history: await this.getProposalHistory(tenantId, proposal.proposalId),
+      }))
+    );
+
+    const nodes: Array<{
+      id: string;
+      type: string;
+      label: string;
+      metadata: Record<string, unknown>;
+    }> = [];
+    const edges: Array<{ from: string; to: string; relation: string }> = [];
+
+    for (const cluster of snapshot.clusters) {
+      nodes.push({
+        id: `signature:${cluster.signature.signature}`,
+        type: "exception_signature",
+        label: cluster.signature.signature,
+        metadata: {
+          volume: cluster.volume,
+          openCount: cluster.openCount,
+          resolvedCount: cluster.resolvedCount,
+          recommendation: cluster.recommendation.action,
+        },
+      });
+
+      for (const source of snapshot.sourceTrustSignals) {
+        const sourceNode = `source:${source.sourceId}`;
+        if (!nodes.some((node) => node.id === sourceNode)) {
+          nodes.push({
+            id: sourceNode,
+            type: "source_system",
+            label: source.sourceName,
+            metadata: {
+              totalExceptions: source.totalExceptions,
+              resolvedRate: source.resolvedRate,
+              trustScore: source.trustScore,
+              basis: source.basis,
+            },
+          });
+        }
+        edges.push({
+          from: sourceNode,
+          to: `signature:${cluster.signature.signature}`,
+          relation: "participates_in",
+        });
+      }
+    }
+
+    for (const counterparty of snapshot.counterparties) {
+      const counterpartyNode = `counterparty:${counterparty.counterpartyKey}`;
+      nodes.push({
+        id: counterpartyNode,
+        type: "counterparty",
+        label: counterparty.displayName ?? counterparty.counterpartyKey,
+        metadata: {
+          exceptionCount: counterparty.exceptionCount,
+          supportLevel: counterparty.supportLevel,
+        },
+      });
+    }
+
+    for (const decision of decisions.decisions) {
+      const decisionNode = `decision:${decision.matchId}`;
+      nodes.push({
+        id: decisionNode,
+        type: "operator_decision",
+        label: decision.decision,
+        metadata: {
+          runId: decision.runId,
+          actorId: decision.actorId,
+          decidedAt: decision.decidedAt,
+          resultingState: decision.resultingState,
+          reason: decision.reason,
+        },
+      });
+      if (decision.signature) {
+        edges.push({
+          from: decisionNode,
+          to: `signature:${decision.signature}`,
+          relation: "resolves",
+        });
+      }
+      if (decision.counterpartyKey) {
+        edges.push({
+          from: decisionNode,
+          to: `counterparty:${decision.counterpartyKey}`,
+          relation: "about_counterparty",
+        });
+      }
+      if (decision.runId) {
+        const runNode = `run:${decision.runId}`;
+        if (!nodes.some((node) => node.id === runNode)) {
+          nodes.push({
+            id: runNode,
+            type: "reconciliation_run",
+            label: decision.runId,
+            metadata: {},
+          });
+        }
+        edges.push({ from: runNode, to: decisionNode, relation: "includes_decision" });
+      }
+    }
+
+    for (const proposal of proposals) {
+      const proposalNode = `proposal:${proposal.proposalId}`;
+      nodes.push({
+        id: proposalNode,
+        type: "policy_evolution_proposal",
+        label: proposal.proposalId,
+        metadata: {
+          status: proposal.status,
+          dataSufficiency: proposal.dataSufficiency,
+          riskFlags: proposal.riskFlags,
+          unsupportedMetrics: proposal.unsupportedMetrics,
+        },
+      });
+      edges.push({
+        from: proposalNode,
+        to: `signature:${proposal.signature.signature}`,
+        relation: "targets_signature",
+      });
+
+      const history = proposalHistory.find(
+        (item) => item.proposalId === proposal.proposalId
+      )?.history;
+      for (const event of history?.events ?? []) {
+        if (event.action !== "proposal_reviewed") continue;
+        const reviewNode = `proposal_review:${proposal.proposalId}:${event.occurredAt}`;
+        nodes.push({
+          id: reviewNode,
+          type: "proposal_review",
+          label: String(event.changes["decision"] ?? "review"),
+          metadata: {
+            actorUserId: event.actorUserId,
+            occurredAt: event.occurredAt,
+            reason: event.changes["reason"] ?? null,
+          },
+        });
+        edges.push({ from: reviewNode, to: proposalNode, relation: "reviews" });
+      }
+    }
+
+    const dedupedNodes = Array.from(new Map(nodes.map((node) => [node.id, node])).values());
+    const dedupedEdges = Array.from(
+      new Map(edges.map((edge) => [`${edge.from}|${edge.relation}|${edge.to}`, edge])).values()
+    );
+
+    const degradedReasons = [
+      ...(snapshot.degraded ? snapshot.degradedReasons : []),
+      ...(decisions.degraded ? decisions.degradedReasons : []),
+      ...(proposals.length === 0 ? ["no_policy_proposals_in_scope"] : []),
+    ];
+
+    return {
+      tenantId,
+      generatedAt: new Date().toISOString(),
+      lookbackDays,
+      degraded: degradedReasons.length > 0,
+      degradedReasons,
+      nodes: dedupedNodes,
+      edges: dedupedEdges,
+    };
+  }
   async simulatePolicy(
     tenantId: string,
     input: PolicySandboxRequest


### PR DESCRIPTION
### Motivation
- Remove silent contract drift and duplicate route blocks in the exception-intelligence surface and centralize business logic in the canonical service layer.
- Expose a runtime-backed reconciliation memory graph so tenant-scoped relationships between runs, signatures, decisions, proposals, sources and counterparties are queryable and explainable.
- Provide explicit degraded-state semantics when historical evidence is missing or insufficient to avoid opaque fallback behavior.

### Description
- Consolidated and cleaned `packages/api/src/routes/v1/exception-intelligence.ts` into a single canonical route layer with uniform tenant checks and added `GET /operator/intelligence/memory-graph`.
- Implemented missing service retrievals in `ExceptionIntelligenceService`: `getPolicyEvolutionProposalDetail`, `getProposalHistory`, `getExceptionPlaybooks`, and `getReconciliationMemoryGraph`, including node/edge assembly, deduplication, tenant scoping, and degraded flags.
- Added a targeted test suite `packages/api/src/services/operator-mode/__tests__/exception-intelligence-memory-graph.test.ts` and updated the existing service test to match the current review API shape; fixed route validation schemas and review payload handling.
- Kept persistence surface unchanged (reused `reconciliationMatch`, `reconAudit`, `reconciliationRun`), avoided new migrations, and preserved explicit non-auto-apply semantics for proposals and reviews.

### Testing
- ✅ `pnpm --filter @settler/api lint` — lint passed (environment Node engine warning observed: runtime uses Node v22, repo expects v24+).
- ✅ `pnpm --filter @settler/api typecheck` — TypeScript checks passed after fixes to tests and service signatures.
- ✅ `pnpm --filter @settler/api exec jest src/services/operator-mode/__tests__/exception-intelligence-memory-graph.test.ts --runInBand` — new memory-graph tests passed.
- ✅ `pnpm --filter @settler/api build` — package build succeeded.
- ✅ `pnpm run verify:routes` — route verification completed without hard-500s on critical routes (UI/server env warnings about missing runtime env vars surfaced but did not cause hard failures for route verification in this environment).
- ⚠️ `pnpm run verify:tenant` — failed due to environment/setup limitation (`security/route-registry.json` missing); this is an external verification dependency and not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8876c0e548328a0c396110067027d)