### PR TITLE
Harden canonical authz on users/operator/knowledge/graph surfaces

### DIFF
--- a/packages/api/src/routes/__tests__/users.authz.test.ts
+++ b/packages/api/src/routes/__tests__/users.authz.test.ts
@@ -1,0 +1,77 @@
+import express from "express";
+import request from "supertest";
+
+const queryMock = jest.fn();
+
+jest.mock("../../db", () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+  transaction: jest.fn(async (fn: (client: { query: typeof queryMock }) => unknown) =>
+    fn({ query: queryMock })
+  ),
+}));
+
+jest.mock("../../middleware/authorization", () => ({
+  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../../utils/hash", () => ({
+  verifyPassword: jest.fn().mockResolvedValue(true),
+}));
+
+const authorizeTenantActionMock = jest.fn();
+jest.mock("../../services/authz/openfga-authorization-service", () => ({
+  getOpenFgaAuthorizationService: () => ({
+    authorizeTenantAction: authorizeTenantActionMock,
+  }),
+}));
+
+const router = require("../users").usersRouter;
+
+describe("users authz hardening", () => {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).tenantId = "tenant-1";
+    (req as any).userId = "11111111-1111-1111-1111-111111111111";
+    (req as any).traceId = "trace-1";
+    next();
+  });
+  app.use("/api/v1/users", router);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: true,
+      degraded: false,
+      mode: "local_rbac",
+      openfga: { state: "disabled", allowed: false, reason: "openfga_disabled" },
+    });
+  });
+
+  it("fails closed on export when canonical authz denies", async () => {
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: false,
+      reason: "openfga_required_unavailable",
+      degraded: true,
+      mode: "fail_closed",
+      openfga: { state: "unavailable", allowed: false, reason: "openfga_unavailable" },
+    });
+
+    const response = await request(app).get(
+      "/api/v1/users/11111111-1111-1111-1111-111111111111/data-export"
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.reason).toBe("openfga_required_unavailable");
+  });
+
+  it("returns explicit 403 reason for cross-user export", async () => {
+    const response = await request(app).get(
+      "/api/v1/users/22222222-2222-2222-2222-222222222222/data-export"
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.reason).toBe("cross_user_export_forbidden");
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -8,7 +8,11 @@ import { query, transaction } from "../db";
 import { verifyPassword } from "../utils/hash";
 import { logInfo } from "../utils/logger";
 import { handleRouteError } from "../utils/error-handler";
-import { UserRole } from "../domain/entities/User";
+import {
+  authorizeTenantActionOr403,
+  requireTenantContext,
+  requireUserContext,
+} from "./authz-helpers";
 
 const router: Router = Router();
 
@@ -32,25 +36,21 @@ router.delete(
   async (req: AuthRequest, res: Response) => {
     try {
       const { id } = req.params;
-      const userId = req.userId!;
+      const userId = requireUserContext(req, res);
+      const tenantId = requireTenantContext(req, res);
+      if (!userId || !tenantId) return;
       const { password } = req.body;
 
-      const tenantId = req.tenantId!;
-
-      // Users can only delete their own data (or admins)
-      if (id !== userId) {
-        // Check if user is admin
-        const users = await query<{ role: UserRole }>(
-          "SELECT role FROM users WHERE id = $1 AND tenant_id = $2",
-          [userId, tenantId]
-        );
-        if (
-          users.length === 0 ||
-          !users[0] ||
-          (users[0].role !== UserRole.ADMIN && users[0].role !== UserRole.OWNER)
-        ) {
-          return res.status(403).json({ error: "Forbidden" });
-        }
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.user.data.delete",
+          "User data deletion is not authorized"
+        ))
+      ) {
+        return;
       }
 
       if (!id || !userId) {
@@ -126,14 +126,31 @@ router.get(
   async (req: AuthRequest, res: Response) => {
     try {
       const { id } = req.params;
-      const userId = req.userId!;
+      const userId = requireUserContext(req, res);
+      const tenantId = requireTenantContext(req, res);
+      if (!userId || !tenantId) return;
 
       // Users can only export their own data
       if (id !== userId) {
-        return res.status(403).json({ error: "Forbidden" });
+        return res.status(403).json({
+          error: "FORBIDDEN",
+          message: "User export is only allowed for the authenticated user",
+          reason: "cross_user_export_forbidden",
+          traceId: req.traceId,
+        });
       }
 
-      const tenantId = req.tenantId!;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.user.data.export",
+          "User data export is not authorized"
+        ))
+      ) {
+        return;
+      }
 
       // Fetch all user data — scoped by tenant_id
       const [users, jobs, reports, webhooks, apiKeys, auditLogs] = await Promise.all([

--- a/packages/api/src/routes/v1/operator-mode.ts
+++ b/packages/api/src/routes/v1/operator-mode.ts
@@ -11,6 +11,7 @@ import { requirePermission } from "../../middleware/authorization";
 import { enforceFreezeState } from "../../middleware/governance";
 import { Permission } from "../../infrastructure/security/Permissions";
 import { handleRouteError } from "../../utils/error-handler";
+import { authorizeTenantActionOr403, requireTenantContext } from "../authz-helpers";
 import {
   generateDailyIntelligence,
   getErrorRateSummary,
@@ -37,21 +38,26 @@ import { getOperatorReplayStatus } from "../../services/operator-mode/replay-sta
 
 const router: Router = Router();
 
-function requireTenantContext(req: AuthRequest, res: Response): string | undefined {
-  if (req.tenantId) {
-    return req.tenantId;
-  }
-
-  res.status(400).json({
-    error: "TENANT_CONTEXT_REQUIRED",
-    message: "Tenant context is required for this operator endpoint",
-  });
-  return undefined;
-}
-
 function shouldUseGlobalScope(req: AuthRequest): boolean {
   return req.query.scope === "global";
 }
+
+router.use("/operator", async (req: AuthRequest, res: Response, next) => {
+  const tenantId = requireTenantContext(req, res);
+  if (!tenantId) return;
+  if (
+    !(await authorizeTenantActionOr403(
+      req,
+      res,
+      tenantId,
+      "tenant.operator.control",
+      "Operator mode control path is not authorized"
+    ))
+  ) {
+    return;
+  }
+  next();
+});
 
 // ============================================================================
 // DAILY INTELLIGENCE
@@ -190,12 +196,12 @@ router.post(
     try {
       const provider = getAlertRoutingProvider();
       const useGlobalScope = shouldUseGlobalScope(req);
-      const tenantId = useGlobalScope ? undefined : requireTenantContext(req, res);
-      if (!useGlobalScope && !tenantId) {
+      const scopedTenantId = useGlobalScope ? undefined : requireTenantContext(req, res);
+      if (!useGlobalScope && !scopedTenantId) {
         return;
       }
 
-      const alerts = await provider.checkThresholds(tenantId);
+      const alerts = await provider.checkThresholds(scopedTenantId ?? undefined);
       const capability = provider.status();
       observeCapabilityStatus(capability, "/api/v1/operator/alerts/check");
 
@@ -203,7 +209,7 @@ router.post(
         data: alerts,
         capability,
         scope: useGlobalScope ? "global" : "tenant",
-        tenantId: tenantId ?? null,
+        tenantId: scopedTenantId ?? null,
         message: `Checked thresholds, triggered ${alerts.length} alerts`,
       });
     } catch (error: unknown) {

--- a/packages/api/src/routes/v2/__tests__/knowledge.authz.test.ts
+++ b/packages/api/src/routes/v2/__tests__/knowledge.authz.test.ts
@@ -1,0 +1,68 @@
+import express from "express";
+import request from "supertest";
+
+jest.mock("../../../middleware/authorization", () => ({
+  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const authorizeTenantActionMock = jest.fn();
+jest.mock("../../../services/authz/openfga-authorization-service", () => ({
+  getOpenFgaAuthorizationService: () => ({
+    authorizeTenantAction: authorizeTenantActionMock,
+  }),
+}));
+
+const router = require("../knowledge").default;
+
+describe("knowledge route authz", () => {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).tenantId = "tenant-1";
+    (req as any).userId = "user-1";
+    (req as any).traceId = "trace-1";
+    next();
+  });
+  app.use("/api/v2/knowledge", router);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: true,
+      degraded: false,
+      mode: "local_rbac",
+      openfga: { state: "disabled", allowed: false, reason: "openfga_disabled" },
+    });
+  });
+
+  it("fails closed when authz denies read", async () => {
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: false,
+      reason: "openfga_required_unavailable",
+      degraded: true,
+      mode: "fail_closed",
+      openfga: { state: "unavailable", allowed: false, reason: "openfga_unavailable" },
+    });
+
+    const response = await request(app).get("/api/v2/knowledge/decisions");
+
+    expect(response.status).toBe(403);
+    expect(response.body.reason).toBe("openfga_required_unavailable");
+  });
+
+  it("returns tenant-context-required when tenant is missing", async () => {
+    const appNoTenant = express();
+    appNoTenant.use(express.json());
+    appNoTenant.use((req, _res, next) => {
+      (req as any).tenantId = null;
+      (req as any).userId = "user-1";
+      (req as any).traceId = "trace-1";
+      next();
+    });
+    appNoTenant.use("/api/v2/knowledge", router);
+
+    const response = await request(appNoTenant).get("/api/v2/knowledge/stats");
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("TENANT_CONTEXT_REQUIRED");
+  });
+});

--- a/packages/api/src/routes/v2/__tests__/reconciliation-graph.authz.test.ts
+++ b/packages/api/src/routes/v2/__tests__/reconciliation-graph.authz.test.ts
@@ -1,0 +1,72 @@
+import express from "express";
+import request from "supertest";
+
+jest.mock("../../../middleware/authorization", () => ({
+  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const addNodeMock = jest.fn();
+const queryMock = jest.fn();
+jest.mock("../../../services/reconciliation-graph/graph-engine", () => ({
+  graphEngine: {
+    addNode: (...args: unknown[]) => addNodeMock(...args),
+    addEdge: jest.fn(),
+    query: (...args: unknown[]) => queryMock(...args),
+    getGraphState: jest.fn(),
+    subscribe: jest.fn(() => () => undefined),
+  },
+}));
+
+jest.mock("../../../services/reconciliation-graph/stream-processor", () => ({
+  streamProcessor: {
+    addEvent: jest.fn(),
+  },
+}));
+
+const authorizeTenantActionMock = jest.fn();
+jest.mock("../../../services/authz/openfga-authorization-service", () => ({
+  getOpenFgaAuthorizationService: () => ({
+    authorizeTenantAction: authorizeTenantActionMock,
+  }),
+}));
+
+const router = require("../reconciliation-graph").default;
+
+describe("reconciliation graph authz", () => {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).tenantId = "tenant-1";
+    (req as any).userId = "user-1";
+    (req as any).traceId = "trace-1";
+    next();
+  });
+  app.use("/api/v2/reconciliation-graph", router);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryMock.mockReturnValue({ nodes: [], edges: [] });
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: true,
+      degraded: false,
+      mode: "local_rbac",
+      openfga: { state: "disabled", allowed: false, reason: "openfga_disabled" },
+    });
+  });
+
+  it("fails closed on graph mutation when authz denies", async () => {
+    authorizeTenantActionMock.mockResolvedValue({
+      allowed: false,
+      reason: "openfga_required_unavailable",
+      degraded: true,
+      mode: "fail_closed",
+      openfga: { state: "unavailable", allowed: false, reason: "openfga_unavailable" },
+    });
+
+    const response = await request(app).post("/api/v2/reconciliation-graph/job-1/nodes").send({});
+
+    expect(response.status).toBe(403);
+    expect(response.body.reason).toBe("openfga_required_unavailable");
+    expect(addNodeMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/v2/knowledge.ts
+++ b/packages/api/src/routes/v2/knowledge.ts
@@ -4,10 +4,18 @@
  * REST API for decision logs and AI knowledge assistant
  */
 
-import { Router, Request, Response } from "express";
+import { Router, Response } from "express";
+import { AuthRequest } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/authorization";
+import { Permission } from "../../infrastructure/security/Permissions";
 import { decisionLog } from "../../services/knowledge/decision-log";
 import { aiKnowledgeAssistant } from "../../services/knowledge/ai-assistant";
 import { handleRouteError } from "../../utils/error-handler";
+import {
+  authorizeTenantActionOr403,
+  requireTenantContext,
+  requireUserContext,
+} from "../authz-helpers";
 
 const router: Router = Router();
 
@@ -15,190 +23,258 @@ const router: Router = Router();
  * POST /api/v2/knowledge/decisions
  * Create a new decision
  */
-router.post("/decisions", async (req: Request, res: Response) => {
-  try {
-    const decision = await decisionLog.createDecision(req.body);
+router.post(
+  "/decisions",
+  requirePermission(Permission.TENANT_WRITE),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      const userId = requireUserContext(req, res);
+      if (!tenantId || !userId) return;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.knowledge.manage",
+          "Knowledge decision creation is not authorized"
+        ))
+      ) {
+        return;
+      }
+      const decision = await decisionLog.createDecision(req.body);
 
-    res.status(201).json({
-      data: decision,
-      message: "Decision created successfully",
-    });
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to create decision", 400);
+      res.status(201).json({
+        data: decision,
+        message: "Decision created successfully",
+      });
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to create decision", 400);
+    }
   }
-});
+);
 
 /**
  * GET /api/v2/knowledge/decisions
  * Query decisions
  */
