### PR TITLE
Harden canonical authz for approvals, API keys, and webhooks

### DIFF
--- a/packages/api/src/routes/__tests__/api-keys.authz.test.ts
+++ b/packages/api/src/routes/__tests__/api-keys.authz.test.ts
@@ -1,0 +1,79 @@
+import express from "express";
+import request from "supertest";
+
+const queryMock = jest.fn();
+
+jest.mock("../../db", () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+  transaction: jest.fn(),
+}));
+
+jest.mock("../../middleware/authorization", () => ({
+  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const authorizeTenantActionMock = jest.fn();
+jest.mock("../../services/authz/openfga-authorization-service", () => ({
+  getOpenFgaAuthorizationService: () => ({
+    authorizeTenantAction: authorizeTenantActionMock,
+  }),
+}));
+
+const router = require("../api-keys").apiKeysRouter;
+
+describe("api keys authz hardening", () => {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).tenantId = "tenant-1";
+    (req as any).userId = "user-1";
+    (req as any).traceId = "trace-1";
+    next();
+  });
+  app.use("/api/v1", router);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: true,
+      degraded: false,
+      mode: "local_rbac",
+      openfga: { state: "disabled", allowed: false, reason: "openfga_disabled" },
+    });
+    queryMock.mockResolvedValue([]);
+  });
+
+  it("fails closed on list when canonical authz denies", async () => {
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: false,
+      reason: "openfga_required_unavailable",
+      degraded: true,
+      mode: "fail_closed",
+      openfga: { state: "unavailable", allowed: false, reason: "openfga_unavailable" },
+    });
+
+    const response = await request(app).get("/api/v1/api-keys");
+
+    expect(response.status).toBe(403);
+    expect(response.body.reason).toBe("openfga_required_unavailable");
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 with machine-visible reason when tenant context is missing", async () => {
+    const appNoTenant = express();
+    appNoTenant.use(express.json());
+    appNoTenant.use((req, _res, next) => {
+      (req as any).tenantId = null;
+      (req as any).userId = "user-1";
+      (req as any).traceId = "trace-1";
+      next();
+    });
+    appNoTenant.use("/api/v1", router);
+
+    const response = await request(appNoTenant).get("/api/v1/api-keys");
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("TENANT_CONTEXT_REQUIRED");
+    expect(response.body.reason).toBe("missing_tenant_context");
+  });
+});

--- a/packages/api/src/routes/__tests__/approvals-freeze.test.ts
+++ b/packages/api/src/routes/__tests__/approvals-freeze.test.ts
@@ -14,6 +14,9 @@ import { clearGovernanceCache } from "../../utils/governance-cache";
 
 // Mock dependencies
 jest.mock("../../db");
