### PR TITLE
api: add OpenFGA-backed tenant action authorization and health integration

### DIFF
--- a/packages/api/src/infrastructure/observability/health.ts
+++ b/packages/api/src/infrastructure/observability/health.ts
@@ -6,6 +6,7 @@
 import { query } from "../../db";
 import { getRedisClient } from "../../utils/cache";
 import { getLedgerService } from "../../domain/services/LedgerService";
+import { getOpenFgaAuthorizationService } from "../../services/authz/openfga-authorization-service";
 
 export interface HealthCheck {
   status: "healthy" | "unhealthy" | "degraded";
@@ -129,6 +130,38 @@ export class HealthCheckService {
     }
   }
 
+  async checkOpenFga(): Promise<HealthCheck> {
+    try {
+      const status = await getOpenFgaAuthorizationService().status();
+      if (status.state === "available") {
+        return {
+          status: "healthy",
+          timestamp: new Date().toISOString(),
+        };
+      }
+
+      if (status.state === "disabled" || status.state === "unconfigured") {
+        return {
+          status: "degraded",
+          error: status.reason,
+          timestamp: new Date().toISOString(),
+        };
+      }
+
+      return {
+        status: "unhealthy",
+        error: status.reason || "openfga_unavailable",
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error: unknown) {
+      return {
+        status: "unhealthy",
+        error: error instanceof Error ? error.message : "Unknown error",
+        timestamp: new Date().toISOString(),
+      };
+    }
+  }
+
   async checkSentry(): Promise<HealthCheck> {
     try {
       // Check if Sentry is configured
@@ -158,7 +191,7 @@ export class HealthCheckService {
 
   async checkAll(): Promise<HealthStatus> {
     const redisClient = this.getRedisClient();
-    const [database, redis, sentry, supabase, ledger] = await Promise.all([
+    const [database, redis, sentry, supabase, ledger, openfga] = await Promise.all([
       this.checkDatabase(),
       redisClient
         ? this.checkRedis()
@@ -170,6 +203,7 @@ export class HealthCheckService {
       this.checkSentry(),
       this.checkSupabase(),
       this.checkTigerBeetle(),
+      this.checkOpenFga(),
     ]);
 
     const checks = {
@@ -178,6 +212,7 @@ export class HealthCheckService {
       sentry,
       supabase,
       tigerbeetle: ledger,
+      openfga,
     };
 
     const allHealthy = Object.values(checks).every((check) => check.status === "healthy");

--- a/packages/api/src/routes/tenant-data.ts
+++ b/packages/api/src/routes/tenant-data.ts
@@ -16,9 +16,9 @@ import { Permission } from "../infrastructure/security/Permissions";
 import { query, transaction } from "../db";
 import { logInfo, logError } from "../utils/logger";
 import { handleRouteError } from "../utils/error-handler";
-import { UserRole } from "../domain/entities/User";
 import { validateTenantId } from "../infrastructure/tenancy/TenantEnforcement";
 import { verifyTenantIntegrityChain } from "../services/reconciliation/integrity";
+import { getOpenFgaAuthorizationService } from "../services/authz/openfga-authorization-service";
 
 const router: Router = Router();
 
@@ -52,21 +52,22 @@ router.get(
       const userId = req.userId!;
       const format = (req.query.format as string) || "json";
 
-      // Verify user has permission to export tenant data
-      const userCheck = await query<{ role: UserRole }>(
-        `SELECT role FROM users WHERE id = $1 AND tenant_id = $2`,
-        [userId, tenantId]
+      const authz = await getOpenFgaAuthorizationService().authorizeTenantAction(
+        userId,
+        tenantId,
+        "tenant.data.export"
       );
 
-      if (userCheck.length === 0 || !userCheck[0]) {
-        return res.status(403).json({ error: "Forbidden", message: "User not found in tenant" });
-      }
-
-      const userRole = userCheck[0].role;
-      if (userRole !== UserRole.OWNER && userRole !== UserRole.ADMIN) {
+      if (!authz.allowed) {
         return res.status(403).json({
           error: "Forbidden",
-          message: "Only tenant owners and admins can export tenant data",
+          message: "Tenant export not authorized",
+          reason: authz.reason,
+          authz: {
+            mode: authz.mode,
+            degraded: authz.degraded,
+            openfga: authz.openfga,
+          },
         });
       }
 
@@ -382,27 +383,38 @@ router.delete(
         });
       }
 
-      // Verify user is tenant owner
-      const userCheck = await query<{ role: UserRole; password_hash: string }>(
-        `SELECT role, password_hash FROM users WHERE id = $1 AND tenant_id = $2`,
+      const authz = await getOpenFgaAuthorizationService().authorizeTenantAction(
+        userId,
+        tenantId,
+        "tenant.data.delete"
+      );
+
+      if (!authz.allowed) {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "Tenant deletion not authorized",
+          reason: authz.reason,
+          authz: {
+            mode: authz.mode,
+            degraded: authz.degraded,
+            openfga: authz.openfga,
+          },
+        });
+      }
+
+      const userCheck = await query<{ password_hash: string }>(
+        `SELECT password_hash FROM users WHERE id = $1 AND tenant_id = $2`,
         [userId, tenantId]
       );
 
-      if (userCheck.length === 0 || !userCheck[0]) {
+      const passwordHash = userCheck[0]?.password_hash;
+      if (!passwordHash) {
         return res.status(403).json({ error: "Forbidden", message: "User not found in tenant" });
-      }
-
-      const userRecord = userCheck[0];
-      if (userRecord.role !== UserRole.OWNER) {
-        return res.status(403).json({
-          error: "Forbidden",
-          message: "Only tenant owners can delete tenant data",
-        });
       }
 
       // Verify password
       const { verifyPassword } = await import("../utils/hash");
-      const isValid = await verifyPassword(password, userRecord.password_hash);
+      const isValid = await verifyPassword(password, passwordHash);
       if (!isValid) {
         return res.status(401).json({ error: "Invalid password" });
       }

--- a/packages/api/src/services/authz/__tests__/openfga-authorization-service.test.ts
+++ b/packages/api/src/services/authz/__tests__/openfga-authorization-service.test.ts
@@ -1,0 +1,80 @@
+import { OpenFgaAuthorizationService } from "../openfga-authorization-service";
+import { UserRole } from "../../../domain/entities/User";
+
+jest.mock("../../../db", () => ({
+  query: jest.fn(),
+}));
+
+const { query } = require("../../../db");
+
+describe("OpenFgaAuthorizationService", () => {
+  const service = new OpenFgaAuthorizationService();
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.OPENFGA_ENABLED = "false";
+    process.env.OPENFGA_REQUIRED = "false";
+    delete process.env.OPENFGA_API_URL;
+    delete process.env.OPENFGA_STORE_ID;
+    delete process.env.OPENFGA_AUTHORIZATION_MODEL_ID;
+    query.mockResolvedValue([{ role: UserRole.OWNER }]);
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("allows owner export via local RBAC when OpenFGA is disabled", async () => {
+    const result = await service.authorizeTenantAction("user-1", "tenant-1", "tenant.data.export");
+
+    expect(result.allowed).toBe(true);
+    expect(result.mode).toBe("local_rbac");
+    expect(result.openfga.state).toBe("disabled");
+  });
+
+  it("fails closed when OpenFGA is required but unavailable", async () => {
+    process.env.OPENFGA_ENABLED = "true";
+    process.env.OPENFGA_REQUIRED = "true";
+    process.env.OPENFGA_API_URL = "http://openfga.local";
+    process.env.OPENFGA_STORE_ID = "store-1";
+    process.env.OPENFGA_AUTHORIZATION_MODEL_ID = "model-1";
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+    const result = await service.authorizeTenantAction("user-1", "tenant-1", "tenant.data.delete");
+
+    expect(result.allowed).toBe(false);
+    expect(result.mode).toBe("fail_closed");
+    expect(result.degraded).toBe(true);
+    expect(result.reason).toBe("openfga_required_unavailable");
+  });
+
+  it("denies when local role is insufficient before OpenFGA check", async () => {
+    query.mockResolvedValue([{ role: UserRole.DEVELOPER }]);
+
+    const result = await service.authorizeTenantAction("user-1", "tenant-1", "tenant.data.delete");
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("insufficient_local_role");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses OpenFGA decision when enabled and reachable", async () => {
+    process.env.OPENFGA_ENABLED = "true";
+    process.env.OPENFGA_API_URL = "http://openfga.local";
+    process.env.OPENFGA_STORE_ID = "store-1";
+    process.env.OPENFGA_AUTHORIZATION_MODEL_ID = "model-1";
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ allowed: false }),
+    });
+
+    const result = await service.authorizeTenantAction("user-1", "tenant-1", "tenant.data.export");
+
+    expect(result.mode).toBe("openfga");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("openfga_denied");
+  });
+});

--- a/packages/api/src/services/authz/openfga-authorization-service.ts
+++ b/packages/api/src/services/authz/openfga-authorization-service.ts
@@ -1,0 +1,255 @@
+import { query } from "../../db";
+import { UserRole } from "../../domain/entities/User";
+import { logWarn } from "../../utils/logger";
+
+export type OpenFgaAuthzState =
+  | "disabled"
+  | "unconfigured"
+  | "available"
+  | "degraded"
+  | "unavailable";
+
+export interface OpenFgaCheckResult {
+  state: OpenFgaAuthzState;
+  allowed: boolean;
+  reason?: string;
+}
+
+interface OpenFgaConfig {
+  enabled: boolean;
+  required: boolean;
+  apiUrl?: string;
+  storeId?: string;
+  modelId?: string;
+}
+
+export interface TenantActionAuthorization {
+  allowed: boolean;
+  reason?: string;
+  degraded: boolean;
+  mode: "local_rbac" | "openfga" | "fail_closed";
+  openfga: OpenFgaCheckResult;
+}
+
+function readConfig(): OpenFgaConfig {
+  const enabled = process.env.OPENFGA_ENABLED === "true";
+  const required = process.env.OPENFGA_REQUIRED === "true";
+  return {
+    enabled,
+    required,
+    apiUrl: process.env.OPENFGA_API_URL,
+    storeId: process.env.OPENFGA_STORE_ID,
+    modelId: process.env.OPENFGA_AUTHORIZATION_MODEL_ID,
+  };
+}
+
+function buildTenantObject(tenantId: string): string {
+  return `tenant:${tenantId}`;
+}
+
+async function checkWithOpenFga(
+  userId: string,
+  relation: string,
+  tenantId: string
+): Promise<OpenFgaCheckResult> {
+  const config = readConfig();
+
+  if (!config.enabled) {
+    return {
+      state: "disabled",
+      allowed: false,
+      reason: "openfga_disabled",
+    };
+  }
+
+  if (!config.apiUrl || !config.storeId || !config.modelId) {
+    return {
+      state: "unconfigured",
+      allowed: false,
+      reason: "openfga_unconfigured",
+    };
+  }
+
+  try {
+    const response = await fetch(`${config.apiUrl}/stores/${config.storeId}/check`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        tuple_key: {
+          user: `user:${userId}`,
+          relation,
+          object: buildTenantObject(tenantId),
+        },
+        authorization_model_id: config.modelId,
+      }),
+    });
+
+    if (!response.ok) {
+      return {
+        state: "degraded",
+        allowed: false,
+        reason: `openfga_http_${response.status}`,
+      };
+    }
+
+    const payload = (await response.json()) as { allowed?: boolean };
+    return {
+      state: "available",
+      allowed: payload.allowed === true,
+      reason: payload.allowed === true ? undefined : "openfga_denied",
+    };
+  } catch (error) {
+    return {
+      state: "unavailable",
+      allowed: false,
+      reason: error instanceof Error ? error.message : "openfga_unknown_error",
+    };
+  }
+}
+
+async function getTenantUserRole(userId: string, tenantId: string): Promise<UserRole | null> {
+  const rows = await query<{ role: UserRole }>(
+    `SELECT role FROM users WHERE id = $1 AND tenant_id = $2`,
+    [userId, tenantId]
+  );
+
+  return rows[0]?.role ?? null;
+}
+
+function relationForAction(action: "tenant.data.export" | "tenant.data.delete"): string {
+  if (action === "tenant.data.delete") {
+    return "can_delete";
+  }
+
+  return "can_export";
+}
+
+function localRoleAllowed(
+  action: "tenant.data.export" | "tenant.data.delete",
+  role: UserRole | null
+): boolean {
+  if (!role) {
+    return false;
+  }
+
+  if (action === "tenant.data.delete") {
+    return role === UserRole.OWNER;
+  }
+
+  return role === UserRole.OWNER || role === UserRole.ADMIN;
+}
+
+export class OpenFgaAuthorizationService {
+  async authorizeTenantAction(
+    userId: string,
+    tenantId: string,
+    action: "tenant.data.export" | "tenant.data.delete"
+  ): Promise<TenantActionAuthorization> {
+    const role = await getTenantUserRole(userId, tenantId);
+    const localAllowed = localRoleAllowed(action, role);
+
+    if (!localAllowed) {
+      return {
+        allowed: false,
+        reason: "insufficient_local_role",
+        degraded: false,
+        mode: "local_rbac",
+        openfga: { state: "disabled", allowed: false, reason: "local_role_denied" },
+      };
+    }
+
+    const config = readConfig();
+    const openfga = await checkWithOpenFga(userId, relationForAction(action), tenantId);
+
+    if (!config.enabled) {
+      return {
+        allowed: true,
+        degraded: false,
+        mode: "local_rbac",
+        openfga,
+      };
+    }
+
+    if (openfga.state === "available") {
+      return {
+        allowed: openfga.allowed,
+        reason: openfga.allowed ? undefined : "openfga_denied",
+        degraded: false,
+        mode: "openfga",
+        openfga,
+      };
+    }
+
+    if (config.required) {
+      logWarn("OpenFGA required but unavailable; failing closed", {
+        tenantId,
+        userId,
+        action,
+        openfgaState: openfga.state,
+        openfgaReason: openfga.reason,
+      });
+      return {
+        allowed: false,
+        reason: "openfga_required_unavailable",
+        degraded: true,
+        mode: "fail_closed",
+        openfga,
+      };
+    }
+
+    return {
+      allowed: true,
+      reason: "openfga_degraded_fallback_local_rbac",
+      degraded: true,
+      mode: "local_rbac",
+      openfga,
+    };
+  }
+
+  async status(): Promise<{
+    key: string;
+    state: OpenFgaAuthzState;
+    available: boolean;
+    reason?: string;
+  }> {
+    const config = readConfig();
+
+    if (!config.enabled) {
+      return {
+        key: "openfga_authorization",
+        state: "disabled",
+        available: false,
+        reason: "openfga_disabled",
+      };
+    }
+
+    if (!config.apiUrl || !config.storeId || !config.modelId) {
+      return {
+        key: "openfga_authorization",
+        state: "unconfigured",
+        available: false,
+        reason: "openfga_unconfigured",
+      };
+    }
+
+    const probe = await checkWithOpenFga("health-probe", "can_view", "health");
+    return {
+      key: "openfga_authorization",
+      state: probe.state,
+      available: probe.state === "available",
+      reason: probe.reason,
+    };
+  }
+}
+
+let service: OpenFgaAuthorizationService | null = null;
+
+export function getOpenFgaAuthorizationService(): OpenFgaAuthorizationService {
+  if (!service) {
+    service = new OpenFgaAuthorizationService();
+  }
+
+  return service;
+}


### PR DESCRIPTION
### Motivation
- Close a high-value authorization seam where tenant export/delete were guarded by route-local role checks instead of a canonical service, risking duplicated logic and inconsistent degraded behavior.
- Centralize sensitive-action decisions so OpenFGA can be the authoritative decision point while preserving tenant-scoped local RBAC fallback and explicit fail-closed semantics when configured as required.
- Make authorization runtime state machine-visible in platform health so operators can distinguish disabled/unconfigured/degraded/unavailable states instead of opaque behavior.

### Description
- Added a canonical `OpenFgaAuthorizationService` (`packages/api/src/services/authz/openfga-authorization-service.ts`) that fuses local tenant-role gating with an HTTP OpenFGA check and exposes explicit modes: `local_rbac`, `openfga`, and `fail_closed`.
- Replaced inline role checks in the tenant routes with calls to the canonical service in `packages/api/src/routes/tenant-data.ts` for `/data-export` and `/data` and return explicit `reason` and `authz` details on denial.
- Integrated OpenFGA into the API health aggregation by adding `checkOpenFga` to `packages/api/src/infrastructure/observability/health.ts` so OpenFGA appears in health readiness with `healthy`/`degraded`/`unhealthy` semantics and reasons.
- Added focused unit tests (`packages/api/src/services/authz/__tests__/openfga-authorization-service.test.ts`) covering disabled fallback, required+unavailable (fail-closed), local-role denial before an OpenFGA call, and reachable OpenFGA decisions.

### Testing
- ✅ `pnpm --filter @settler/api test -- src/services/authz/__tests__/openfga-authorization-service.test.ts` — targeted unit tests passed.
- ✅ `pnpm --filter @settler/api lint` — lint completed successfully.
- ✅ `pnpm --filter @settler/api typecheck` — TypeScript typecheck passed.
- ✅ `pnpm --filter @settler/api build` — package build succeeded.
- ⚠️ `pnpm run verify:tenant` — environment-limited failure due to missing `security/route-registry.json` in the workspace (pre-existing, not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c893bd0d6c8328bdd21c7383dc32c4)