-router.get("/decisions", async (req: Request, res: Response) => {
-  try {
-    const queryOptions: {
-      status?: "proposed" | "accepted" | "rejected" | "superseded";
-      decisionMaker?: string;
-      tag?: string;
-      dateRange?: { start: Date; end: Date };
-      search?: string;
-    } = {};
-    if (req.query.status) {
-      queryOptions.status = req.query.status as "proposed" | "accepted" | "rejected" | "superseded";
-    }
-    if (req.query.decisionMaker) {
-      queryOptions.decisionMaker = req.query.decisionMaker as string;
-    }
-    if (req.query.tag) {
-      queryOptions.tag = req.query.tag as string;
-    }
-    if (req.query.startDate && req.query.endDate) {
-      queryOptions.dateRange = {
-        start: new Date(req.query.startDate as string),
-        end: new Date(req.query.endDate as string),
-      };
-    }
-    if (req.query.search) {
-      queryOptions.search = req.query.search as string;
-    }
-    const decisions = decisionLog.queryDecisions(queryOptions);
+router.get(
+  "/decisions",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.knowledge.read",
+          "Knowledge decision read is not authorized"
+        ))
+      ) {
+        return;
+      }
+      const queryOptions: {
+        status?: "proposed" | "accepted" | "rejected" | "superseded";
+        decisionMaker?: string;
+        tag?: string;
+        dateRange?: { start: Date; end: Date };
+        search?: string;
+      } = {};
+      if (req.query.status) {
+        queryOptions.status = req.query.status as
+          | "proposed"
+          | "accepted"
+          | "rejected"
+          | "superseded";
+      }
+      if (req.query.decisionMaker) {
+        queryOptions.decisionMaker = req.query.decisionMaker as string;
+      }
+      if (req.query.tag) {
+        queryOptions.tag = req.query.tag as string;
+      }
+      if (req.query.startDate && req.query.endDate) {
+        queryOptions.dateRange = {
+          start: new Date(req.query.startDate as string),
+          end: new Date(req.query.endDate as string),
+        };
+      }
+      if (req.query.search) {
+        queryOptions.search = req.query.search as string;
+      }
+      const decisions = decisionLog.queryDecisions(queryOptions);
 
-    res.json({
-      data: decisions,
-      count: decisions.length,
-    });
-    return;
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to query decisions", 400);
-    return;
+      res.json({
+        data: decisions,
+        count: decisions.length,
+      });
+      return;
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to query decisions", 400);
+      return;
+    }
   }
