### PR TITLE
Harden sensitive v1 routes with canonical OpenFGA tenant-action checks

### DIFF
--- a/packages/api/src/routes/v1/__tests__/custom-integrations.route.test.ts
+++ b/packages/api/src/routes/v1/__tests__/custom-integrations.route.test.ts
@@ -1,0 +1,88 @@
+import express from "express";
+import request from "supertest";
+
+const createCustomIntegrationMock = jest.fn();
+const listCustomIntegrationsMock = jest.fn();
+
+jest.mock("../../../services/custom-integrations", () => ({
+  createCustomIntegration: (...args: unknown[]) => createCustomIntegrationMock(...args),
+  listCustomIntegrations: (...args: unknown[]) => listCustomIntegrationsMock(...args),
+  getCustomIntegration: jest.fn(),
+  updateCustomIntegration: jest.fn(),
+}));
+
+jest.mock("../../../middleware/authorization", () => ({
+  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../../../middleware/governance", () => ({
+  enforceFreezeState: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const authorizeTenantActionMock = jest.fn();
+jest.mock("../../../services/authz/openfga-authorization-service", () => ({
+  getOpenFgaAuthorizationService: () => ({
+    authorizeTenantAction: authorizeTenantActionMock,
+  }),
+}));
+
+const router = require("../custom-integrations").default;
+
+describe("custom integrations authz hardening", () => {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).tenantId = "tenant-1";
+    (req as any).userId = "user-1";
+    next();
+  });
+  app.use("/api/v1/custom-integrations", router);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: true,
+      degraded: false,
+      mode: "local_rbac",
+      openfga: { state: "disabled", allowed: false, reason: "openfga_disabled" },
+    });
+  });
+
+  it("returns 403 and does not mutate when OpenFGA denies integration management", async () => {
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: false,
+      reason: "openfga_required_unavailable",
+      degraded: true,
+      mode: "fail_closed",
+      openfga: { state: "unavailable", allowed: false, reason: "openfga_unavailable" },
+    });
+
+    const response = await request(app)
+      .post("/api/v1/custom-integrations")
+      .send({
+        integrationName: "ERP",
+        integrationType: "erp",
+        adapterConfig: { provider: "x" },
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.reason).toBe("openfga_required_unavailable");
+    expect(createCustomIntegrationMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when tenant context is missing for list route", async () => {
+    const appNoTenant = express();
+    appNoTenant.use(express.json());
+    appNoTenant.use((req, _res, next) => {
+      (req as any).tenantId = null;
+      (req as any).userId = "user-1";
+      next();
+    });
+    appNoTenant.use("/api/v1/custom-integrations", router);
+
+    const response = await request(appNoTenant).get("/api/v1/custom-integrations");
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("TENANT_CONTEXT_REQUIRED");
+    expect(listCustomIntegrationsMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/v1/__tests__/exception-intelligence.route.test.ts
+++ b/packages/api/src/routes/v1/__tests__/exception-intelligence.route.test.ts
@@ -29,6 +29,13 @@ jest.mock("../../../middleware/authorization", () => ({
   requirePermission: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+const authorizeTenantActionMock = jest.fn();
+jest.mock("../../../services/authz/openfga-authorization-service", () => ({
+  getOpenFgaAuthorizationService: () => ({
+    authorizeTenantAction: authorizeTenantActionMock,
+  }),
+}));
+
 const router = require("../exception-intelligence").default;
 
 describe("exception intelligence route contracts", () => {
@@ -42,6 +49,14 @@ describe("exception intelligence route contracts", () => {
   app.use("/api/v1", router);
 
   beforeEach(() => jest.clearAllMocks());
+  beforeEach(() =>
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: true,
+      degraded: false,
+      mode: "local_rbac",
+      openfga: { state: "disabled", allowed: false, reason: "openfga_disabled" },
+    })
+  );
 
   it("serves policy proposal list", async () => {
     serviceMock.listPolicyEvolutionProposals.mockResolvedValue([{ proposalId: "proposal-1" }]);
@@ -98,5 +113,23 @@ describe("exception intelligence route contracts", () => {
     );
     expect(response.status).toBe(400);
     expect(response.body.error).toBe("TENANT_CONTEXT_REQUIRED");
+  });
+
+  it("fails closed on proposal review when OpenFGA authorization denies", async () => {
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: false,
+      reason: "openfga_required_unavailable",
+      degraded: true,
+      mode: "fail_closed",
+      openfga: { state: "unavailable", allowed: false, reason: "openfga_unavailable" },
+    });
+
+    const response = await request(app)
+      .post("/api/v1/operator/intelligence/policy/proposals/proposal-12345/review")
+      .send({ decision: "approved" });
+
+    expect(response.status).toBe(403);
+    expect(response.body.reason).toBe("openfga_required_unavailable");
+    expect(serviceMock.reviewPolicyEvolutionProposal).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/routes/v1/custom-integrations.ts
+++ b/packages/api/src/routes/v1/custom-integrations.ts
@@ -5,7 +5,13 @@
 import { Router, Response } from "express";
 import { AuthRequest } from "../../middleware/auth";
 import { enforceFreezeState } from "../../middleware/governance";
+import { requirePermission } from "../../middleware/authorization";
+import { Permission } from "../../infrastructure/security/Permissions";
 import { logError } from "../../utils/logger";
+import {
+  getOpenFgaAuthorizationService,
+  TenantAction,
+} from "../../services/authz/openfga-authorization-service";
 import {
   createCustomIntegration,
   getCustomIntegration,
@@ -15,124 +21,206 @@ import {
 
 const router: Router = Router();
 
-router.post("/", enforceFreezeState(), async (req: AuthRequest, res: Response) => {
-  try {
-    const tenantId = req.tenantId!;
-    const { integrationName, integrationType, adapterConfig, whiteLabelConfig } = req.body;
+function tenantOr400(req: AuthRequest, res: Response): string | null {
+  if (!req.tenantId) {
+    res.status(400).json({
+      error: "TENANT_CONTEXT_REQUIRED",
+      message: "Tenant context is required",
+      traceId: req.traceId,
+    });
+    return null;
+  }
+  return req.tenantId;
+}
 
-    if (!integrationName || !integrationType || !adapterConfig) {
-      return res.status(400).json({
-        error: "Bad Request",
-        message: "integrationName, integrationType, and adapterConfig are required",
+async function authorizeTenantActionOr403(
+  req: AuthRequest,
+  res: Response,
+  tenantId: string,
+  action: TenantAction
+): Promise<boolean> {
+  const userId = req.userId;
+  if (!userId) {
+    res.status(401).json({
+      error: "UNAUTHORIZED",
+      message: "Authentication required",
+      reason: "missing_user_context",
+      traceId: req.traceId,
+    });
+    return false;
+  }
+
+  const authz = await getOpenFgaAuthorizationService().authorizeTenantAction(
+    userId,
+    tenantId,
+    action
+  );
+  if (authz.allowed) {
+    return true;
+  }
+
+  res.status(403).json({
+    error: "FORBIDDEN",
+    message: "Tenant action is not authorized",
+    reason: authz.reason,
+    authz: {
+      mode: authz.mode,
+      degraded: authz.degraded,
+      openfga: authz.openfga,
+    },
+    traceId: req.traceId,
+  });
+  return false;
+}
+
+router.post(
+  "/",
+  requirePermission(Permission.TENANT_WRITE),
+  enforceFreezeState(),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.integration.manage")))
+        return;
+      const { integrationName, integrationType, adapterConfig, whiteLabelConfig } = req.body;
+
+      if (!integrationName || !integrationType || !adapterConfig) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "integrationName, integrationType, and adapterConfig are required",
+          traceId: req.traceId,
+        });
+      }
+
+      const integrationId = await createCustomIntegration(
+        tenantId,
+        integrationName,
+        integrationType,
+        adapterConfig,
+        whiteLabelConfig
+      );
+
+      return res.status(201).json({ id: integrationId, traceId: req.traceId });
+    } catch (error) {
+      logError("Failed to create custom integration", error, { traceId: req.traceId });
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to create custom integration",
         traceId: req.traceId,
       });
     }
-
-    const integrationId = await createCustomIntegration(
-      tenantId,
-      integrationName,
-      integrationType,
-      adapterConfig,
-      whiteLabelConfig
-    );
-
-    return res.status(201).json({ id: integrationId, traceId: req.traceId });
-  } catch (error) {
-    logError("Failed to create custom integration", error, { traceId: req.traceId });
-    return res.status(500).json({
-      error: "Internal Server Error",
-      message: "Failed to create custom integration",
-      traceId: req.traceId,
-    });
   }
-});
+);
 
-router.get("/", async (req: AuthRequest, res: Response) => {
-  try {
-    const tenantId = req.tenantId!;
-    const { isActive, integrationType } = req.query;
+router.get(
+  "/",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.integration.read")))
+        return;
+      const { isActive, integrationType } = req.query;
 
-    const integrations = await listCustomIntegrations(tenantId, {
-      isActive: isActive === "true" ? true : isActive === "false" ? false : undefined,
-      integrationType: integrationType as string | undefined,
-    });
+      const integrations = await listCustomIntegrations(tenantId, {
+        isActive: isActive === "true" ? true : isActive === "false" ? false : undefined,
+        integrationType: integrationType as string | undefined,
+      });
 
-    return res.json({ data: integrations, traceId: req.traceId });
-  } catch (error) {
-    logError("Failed to list custom integrations", error, { traceId: req.traceId });
-    return res.status(500).json({
-      error: "Internal Server Error",
-      message: "Failed to list custom integrations",
-      traceId: req.traceId,
-    });
-  }
-});
-
-router.get("/:integrationId", async (req: AuthRequest, res: Response) => {
-  try {
-    const integrationIdParam = req.params["integrationId"];
-    const integrationId = Array.isArray(integrationIdParam)
-      ? (integrationIdParam[0] ?? "")
-      : (integrationIdParam ?? "");
-    const tenantId = req.tenantId!;
-
-    if (!integrationId) {
-      return res.status(400).json({
-        error: "Bad Request",
-        message: "integrationId is required",
+      return res.json({ data: integrations, traceId: req.traceId });
+    } catch (error) {
+      logError("Failed to list custom integrations", error, { traceId: req.traceId });
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to list custom integrations",
         traceId: req.traceId,
       });
     }
+  }
+);
 
-    const integration = await getCustomIntegration(tenantId, integrationId);
+router.get(
+  "/:integrationId",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const integrationIdParam = req.params["integrationId"];
+      const integrationId = Array.isArray(integrationIdParam)
+        ? (integrationIdParam[0] ?? "")
+        : (integrationIdParam ?? "");
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.integration.read")))
+        return;
 
-    if (!integration) {
-      return res.status(404).json({
-        error: "Not Found",
-        message: "Custom integration not found",
+      if (!integrationId) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "integrationId is required",
+          traceId: req.traceId,
+        });
+      }
+
+      const integration = await getCustomIntegration(tenantId, integrationId);
+
+      if (!integration) {
+        return res.status(404).json({
+          error: "Not Found",
+          message: "Custom integration not found",
+          traceId: req.traceId,
+        });
+      }
+
+      return res.json({ ...integration, traceId: req.traceId });
+    } catch (error) {
+      logError("Failed to get custom integration", error, { traceId: req.traceId });
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to get custom integration",
         traceId: req.traceId,
       });
     }
-
-    return res.json({ ...integration, traceId: req.traceId });
-  } catch (error) {
-    logError("Failed to get custom integration", error, { traceId: req.traceId });
-    return res.status(500).json({
-      error: "Internal Server Error",
-      message: "Failed to get custom integration",
-      traceId: req.traceId,
-    });
   }
-});
+);
 
-router.patch("/:integrationId", enforceFreezeState(), async (req: AuthRequest, res: Response) => {
-  try {
-    const integrationIdParam2 = req.params["integrationId"];
-    const integrationId = Array.isArray(integrationIdParam2)
-      ? (integrationIdParam2[0] ?? "")
-      : (integrationIdParam2 ?? "");
-    const tenantId = req.tenantId!;
-    const updates = req.body;
+router.patch(
+  "/:integrationId",
+  requirePermission(Permission.TENANT_WRITE),
+  enforceFreezeState(),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const integrationIdParam2 = req.params["integrationId"];
+      const integrationId = Array.isArray(integrationIdParam2)
+        ? (integrationIdParam2[0] ?? "")
+        : (integrationIdParam2 ?? "");
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.integration.manage")))
+        return;
+      const updates = req.body;
 
-    if (!integrationId) {
-      return res.status(400).json({
-        error: "Bad Request",
-        message: "integrationId is required",
+      if (!integrationId) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "integrationId is required",
+          traceId: req.traceId,
+        });
+      }
+
+      await updateCustomIntegration(tenantId, integrationId, updates);
+
+      return res.json({ message: "Integration updated", traceId: req.traceId });
+    } catch (error) {
+      logError("Failed to update custom integration", error, { traceId: req.traceId });
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to update custom integration",
         traceId: req.traceId,
       });
     }
-
-    await updateCustomIntegration(tenantId, integrationId, updates);
-
-    return res.json({ message: "Integration updated", traceId: req.traceId });
-  } catch (error) {
-    logError("Failed to update custom integration", error, { traceId: req.traceId });
-    return res.status(500).json({
-      error: "Internal Server Error",
-      message: "Failed to update custom integration",
-      traceId: req.traceId,
-    });
   }
-});
+);
 
 export default router;

--- a/packages/api/src/routes/v1/exception-intelligence.ts
+++ b/packages/api/src/routes/v1/exception-intelligence.ts
@@ -6,6 +6,10 @@ import { Permission } from "../../infrastructure/security/Permissions";
 import { validateRequest } from "../../middleware/validation";
 import { handleRouteError } from "../../utils/error-handler";
 import { ExceptionIntelligenceService } from "../../services/operator-mode/exception-intelligence-service";
+import {
+  getOpenFgaAuthorizationService,
+  TenantAction,
+} from "../../services/authz/openfga-authorization-service";
 
 const router: Router = Router();
 const service = new ExceptionIntelligenceService();
@@ -76,6 +80,44 @@ function tenantOr400(req: AuthRequest, res: Response): string | null {
   return req.tenantId;
 }
 
+async function authorizeTenantActionOr403(
+  req: AuthRequest,
+  res: Response,
+  tenantId: string,
+  action: TenantAction
+): Promise<boolean> {
+  const userId = req.userId;
+  if (!userId) {
+    res.status(401).json({
+      error: "UNAUTHORIZED",
+      message: "Authentication required",
+      reason: "missing_user_context",
+    });
+    return false;
+  }
+
+  const authz = await getOpenFgaAuthorizationService().authorizeTenantAction(
+    userId,
+    tenantId,
+    action
+  );
+  if (authz.allowed) {
+    return true;
+  }
+
+  res.status(403).json({
+    error: "FORBIDDEN",
+    message: "Tenant action is not authorized",
+    reason: authz.reason,
+    authz: {
+      mode: authz.mode,
+      degraded: authz.degraded,
+      openfga: authz.openfga,
+    },
+  });
+  return false;
+}
+
 router.get(
   "/operator/intelligence/ontology/summary",
   requirePermission(Permission.ADMIN_READ),
@@ -124,6 +166,8 @@ router.get(
     try {
       const tenantId = tenantOr400(req, res);
       if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.memory.graph.read")))
+        return;
       const lookbackDays = Number(req.query.lookbackDays ?? 30);
       const data = await service.getReconciliationMemoryGraph(tenantId, lookbackDays);
       return res.status(200).json({ data });
@@ -187,6 +231,8 @@ router.post(
     try {
       const tenantId = tenantOr400(req, res);
       if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.policy.proposal.review")))
+        return;
       const proposalId = req.params["proposalId"] as string;
       const data = await service.reviewPolicyEvolutionProposal(tenantId, {
         proposalId,
@@ -300,6 +346,8 @@ router.get(
     try {
       const tenantId = tenantOr400(req, res);
       if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.proof.evidence.export")))
+        return;
       const runId = req.params["runId"] as string;
       const data = await service.buildEvidencePack(tenantId, runId);
       return res.status(200).json({ data });

--- a/packages/api/src/services/authz/__tests__/openfga-authorization-service.test.ts
+++ b/packages/api/src/services/authz/__tests__/openfga-authorization-service.test.ts
@@ -61,6 +61,33 @@ describe("OpenFgaAuthorizationService", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  it("denies policy proposal review for developer role", async () => {
+    query.mockResolvedValue([{ role: UserRole.DEVELOPER }]);
+
+    const result = await service.authorizeTenantAction(
+      "user-1",
+      "tenant-1",
+      "tenant.policy.proposal.review"
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("insufficient_local_role");
+  });
+
+  it("allows integration read for developer role when OpenFGA is disabled", async () => {
+    query.mockResolvedValue([{ role: UserRole.DEVELOPER }]);
+
+    const result = await service.authorizeTenantAction(
+      "user-1",
+      "tenant-1",
+      "tenant.integration.read"
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.mode).toBe("local_rbac");
+    expect(result.openfga.state).toBe("disabled");
+  });
+
   it("uses OpenFGA decision when enabled and reachable", async () => {
     process.env.OPENFGA_ENABLED = "true";
     process.env.OPENFGA_API_URL = "http://openfga.local";

--- a/packages/api/src/services/authz/openfga-authorization-service.ts
+++ b/packages/api/src/services/authz/openfga-authorization-service.ts
@@ -31,6 +31,15 @@ export interface TenantActionAuthorization {
   openfga: OpenFgaCheckResult;
 }
 
+export type TenantAction =
+  | "tenant.data.export"
+  | "tenant.data.delete"
+  | "tenant.policy.proposal.review"
+  | "tenant.proof.evidence.export"
+  | "tenant.memory.graph.read"
+  | "tenant.integration.read"
+  | "tenant.integration.manage";
+
 function readConfig(): OpenFgaConfig {
   const enabled = process.env.OPENFGA_ENABLED === "true";
   const required = process.env.OPENFGA_REQUIRED === "true";
@@ -118,34 +127,47 @@ async function getTenantUserRole(userId: string, tenantId: string): Promise<User
   return rows[0]?.role ?? null;
 }
 
-function relationForAction(action: "tenant.data.export" | "tenant.data.delete"): string {
-  if (action === "tenant.data.delete") {
-    return "can_delete";
+function relationForAction(action: TenantAction): string {
+  switch (action) {
+    case "tenant.data.delete":
+      return "can_delete";
+    case "tenant.data.export":
+    case "tenant.proof.evidence.export":
+      return "can_export";
+    case "tenant.policy.proposal.review":
+      return "can_review_policy";
+    case "tenant.memory.graph.read":
+    case "tenant.integration.read":
+      return "can_view";
+    case "tenant.integration.manage":
+      return "can_manage_integrations";
   }
-
-  return "can_export";
 }
 
-function localRoleAllowed(
-  action: "tenant.data.export" | "tenant.data.delete",
-  role: UserRole | null
-): boolean {
+function localRoleAllowed(action: TenantAction, role: UserRole | null): boolean {
   if (!role) {
     return false;
   }
 
-  if (action === "tenant.data.delete") {
-    return role === UserRole.OWNER;
+  switch (action) {
+    case "tenant.data.delete":
+      return role === UserRole.OWNER;
+    case "tenant.data.export":
+    case "tenant.policy.proposal.review":
+    case "tenant.proof.evidence.export":
+    case "tenant.memory.graph.read":
+    case "tenant.integration.manage":
+      return role === UserRole.OWNER || role === UserRole.ADMIN;
+    case "tenant.integration.read":
+      return role === UserRole.OWNER || role === UserRole.ADMIN || role === UserRole.DEVELOPER;
   }
-
-  return role === UserRole.OWNER || role === UserRole.ADMIN;
 }
 
 export class OpenFgaAuthorizationService {
   async authorizeTenantAction(
     userId: string,
     tenantId: string,
-    action: "tenant.data.export" | "tenant.data.delete"
+    action: TenantAction
   ): Promise<TenantActionAuthorization> {
     const role = await getTenantUserRole(userId, tenantId);
     const localAllowed = localRoleAllowed(action, role);


### PR DESCRIPTION
### Motivation

- Close high-risk authorization seams by moving sensitive route decisions out of route-local branching and into the canonical `OpenFgaAuthorizationService` so tenant isolation and fail-closed behavior are consistent and auditable.  
- Make degraded / unavailable OpenFGA states machine-visible in route responses to preserve operator truth and avoid silent fallback widening.  
- Protect high-value control surfaces (policy proposal review, evidence export, memory-graph read, and custom integration management) from cross-tenant or role-floor leaks.  

### Description

- Extended `OpenFgaAuthorizationService` with a `TenantAction` union and added canonical `relationForAction` mapping and `localRoleAllowed` (local role floor) logic so routes call a single, testable authorization API instead of duplicating role logic (`packages/api/src/services/authz/openfga-authorization-service.ts`).  
- Hardened `v1/exception-intelligence` by adding an `authorizeTenantActionOr403` helper and applying it to `tenant.memory.graph.read`, `tenant.policy.proposal.review`, and `tenant.proof.evidence.export`, returning consistent denial payloads (`reason`, `authz.mode`, `authz.degraded`, `authz.openfga`) on 403s (`packages/api/src/routes/v1/exception-intelligence.ts`).  
- Hardened `v1/custom-integrations` with explicit tenant-context 400 handling, RBAC middleware (`requirePermission`) on read/write flows, and OpenFGA-backed checks for `tenant.integration.read` and `tenant.integration.manage`, plus consistent non-500 denial payloads (`packages/api/src/routes/v1/custom-integrations.ts`).  
- Added and extended unit/integration route tests to cover fail-closed behavior and tenant-context safety: updated OpenFGA service tests for new role-floor semantics, added `custom-integrations` route tests, and extended `exception-intelligence` tests to assert denied/fail-closed behavior (`packages/api/src/services/authz/__tests__/openfga-authorization-service.test.ts`, `packages/api/src/routes/v1/__tests__/exception-intelligence.route.test.ts`, `packages/api/src/routes/v1/__tests__/custom-integrations.route.test.ts`).  
- Kept changes minimal and deterministic (no schema migrations); denial payloads are explicit and machine-visible for operator/automation use.  

### Testing

- ✅ `pnpm --filter @settler/api test -- --runTestsByPath src/services/authz/__tests__/openfga-authorization-service.test.ts src/routes/v1/__tests__/exception-intelligence.route.test.ts src/routes/v1/__tests__/custom-integrations.route.test.ts` — 3 test suites, 13 tests passed.  
- ✅ `pnpm --filter @settler/api lint` — lint passed (repository engine warnings surfaced but not introduced by this change).  
- ✅ `pnpm --filter @settler/api typecheck` — TypeScript checks passed.  
- ✅ `pnpm --filter @settler/api build` — package build passed.  
- ⚠️ `pnpm run verify:tenant` — failed due to missing repository runtime artifact `security/route-registry.json` (pre-existing environment/setup dependency), so full tenant-coverage verification could not be completed in this environment.  

Files changed (high level):  
- `packages/api/src/services/authz/openfga-authorization-service.ts` (TenantAction, relation mapping, role-floor logic)  
- `packages/api/src/services/authz/__tests__/openfga-authorization-service.test.ts` (new assertions)  
- `packages/api/src/routes/v1/exception-intelligence.ts` (added OpenFGA checks + helper)  
- `packages/api/src/routes/v1/custom-integrations.ts` (tenant guard, RBAC, OpenFGA checks)  
- `packages/api/src/routes/v1/__tests__/exception-intelligence.route.test.ts` (extended)  
- `packages/api/src/routes/v1/__tests__/custom-integrations.route.test.ts` (new)  

Residual risk / next steps: run `pnpm run verify:tenant` in CI or a developer environment where `security/route-registry.json` is present to produce complete tenant-coverage evidence, and continue migrating other sensitive route families that still only use `requirePermission` to the canonical OpenFGA tenant-action checks in prioritized order.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a0c8db988328ac23312c76403b3e)