+jest.mock("../../middleware/authorization", () => ({
+  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
 
 const mockQuery = query as jest.MockedFunction<typeof query>;
 

--- a/packages/api/src/routes/api-keys.ts
+++ b/packages/api/src/routes/api-keys.ts
@@ -9,6 +9,11 @@ import { generateApiKey, hashApiKey } from "../utils/hash";
 import { logInfo } from "../utils/logger";
 import { handleRouteError } from "../utils/error-handler";
 import { NotFoundError } from "../utils/typed-errors";
+import {
+  authorizeTenantActionOr403,
+  requireTenantContext,
+  requireUserContext,
+} from "./authz-helpers";
 
 const router: Router = Router();
 
@@ -45,8 +50,10 @@ router.get(
   requirePermission(Permission.USERS_WRITE),
   async (req: AuthRequest, res: Response) => {
     try {
-      const userId = req.userId!;
-      const tenantId = req.tenantId!;
+      const userId = requireUserContext(req, res);
+      const tenantId = requireTenantContext(req, res);
+      if (!userId || !tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.api_key.read"))) return;
 
       const keys = await query<{
         id: string;
@@ -101,7 +108,9 @@ router.get(
         return;
       }
       const userId = req.userId!;
-      const tenantId = req.tenantId!;
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.api_key.read"))) return;
 
       const keys = await query<{
         id: string;
@@ -153,17 +162,21 @@ router.post(
   async (req: AuthRequest, res: Response) => {
     try {
       const { name, scopes, rateLimit, expiresAt } = req.body;
-      const userId = req.userId!;
+      const userId = requireUserContext(req, res);
+      const tenantId = requireTenantContext(req, res);
+      if (!userId || !tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.api_key.manage"))) return;
 
       const { key, prefix } = generateApiKey();
       const keyHash = await hashApiKey(key);
 
       const result = await query<{ id: string }>(
-        `INSERT INTO api_keys (user_id, key_prefix, key_hash, name, scopes, rate_limit, expires_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+        `INSERT INTO api_keys (user_id, tenant_id, key_prefix, key_hash, name, scopes, rate_limit, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          RETURNING id`,
         [
           userId,
+          tenantId,
           prefix,
           keyHash,
           name,
@@ -234,9 +247,10 @@ router.patch(
         return;
       }
       const { name, scopes, rateLimit, revoked } = req.body;
-      const userId = req.userId!;
-
-      const tenantId = req.tenantId!;
+      const userId = requireUserContext(req, res);
+      const tenantId = requireTenantContext(req, res);
+      if (!userId || !tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.api_key.manage"))) return;
 
       // Verify ownership
       const existing = await query<{ id: string; revoked_at: Date | null }>(
@@ -322,9 +336,10 @@ router.post(
         res.status(400).json({ error: "API key ID required" });
         return;
       }
-      const userId = req.userId!;
-
-      const tenantId = req.tenantId!;
+      const userId = requireUserContext(req, res);
+      const tenantId = requireTenantContext(req, res);
+      if (!userId || !tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.api_key.manage"))) return;
 
       // Verify ownership
       const existing = await query<{
@@ -349,8 +364,8 @@ router.post(
       await transaction(async (client) => {
         // Revoke old key
         await client.query(
-          `UPDATE api_keys SET revoked_at = NOW(), updated_at = NOW() WHERE id = $1`,
-          [id]
+          `UPDATE api_keys SET revoked_at = NOW(), updated_at = NOW() WHERE id = $1 AND user_id = $2 AND tenant_id = $3`,
+          [id, userId, tenantId]
         );
 
         // Create new key with same settings
@@ -358,11 +373,12 @@ router.post(
         const keyHash = await hashApiKey(key);
 
         const result = await client.query<{ id: string }>(
-          `INSERT INTO api_keys (user_id, key_prefix, key_hash, name, scopes, rate_limit, expires_at)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)
+          `INSERT INTO api_keys (user_id, tenant_id, key_prefix, key_hash, name, scopes, rate_limit, expires_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
            RETURNING id`,
           [
             userId,
+            tenantId,
             prefix,
             keyHash,
             oldKey.name,
@@ -435,9 +451,10 @@ router.delete(
         res.status(400).json({ error: "API key ID required" });
         return;
       }
-      const userId = req.userId!;
-
-      const tenantId = req.tenantId!;
+      const userId = requireUserContext(req, res);
+      const tenantId = requireTenantContext(req, res);
+      if (!userId || !tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.api_key.manage"))) return;
 
       // Verify ownership
       const existing = await query<{ id: string }>(
@@ -450,9 +467,10 @@ router.delete(
       }
 
       // Revoke instead of delete (soft delete)
-      await query(`UPDATE api_keys SET revoked_at = NOW(), updated_at = NOW() WHERE id = $1`, [
-        id || null,
-      ]);
+      await query(
+        `UPDATE api_keys SET revoked_at = NOW(), updated_at = NOW() WHERE id = $1 AND user_id = $2 AND tenant_id = $3`,
+        [id, userId, tenantId]
+      );
 
       // Log audit event
       await query(

--- a/packages/api/src/routes/authz-helpers.ts
+++ b/packages/api/src/routes/authz-helpers.ts
@@ -1,0 +1,71 @@
+import { Response } from "express";
+import { AuthRequest } from "../middleware/auth";
+import {
+  getOpenFgaAuthorizationService,
+  TenantAction,
+} from "../services/authz/openfga-authorization-service";
+
+export function requireTenantContext(req: AuthRequest, res: Response): string | null {
+  if (req.tenantId) {
+    return req.tenantId;
+  }
+
+  res.status(400).json({
+    error: "TENANT_CONTEXT_REQUIRED",
+    message: "Tenant context is required",
+    reason: "missing_tenant_context",
+    traceId: req.traceId,
+  });
+  return null;
+}
+
+export function requireUserContext(req: AuthRequest, res: Response): string | null {
+  if (req.userId) {
+    return req.userId;
+  }
+
+  res.status(401).json({
+    error: "UNAUTHORIZED",
+    message: "Authentication required",
+    reason: "missing_user_context",
+    traceId: req.traceId,
+  });
+  return null;
+}
+
+export async function authorizeTenantActionOr403(
+  req: AuthRequest,
+  res: Response,
+  tenantId: string,
+  action: TenantAction,
+  message = "Tenant action is not authorized"
+): Promise<boolean> {
+  const userId = requireUserContext(req, res);
+  if (!userId) {
+    return false;
+  }
+
+  const authz = await getOpenFgaAuthorizationService().authorizeTenantAction(
+    userId,
+    tenantId,
+    action
+  );
+  if (authz.allowed) {
+    return true;
+  }
+
+  res.status(403).json({
+    error: "FORBIDDEN",
+    message,
+    reason: authz.reason ?? "forbidden",
+    authz: {
+      mode: authz.mode,
+      degraded: authz.degraded,
+      provider: "openfga",
+      required: process.env.OPENFGA_REQUIRED === "true",
+      openfga: authz.openfga,
+    },
+    traceId: req.traceId,
+  });
+  return false;
+}

--- a/packages/api/src/routes/v1/__tests__/approvals.route.test.ts
+++ b/packages/api/src/routes/v1/__tests__/approvals.route.test.ts
@@ -1,0 +1,79 @@
+import express from "express";
+import request from "supertest";
+
+const approveRequestMock = jest.fn();
+
+jest.mock("../../../services/approval-workflows", () => ({
+  createApprovalRequest: jest.fn(),
+  approveRequest: (...args: unknown[]) => approveRequestMock(...args),
+  rejectRequest: jest.fn(),
+  getApprovalRequest: jest.fn(),
+  listApprovalRequests: jest.fn().mockResolvedValue([]),
+  addApprover: jest.fn(),
+}));
+
+jest.mock("../../../middleware/authorization", () => ({
+  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../../../middleware/governance", () => ({
+  enforceFreezeState: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const authorizeTenantActionMock = jest.fn();
+jest.mock("../../../services/authz/openfga-authorization-service", () => ({
+  getOpenFgaAuthorizationService: () => ({
+    authorizeTenantAction: authorizeTenantActionMock,
+  }),
+}));
+
+const router = require("../approvals").default;
+
+describe("approvals authz hardening", () => {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).tenantId = "tenant-1";
+    (req as any).userId = "user-1";
+    (req as any).traceId = "trace-1";
+    next();
+  });
+  app.use("/api/v1/approvals", router);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: true,
+      degraded: false,
+      mode: "local_rbac",
+      openfga: { state: "disabled", allowed: false, reason: "openfga_disabled" },
+    });
+  });
+
+  it("fails closed on approve when canonical authz denies", async () => {
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: false,
+      reason: "openfga_required_unavailable",
+      degraded: true,
+      mode: "fail_closed",
+      openfga: { state: "unavailable", allowed: false, reason: "openfga_unavailable" },
+    });
+
+    const response = await request(app).post("/api/v1/approvals/requests/appr-1/approve").send({});
+
+    expect(response.status).toBe(403);
+    expect(response.body.reason).toBe("openfga_required_unavailable");
+    expect(approveRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 with explicit SoD reason when requester tries to approve", async () => {
+    approveRequestMock.mockRejectedValue(
+      new Error("separation_of_duties_violation: requester cannot approve own request")
+    );
+
+    const response = await request(app).post("/api/v1/approvals/requests/appr-1/approve").send({});
+
+    expect(response.status).toBe(409);
+    expect(response.body.reason).toBe("separation_of_duties_violation");
+  });
+});

--- a/packages/api/src/routes/v1/approvals.ts
+++ b/packages/api/src/routes/v1/approvals.ts
@@ -6,7 +6,14 @@
 import { Router, Response } from "express";
 import { AuthRequest } from "../../middleware/auth";
 import { enforceFreezeState } from "../../middleware/governance";
+import { requirePermission } from "../../middleware/authorization";
+import { Permission } from "../../infrastructure/security/Permissions";
 import { logError, logInfo } from "../../utils/logger";
+import {
+  authorizeTenantActionOr403,
+  requireTenantContext,
+  requireUserContext,
+} from "../authz-helpers";
 import {
   createApprovalRequest,
   approveRequest,
@@ -23,135 +30,190 @@ const router: Router = Router();
  * POST /api/v1/approvals/requests
  * Create an approval request
  */
-router.post("/requests", enforceFreezeState(), async (req: AuthRequest, res: Response) => {
-  try {
-    const tenantId = req.tenantId!;
-    const userId = req.userId!;
-    const {
-      requestType,
-      requestDetails,
-      reconciliationRunId,
-      reconJobId,
-      reconResultId,
-      approverId,
-      approverRole,
-      expiresInHours,
-      comments,
-    } = req.body;
+router.post(
+  "/requests",
+  requirePermission(Permission.TENANT_WRITE),
+  enforceFreezeState(),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      const userId = requireUserContext(req, res);
+      if (!tenantId || !userId) return;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.approval.request",
+          "Approval request creation is not authorized"
+        ))
+      ) {
+        return;
+      }
+      const {
+        requestType,
+        requestDetails,
+        reconciliationRunId,
+        reconJobId,
+        reconResultId,
+        approverId,
+        approverRole,
+        expiresInHours,
+        comments,
+      } = req.body;
 
-    if (!requestType || !requestDetails) {
-      return res.status(400).json({
-        error: "Bad Request",
-        message: "requestType and requestDetails are required",
+      if (!requestType || !requestDetails) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "requestType and requestDetails are required",
+          traceId: req.traceId,
+        });
+      }
+
+      const approvalId = await createApprovalRequest(
+        tenantId,
+        userId,
+        requestType,
+        requestDetails,
+        {
+          reconciliationRunId,
+          reconJobId,
+          reconResultId,
+          approverId,
+          approverRole,
+          expiresInHours,
+          comments,
+        }
+      );
+
+      logInfo("Approval request created", { approvalId, tenantId, userId, traceId: req.traceId });
+
+      return res.status(201).json({
+        id: approvalId,
+        traceId: req.traceId,
+      });
+    } catch (error) {
+      logError("Failed to create approval request", error, { traceId: req.traceId });
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to create approval request",
         traceId: req.traceId,
       });
     }
-
-    const approvalId = await createApprovalRequest(tenantId, userId, requestType, requestDetails, {
-      reconciliationRunId,
-      reconJobId,
-      reconResultId,
-      approverId,
-      approverRole,
-      expiresInHours,
-      comments,
-    });
-
-    logInfo("Approval request created", { approvalId, tenantId, userId, traceId: req.traceId });
-
-    return res.status(201).json({
-      id: approvalId,
-      traceId: req.traceId,
-    });
-  } catch (error) {
-    logError("Failed to create approval request", error, { traceId: req.traceId });
-    return res.status(500).json({
-      error: "Internal Server Error",
-      message: "Failed to create approval request",
-      traceId: req.traceId,
-    });
   }
-});
+);
 
 /**
  * GET /api/v1/approvals/requests
  * List approval requests
  */
-router.get("/requests", async (req: AuthRequest, res: Response) => {
-  try {
-    const tenantId = req.tenantId!;
-    const { status, approverId, requestedBy, limit = 100, offset = 0 } = req.query;
+router.get(
+  "/requests",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.approval.read",
+          "Approval request read is not authorized"
+        ))
+      ) {
+        return;
+      }
+      const { status, approverId, requestedBy, limit = 100, offset = 0 } = req.query;
 
-    const requests = await listApprovalRequests(tenantId, {
-      status: status as ApprovalStatus | undefined,
-      approverId: approverId as string | undefined,
-      requestedBy: requestedBy as string | undefined,
-      limit: parseInt(limit as string),
-      offset: parseInt(offset as string),
-    });
-
-    return res.json({
-      data: requests,
-      pagination: {
+      const requests = await listApprovalRequests(tenantId, {
+        status: status as ApprovalStatus | undefined,
+        approverId: approverId as string | undefined,
+        requestedBy: requestedBy as string | undefined,
         limit: parseInt(limit as string),
         offset: parseInt(offset as string),
-        total: requests.length,
-      },
-      traceId: req.traceId,
-    });
-  } catch (error) {
-    logError("Failed to list approval requests", error, { traceId: req.traceId });
-    return res.status(500).json({
-      error: "Internal Server Error",
-      message: "Failed to list approval requests",
-      traceId: req.traceId,
-    });
+      });
+
+      return res.json({
+        data: requests,
+        pagination: {
+          limit: parseInt(limit as string),
+          offset: parseInt(offset as string),
+          total: requests.length,
+        },
+        traceId: req.traceId,
+      });
+    } catch (error) {
+      logError("Failed to list approval requests", error, { traceId: req.traceId });
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to list approval requests",
+        traceId: req.traceId,
+      });
+    }
   }
-});
+);
 
 /**
  * GET /api/v1/approvals/requests/:approvalId
  * Get approval request details
  */
-router.get("/requests/:approvalId", async (req: AuthRequest, res: Response) => {
-  try {
-    const approvalIdParam = req.params["approvalId"];
-    const approvalId = Array.isArray(approvalIdParam)
-      ? (approvalIdParam[0] ?? "")
-      : (approvalIdParam ?? "");
-    const tenantId = req.tenantId!;
+router.get(
+  "/requests/:approvalId",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const approvalIdParam = req.params["approvalId"];
+      const approvalId = Array.isArray(approvalIdParam)
+        ? (approvalIdParam[0] ?? "")
+        : (approvalIdParam ?? "");
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.approval.read",
+          "Approval request read is not authorized"
+        ))
+      ) {
+        return;
+      }
 
-    if (!approvalId) {
-      return res.status(400).json({
-        error: "Bad Request",
-        message: "approvalId is required",
+      if (!approvalId) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "approvalId is required",
+          traceId: req.traceId,
+        });
+      }
+
+      const request = await getApprovalRequest(tenantId, approvalId);
+
+      if (!request) {
+        return res.status(404).json({
+          error: "Not Found",
+          message: "Approval request not found",
+          traceId: req.traceId,
+        });
+      }
+
+      return res.json({
+        ...request,
+        traceId: req.traceId,
+      });
+    } catch (error) {
+      logError("Failed to get approval request", error, { traceId: req.traceId });
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to get approval request",
         traceId: req.traceId,
       });
     }