-});
+);
 
 /**
  * GET /api/v2/knowledge/decisions/:id
  * Get a decision by ID
  */
-router.get("/decisions/:id", async (req: Request, res: Response) => {
-  try {
-    const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
-    if (!id) {
-      return res.status(400).json({ error: "Decision ID is required" });
-    }
-    const decision = decisionLog.getDecision(id);
+router.get(
+  "/decisions/:id",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.knowledge.read"))) return;
+      const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+      if (!id) {
+        return res.status(400).json({ error: "Decision ID is required" });
+      }
+      const decision = decisionLog.getDecision(id);
 
-    if (!decision) {
-      return res.status(404).json({
-        error: "Decision not found",
-        message: `Decision ${id} not found`,
+      if (!decision) {
+        return res.status(404).json({
+          error: "Decision not found",
+          message: `Decision ${id} not found`,
+        });
+      }
+
+      const related = decisionLog.getRelatedDecisions(id);
+
+      res.json({
+        data: {
+          ...decision,
+          relatedDecisions: related,
+        },
       });
+      return;
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to get decision", 400);
+      return;
     }
-
-    const related = decisionLog.getRelatedDecisions(id);
-
-    res.json({
-      data: {
-        ...decision,
-        relatedDecisions: related,
-      },
-    });
-    return;
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to get decision", 400);
-    return;
   }
-});
+);
 
 /**
  * PATCH /api/v2/knowledge/decisions/:id/outcomes
  * Update decision outcomes
  */
-router.patch("/decisions/:id/outcomes", async (req: Request, res: Response) => {
-  try {
-    const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
-    const { outcome } = req.body;
+router.patch(
+  "/decisions/:id/outcomes",
+  requirePermission(Permission.TENANT_WRITE),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.knowledge.manage")))
+        return;
+      const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+      const { outcome } = req.body;
 
-    if (!id) {
-      return res.status(400).json({ error: "Decision ID is required" });
-    }
+      if (!id) {
+        return res.status(400).json({ error: "Decision ID is required" });
+      }
 
-    if (!outcome) {
-      return res.status(400).json({
-        error: "Missing outcome",
+      if (!outcome) {
+        return res.status(400).json({
+          error: "Missing outcome",
+        });
+      }
+
+      const decision = await decisionLog.updateOutcomes(id, outcome);
+
+      res.json({
+        data: decision,
+        message: "Outcome updated successfully",
       });
+      return;
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to update outcome", 400);
+      return;
     }
-
-    const decision = await decisionLog.updateOutcomes(id, outcome);
-
-    res.json({
-      data: decision,
-      message: "Outcome updated successfully",
-    });
-    return;
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to update outcome", 400);
-    return;
   }
-});
+);
 
 /**
  * POST /api/v2/knowledge/assistant/query
  * Query the AI knowledge assistant
  */
-router.post("/assistant/query", async (req: Request, res: Response) => {
-  try {
-    const { question, context } = req.body;
+router.post(
+  "/assistant/query",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.knowledge.read"))) return;
+      const { question, context } = req.body;
 
-    if (!question || typeof question !== "string") {
-      return res.status(400).json({
-        error: "Missing question",
+      if (!question || typeof question !== "string") {
+        return res.status(400).json({
+          error: "Missing question",
+        });
+      }
+
+      const response = await aiKnowledgeAssistant.query({
+        question,
+        context,
       });
+
+      res.json({
+        data: response,
+      });
+      return;
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to query assistant", 400);
+      return;
     }
-
-    const response = await aiKnowledgeAssistant.query({
-      question,
-      context,
-    });
-
-    res.json({
-      data: response,
-    });
-    return;
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to query assistant", 400);
-    return;
   }
-});
+);
 
 /**
  * GET /api/v2/knowledge/stats
  * Get knowledge base statistics
  */
-router.get("/stats", async (_req: Request, res: Response) => {
-  try {
-    const assistantStats = aiKnowledgeAssistant.getStats();
+router.get(
+  "/stats",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.knowledge.read"))) return;
+      const assistantStats = aiKnowledgeAssistant.getStats();
 
-    // Get decision stats
-    const allDecisions = decisionLog.queryDecisions({});
-    const decisionsByStatus = allDecisions.reduce(
-      (acc, d) => {
-        acc[d.status] = (acc[d.status] || 0) + 1;
-        return acc;
-      },
-      {} as Record<string, number>
-    );
-
-    res.json({
-      data: {
-        assistant: assistantStats,
-        decisions: {
-          total: allDecisions.length,
-          byStatus: decisionsByStatus,
+      // Get decision stats
+      const allDecisions = decisionLog.queryDecisions({});
+      const decisionsByStatus = allDecisions.reduce(
+        (acc, d) => {
+          acc[d.status] = (acc[d.status] || 0) + 1;
+          return acc;
         },
-      },
-    });
-    return;
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to get stats", 500);
-    return;
+        {} as Record<string, number>
+      );
+
+      res.json({
+        data: {
+          assistant: assistantStats,
+          decisions: {
+            total: allDecisions.length,
+            byStatus: decisionsByStatus,
+          },
+        },
+      });
+      return;
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to get stats", 500);
+      return;
+    }
   }
-});
+);
 
 export default router;

--- a/packages/api/src/routes/v2/reconciliation-graph.ts
+++ b/packages/api/src/routes/v2/reconciliation-graph.ts
@@ -4,7 +4,10 @@
  * REST API for graph-based reconciliation
  */
 
-import { Router, Request, Response } from "express";
+import { Router, Response } from "express";
+import { AuthRequest } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/authorization";
+import { Permission } from "../../infrastructure/security/Permissions";
 import { graphEngine } from "../../services/reconciliation-graph/graph-engine";
 import { streamProcessor } from "../../services/reconciliation-graph/stream-processor";
 import {
@@ -13,6 +16,7 @@ import {
   GraphQuery,
 } from "../../services/reconciliation-graph/types";
 import { handleRouteError } from "../../utils/error-handler";
+import { authorizeTenantActionOr403, requireTenantContext } from "../authz-helpers";
 
 const router: Router = Router();
 
@@ -20,228 +24,276 @@ const router: Router = Router();
  * POST /api/v2/reconciliation-graph/:jobId/nodes
  * Add a node to the graph
  */
-router.post("/:jobId/nodes", async (req: Request, res: Response) => {
-  try {
-    const jobId = req.params.jobId as string;
-    if (!jobId) {
-      return res.status(400).json({ error: "Job ID is required" });
-    }
-    const node: ReconciliationNode = {
-      id: req.body.id || `node_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-      type: req.body.type || "transaction",
-      jobId,
-      sourceId: req.body.sourceId || undefined,
-      targetId: req.body.targetId || undefined,
-      data: req.body.data || {},
-      amount: req.body.amount,
-      currency: req.body.currency,
-      timestamp: req.body.timestamp ? new Date(req.body.timestamp) : new Date(),
-      confidence: req.body.confidence,
-      metadata: req.body.metadata,
-    };
+router.post(
+  "/:jobId/nodes",
+  requirePermission(Permission.TENANT_WRITE),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (
+        !(await authorizeTenantActionOr403(
+          req,
+          res,
+          tenantId,
+          "tenant.knowledge.manage",
+          "Reconciliation graph mutation is not authorized"
+        ))
+      ) {
+        return;
+      }
+      const jobId = req.params.jobId as string;
+      if (!jobId) {
+        return res.status(400).json({ error: "Job ID is required" });
+      }
+      const node: ReconciliationNode = {
+        id: req.body.id || `node_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+        type: req.body.type || "transaction",
+        jobId,
+        sourceId: req.body.sourceId || undefined,
+        targetId: req.body.targetId || undefined,
+        data: req.body.data || {},
+        amount: req.body.amount,
+        currency: req.body.currency,
+        timestamp: req.body.timestamp ? new Date(req.body.timestamp) : new Date(),
+        confidence: req.body.confidence,
+        metadata: req.body.metadata,
+      };
 
-    graphEngine.addNode(jobId, node);
+      graphEngine.addNode(jobId, node);
 
-    // Add to stream processor for real-time matching
-    const event: {
-      id: string;
-      jobId: string;
-      type: "source" | "target";
-      sourceId?: string;
-      targetId?: string;
-      data: Record<string, unknown>;
-      amount?: number;
-      currency?: string;
-      timestamp: Date;
-    } = {
-      id: node.id,
-      jobId: jobId,
-      type: node.sourceId ? "source" : "target",
-      data: node.data,
-      timestamp: node.timestamp,
-    };
-    if (node.sourceId) {
-      event.sourceId = node.sourceId;
-    }
-    if (node.targetId) {
-      event.targetId = node.targetId;
-    }
-    if (node.amount !== undefined) {
-      event.amount = node.amount;
-    }
-    if (node.currency) {
-      event.currency = node.currency;
-    }
-    await streamProcessor.addEvent(event);
+      // Add to stream processor for real-time matching
+      const event: {
+        id: string;
+        jobId: string;
+        type: "source" | "target";
+        sourceId?: string;
+        targetId?: string;
+        data: Record<string, unknown>;
+        amount?: number;
+        currency?: string;
+        timestamp: Date;
+      } = {
+        id: node.id,
+        jobId: jobId,
+        type: node.sourceId ? "source" : "target",
+        data: node.data,
+        timestamp: node.timestamp,
+      };
+      if (node.sourceId) {
+        event.sourceId = node.sourceId;
+      }
+      if (node.targetId) {
+        event.targetId = node.targetId;
+      }
+      if (node.amount !== undefined) {
+        event.amount = node.amount;
+      }
+      if (node.currency) {
+        event.currency = node.currency;
+      }
+      await streamProcessor.addEvent(event);
 
-    res.status(201).json({
-      data: node,
-      message: "Node added successfully",
-    });
-    return;
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to add node", 400);
-    return;
+      res.status(201).json({
+        data: node,
+        message: "Node added successfully",
+      });
+      return;
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to add node", 400);
+      return;
+    }
   }
-});
+);
 
 /**
  * POST /api/v2/reconciliation-graph/:jobId/edges
  * Add an edge to the graph
  */
-router.post("/:jobId/edges", async (req: Request, res: Response) => {
-  try {
-    const jobId = req.params.jobId as string;
-    if (!jobId) {
-      return res.status(400).json({ error: "Job ID is required" });
+router.post(
+  "/:jobId/edges",
+  requirePermission(Permission.TENANT_WRITE),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.knowledge.manage")))
+        return;
+      const jobId = req.params.jobId as string;
+      if (!jobId) {
+        return res.status(400).json({ error: "Job ID is required" });
+      }
+      const edge: ReconciliationEdge = {
+        id: req.body.id || `edge_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+        source: req.body.source || "",
+        target: req.body.target || "",
+        type: req.body.type || "matches",
+        confidence: req.body.confidence || 1.0,
+        metadata: req.body.metadata,
+        createdAt: req.body.createdAt ? new Date(req.body.createdAt) : new Date(),
+      };
+
+      graphEngine.addEdge(jobId, edge);
+
+      res.status(201).json({
+        data: edge,
+        message: "Edge added successfully",
+      });
+      return;
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to add edge", 400);
+      return;
     }
-    const edge: ReconciliationEdge = {
-      id: req.body.id || `edge_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-      source: req.body.source || "",
-      target: req.body.target || "",
-      type: req.body.type || "matches",
-      confidence: req.body.confidence || 1.0,
-      metadata: req.body.metadata,
-      createdAt: req.body.createdAt ? new Date(req.body.createdAt) : new Date(),
-    };
-
-    graphEngine.addEdge(jobId, edge);
-
-    res.status(201).json({
-      data: edge,
-      message: "Edge added successfully",
-    });
-    return;
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to add edge", 400);
-    return;
   }
-});
+);
 
 /**
  * GET /api/v2/reconciliation-graph/:jobId/query
  * Query the graph
  */
-router.get("/:jobId/query", async (req: Request, res: Response) => {
-  try {
-    const jobId = req.params.jobId as string;
-    if (!jobId) {
-      return res.status(400).json({ error: "Job ID is required" });
-    }
-    const queryOptions: {
-      jobId: string;
-      nodeType?: ReconciliationNode["type"];
-      sourceId?: string;
-      targetId?: string;
-      dateRange?: { start: Date; end: Date };
-      limit?: number;
-      offset?: number;
-    } = {
-      jobId,
-    };
-    if (req.query.nodeType) {
-      queryOptions.nodeType = req.query.nodeType as ReconciliationNode["type"];
-    }
-    if (req.query.sourceId) {
-      queryOptions.sourceId = req.query.sourceId as string;
-    }
-    if (req.query.targetId) {
-      queryOptions.targetId = req.query.targetId as string;
-    }
-    if (req.query.startDate && req.query.endDate) {
-      queryOptions.dateRange = {
-        start: new Date(req.query.startDate as string),
-        end: new Date(req.query.endDate as string),
+router.get(
+  "/:jobId/query",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.memory.graph.read")))
+        return;
+      const jobId = req.params.jobId as string;
+      if (!jobId) {
+        return res.status(400).json({ error: "Job ID is required" });
+      }
+      const queryOptions: {
+        jobId: string;
+        nodeType?: ReconciliationNode["type"];
+        sourceId?: string;
+        targetId?: string;
+        dateRange?: { start: Date; end: Date };
+        limit?: number;
+        offset?: number;
+      } = {
+        jobId,
       };
-    }
-    if (req.query.limit) {
-      queryOptions.limit = parseInt(req.query.limit as string);
-    }
-    if (req.query.offset) {
-      queryOptions.offset = parseInt(req.query.offset as string);
-    }
-    const query = queryOptions as GraphQuery;
+      if (req.query.nodeType) {
+        queryOptions.nodeType = req.query.nodeType as ReconciliationNode["type"];
+      }
+      if (req.query.sourceId) {
+        queryOptions.sourceId = req.query.sourceId as string;
+      }
+      if (req.query.targetId) {
+        queryOptions.targetId = req.query.targetId as string;
+      }
+      if (req.query.startDate && req.query.endDate) {
+        queryOptions.dateRange = {
+          start: new Date(req.query.startDate as string),
+          end: new Date(req.query.endDate as string),
+        };
+      }
+      if (req.query.limit) {
+        queryOptions.limit = parseInt(req.query.limit as string);
+      }
+      if (req.query.offset) {
+        queryOptions.offset = parseInt(req.query.offset as string);
+      }
+      const query = queryOptions as GraphQuery;
 
-    const result = graphEngine.query(query);
+      const result = graphEngine.query(query);
 
-    res.json({
-      data: {
-        nodes: result.nodes,
-        edges: result.edges,
-        count: result.nodes.length,
-      },
-    });
-    return;
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to query graph", 400);
-    return;
+      res.json({
+        data: {
+          nodes: result.nodes,
+          edges: result.edges,
+          count: result.nodes.length,
+        },
+      });
+      return;
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to query graph", 400);
+      return;
+    }
   }
-});
+);
 
 /**
  * GET /api/v2/reconciliation-graph/:jobId/state
  * Get current graph state
  */
-router.get("/:jobId/state", async (req: Request, res: Response) => {
-  try {
-    const jobId = req.params.jobId as string;
-    if (!jobId) {
-      return res.status(400).json({ error: "Job ID is required" });
-    }
-    const graph = graphEngine.getGraphState(jobId);
+router.get(
+  "/:jobId/state",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = requireTenantContext(req, res);
+      if (!tenantId) return;
+      if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.memory.graph.read")))
+        return;
+      const jobId = req.params.jobId as string;
+      if (!jobId) {
+        return res.status(400).json({ error: "Job ID is required" });
+      }
+      const graph = graphEngine.getGraphState(jobId);
 
-    if (!graph) {
-      return res.status(404).json({
-        error: "Graph not found",
-        message: `No graph found for job ${jobId}`,
+      if (!graph) {
+        return res.status(404).json({
+          error: "Graph not found",
+          message: `No graph found for job ${jobId}`,
+        });
+      }
+
+      res.json({
+        data: {
+          jobId: graph.jobId,
+          nodeCount: graph.nodes.size,
+          edgeCount: graph.edges.size,
+          updatedAt: graph.updatedAt,
+        },
       });
+      return;
+    } catch (error: unknown) {
+      handleRouteError(res, error, "Failed to get graph state", 400);
+      return;
     }
-
-    res.json({
-      data: {
-        jobId: graph.jobId,
-        nodeCount: graph.nodes.size,
-        edgeCount: graph.edges.size,
-        updatedAt: graph.updatedAt,
-      },
-    });
-    return;
-  } catch (error: unknown) {
-    handleRouteError(res, error, "Failed to get graph state", 400);
-    return;
   }
-});
+);
 
 /**
  * GET /api/v2/reconciliation-graph/:jobId/stream
  * Server-Sent Events stream for real-time updates
  */
-router.get("/:jobId/stream", (req: Request, res: Response) => {
-  const jobIdParam = req.params["jobId"];
-  const jobId = Array.isArray(jobIdParam) ? (jobIdParam[0] ?? "") : (jobIdParam ?? "");
-  if (!jobId) {
-    res.status(400).json({ error: "Job ID is required" });
-    return;
+router.get(
+  "/:jobId/stream",
+  requirePermission(Permission.TENANT_READ),
+  async (req: AuthRequest, res: Response) => {
+    const tenantId = requireTenantContext(req, res);
+    if (!tenantId) return;
+    if (!(await authorizeTenantActionOr403(req, res, tenantId, "tenant.memory.graph.read"))) return;
+    const jobIdParam = req.params["jobId"];
+    const jobId = Array.isArray(jobIdParam) ? (jobIdParam[0] ?? "") : (jobIdParam ?? "");
+    if (!jobId) {
+      res.status(400).json({ error: "Job ID is required" });
+      return;
+    }
+
+    // Set up SSE headers
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+
+    // Subscribe to graph updates
+    const unsubscribe = graphEngine.subscribe(jobId, (update) => {
+      res.write(`data: ${JSON.stringify(update)}\n\n`);
+    });
+
+    // Clean up on client disconnect
+    req.on("close", () => {
+      unsubscribe();
+      res.end();
+    });
+
+    // Send initial connection message
+    res.write(`data: ${JSON.stringify({ type: "connected", jobId })}\n\n`);
   }
-
-  // Set up SSE headers
-  res.setHeader("Content-Type", "text/event-stream");
-  res.setHeader("Cache-Control", "no-cache");
-  res.setHeader("Connection", "keep-alive");
-
-  // Subscribe to graph updates
-  const unsubscribe = graphEngine.subscribe(jobId, (update) => {
-    res.write(`data: ${JSON.stringify(update)}\n\n`);
-  });
-
-  // Clean up on client disconnect
-  req.on("close", () => {
-    unsubscribe();
-    res.end();
-  });
-
-  // Send initial connection message
-  res.write(`data: ${JSON.stringify({ type: "connected", jobId })}\n\n`);
-});
+);
 
 export default router;

--- a/packages/api/src/services/approval-workflows.ts
+++ b/packages/api/src/services/approval-workflows.ts
@@ -160,19 +160,19 @@ export async function approveRequest(
         throw new Error("separation_of_duties_violation: requester cannot approve own request");
       }
 
-      // Verify approver has permission
       if (request.approver_id && request.approver_id !== approverId) {
-        // Check if user has the required role
-        if (request.approver_role) {
-          const approverResult = await client.query(
-            `SELECT id FROM approvers
-             WHERE tenant_id = $1 AND user_id = $2 AND role = $3`,
-            [tenantId, approverId, request.approver_role]
-          );
+        throw new Error("User does not have permission to approve this request");
+      }
 
-          if (approverResult.rows.length === 0) {
-            throw new Error("User does not have permission to approve this request");
-          }
+      if (request.approver_role) {
+        const approverResult = await client.query(
+          `SELECT id FROM approvers
+             WHERE tenant_id = $1 AND user_id = $2 AND role = $3`,
+          [tenantId, approverId, request.approver_role]
+        );
+
+        if (approverResult.rows.length === 0) {
+          throw new Error("User does not have permission to approve this request");
         }
       }
 
@@ -238,16 +238,18 @@ export async function rejectRequest(
       }
 
       if (request.approver_id && request.approver_id !== approverId) {
-        if (request.approver_role) {
-          const approverResult = await client.query(
-            `SELECT id FROM approvers
-             WHERE tenant_id = $1 AND user_id = $2 AND role = $3`,
-            [tenantId, approverId, request.approver_role]
-          );
+        throw new Error("User does not have permission to reject this request");
+      }
 
-          if (approverResult.rows.length === 0) {
-            throw new Error("User does not have permission to reject this request");
-          }
+      if (request.approver_role) {
+        const approverResult = await client.query(
+          `SELECT id FROM approvers
+             WHERE tenant_id = $1 AND user_id = $2 AND role = $3`,
+          [tenantId, approverId, request.approver_role]
+        );
+
+        if (approverResult.rows.length === 0) {
+          throw new Error("User does not have permission to reject this request");
         }
       }
 

--- a/packages/api/src/services/authz/openfga-authorization-service.ts
+++ b/packages/api/src/services/authz/openfga-authorization-service.ts
@@ -46,7 +46,12 @@ export type TenantAction =
   | "tenant.api_key.read"
   | "tenant.api_key.manage"
   | "tenant.webhook.read"
-  | "tenant.webhook.manage";
+  | "tenant.webhook.manage"
+  | "tenant.user.data.export"
+  | "tenant.user.data.delete"
+  | "tenant.operator.control"
+  | "tenant.knowledge.read"
+  | "tenant.knowledge.manage";
 
 function readConfig(): OpenFgaConfig {
   const enabled = process.env.OPENFGA_ENABLED === "true";
@@ -147,11 +152,16 @@ function relationForAction(action: TenantAction): string {
     case "tenant.approval.manage":
       return "can_review_policy";
     case "tenant.memory.graph.read":
+    case "tenant.knowledge.read":
     case "tenant.integration.read":
+    case "tenant.user.data.export":
       return "can_view";
     case "tenant.integration.manage":
     case "tenant.api_key.manage":
     case "tenant.webhook.manage":
+    case "tenant.knowledge.manage":
+    case "tenant.operator.control":
+    case "tenant.user.data.delete":
       return "can_manage_integrations";
     case "tenant.approval.read":
     case "tenant.approval.request":
@@ -182,8 +192,13 @@ function localRoleAllowed(action: TenantAction, role: UserRole | null): boolean 
     case "tenant.api_key.manage":
     case "tenant.webhook.read":
     case "tenant.webhook.manage":
+    case "tenant.user.data.delete":
+    case "tenant.operator.control":
+    case "tenant.knowledge.manage":
       return role === UserRole.OWNER || role === UserRole.ADMIN;
     case "tenant.integration.read":
+    case "tenant.knowledge.read":
+    case "tenant.user.data.export":
       return role === UserRole.OWNER || role === UserRole.ADMIN || role === UserRole.DEVELOPER;
   }
 }


### PR DESCRIPTION
### Motivation
- Finish missing canonical authz closure for high-risk sensitive surfaces so tenant-sensitive actions are enforced by a single fail-closed service rather than route-local role branching or permission-only guards. 
- Ensure sensitive export/delete/operator-control/knowledge/graph flows are tenant-scoped, fail-closed when OpenFGA is required/unavailable, and return machine-visible denial/degraded payloads. 
- Tighten approval decision integrity so separation-of-duties and approver eligibility are enforced symmetrically in the service layer.

### Description
- Expanded the tenant action taxonomy and relation/local-role mapping in `packages/api/src/services/authz/openfga-authorization-service.ts` to cover user-data, operator-control, and knowledge surfaces and wired them into authorization decisions. 
- Hardened `users` flows by requiring tenant and user context via `authz-helpers`, calling `authorizeTenantActionOr403` for `tenant.user.data.export` and `tenant.user.data.delete`, and returning an explicit `cross_user_export_forbidden` denial when a user attempts to export another user’s data (`packages/api/src/routes/users.ts`). 
- Added canonical authz gating to v2 knowledge and reconciliation-graph routes so read/mutation/stream paths require tenant context and `authorizeTenantActionOr403` checks, and added a router-level `/operator/*` guard for operator control actions (`packages/api/src/routes/v2/knowledge.ts`, `packages/api/src/routes/v2/reconciliation-graph.ts`, `packages/api/src/routes/v1/operator-mode.ts`). 
- Tightened approval workflow eligibility by enforcing direct `approver_id` and `approver_role` checks (symmetrically for approve/reject) in the approval service, and added focused authz regression tests for users, knowledge, and graph routes (`packages/api/src/services/approval-workflows.ts`, `packages/api/src/routes/__tests__/*`, `packages/api/src/routes/v2/__tests__/*`).

### Testing
- `pnpm --filter @settler/api lint` ✅ (completed; lint fixes applied by pre-commit hooks). 
- `pnpm --filter @settler/api typecheck` ✅ (TS typecheck passed). 
- `pnpm --filter @settler/api test -- src/routes/__tests__/users.authz.test.ts src/routes/v2/__tests__/knowledge.authz.test.ts src/routes/v2/__tests__/reconciliation-graph.authz.test.ts src/routes/v1/__tests__/approvals.route.test.ts` ✅ (all targeted suites passed). 
- `pnpm --filter @settler/api build` ✅ (package build succeeded). 
- ⚠️ Environment note: repo engine policy targets Node `>=24 <25` while the verification environment used Node `v22.x`, which produced engine warnings but did not block the verification commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a9bf54bc8328a35f5ddf925f424c)