-
-    const request = await getApprovalRequest(tenantId, approvalId);
-
-    if (!request) {
-      return res.status(404).json({
-        error: "Not Found",
-        message: "Approval request not found",
-        traceId: req.traceId,
-      });
-    }
-
-    return res.json({
-      ...request,
-      traceId: req.traceId,
-    });
-  } catch (error) {
-    logError("Failed to get approval request", error, { traceId: req.traceId });
-    return res.status(500).json({
-      error: "Internal Server Error",
-      message: "Failed to get approval request",
-      traceId: req.traceId,
-    });
   }
-});
+);
 
 /**
  * POST /api/v1/approvals/requests/:approvalId/approve
@@ -159,6 +221,7 @@ router.get("/requests/:approvalId", async (req: AuthRequest, res: Response) => {
  */
 router.post(
   "/requests/:approvalId/approve",
+  requirePermission(Permission.TENANT_WRITE),
   enforceFreezeState(),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -166,8 +229,20 @@ router.post(
       const approvalId = Array.isArray(approvalIdParam2)
         ? (approvalIdParam2[0] ?? "")
         : (approvalIdParam2 ?? "");
-      const tenantId = req.tenantId!;
-      const userId = req.userId!;
+      const tenantId = requireTenantContext(req, res);
+      const userId = requireUserContext(req, res);
+      if (!tenantId || !userId) return;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.approval.decide",
+          "Approval decision is not authorized"
+        ))
+      ) {
+        return;
+      }
 
       if (!approvalId) {
         return res.status(400).json({
@@ -187,10 +262,18 @@ router.post(
       });
     } catch (error) {
       logError("Failed to approve request", error, { traceId: req.traceId });
-      const statusCode = (error as Error).message.includes("not found") ? 404 : 500;
+      const message = (error as Error).message;
+      const statusCode = message.includes("not found")
+        ? 404
+        : message.includes("permission")
+          ? 403
+          : 409;
       return res.status(statusCode).json({
-        error: statusCode === 404 ? "Not Found" : "Internal Server Error",
-        message: (error as Error).message || "Failed to approve request",
+        error: statusCode === 404 ? "Not Found" : statusCode === 403 ? "Forbidden" : "Conflict",
+        message: message || "Failed to approve request",
+        reason: message.includes("separation_of_duties")
+          ? "separation_of_duties_violation"
+          : "approval_transition_denied",
         traceId: req.traceId,
       });
     }
@@ -203,6 +286,7 @@ router.post(
  */
 router.post(
   "/requests/:approvalId/reject",
+  requirePermission(Permission.TENANT_WRITE),
   enforceFreezeState(),
   async (req: AuthRequest, res: Response) => {
     try {
@@ -211,8 +295,20 @@ router.post(
         ? (approvalIdParam3[0] ?? "")
         : (approvalIdParam3 ?? "");
       const { comments } = req.body;
-      const tenantId = req.tenantId!;
-      const userId = req.userId!;
+      const tenantId = requireTenantContext(req, res);
+      const userId = requireUserContext(req, res);
+      if (!tenantId || !userId) return;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.approval.decide",
+          "Approval decision is not authorized"
+        ))
+      ) {
+        return;
+      }
 
       if (!approvalId) {
         return res.status(400).json({
@@ -232,10 +328,18 @@ router.post(
       });
     } catch (error) {
       logError("Failed to reject request", error, { traceId: req.traceId });
-      const statusCode = (error as Error).message.includes("not found") ? 404 : 500;
+      const message = (error as Error).message;
+      const statusCode = message.includes("not found")
+        ? 404
+        : message.includes("permission")
+          ? 403
+          : 409;
       return res.status(statusCode).json({
-        error: statusCode === 404 ? "Not Found" : "Internal Server Error",
-        message: (error as Error).message || "Failed to reject request",
+        error: statusCode === 404 ? "Not Found" : statusCode === 403 ? "Forbidden" : "Conflict",
+        message: message || "Failed to reject request",
+        reason: message.includes("separation_of_duties")
+          ? "separation_of_duties_violation"
+          : "approval_transition_denied",
         traceId: req.traceId,
       });
     }
@@ -246,39 +350,56 @@ router.post(
  * POST /api/v1/approvals/approvers
  * Add an approver
  */
-router.post("/approvers", enforceFreezeState(), async (req: AuthRequest, res: Response) => {
-  try {
-    const tenantId = req.tenantId!;
-    const { userId, role, approvalThreshold, canApproveFinal } = req.body;
+router.post(
+  "/approvers",
+  requirePermission(Permission.TENANT_WRITE),
+  enforceFreezeState(),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.approval.manage",
+          "Approver management is not authorized"
+        ))
+      ) {
+        return;
+      }
+      const { userId, role, approvalThreshold, canApproveFinal } = req.body;
 
-    if (!userId || !role) {
-      return res.status(400).json({
-        error: "Bad Request",
-        message: "userId and role are required",
+      if (!userId || !role) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "userId and role are required",
+          traceId: req.traceId,
+        });
+      }
+
+      const approverId = await addApprover(tenantId, userId, role, {
+        approvalThreshold,
+        canApproveFinal,
+      });
+
+      logInfo("Approver added", { approverId, tenantId, userId, role, traceId: req.traceId });
+
+      return res.status(201).json({
+        id: approverId,
+        traceId: req.traceId,
+      });
+    } catch (error) {
+      logError("Failed to add approver", error, { traceId: req.traceId });
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to add approver",
         traceId: req.traceId,
       });
     }
-
-    const approverId = await addApprover(tenantId, userId, role, {
-      approvalThreshold,
-      canApproveFinal,
-    });
-
-    logInfo("Approver added", { approverId, tenantId, userId, role, traceId: req.traceId });
-
-    return res.status(201).json({
-      id: approverId,
-      traceId: req.traceId,
-    });
-  } catch (error) {
-    logError("Failed to add approver", error, { traceId: req.traceId });
-    return res.status(500).json({
-      error: "Internal Server Error",
-      message: "Failed to add approver",
-      traceId: req.traceId,
-    });
   }
-});
+);
 
 export const approvalsRouter = router;
 export default router;

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -22,6 +22,11 @@ import {
 } from "../services/webhooks/security";
 import { IngestionBoundary } from "../services/ingestion/boundary";
 import { isValidTenantUuid } from "../utils/tenant-id";
+import {
+  authorizeTenantActionOr403,
+  requireTenantContext,
+  requireUserContext,
+} from "./authz-helpers";
 
 // Initialize Boundary
 const ingestionBoundary = new IngestionBoundary({ query } as any);
@@ -93,7 +98,10 @@ router.post(
   async (req: AuthRequest, res: Response) => {
     try {
       const { url, events, secret } = req.body;
-      const userId = req.userId!;
+      const userId = requireUserContext(req, res);
+      const tenantId = requireTenantContext(req, res);
+      if (!userId || !tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.webhook.manage"))) return;
 
       const isValidUrl = await validateExternalUrl(url);
       if (!isValidUrl) {
@@ -122,10 +130,10 @@ router.post(
       const webhookSecret = secret || `whsec_${randomBytes(32).toString("base64url")}`;
 
       const result = await query<{ id: string }>(
-        `INSERT INTO webhooks (user_id, url, events, secret, status)
-         VALUES ($1, $2, $3, $4, 'active')
+        `INSERT INTO webhooks (user_id, tenant_id, url, events, secret, status)
+         VALUES ($1, $2, $3, $4, $5, 'active')
          RETURNING id`,
-        [userId, url, events, webhookSecret]
+        [userId, tenantId, url, events, webhookSecret]
       );
 
       if (!result[0]) {
@@ -170,7 +178,9 @@ router.get(
       const limit = Math.min(parseInt(req.query.limit as string) || 100, 1000);
       const offset = (page - 1) * limit;
 
-      const tenantId = req.tenantId!;
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.webhook.read"))) return;
 
       const [webhooks, totalResult] = await Promise.all([
         query<{
@@ -237,8 +247,7 @@ router.post(
       const idempotencyKey = req.headers["x-idempotency-key"] as string | undefined;
 
       const body = req.body as Record<string, unknown> | undefined;
-      const fromBody =
-        typeof body?.tenant_id === "string" ? body.tenant_id.trim() : undefined;
+      const fromBody = typeof body?.tenant_id === "string" ? body.tenant_id.trim() : undefined;
       const rawTenant = (req.headers["x-tenant-id"] as string | undefined)?.trim() || fromBody;
       if (!isValidTenantUuid(rawTenant)) {
         return res.status(400).json({
@@ -401,7 +410,10 @@ router.delete(
     try {
       const idParam = req.params["id"];
       const id = Array.isArray(idParam) ? (idParam[0] ?? "") : (idParam ?? "");
-      const userId = req.userId!;
+      const userId = requireUserContext(req, res);
+      const tenantId = requireTenantContext(req, res);
+      if (!userId || !tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.webhook.manage"))) return;
 
       await new Promise<void>((resolve, reject) => {
         requireResourceOwnership(
@@ -416,7 +428,6 @@ router.delete(
         );
       });
 
-      const tenantId = req.tenantId!;
       await query(`DELETE FROM webhooks WHERE id = $1 AND user_id = $2 AND tenant_id = $3`, [
         id || "",
         userId,

--- a/packages/api/src/services/approval-workflows.ts
+++ b/packages/api/src/services/approval-workflows.ts
@@ -58,21 +58,21 @@ export async function createApprovalRequest(
     let approverId = options.approverId;
     let approverRole = options.approverRole;
 
-      // Auto-assign approver if not provided
-      if (!approverId && !approverRole) {
-        const approverResult = await query<{ user_id: string; role: string }>(
-          `SELECT user_id, role FROM approvers
+    // Auto-assign approver if not provided
+    if (!approverId && !approverRole) {
+      const approverResult = await query<{ user_id: string; role: string }>(
+        `SELECT user_id, role FROM approvers
            WHERE tenant_id = $1 AND can_approve_final = true
            ORDER BY created_at ASC
            LIMIT 1`,
-          [tenantId]
-        );
+        [tenantId]
+      );
 
-        if (approverResult.length > 0) {
-          approverId = approverResult[0]?.user_id;
-          approverRole = approverResult[0]?.role;
-        }
+      if (approverResult.length > 0) {
+        approverId = approverResult[0]?.user_id;
+        approverRole = approverResult[0]?.role;
       }
+    }
 
     const expiresAt = options.expiresInHours
       ? new Date(Date.now() + options.expiresInHours * 60 * 60 * 1000)
@@ -100,7 +100,7 @@ export async function createApprovalRequest(
       ] as (string | number | boolean | null | Date)[]
     );
 
-    const approvalId = result[0]?.id || '';
+    const approvalId = result[0]?.id || "";
 
     logInfo("Approval request created", {
       approvalId,
@@ -130,7 +130,7 @@ export async function approveRequest(
     await transaction(async (client) => {
       // Verify the request exists and is pending
       const requestResult = await client.query(
-        `SELECT id, approver_id, approver_role, status, expires_at
+        `SELECT id, requested_by, approver_id, approver_role, status, expires_at
          FROM approval_requests
          WHERE id = $1 AND tenant_id = $2`,
         [approvalId, tenantId]
@@ -141,6 +141,7 @@ export async function approveRequest(
       }
 
       const request = requestResult.rows[0] as {
+        requested_by?: string;
         approver_id?: string;
         approver_role?: string;
         status: string;
@@ -153,6 +154,10 @@ export async function approveRequest(
 
       if (request.expires_at && new Date(request.expires_at) < new Date()) {
         throw new Error("Approval request has expired");
+      }
+
+      if (request.requested_by === approverId) {
+        throw new Error("separation_of_duties_violation: requester cannot approve own request");
       }
 
       // Verify approver has permission
@@ -202,7 +207,7 @@ export async function rejectRequest(
     await transaction(async (client) => {
       // Verify the request exists and is pending
       const requestResult = await client.query(
-        `SELECT id, approver_id, approver_role, status
+        `SELECT id, requested_by, approver_id, approver_role, status, expires_at
          FROM approval_requests
          WHERE id = $1 AND tenant_id = $2`,
         [approvalId, tenantId]
@@ -213,13 +218,37 @@ export async function rejectRequest(
       }
 
       const request = requestResult.rows[0] as {
+        requested_by?: string;
         approver_id?: string;
         approver_role?: string;
         status: string;
+        expires_at?: Date;
       };
 
       if (request.status !== "pending") {
         throw new Error(`Request is not pending (status: ${request.status})`);
+      }
+
+      if (request.expires_at && new Date(request.expires_at) < new Date()) {
+        throw new Error("Approval request has expired");
+      }
+
+      if (request.requested_by === approverId) {
+        throw new Error("separation_of_duties_violation: requester cannot reject own request");
+      }
+
+      if (request.approver_id && request.approver_id !== approverId) {
+        if (request.approver_role) {
+          const approverResult = await client.query(
+            `SELECT id FROM approvers
+             WHERE tenant_id = $1 AND user_id = $2 AND role = $3`,
+            [tenantId, approverId, request.approver_role]
+          );
+
+          if (approverResult.rows.length === 0) {
+            throw new Error("User does not have permission to reject this request");
+          }
+        }
       }
 
       // Update approval request
@@ -391,7 +420,7 @@ export async function addApprover(
       ] as (string | number | boolean | null | Date)[]
     );
 
-    const approverId = result[0]?.id || '';
+    const approverId = result[0]?.id || "";
     logInfo("Approver added", { approverId, tenantId, userId, role });
     return approverId;
   } catch (error) {

--- a/packages/api/src/services/authz/openfga-authorization-service.ts
+++ b/packages/api/src/services/authz/openfga-authorization-service.ts
@@ -38,7 +38,15 @@ export type TenantAction =
   | "tenant.proof.evidence.export"
   | "tenant.memory.graph.read"
   | "tenant.integration.read"
-  | "tenant.integration.manage";
+  | "tenant.integration.manage"
+  | "tenant.approval.read"
+  | "tenant.approval.request"
+  | "tenant.approval.decide"
+  | "tenant.approval.manage"
+  | "tenant.api_key.read"
+  | "tenant.api_key.manage"
+  | "tenant.webhook.read"
+  | "tenant.webhook.manage";
 
 function readConfig(): OpenFgaConfig {
   const enabled = process.env.OPENFGA_ENABLED === "true";
@@ -135,12 +143,21 @@ function relationForAction(action: TenantAction): string {
     case "tenant.proof.evidence.export":
       return "can_export";
     case "tenant.policy.proposal.review":
+    case "tenant.approval.decide":
+    case "tenant.approval.manage":
       return "can_review_policy";
     case "tenant.memory.graph.read":
     case "tenant.integration.read":
       return "can_view";
     case "tenant.integration.manage":
+    case "tenant.api_key.manage":
+    case "tenant.webhook.manage":
       return "can_manage_integrations";
+    case "tenant.approval.read":
+    case "tenant.approval.request":
+    case "tenant.api_key.read":
+    case "tenant.webhook.read":
+      return "can_view";
   }
 }
 
@@ -156,7 +173,15 @@ function localRoleAllowed(action: TenantAction, role: UserRole | null): boolean 
     case "tenant.policy.proposal.review":
     case "tenant.proof.evidence.export":
     case "tenant.memory.graph.read":
+    case "tenant.approval.read":
+    case "tenant.approval.request":
+    case "tenant.approval.decide":
+    case "tenant.approval.manage":
     case "tenant.integration.manage":
+    case "tenant.api_key.read":
+    case "tenant.api_key.manage":
+    case "tenant.webhook.read":
+    case "tenant.webhook.manage":
       return role === UserRole.OWNER || role === UserRole.ADMIN;
     case "tenant.integration.read":
       return role === UserRole.OWNER || role === UserRole.ADMIN || role === UserRole.DEVELOPER;


### PR DESCRIPTION
### Motivation
- Close high-risk seams where sensitive operations relied on route-local permissions or broad role checks instead of canonical tenant/object OpenFGA checks. 
- Make authz fail-closed and machine-visible for approval decisions, API key lifecycle, and webhook management to prevent cross-tenant leaks and silent degraded behavior. 
- Enforce basic governance (tenant/user context, separation-of-duties) on approval transitions to increase auditability and reduce false-success mutations.

### Description
- Added shared route helpers `packages/api/src/routes/authz-helpers.ts` providing `requireTenantContext`, `requireUserContext`, and `authorizeTenantActionOr403` that return consistent machine-visible deny payloads including `reason`, `authz.mode`, `authz.degraded`, `authz.provider`, `authz.required`, and `traceId`.
- Expanded `TenantAction` taxonomy in `packages/api/src/services/authz/openfga-authorization-service.ts` to include approval, API key, and webhook actions and wired them to relation mapping and local-role fallbacks.
- Hardened routes to use canonical authz helpers and explicit tenant/user guards for: approvals (`packages/api/src/routes/v1/approvals.ts`), API keys (`packages/api/src/routes/api-keys.ts`), and webhooks (`packages/api/src/routes/webhooks.ts`).
- Strengthened approval service semantics in `packages/api/src/services/approval-workflows.ts` with separation-of-duties checks (prevent requester from approving/rejecting own request) and symmetrical approver-role verification for approve/reject flows.
- Fixed tenant scoping in mutations and queries (added `tenant_id` where missing) and mapped transition errors to deterministic non-500 statuses with machine-readable `reason` values.
- Added targeted regression tests covering fail-closed authz behavior and tenant-context requirements: `packages/api/src/routes/v1/__tests__/approvals.route.test.ts` and `packages/api/src/routes/__tests__/api-keys.authz.test.ts`, and adjusted freeze tests to work with the new middleware wiring.

### Testing
- Ran lint: `pnpm --filter @settler/api lint` — ✅ pass.
- Ran typecheck: `pnpm --filter @settler/api typecheck` — ✅ pass.
- Ran build: `pnpm --filter @settler/api build` — ✅ pass.
- Ran unit tests (focused suites): `pnpm --filter @settler/api test -- --runInBand src/routes/v1/__tests__/approvals.route.test.ts src/routes/__tests__/api-keys.authz.test.ts src/routes/__tests__/approvals-freeze.test.ts` — ✅ all three suites passed (8 tests total in run).
- Attempted tenant verification: `pnpm run verify:tenant` — ⚠️ warning: environment/repo limitation (missing `security/route-registry.json`) caused the script to fail before tenant assertions could complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a55ab92c8328af8fba5cc483aa13)