### PR TITLE
feat(web): enterprise UX uplift — sidebar icons, PageHeader primitive, dark-mode fixes

### DIFF
--- a/packages/web/src/app/admin/audit/page.tsx
+++ b/packages/web/src/app/admin/audit/page.tsx
@@ -14,8 +14,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Download, Search, FileDown } from "lucide-react";
+import { Download, Search, FileDown, History } from "lucide-react";
 import { NoAuditEmptyState, NoResultsEmptyState } from "@/components/admin/empty-states";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 
 export default function AdminAuditPage() {
   const [ruleIdFilter, setRuleIdFilter] = useState("");
@@ -50,22 +51,19 @@ export default function AdminAuditPage() {
     }) || [];
 
   return (
-    <div className="p-8 space-y-6 bg-muted/10 min-h-screen">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-foreground">Audit Trail</h1>
-          <p className="text-muted-foreground mt-1">
-            Complete audit log explorer and export
-          </p>
-        </div>
-        <div className="flex items-center gap-4">
+    <div className="space-y-6 pb-8">
+      <AdminPageHeader
+        eyebrow="Compliance & Governance"
+        title="Audit Trail"
+        description="Complete immutable log of all system and user actions. Filter, inspect, and export evidence for compliance review."
+        icon={History}
+        actions={
           <div className="relative group">
-            <Button variant="outline">
+            <Button variant="outline" size="sm">
               <Download className="w-4 h-4 mr-2" />
               Export
             </Button>
-            <div className="absolute right-0 top-full mt-1 bg-white dark:bg-card border border-border/40 dark:border-border rounded-lg shadow-lg p-1 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10">
+            <div className="absolute right-0 top-full mt-1 bg-card border border-border/60 rounded-lg shadow-lg p-1 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10 min-w-[160px]">
               <button
                 onClick={() => {
                   if (filteredItems.length > 0) {
@@ -73,7 +71,7 @@ export default function AdminAuditPage() {
                     downloadFile(csv, `audit-${new Date().toISOString().split("T")[0]}.csv`);
                   }
                 }}
-                className="w-full text-left px-3 py-2 text-sm hover:bg-muted/30 dark:hover:bg-card/80 rounded flex items-center gap-2"
+                className="w-full text-left px-3 py-2 text-sm hover:bg-muted/30 rounded flex items-center gap-2"
               >
                 <FileDown className="w-4 h-4" />
                 Export as CSV
@@ -84,15 +82,16 @@ export default function AdminAuditPage() {
                     exportAuditToJSON(filteredItems);
                   }
                 }}
-                className="w-full text-left px-3 py-2 text-sm hover:bg-muted/30 dark:hover:bg-card/80 rounded flex items-center gap-2"
+                className="w-full text-left px-3 py-2 text-sm hover:bg-muted/30 rounded flex items-center gap-2"
               >
                 <FileDown className="w-4 h-4" />
                 Export as JSON
               </button>
             </div>
           </div>
-        </div>
-      </div>
+        }
+      />
+      <div className="px-6 sm:px-8 space-y-6">
 
       {/* Filters */}
       <Card>
@@ -151,13 +150,14 @@ export default function AdminAuditPage() {
           )}
         </CardContent>
       </Card>
+      </div>
     </div>
   );
 }
 
 function AuditRow({ item }: { item: AuditItem }) {
   return (
-    <div className="p-4 border border-border/40 dark:border-border rounded-lg hover:bg-muted/10 dark:hover:bg-card/80 transition-colors">
+    <div className="p-4 border border-border/40 rounded-lg hover:bg-muted/10 transition-colors">
       <div className="flex items-start justify-between">
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-2">

--- a/packages/web/src/app/admin/layout.tsx
+++ b/packages/web/src/app/admin/layout.tsx
@@ -7,7 +7,7 @@
  */
 
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import {
   LayoutDashboard,
   FileText,
@@ -21,6 +21,8 @@ import {
   PlayCircle,
   FileSearch,
   Workflow,
+  Webhook,
+  type LucideIcon,
 } from "lucide-react";
 import { isSuperAdmin } from "@/lib/auth/super-admin";
 import { redirect } from "next/navigation";
@@ -32,7 +34,14 @@ import { OperationalRouteNotice } from "@/components/shared/OperationalRouteNoti
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const adminNavSections = [
+interface NavItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  [key: string]: unknown;
+}
+
+const adminNavSections: { label: string; items: NavItem[] }[] = [
   {
     label: "Operations",
     items: [
@@ -52,7 +61,7 @@ const adminNavSections = [
       { href: "/admin/flags", label: "Feature Flags", icon: Flag },
       { href: "/admin/pages", label: "Pages", icon: FileText },
       { href: "/admin/experiments", label: "Experiments", icon: FlaskConical },
-      { href: "/admin/webhooks", label: "Webhooks", icon: FlaskConical },
+      { href: "/admin/webhooks", label: "Webhooks", icon: Webhook },
     ],
   },
   {
@@ -64,25 +73,33 @@ const adminNavSections = [
   },
 ];
 
+function AdminNavItem({ href, label, icon: Icon }: NavItem) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors",
+        "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      )}
+      aria-label={label}
+    >
+      <Icon size={15} className="shrink-0 text-muted-foreground/70" aria-hidden="true" />
+      {label}
+    </Link>
+  );
+}
+
 function AdminNavContent() {
   return (
     <>
       {adminNavSections.map((section, idx) => (
-        <div key={section.label} className={idx > 0 ? "mt-4 pt-4 border-t border-border" : ""}>
-          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2 px-2">
+        <div key={section.label} className={cn("space-y-0.5", idx > 0 && "mt-5 pt-5 border-t border-border/60")}>
+          <p className="mb-1.5 px-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/60">
             {section.label}
-          </div>
+          </p>
           {section.items.map((item) => (
-            <Link key={item.href} href={item.href}>
-              <Button
-                variant="ghost"
-                className="w-full justify-start gap-2 text-muted-foreground hover:text-foreground"
-                aria-label={item.label}
-              >
-                <item.icon size={16} aria-hidden="true" />
-                {item.label}
-              </Button>
-            </Link>
+            <AdminNavItem key={item.href} href={item.href} label={item.label} icon={item.icon} />
           ))}
         </div>
       ))}
@@ -100,8 +117,6 @@ export default async function AdminLayout({ children }: { children: React.ReactN
       redirect("/login?next=" + encodeURIComponent("/admin"));
     }
   } catch {
-    // Log error but don't expose internal details
-    // Error handling is done in isSuperAdmin function
     // Redirect to sign-in on error - fail secure
     redirect("/login?next=" + encodeURIComponent("/admin"));
   }
@@ -109,41 +124,49 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   return (
     <AdminErrorBoundary>
       <SkipLinks />
-      <div className="flex h-screen bg-background-light dark:bg-background">
+      <div className="flex h-screen bg-background">
         {/* Mobile Menu */}
         <MobileMenu>
           <AdminNavContent />
         </MobileMenu>
 
         {/* Sidebar - Desktop Only */}
-        <aside className="hidden lg:flex w-64 border-r border-border bg-card dark:bg-card flex-col fixed h-full z-10">
-          <div className="p-5 border-b border-border">
-            <Link
-              href="/admin"
-              className="flex items-center gap-2.5 font-bold text-lg text-foreground"
-            >
-              <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center text-primary-foreground text-sm font-bold">
-                S
-              </div>
-              Settler Admin
-            </Link>
+        <aside className="hidden lg:flex w-60 border-r border-border bg-card/80 backdrop-blur-sm flex-col fixed h-full z-10">
+          {/* Sidebar header */}
+          <div className="flex h-14 items-center gap-2.5 border-b border-border px-4">
+            <div className="flex h-7 w-7 items-center justify-center rounded-md bg-primary text-primary-foreground text-xs font-bold shrink-0">
+              S
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-foreground truncate">Settler Admin</p>
+              <p className="text-[10px] text-muted-foreground/60 uppercase tracking-wide">
+                Control Plane
+              </p>
+            </div>
           </div>
 
+          {/* Nav */}
           <nav
             id="admin-navigation"
-            className="flex-1 p-3 space-y-1 overflow-y-auto"
+            className="flex-1 overflow-y-auto p-3"
             aria-label="Admin navigation"
           >
             <AdminNavContent />
           </nav>
 
-          <div className="p-4 border-t border-border">
-            <div className="text-xs text-muted-foreground font-medium">Tenant: default</div>
+          {/* Footer */}
+          <div className="border-t border-border/60 p-3">
+            <div className="flex items-center gap-2 rounded-md px-3 py-2">
+              <span className="h-1.5 w-1.5 rounded-full bg-success flex-shrink-0" aria-hidden="true" />
+              <span className="text-[10px] text-muted-foreground/60 font-medium uppercase tracking-wide">
+                Tenant: default
+              </span>
+            </div>
           </div>
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 lg:ml-64 overflow-auto" role="main" id="main-content">
+        <main className="flex-1 lg:ml-60 overflow-auto" role="main" id="main-content">
           <div className="p-4">
             <OperationalRouteNotice />
           </div>

--- a/packages/web/src/app/admin/monitoring/page.tsx
+++ b/packages/web/src/app/admin/monitoring/page.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { AlertCircle, CheckCircle2, Clock, Users, DollarSign, Activity, Shield, Database, TrendingUp, AlertTriangle, XCircle } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 
 interface SystemHealth {
   status: string;
@@ -182,32 +183,30 @@ export default function MonitoringDashboard() {
   if (error) {
     return (
       <div className="p-8">
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-          <div className="flex items-center gap-2 mb-2">
-            <AlertCircle className="h-5 w-5 text-red-600" />
-            <h3 className="font-semibold text-red-900 dark:text-red-200">
-              Unable to Load Metrics
-            </h3>
+        <div className="error-well">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" aria-hidden="true" />
+            <div>
+              <h3 className="font-semibold text-foreground">Unable to Load Metrics</h3>
+              <p className="text-sm text-muted-foreground mt-1 mb-4">
+                We encountered an error while loading monitoring metrics. Please try again or contact support if the problem persists.
+              </p>
+              {process.env.NODE_ENV === 'development' && (
+                <p className="code-inline text-xs mb-4 block">{error}</p>
+              )}
+              <Button
+                onClick={() => {
+                  setError(null);
+                  setLoading(true);
+                  window.location.reload();
+                }}
+                variant="outline"
+                size="sm"
+              >
+                Retry
+              </Button>
+            </div>
           </div>
-          <p className="text-sm text-red-800 dark:text-red-300 mb-4">
-            We encountered an error while loading monitoring metrics. Please try again or contact support if the problem persists.
-          </p>
-          {process.env.NODE_ENV === 'development' && (
-            <p className="text-xs font-mono text-red-600 dark:text-red-400 mb-4">
-              {error}
-            </p>
-          )}
-          <Button 
-            onClick={() => {
-              setError(null);
-              setLoading(true);
-              // Trigger re-fetch
-              window.location.reload();
-            }}
-            variant="outline"
-          >
-            Retry
-          </Button>
         </div>
       </div>
     );
@@ -218,15 +217,14 @@ export default function MonitoringDashboard() {
     : 0;
 
   return (
-    <div className="p-8 space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-foreground mb-2">
-          Monitoring Dashboard
-        </h1>
-        <p className="text-muted-foreground">
-          Real-time system health and business metrics
-        </p>
-      </div>
+    <div className="space-y-6 pb-8">
+      <AdminPageHeader
+        eyebrow="System Observability"
+        title="Monitoring Dashboard"
+        description="Real-time system health, business metrics, SLA compliance, and reliability signals."
+        icon={Activity}
+      />
+      <div className="px-6 sm:px-8 space-y-6">
 
       {/* System Health */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -608,6 +606,7 @@ export default function MonitoringDashboard() {
         Last updated: {health?.metrics.timestamp ? new Date(health.metrics.timestamp).toLocaleString() : 'Never'}
         {' • '}
         Auto-refresh: 30s
+      </div>
       </div>
     </div>
   );

--- a/packages/web/src/app/admin/ops/page.tsx
+++ b/packages/web/src/app/admin/ops/page.tsx
@@ -147,11 +147,11 @@ export default function AdminOpsConsole() {
   const getSeverityColor = (severity: string) => {
     switch (severity) {
       case 'critical':
-        return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+        return 'bg-destructive/10 text-destructive border-destructive/20';
       case 'warn':
-        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300';
+        return 'bg-amber-500/10 text-amber-600 border-amber-500/20';
       default:
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
+        return 'bg-primary/10 text-primary border-primary/20';
     }
   };
 
@@ -167,13 +167,13 @@ export default function AdminOpsConsole() {
   };
 
   return (
-    <div className="flex flex-col lg:flex-row h-[calc(100vh-4rem)] bg-muted/20 dark:bg-background" id="main-content">
+    <div className="flex flex-col lg:flex-row h-[calc(100vh-4rem)] bg-muted/20" id="main-content">
       {/* Left Panel: Exception List */}
-      <div className="w-full lg:w-1/2 border-r border-border dark:border-border flex flex-col">
+      <div className="w-full lg:w-1/2 border-r border-border flex flex-col">
         {/* Header */}
-        <div className="p-4 border-b border-border dark:border-border bg-card bg-muted">
+        <div className="p-4 border-b border-border bg-card/80">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-foreground dark:text-white">
+            <h2 className="text-lg font-semibold text-foreground">
               Exception Queue
             </h2>
             <div className="flex items-center gap-2">
@@ -181,7 +181,7 @@ export default function AdminOpsConsole() {
                 connectionState === 'connected' ? 'bg-green-500' :
                 connectionState === 'reconnecting' ? 'bg-yellow-500' : 'bg-red-500'
               }`} />
-              <span className="text-xs text-muted-foreground dark:text-muted-foreground">
+              <span className="text-xs text-muted-foreground">
                 {connectionState}
               </span>
             </div>
@@ -203,7 +203,7 @@ export default function AdminOpsConsole() {
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="text-sm border border-border dark:border-border rounded px-2 py-1 bg-card dark:bg-background text-foreground dark:text-white"
+              className="text-sm border border-border rounded px-2 py-1 bg-card text-foreground"
             >
               <option value="all">All Status</option>
               <option value="new">New</option>
@@ -213,7 +213,7 @@ export default function AdminOpsConsole() {
             <select
               value={severityFilter}
               onChange={(e) => setSeverityFilter(e.target.value)}
-              className="text-sm border border-border dark:border-border rounded px-2 py-1 bg-card dark:bg-background text-foreground dark:text-white"
+              className="text-sm border border-border rounded px-2 py-1 bg-card text-foreground"
             >
               <option value="all">All Severity</option>
               <option value="critical">Critical</option>
@@ -226,15 +226,15 @@ export default function AdminOpsConsole() {
         {/* List */}
         <div className="flex-1 overflow-y-auto">
           {isLoading ? (
-            <div className="p-4 text-center text-muted-foreground dark:text-muted-foreground">
+            <div className="p-4 text-center text-muted-foreground">
               Loading exceptions...
             </div>
           ) : filteredExceptions.length === 0 ? (
-            <div className="p-4 text-center text-muted-foreground dark:text-muted-foreground">
+            <div className="p-4 text-center text-muted-foreground">
               No exceptions found
             </div>
           ) : (
-            <div className="divide-y divide-slate-200 dark:divide-border">
+            <div className="divide-y divide-border/40">
               {filteredExceptions.map((ex: ExceptionItem, index: number) => (
                 <button
                   key={ex.id}
@@ -242,8 +242,8 @@ export default function AdminOpsConsole() {
                     setSelectedException(ex.id);
                     selectedIndexRef.current = index;
                   }}
-                  className={`w-full p-4 text-left hover:bg-muted/40 dark:hover:bg-card transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
-                    selectedException === ex.id ? 'bg-muted/40 dark:bg-card ring-2 ring-blue-500' : ''
+                  className={`w-full p-4 text-left hover:bg-muted/30 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                    selectedException === ex.id ? 'bg-muted/30 ring-2 ring-primary' : ''
                   }`}
                   aria-selected={selectedException === ex.id}
                   role="option"
@@ -260,11 +260,11 @@ export default function AdminOpsConsole() {
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-1">
                         {getStatusIcon(ex.status)}
-                        <span className="text-sm font-medium text-foreground dark:text-white">
+                        <span className="text-sm font-medium text-foreground">
                           {ex.reason}
                         </span>
                       </div>
-                      <div className="flex items-center gap-2 text-xs text-muted-foreground dark:text-muted-foreground">
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
                         <span>{ex.source}</span>
                         <span>•</span>
                         <span>{new Date(ex.createdAt).toLocaleString()}</span>
@@ -286,7 +286,7 @@ export default function AdminOpsConsole() {
         {selectedExceptionData ? (
           <ExceptionDetail exception={selectedExceptionData} />
         ) : (
-          <div className="flex-1 flex items-center justify-center text-muted-foreground dark:text-muted-foreground">
+          <div className="flex-1 flex items-center justify-center text-muted-foreground">
             Select an exception to view details
           </div>
         )}
@@ -345,9 +345,9 @@ function ExceptionDetail({ exception }: { exception: ExceptionItem }) {
           <div className="flex items-center justify-between">
             <CardTitle>{exception.reason}</CardTitle>
             <Badge className={
-              exception.severity === 'critical' ? 'bg-red-100 text-red-800' :
-              exception.severity === 'warn' ? 'bg-yellow-100 text-yellow-800' :
-              'bg-blue-100 text-blue-800'
+              exception.severity === 'critical' ? 'bg-destructive/10 text-destructive border-destructive/20' :
+              exception.severity === 'warn' ? 'bg-amber-500/10 text-amber-600 border-amber-500/20' :
+              'bg-primary/10 text-primary border-primary/20'
             }>
               {exception.severity}
             </Badge>
@@ -355,28 +355,28 @@ function ExceptionDetail({ exception }: { exception: ExceptionItem }) {
         </CardHeader>
         <CardContent className="space-y-4">
           <div>
-            <h3 className="text-sm font-medium text-foreground dark:text-muted-foreground mb-2">
+            <h3 className="text-sm font-medium text-foreground mb-2">
               Details
             </h3>
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
-                <span className="text-muted-foreground dark:text-muted-foreground">Source:</span>
-                <span className="text-foreground dark:text-white">{exception.source}</span>
+                <span className="text-muted-foreground">Source:</span>
+                <span className="text-foreground">{exception.source}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-muted-foreground dark:text-muted-foreground">Status:</span>
-                <span className="text-foreground dark:text-white">{exception.status}</span>
+                <span className="text-muted-foreground">Status:</span>
+                <span className="text-foreground">{exception.status}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-muted-foreground dark:text-muted-foreground">Created:</span>
-                <span className="text-foreground dark:text-white">
+                <span className="text-muted-foreground">Created:</span>
+                <span className="text-foreground">
                   {new Date(exception.createdAt).toLocaleString()}
                 </span>
               </div>
               {exception.ruleId && (
                 <div className="flex justify-between">
-                  <span className="text-muted-foreground dark:text-muted-foreground">Rule ID:</span>
-                  <span className="text-foreground dark:text-white font-mono text-xs">
+                  <span className="text-muted-foreground">Rule ID:</span>
+                  <span className="text-foreground font-mono text-xs">
                     {exception.ruleId}
                   </span>
                 </div>
@@ -386,7 +386,7 @@ function ExceptionDetail({ exception }: { exception: ExceptionItem }) {
 
           {exception.evidence && (
             <div>
-              <h3 className="text-sm font-medium text-foreground dark:text-muted-foreground mb-2">
+              <h3 className="text-sm font-medium text-foreground mb-2">
                 Evidence
               </h3>
               <pre className="text-xs bg-muted/40 dark:bg-card p-3 rounded overflow-auto">
@@ -395,7 +395,7 @@ function ExceptionDetail({ exception }: { exception: ExceptionItem }) {
             </div>
           )}
 
-          <div className="flex gap-2 pt-4 border-t border-border dark:border-border">
+          <div className="flex gap-2 pt-4 border-t border-border/40">
             <Button 
               variant="default" 
               size="sm"

--- a/packages/web/src/app/app/alerts/page.tsx
+++ b/packages/web/src/app/app/alerts/page.tsx
@@ -1,8 +1,9 @@
 import { getAlertsList } from "@/lib/domain/runs/runs-reader";
 import { AlertsList } from "@/components/AlertsList";
 import { Bell, Search, Activity, ShieldAlert, ShieldCheck, Zap, Filter } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/app/PageHeader";
 
 export default async function AlertsPage() {
   const alerts: any[] = await getAlertsList();
@@ -13,80 +14,63 @@ export default async function AlertsPage() {
 
   return (
     <div className="space-y-8 pb-8">
-      {/* Page Header */}
-      <section className="relative overflow-hidden rounded-2xl border border-primary/10 bg-gradient-to-br from-primary/5 via-background to-background p-8 shadow-sm">
-        <div className="relative z-10">
-          <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary/70">
-            Operator Intelligence
-          </p>
-          <div className="flex items-center gap-4 mt-3">
-            <h1 className="text-4xl font-bold tracking-tight text-foreground">Live Alerts</h1>
-            {openCount > 0 && (
-              <Badge
-                variant="destructive"
-                className="h-6 px-3 bg-destructive/80 animate-pulse border-none"
-              >
-                {openCount} ACTIVE
-              </Badge>
-            )}
-          </div>
-          <p className="mt-4 max-w-2xl text-base text-muted-foreground leading-relaxed">
-            Monitor infrastructure-level drift and runtime reconciliation failures. Drill into
-            specific runs to confirm stable output hashes and root-cause analysis.
-          </p>
-        </div>
-        <div className="absolute -right-12 -top-12 opacity-[0.03] pointer-events-none">
-          <Bell size={320} className="text-primary" />
-        </div>
-      </section>
+      <PageHeader
+        eyebrow="Operator Intelligence"
+        title="Live Alerts"
+        description="Monitor infrastructure-level drift and runtime reconciliation failures. Drill into specific runs to confirm stable output hashes and root-cause analysis."
+        icon={Bell}
+        variant="hero"
+        actions={
+          openCount > 0 ? (
+            <Badge variant="destructive" className="h-6 px-3 animate-pulse">
+              {openCount} ACTIVE
+            </Badge>
+          ) : undefined
+        }
+      />
 
       {/* Summary Matrix */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card className="bg-destructive/5 border-destructive/20 shadow-none">
-          <CardHeader className="p-4 pb-1">
-            <CardDescription className="text-[10px] uppercase font-bold tracking-wider text-destructive/80 flex justify-between">
-              Critical
-              <ShieldAlert className="w-3 h-3" />
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="p-4 pt-0">
-            <p className="text-3xl font-mono font-bold text-destructive">{criticalCount}</p>
+      <div className="stat-strip">
+        <Card className="panel bg-destructive/5 border-destructive/20 shadow-none">
+          <CardContent className="p-4 pt-3">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-destructive/80">Critical</p>
+              <ShieldAlert className="w-3 h-3 text-destructive/60" aria-hidden="true" />
+            </div>
+            <p className="kpi-value text-destructive">{criticalCount}</p>
             <p className="text-[10px] text-destructive/60 mt-1">Immediate triage required</p>
           </CardContent>
         </Card>
-        <Card className="bg-amber-500/5 border-amber-500/20 shadow-none">
-          <CardHeader className="p-4 pb-1">
-            <CardDescription className="text-[10px] uppercase font-bold tracking-wider text-amber-600 flex justify-between">
-              Warning
-              <Zap className="w-3 h-3" />
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="p-4 pt-0">
-            <p className="text-3xl font-mono font-bold text-amber-600">{warningCount}</p>
+
+        <Card className="panel bg-amber-500/5 border-amber-500/20 shadow-none">
+          <CardContent className="p-4 pt-3">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-amber-600">Warning</p>
+              <Zap className="w-3 h-3 text-amber-500/60" aria-hidden="true" />
+            </div>
+            <p className="kpi-value text-amber-600 dark:text-amber-400">{warningCount}</p>
             <p className="text-[10px] text-amber-600/60 mt-1">Potential drift detected</p>
           </CardContent>
         </Card>
-        <Card className="bg-primary/5 border-primary/20 shadow-none">
-          <CardHeader className="p-4 pb-1">
-            <CardDescription className="text-[10px] uppercase font-bold tracking-wider text-primary flex justify-between">
-              Health Check
-              <ShieldCheck className="w-3 h-3" />
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="p-4 pt-0">
-            <p className="text-3xl font-mono font-bold text-primary">Normal</p>
+
+        <Card className="panel bg-primary/5 border-primary/20 shadow-none">
+          <CardContent className="p-4 pt-3">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-primary">Health Check</p>
+              <ShieldCheck className="w-3 h-3 text-primary/60" aria-hidden="true" />
+            </div>
+            <p className="kpi-value text-primary">Normal</p>
             <p className="text-[10px] text-primary/60 mt-1">Continuous verification active</p>
           </CardContent>
         </Card>
-        <Card className="bg-muted/50 border-border/60 shadow-none">
-          <CardHeader className="p-4 pb-1">
-            <CardDescription className="text-[10px] uppercase font-bold tracking-wider text-muted-foreground flex justify-between">
-              Uptime
-              <Activity className="w-3 h-3" />
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="p-4 pt-0">
-            <p className="text-3xl font-mono font-bold text-foreground">99.98%</p>
+
+        <Card className="panel shadow-none">
+          <CardContent className="p-4 pt-3">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">Uptime</p>
+              <Activity className="w-3 h-3 text-muted-foreground/60" aria-hidden="true" />
+            </div>
+            <p className="kpi-value">99.98%</p>
             <p className="text-[10px] text-muted-foreground mt-1">Last 30 days active</p>
           </CardContent>
         </Card>
@@ -98,79 +82,59 @@ export default async function AlertsPage() {
           <AlertsList initialAlerts={alerts} />
         </div>
 
-        {/* Sidebar Filters & Settings */}
-        <aside className="space-y-6">
-          <Card className="border-border/60">
-            <CardHeader className="p-4">
+        {/* Sidebar Filters */}
+        <aside className="space-y-4">
+          <Card className="panel border-border/60 shadow-none">
+            <CardHeader className="p-4 pb-2">
               <CardTitle className="text-sm font-bold flex items-center gap-2">
-                <Search className="w-4 h-4 text-primary" />
+                <Search className="w-4 h-4 text-primary" aria-hidden="true" />
                 Search & Filter
               </CardTitle>
             </CardHeader>
             <CardContent className="p-4 pt-0 space-y-4">
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" aria-hidden="true" />
                 <input
                   type="text"
                   placeholder="Search by ID or type..."
-                  className="w-full bg-muted/30 border border-border/40 rounded-lg py-2 pl-9 pr-3 text-xs focus:outline-none focus:ring-1 focus:ring-primary/40 transition-all font-mono"
+                  className="input-field pl-9 text-xs font-mono"
+                  aria-label="Search alerts"
                 />
               </div>
+
               <div className="space-y-2">
-                <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                  Severity Level
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  <Badge
-                    variant="outline"
-                    className="text-[10px] bg-destructive/5 text-destructive border-destructive/20 cursor-pointer hover:bg-destructive/10"
-                  >
-                    CRITICAL
-                  </Badge>
-                  <Badge
-                    variant="outline"
-                    className="text-[10px] bg-amber-500/5 text-amber-600 border-amber-500/20 cursor-pointer hover:bg-amber-500/10"
-                  >
-                    WARNING
-                  </Badge>
-                  <Badge
-                    variant="outline"
-                    className="text-[10px] bg-blue-500/5 text-blue-600 border-blue-500/20 cursor-pointer hover:bg-blue-500/10"
-                  >
-                    INFO
-                  </Badge>
+                <p className="nav-section-label">Severity</p>
+                <div className="flex flex-wrap gap-1.5">
+                  <Badge variant="outline" className="text-[10px] bg-destructive/5 text-destructive border-destructive/20 cursor-pointer hover:bg-destructive/10">CRITICAL</Badge>
+                  <Badge variant="outline" className="text-[10px] bg-amber-500/5 text-amber-600 border-amber-500/20 cursor-pointer hover:bg-amber-500/10">WARNING</Badge>
+                  <Badge variant="outline" className="text-[10px] bg-blue-500/5 text-blue-600 border-blue-500/20 cursor-pointer hover:bg-blue-500/10">INFO</Badge>
                 </div>
               </div>
+
               <div className="space-y-2">
-                <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                  Component
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  <Badge variant="outline" className="text-[10px] cursor-pointer hover:bg-muted/60">
-                    RECONCILIATION
-                  </Badge>
-                  <Badge variant="outline" className="text-[10px] cursor-pointer hover:bg-muted/60">
-                    SYSTEM
-                  </Badge>
-                  <Badge variant="outline" className="text-[10px] cursor-pointer hover:bg-muted/60">
-                    SCHEMA
-                  </Badge>
+                <p className="nav-section-label">Component</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {["RECONCILIATION", "SYSTEM", "SCHEMA"].map((c) => (
+                    <Badge key={c} variant="outline" className="text-[10px] cursor-pointer hover:bg-muted/60">
+                      {c}
+                    </Badge>
+                  ))}
                 </div>
               </div>
             </CardContent>
           </Card>
 
-          <Card className="bg-primary/5 border-primary/20 shadow-none">
+          <Card className="panel bg-primary/5 border-primary/20 shadow-none">
             <CardContent className="p-4">
-              <h3 className="text-xs font-bold text-primary mb-2 flex items-center gap-2">
-                <Filter className="w-3 h-3" />
+              <h3 className="text-xs font-bold text-primary mb-2 flex items-center gap-1.5">
+                <Filter className="w-3 h-3" aria-hidden="true" />
                 Smart Alert Routing
               </h3>
               <p className="text-[10px] text-muted-foreground leading-relaxed">
                 Settler automatically routes drift events based on their affected policy context.
                 Configure PagerDuty or Slack integrations in settings.
               </p>
-              <button className="mt-3 text-[10px] font-bold text-primary hover:underline">
+              <button className="mt-3 text-[10px] font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary rounded">
                 Edit Alert Rules →
               </button>
             </CardContent>

--- a/packages/web/src/app/app/audit/page.tsx
+++ b/packages/web/src/app/app/audit/page.tsx
@@ -3,6 +3,7 @@ import SecurityOverview from "@/components/stitch-import/SecurityOverview";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { History, User, Shield, Database, Globe, MoreHorizontal } from "lucide-react";
+import { PageHeader } from "@/components/app/PageHeader";
 
 export const metadata = {
   title: "Audit Surfaces | Settler",
@@ -30,28 +31,26 @@ export default async function AuditPage() {
   const logs = await getAuditLogs();
 
   return (
-    <div className="space-y-12 pb-12">
-      <div>
-        <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary/70 mb-2">
-          Governance & Assurance
-        </p>
-        <h1 className="text-4xl font-bold tracking-tight text-foreground">Audit Surfaces</h1>
-        <p className="mt-4 max-w-2xl text-base text-muted-foreground leading-relaxed">
-          The immutable ledger of all workspace activities. Audit trails track mutations across
-          policies, data connections, and reconciliation runs to maintain a verifiable chain of
-          custody.
-        </p>
-      </div>
-
-      <section className="space-y-6">
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-bold uppercase tracking-widest text-muted-foreground flex items-center gap-2">
-            <History className="h-4 w-4" />
-            Immutable Activity Trail
-          </h2>
+    <div className="space-y-10 pb-12">
+      <PageHeader
+        eyebrow="Governance & Assurance"
+        title="Audit Surfaces"
+        description="The immutable ledger of all workspace activities. Audit trails track mutations across policies, data connections, and reconciliation runs to maintain a verifiable chain of custody."
+        icon={Shield}
+        variant="hero"
+        actions={
           <Badge variant="outline" className="font-mono text-[10px]">
             {logs.length} ENTRIES
           </Badge>
+        }
+      />
+
+      <section className="space-y-6">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-bold uppercase tracking-widest text-muted-foreground flex items-center gap-2">
+            <History className="h-4 w-4" aria-hidden="true" />
+            Immutable Activity Trail
+          </h2>
         </div>
 
         <div className="space-y-3">

--- a/packages/web/src/app/app/connections/page.tsx
+++ b/packages/web/src/app/app/connections/page.tsx
@@ -3,25 +3,28 @@
 import ConnectionsTable from "@/components/stitch-import/ConnectionsTable";
 import ConnectionDrawer from "@/components/stitch-import/ConnectionDrawer";
 import Link from "next/link";
+import { Network } from "lucide-react";
+import { PageHeader } from "@/components/app/PageHeader";
+import { Button } from "@/components/ui/button";
 
 export default function ConnectionsPage() {
   return (
-    <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold text-foreground">Connections</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Manage data source connections and monitor integration health.
-          </p>
-        </div>
-        <Link
-          href="/app/integrations"
-          className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
-          Add Connection
-        </Link>
-      </div>
-      <div className="rounded-xl border border-border bg-card p-4">
+    <div className="space-y-8 pb-8">
+      <PageHeader
+        eyebrow="Operator Intelligence"
+        title="Connections"
+        description="Manage data source connections and monitor integration health. Active connections provide live transaction data for reconciliation runs."
+        icon={Network}
+        variant="hero"
+        actions={
+          <Button size="sm" asChild>
+            <Link href="/app/integrations">
+              Add Connection
+            </Link>
+          </Button>
+        }
+      />
+      <div className="panel p-4">
         <ConnectionsTable />
       </div>
       <ConnectionDrawer />

--- a/packages/web/src/app/app/evidence/page.tsx
+++ b/packages/web/src/app/app/evidence/page.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
-import { FileSearch, Fingerprint, Shield, ArrowRight } from "lucide-react";
+import { FileSearch, Fingerprint, Shield, ArrowRight, BookOpen, Terminal } from "lucide-react";
+import { PageHeader } from "@/components/app/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 
 const queryModes = [
   {
@@ -8,6 +11,8 @@ const queryModes = [
       "Fetch the canonical evidence bundle for a specific reconciliation run, including all matched and unmatched records, policy evaluations, and deterministic fingerprints.",
     example: "/api/v1/runs/run_01HXYZ/evidence",
     icon: FileSearch,
+    badge: "Primary",
+    badgeVariant: "default" as const,
   },
   {
     key: "Fingerprint",
@@ -15,6 +20,8 @@ const queryModes = [
       "Confirm exact deterministic output lineage for a known fingerprint. Validates that the run output has not been modified since execution.",
     example: "/api/v1/runs/:id/evidence?fingerprint=sha256:...",
     icon: Fingerprint,
+    badge: "Cryptographic",
+    badgeVariant: "info" as const,
   },
   {
     key: "Policy Hash",
@@ -22,6 +29,8 @@ const queryModes = [
       "Audit which policy version was active when a run was executed. Ensures regulatory compliance by linking execution context to governance rules.",
     example: "/api/v1/runs/:id/evidence?policy_hash=...",
     icon: Shield,
+    badge: "Compliance",
+    badgeVariant: "success" as const,
   },
 ];
 
@@ -30,92 +39,129 @@ const relatedLinks = [
     href: "/app/runs",
     label: "Run Explorer",
     description: "Browse and inspect reconciliation runs",
+    icon: Terminal,
   },
   {
     href: "/console/proof-explorer",
     label: "Truth Explorer",
     description: "Verify deterministic proof artifacts",
+    icon: Shield,
   },
   {
     href: "/console/exceptions",
     label: "Exception Queue",
     description: "Review and adjudicate reconciliation exceptions",
+    icon: FileSearch,
   },
 ];
 
 export default function EvidencePage() {
   return (
-    <div className="space-y-8">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Trust Surface
-        </p>
-        <h1 className="text-2xl font-semibold text-foreground">Evidence Query Surface</h1>
-        <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
-          Evidence retrieval is tenant-scoped and designed for deterministic audit workflows. Every
-          reconciliation run produces an immutable evidence bundle that can be queried by run
-          identifier, fingerprint, or policy hash.
-        </p>
-      </div>
-
-      <div className="rounded-xl border border-border bg-card p-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-1">
-              API Endpoint
-            </p>
-            <code className="rounded bg-muted px-2 py-1 text-sm font-mono text-foreground">
-              GET /api/v1/runs/:id/evidence
-            </code>
-          </div>
-          <Link href="/docs/api" className="text-sm text-primary hover:underline">
+    <div className="space-y-8 pb-8">
+      <PageHeader
+        eyebrow="Trust Surface"
+        title="Evidence Query Surface"
+        description="Evidence retrieval is tenant-scoped and designed for deterministic audit workflows. Every reconciliation run produces an immutable evidence bundle queryable by run identifier, fingerprint, or policy hash."
+        icon={FileSearch}
+        variant="hero"
+        actions={
+          <Link
+            href="/docs/api"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline focus-visible:outline-none"
+          >
+            <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
             Full API reference
           </Link>
-        </div>
-      </div>
+        }
+      />
 
-      <div>
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-          Query Modes
-        </h2>
+      {/* Endpoint reference */}
+      <Card className="panel shadow-sm">
+        <CardContent className="p-5">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <div className="space-y-1.5">
+              <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+                REST Endpoint
+              </p>
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="rounded-md bg-primary/10 px-2 py-0.5 text-xs font-bold text-primary uppercase tracking-wide">
+                  GET
+                </span>
+                <code className="code-inline text-sm">
+                  /api/v1/runs/:id/evidence
+                </code>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <Badge variant="success">Tenant-scoped</Badge>
+              <Badge variant="outline">Immutable</Badge>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Query modes */}
+      <section>
+        <h2 className="section-eyebrow mb-4">Query Modes</h2>
         <div className="grid gap-4 md:grid-cols-3">
           {queryModes.map((mode) => (
-            <article key={mode.key} className="rounded-xl border border-border bg-card p-5">
-              <div className="flex items-center gap-2 mb-3">
-                <div className="rounded-lg bg-muted p-2">
-                  <mode.icon className="h-4 w-4 text-muted-foreground" />
+            <article
+              key={mode.key}
+              className="evidence-block flex flex-col gap-3 hover:border-primary/30 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-2.5">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 shrink-0">
+                    <mode.icon className="h-4 w-4 text-primary" aria-hidden="true" />
+                  </div>
+                  <h3 className="text-sm font-bold text-foreground">{mode.key}</h3>
                 </div>
-                <h3 className="text-sm font-semibold text-foreground">{mode.key}</h3>
+                <Badge variant={mode.badgeVariant} size="sm">
+                  {mode.badge}
+                </Badge>
               </div>
-              <p className="text-sm text-muted-foreground leading-relaxed">{mode.description}</p>
-              <div className="mt-4 rounded-lg bg-muted/50 p-3">
+              <p className="text-sm text-muted-foreground leading-relaxed flex-1">
+                {mode.description}
+              </p>
+              <div className="rounded-lg bg-muted/40 border border-border/60 p-3">
                 <p className="break-all font-mono text-xs text-foreground">{mode.example}</p>
               </div>
             </article>
           ))}
         </div>
-      </div>
+      </section>
 
-      <div>
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-          Related Surfaces
-        </h2>
+      {/* Related surfaces */}
+      <section>
+        <h2 className="section-eyebrow mb-4">Related Surfaces</h2>
         <div className="grid gap-3 md:grid-cols-3">
           {relatedLinks.map((link) => (
             <Link
               key={link.href}
               href={link.href}
-              className="flex items-center justify-between rounded-lg border border-border bg-card p-4 hover:border-primary/50 hover:bg-primary/5 transition-colors group"
+              className="group flex items-center justify-between rounded-xl border border-border/60 bg-card p-4 hover:border-primary/40 hover:bg-primary/5 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              <div>
-                <p className="text-sm font-medium text-foreground">{link.label}</p>
-                <p className="text-xs text-muted-foreground mt-0.5">{link.description}</p>
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/40 group-hover:bg-primary/10 transition-colors">
+                  <link.icon className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" aria-hidden="true" />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-foreground group-hover:text-primary transition-colors truncate">
+                    {link.label}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                    {link.description}
+                  </p>
+                </div>
               </div>
-              <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
+              <ArrowRight
+                className="h-4 w-4 text-muted-foreground/40 group-hover:text-primary group-hover:translate-x-0.5 transition-all shrink-0 ml-2"
+                aria-hidden="true"
+              />
             </Link>
           ))}
         </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/packages/web/src/app/app/governance/page.tsx
+++ b/packages/web/src/app/app/governance/page.tsx
@@ -1,160 +1,122 @@
 "use client";
 
-import { ArrowLeft, ChevronDown } from "lucide-react";
 import RoleMatrix from "@/components/RoleMatrix";
 import PolicyViewer from "@/components/stitch-import/PolicyViewer";
 import FreezeToggle from "@/components/FreezeToggle";
+import { PageHeader } from "@/components/app/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ShieldCheck, History } from "lucide-react";
+
+const recentMutations = [
+  {
+    id: "1",
+    title: "Policy Update",
+    detail: <>Modified restrict level from &apos;Internal&apos; to &apos;Confidential&apos; on <span className="font-mono text-primary">Auth_V2</span>.</>,
+    actor: "Alex M.",
+    actorInitials: "AM",
+    actorColor: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+    relativeTime: "2m ago",
+    dotColor: "bg-primary",
+  },
+  {
+    id: "2",
+    title: "New Role Assigned",
+    detail: <>Assigned &apos;Analyst&apos; role to <span className="text-primary font-medium">@sarah_j</span>.</>,
+    actor: "Marcus R.",
+    actorInitials: "MR",
+    actorColor: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300",
+    relativeTime: "15m ago",
+    dotColor: "bg-success",
+  },
+  {
+    id: "3",
+    title: "Failed Login Attempt",
+    detail: "Multiple failed attempts from IP 192.168.x.x detected.",
+    actor: "System",
+    actorInitials: "S",
+    actorColor: "bg-muted text-muted-foreground",
+    relativeTime: "1h ago",
+    dotColor: "bg-destructive",
+  },
+  {
+    id: "4",
+    title: "Workspace Config",
+    detail: "Updated reconciliation batch size limit.",
+    actor: "Alex M.",
+    actorInitials: "AM",
+    actorColor: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+    relativeTime: "2h ago",
+    dotColor: "bg-muted-foreground",
+  },
+];
 
 export default function GovernancePage() {
   return (
-    <div className="bg-background-light dark:bg-background-dark font-display text-text-main-light dark:text-text-main-dark min-h-screen flex flex-col antialiased">
-      <header className="sticky top-0 z-50 bg-background-light/80 dark:bg-background-dark/80 backdrop-blur-md border-b border-border-light dark:border-border-dark px-4 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <button
-            aria-label="Go back"
-            className="flex items-center justify-center p-2 -ml-2 rounded-full hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
-          >
-            <ArrowLeft className="h-5 w-5 text-text-main-light dark:text-text-main-dark" />
-          </button>
-          <h1 className="text-lg font-bold">Governance</h1>
+    <div className="space-y-8 pb-8">
+      <PageHeader
+        eyebrow="Governance & Compliance"
+        title="Governance"
+        description="Manage policy versions, role boundaries, and operational freeze controls for this workspace."
+        icon={ShieldCheck}
+        variant="hero"
+      />
+
+      {/* Controls */}
+      <div className="space-y-4">
+        <div className="panel p-6">
+          <FreezeToggle />
         </div>
-        <button
-          aria-label="Change environment"
-          className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-surface-light dark:bg-surface-dark border border-border-light dark:border-border-dark"
-        >
-          <span className="w-2 h-2 rounded-full bg-emerald-500"></span>
-          <span className="text-xs font-semibold text-text-main-light dark:text-text-main-dark">
-            Finance Prod
-          </span>
-          <ChevronDown className="h-4 w-4 text-text-muted-light dark:text-text-muted-dark" />
-        </button>
-      </header>
-      <main className="flex-1 overflow-y-auto pb-24">
-        <FreezeToggle />
-        <RoleMatrix />
-        <div className="h-px bg-border-light dark:bg-border-dark mx-4 my-4"></div>
-        <PolicyViewer initialPolicies={[]} />
-        <div className="h-px bg-border-light dark:bg-border-dark mx-4 my-4"></div>
-        <section className="px-4">
-          <h3 className="text-sm font-bold uppercase tracking-wider text-text-muted-light dark:text-text-muted-dark mb-4">
+        <div className="panel p-6">
+          <RoleMatrix />
+        </div>
+        <div className="rounded-2xl border border-border/40 bg-card/50 p-6 sm:p-8">
+          <PolicyViewer initialPolicies={[]} />
+        </div>
+      </div>
+
+      {/* Recent Mutations Timeline */}
+      <Card className="panel shadow-sm">
+        <CardHeader className="pb-3 border-b border-border/40">
+          <CardTitle className="text-sm font-bold flex items-center gap-2">
+            <History className="w-4 h-4 text-primary" aria-hidden="true" />
             Recent Mutations
-          </h3>
-          <div className="relative pl-4 border-l border-border-light dark:border-border-dark space-y-6">
-            {/* Timeline Item 1 */}
-            <div className="relative">
-              <div className="absolute -left-[21px] top-1 bg-background-light dark:bg-background-dark p-1">
-                <div className="w-2 h-2 rounded-full bg-primary ring-4 ring-background-light dark:ring-background-dark"></div>
-              </div>
-              <div className="flex flex-col gap-1">
-                <div className="flex justify-between items-start">
-                  <p className="text-xs font-bold text-text-main-light dark:text-text-main-dark">
-                    Policy Update: <span className="font-mono text-primary">Auth_V2</span>
-                  </p>
-                  <span className="text-[10px] text-text-muted-light dark:text-text-muted-dark">
-                    2m ago
-                  </span>
-                </div>
-                <p className="text-xs text-text-muted-light dark:text-text-muted-dark">
-                  Modified restrict level from &apos;Internal&apos; to &apos;Confidential&apos;.
-                </p>
-                <div className="flex items-center gap-2 mt-1">
-                  <div className="w-4 h-4 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center text-[8px] font-medium text-blue-700 dark:text-blue-300">
-                    AM
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-5">
+          <div className="timeline-track">
+            {recentMutations.map((item) => (
+              <div key={item.id} className="relative">
+                <div
+                  className={`timeline-node ${item.dotColor}`}
+                  aria-hidden="true"
+                />
+                <div className="flex flex-col gap-1">
+                  <div className="flex justify-between items-start gap-4">
+                    <p className="text-xs font-bold text-foreground">{item.title}</p>
+                    <span className="text-[10px] text-muted-foreground shrink-0">
+                      {item.relativeTime}
+                    </span>
                   </div>
-                  <span className="text-[10px] font-medium text-text-main-light dark:text-text-main-dark">
-                    Alex M.
-                  </span>
-                </div>
-              </div>
-            </div>
-            {/* Timeline Item 2 */}
-            <div className="relative">
-              <div className="absolute -left-[21px] top-1 bg-background-light dark:bg-background-dark p-1">
-                <div className="w-2 h-2 rounded-full bg-emerald-500 ring-4 ring-background-light dark:ring-background-dark"></div>
-              </div>
-              <div className="flex flex-col gap-1">
-                <div className="flex justify-between items-start">
-                  <p className="text-xs font-bold text-text-main-light dark:text-text-main-dark">
-                    New Role Assigned
-                  </p>
-                  <span className="text-[10px] text-text-muted-light dark:text-text-muted-dark">
-                    15m ago
-                  </span>
-                </div>
-                <p className="text-xs text-text-muted-light dark:text-text-muted-dark">
-                  Assigned &apos;Analyst&apos; role to{" "}
-                  <span className="text-primary hover:underline cursor-pointer">@sarah_j</span>.
-                </p>
-                <div className="flex items-center gap-2 mt-1">
-                  <div className="w-4 h-4 rounded-full bg-purple-100 dark:bg-purple-900 flex items-center justify-center text-[8px] font-medium text-purple-700 dark:text-purple-300">
-                    MR
+                  <p className="text-xs text-muted-foreground">{item.detail}</p>
+                  <div className="flex items-center gap-2 mt-1">
+                    <span
+                      className={`flex h-4 w-4 items-center justify-center rounded-full text-[8px] font-medium shrink-0 ${item.actorColor}`}
+                      aria-hidden="true"
+                    >
+                      {item.actorInitials}
+                    </span>
+                    <span className="text-[10px] font-medium text-foreground">{item.actor}</span>
                   </div>
-                  <span className="text-[10px] font-medium text-text-main-light dark:text-text-main-dark">
-                    Marcus R.
-                  </span>
                 </div>
               </div>
-            </div>
-            {/* Timeline Item 3 */}
-            <div className="relative">
-              <div className="absolute -left-[21px] top-1 bg-background-light dark:bg-background-dark p-1">
-                <div className="w-2 h-2 rounded-full bg-danger ring-4 ring-background-light dark:ring-background-dark"></div>
-              </div>
-              <div className="flex flex-col gap-1">
-                <div className="flex justify-between items-start">
-                  <p className="text-xs font-bold text-text-main-light dark:text-text-main-dark">
-                    Failed Login Attempt
-                  </p>
-                  <span className="text-[10px] text-text-muted-light dark:text-text-muted-dark">
-                    1h ago
-                  </span>
-                </div>
-                <p className="text-xs text-text-muted-light dark:text-text-muted-dark">
-                  Multiple failed attempts from IP 192.168.x.x detected.
-                </p>
-                <div className="flex items-center gap-2 mt-1">
-                  <span className="w-4 h-4 rounded-full bg-slate-700 flex items-center justify-center text-[8px] text-white">
-                    S
-                  </span>
-                  <span className="text-[10px] font-medium text-text-main-light dark:text-text-main-dark">
-                    System
-                  </span>
-                </div>
-              </div>
-            </div>
-            {/* Timeline Item 4 */}
-            <div className="relative pb-4">
-              <div className="absolute -left-[21px] top-1 bg-background-light dark:bg-background-dark p-1">
-                <div className="w-2 h-2 rounded-full bg-slate-500 ring-4 ring-background-light dark:ring-background-dark"></div>
-              </div>
-              <div className="flex flex-col gap-1">
-                <div className="flex justify-between items-start">
-                  <p className="text-xs font-bold text-text-main-light dark:text-text-main-dark">
-                    Workspace Config
-                  </p>
-                  <span className="text-[10px] text-text-muted-light dark:text-text-muted-dark">
-                    2h ago
-                  </span>
-                </div>
-                <p className="text-xs text-text-muted-light dark:text-text-muted-dark">
-                  Updated reconciliation batch size limit.
-                </p>
-                <div className="flex items-center gap-2 mt-1">
-                  <div className="w-4 h-4 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center text-[8px] font-medium text-blue-700 dark:text-blue-300">
-                    AM
-                  </div>
-                  <span className="text-[10px] font-medium text-text-main-light dark:text-text-main-dark">
-                    Alex M.
-                  </span>
-                </div>
-              </div>
-            </div>
+            ))}
           </div>
-          <button className="w-full py-3 text-xs text-primary font-medium hover:bg-primary/5 rounded-lg transition-colors mt-2 mb-6">
+
+          <button className="mt-6 w-full py-2.5 text-xs text-primary font-semibold rounded-lg border border-border/60 hover:bg-primary/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
             View All Activity
           </button>
-        </section>
-      </main>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/packages/web/src/app/app/integrations/page.tsx
+++ b/packages/web/src/app/app/integrations/page.tsx
@@ -1,27 +1,35 @@
 import IntegrationList from "@/components/stitch-import/IntegrationList";
 import Link from "next/link";
+import { Plug, BookOpen } from "lucide-react";
+import { PageHeader } from "@/components/app/PageHeader";
+import { Button } from "@/components/ui/button";
 
 export default function IntegrationsPage() {
   return (
-    <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Operator Intelligence
-          </p>
-          <h1 className="text-2xl font-semibold text-foreground">Integrations</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Manage active connectors and data source integrations.
-          </p>
-        </div>
-        <Link
-          href="/docs/integrations"
-          className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
-          Add Integration
-        </Link>
-      </div>
-      <div className="rounded-xl border border-border bg-card p-4">
+    <div className="space-y-8 pb-8">
+      <PageHeader
+        eyebrow="Operator Intelligence"
+        title="Integrations"
+        description="Manage active connectors and upstream data source integrations. Each integration feeds into the reconciliation pipeline and must be verified before use in production runs."
+        icon={Plug}
+        variant="hero"
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/docs/integrations">
+                <BookOpen className="h-3.5 w-3.5 mr-1.5" aria-hidden="true" />
+                Docs
+              </Link>
+            </Button>
+            <Button size="sm" asChild>
+              <Link href="/docs/integrations">
+                Add Integration
+              </Link>
+            </Button>
+          </div>
+        }
+      />
+      <div className="panel p-6">
         <IntegrationList />
       </div>
     </div>

--- a/packages/web/src/app/app/layout.tsx
+++ b/packages/web/src/app/app/layout.tsx
@@ -4,6 +4,7 @@ import { getAppEnvStatus } from "@/lib/env/runtime-access";
 import { createClient } from "@/lib/supabase/server";
 import { AppSidebar, MobileNav } from "@/components/app/AppNav";
 import { OperationalRouteNotice } from "@/components/shared/OperationalRouteNotice";
+import { ShieldCheck } from "lucide-react";
 
 // All /app/* routes require authenticated session state via cookies.
 // Force dynamic rendering to prevent Next.js from attempting static prerender
@@ -13,23 +14,26 @@ export const dynamic = "force-dynamic";
 function SignedOutScreen() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-6">
-      <div className="max-w-md rounded-xl border border-border bg-card p-6 shadow-sm">
-        <h2 className="text-xl font-semibold">You&apos;re signed out</h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          The Settler app shell requires an authenticated session. Sign in to continue.
+      <div className="max-w-md rounded-xl border border-border bg-card p-8 shadow-md">
+        <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-muted/40 border border-border/60">
+          <ShieldCheck className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+        </div>
+        <h2 className="text-xl font-semibold text-foreground">Session required</h2>
+        <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+          The Settler operator console requires an authenticated session. Sign in to access your workspace.
         </p>
-        <div className="mt-4 flex gap-3">
+        <div className="mt-6 flex gap-3">
           <Link
             href="/login"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Sign in
           </Link>
           <Link
             href="/"
-            className="rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground"
+            className="inline-flex items-center justify-center rounded-md border border-border bg-card px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            Back to marketing site
+            Homepage
           </Link>
         </div>
       </div>
@@ -42,30 +46,33 @@ function NoTenantScreen() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-6">
-      <div className="w-full max-w-md rounded-xl border border-border bg-card p-6 text-center shadow-sm">
-        <h2 className="text-xl font-semibold text-foreground mb-2">No workspace assigned</h2>
-        <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+      <div className="w-full max-w-md rounded-xl border border-border bg-card p-8 text-center shadow-md">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-muted/40 border border-border/60">
+          <ShieldCheck className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        </div>
+        <h2 className="text-xl font-semibold text-foreground">No workspace assigned</h2>
+        <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
           Your account has not been assigned to a Settler workspace. Complete setup to access the operational control plane.
         </p>
-        
+
         {isLocalDev && (
-          <div className="mb-4 rounded-lg bg-blue-50 dark:bg-blue-950 p-3 text-left">
-            <p className="text-xs font-medium text-blue-900 dark:text-blue-200">
-              💡 Running locally? Create a workspace to get started:
+          <div className="mt-4 mb-2 rounded-lg bg-blue-500/10 border border-blue-500/20 p-3 text-left">
+            <p className="text-xs font-medium text-blue-600 dark:text-blue-400">
+              Running locally? Create a workspace to get started.
             </p>
           </div>
         )}
-        
-        <div className="flex flex-col gap-3">
+
+        <div className="mt-5 flex flex-col gap-2.5">
           <Link
             href="/console/onboarding"
-            className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {isLocalDev ? "Create your workspace" : "Complete workspace setup"}
           </Link>
           <Link
             href="/docs/getting-started"
-            className="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            className="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-input bg-card px-4 py-2.5 text-sm font-medium shadow-sm transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Read setup documentation
           </Link>
@@ -95,16 +102,46 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const tenantId = user.user_metadata?.tenant_id;
   if (!tenantId) return <NoTenantScreen />;
 
+  // Abbreviate long tenant IDs for display
+  const tenantDisplay = tenantId.length > 16
+    ? `${tenantId.slice(0, 8)}…${tenantId.slice(-4)}`
+    : tenantId;
+
   return (
     <div className="flex h-screen bg-background">
       <AppSidebar />
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-card px-4">
-          <div className="flex items-center gap-3">
+        {/* Top header bar */}
+        <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-card/50 backdrop-blur-sm px-4 gap-4">
+          <div className="flex items-center gap-3 min-w-0">
             <MobileNav />
-            <span className="text-sm text-muted-foreground">
-              Tenant: <span className="font-medium text-foreground">{tenantId}</span>
-            </span>
+            {/* Tenant context pill */}
+            <div
+              className="hidden sm:flex items-center gap-2 rounded-full border border-border/60 bg-background/40 px-3 py-1 text-xs"
+              title={`Workspace: ${tenantId}`}
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-success flex-shrink-0" aria-hidden="true" />
+              <span className="font-mono text-muted-foreground truncate max-w-[180px]">
+                {tenantDisplay}
+              </span>
+            </div>
+          </div>
+          {/* Right-side header actions */}
+          <div className="flex items-center gap-2 shrink-0">
+            <Link
+              href="/app/alerts"
+              className="flex items-center justify-center rounded-md p-2 text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="View live alerts"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></svg>
+            </Link>
+            <Link
+              href="/app/settings"
+              className="flex items-center justify-center rounded-md p-2 text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="Settings"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+            </Link>
           </div>
         </header>
         <main className="min-h-0 flex-1 overflow-auto p-4 md:p-6" id="main-content">

--- a/packages/web/src/app/app/metrics/page.tsx
+++ b/packages/web/src/app/app/metrics/page.tsx
@@ -1,4 +1,8 @@
 import { headers } from "next/headers";
+import { BarChart2, Clock, AlertCircle } from "lucide-react";
+import { PageHeader } from "@/components/app/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 
 async function getTop() {
   const h = await headers();
@@ -16,44 +20,98 @@ async function getTop() {
   return data.rows || [];
 }
 
+function LatencyBadge({ ms }: { ms: number }) {
+  if (ms >= 1000) {
+    return <Badge variant="destructive" size="sm">{Math.round(ms)}ms</Badge>;
+  }
+  if (ms >= 500) {
+    return <Badge variant="warning" size="sm">{Math.round(ms)}ms</Badge>;
+  }
+  return <Badge variant="success" size="sm">{Math.round(ms)}ms</Badge>;
+}
+
 export default async function MetricsPage() {
   const rows = await getTop();
-  return (
-    <div className="space-y-4">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Runtime Event Model
-        </p>
-        <h1 className="text-2xl font-semibold text-foreground">Runtime Event Signals</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Event-derived route telemetry for operator triage. This surface currently focuses on top
-          slow routes and should be read as partial runtime event visibility.
-        </p>
-      </div>
 
-      <div className="rounded-xl border border-border bg-card p-4">
-        <div className="mb-3 text-sm font-medium text-foreground">Top slow routes (7d)</div>
-        {rows.length === 0 ? (
-          <div className="py-8 text-center">
-            <p className="text-sm text-muted-foreground mb-1">No metrics found for this period.</p>
-            <p className="text-xs text-muted-foreground/70">
-              Metrics are collected from API route telemetry. Data will appear once routes begin
-              receiving traffic.
-            </p>
+  return (
+    <div className="space-y-8 pb-8">
+      <PageHeader
+        eyebrow="Runtime Event Model"
+        title="Runtime Event Signals"
+        description="Event-derived route telemetry for operator triage. This surface focuses on top slow routes and should be read as partial runtime event visibility — not a full observability stack."
+        icon={BarChart2}
+        variant="hero"
+      />
+
+      <Card className="panel shadow-sm">
+        <CardHeader className="pb-3 border-b border-border/40">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm font-bold flex items-center gap-2">
+              <Clock className="w-4 h-4 text-primary" aria-hidden="true" />
+              Top Slow Routes
+            </CardTitle>
+            <Badge variant="outline" size="sm">7-day window</Badge>
           </div>
-        ) : (
-          <div className="divide-y divide-border">
-            {rows.map((row: any) => (
-              <div key={row.route} className="flex items-center justify-between py-2">
-                <code className="text-sm text-foreground font-mono">{row.route}</code>
-                <span className="text-sm font-medium text-foreground">
-                  {Math.round(Number(row.avg_latency_ms ?? 0))}ms
-                  <span className="text-xs text-muted-foreground ml-1">avg</span>
+        </CardHeader>
+        <CardContent className="p-0">
+          {rows.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-muted/40 border border-border/60">
+                <AlertCircle className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+              </div>
+              <h3 className="text-sm font-semibold text-foreground mb-1">No metrics collected yet</h3>
+              <p className="text-xs text-muted-foreground max-w-sm leading-relaxed">
+                Route telemetry will appear here once your API endpoints begin receiving traffic.
+                Metrics are captured automatically from API route instrumentation.
+              </p>
+            </div>
+          ) : (
+            <div
+              className="divide-y divide-border/40"
+              role="table"
+              aria-label="Slow routes by average latency"
+            >
+              <div
+                className="flex items-center justify-between px-5 py-2.5 bg-muted/20"
+                role="row"
+                aria-rowindex={0}
+              >
+                <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+                  Route
+                </span>
+                <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+                  Avg Latency
                 </span>
               </div>
-            ))}
-          </div>
-        )}
+              {rows.map((row: any, i: number) => (
+                <div
+                  key={row.route}
+                  className="flex items-center justify-between px-5 py-3.5 hover:bg-muted/20 transition-colors"
+                  role="row"
+                  aria-rowindex={i + 1}
+                >
+                  <code className="text-sm text-foreground font-mono truncate max-w-[60%]">
+                    {row.route}
+                  </code>
+                  <LatencyBadge ms={Number(row.avg_latency_ms ?? 0)} />
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Context note */}
+      <div className="notice-strip text-muted-foreground">
+        <BarChart2 className="h-4 w-4 text-muted-foreground/60 shrink-0" aria-hidden="true" />
+        <p className="text-xs leading-relaxed">
+          This surface reflects route-level event telemetry only. For full observability, connect
+          an APM integration in{" "}
+          <a href="/app/integrations" className="text-primary hover:underline font-medium">
+            Integrations
+          </a>
+          .
+        </p>
       </div>
     </div>
   );

--- a/packages/web/src/app/app/onboarding/page.tsx
+++ b/packages/web/src/app/app/onboarding/page.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import {
-  ArrowLeft,
   CheckCircle,
   Info,
   Network,
@@ -10,220 +9,207 @@ import {
   Circle,
   ArrowRight,
 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 
 const OnboardingPage: React.FC = () => {
   return (
-    <div className="bg-background-light dark:bg-background-dark font-display text-text-main text-muted-foreground antialiased selection:bg-primary selection:text-white">
-      <div className="relative flex h-full min-h-screen w-full flex-col max-w-md mx-auto bg-background-light dark:bg-background-dark shadow-2xl overflow-hidden">
-        {/* Header */}
-        <header className="flex items-center justify-between px-4 py-3 bg-background-light dark:bg-background-dark sticky top-0 z-10 border-b border-border dark:border-border">
-          <button className="flex items-center justify-center w-10 h-10 -ml-2 rounded-full hover:bg-muted/40 dark:hover:bg-card text-text-main dark:text-white transition-colors">
-            <ArrowLeft className="h-6 w-6" />
-          </button>
-          <h1 className="text-base font-semibold text-text-main dark:text-white tracking-tight">
-            Settler Workspace
-          </h1>
-          <button className="flex items-center text-primary font-medium text-sm hover:text-primary-dark transition-colors px-2">
-            Help
-          </button>
-        </header>
-        {/* Progress Stepper */}
-        <div className="w-full bg-background-light dark:bg-background-dark pt-6 pb-2 px-6">
-          <div className="flex w-full items-center justify-center gap-3">
-            <div className="h-1.5 w-8 rounded-full bg-primary"></div>
-            <div className="h-1.5 w-8 rounded-full bg-slate-200 dark:bg-muted"></div>
-            <div className="h-1.5 w-8 rounded-full bg-slate-200 dark:bg-muted"></div>
-            <div className="h-1.5 w-8 rounded-full bg-slate-200 dark:bg-muted"></div>
-          </div>
-          <div className="mt-2 text-center">
-            <span className="text-xs font-medium text-text-secondary dark:text-muted-foreground uppercase tracking-wider">
-              Step 1 of 4
-            </span>
-          </div>
+    <div className="max-w-lg mx-auto space-y-0 pb-8">
+      {/* Progress header */}
+      <div className="pt-2 pb-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Badge variant="outline" className="text-[10px] font-bold uppercase tracking-wide">
+            Step 1 of 4
+          </Badge>
         </div>
-        {/* Scrollable Content */}
-        <main className="flex-1 overflow-y-auto px-6 py-4 pb-24">
-          <div className="mb-8">
-            <h2 className="text-2xl font-bold text-text-main dark:text-white tracking-tight mb-2">
-              Set up your Workspace
-            </h2>
-            <p className="text-text-secondary dark:text-muted-foreground text-sm leading-relaxed">
-              Let's configure your secure, audit-ready environment. First, give it an identity.
+        {/* Step progress bar */}
+        <div className="flex gap-1.5">
+          {[0, 1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className={`h-1.5 flex-1 rounded-full transition-colors ${
+                i === 0 ? "bg-primary" : "bg-border"
+              }`}
+              aria-hidden="true"
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Card shell */}
+      <div className="panel p-6 sm:p-8 space-y-8">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground tracking-tight">
+            Set up your Workspace
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+            Let&apos;s configure your secure, audit-ready environment. First, give it an identity.
+          </p>
+        </div>
+
+        <form className="flex flex-col gap-6" onSubmit={(e) => e.preventDefault()}>
+          {/* Workspace Name */}
+          <div className="space-y-1.5">
+            <label
+              className="block text-sm font-medium text-foreground"
+              htmlFor="workspace-name"
+            >
+              Workspace Name
+            </label>
+            <div className="relative">
+              <input
+                className="input-field h-11 pr-10"
+                id="workspace-name"
+                placeholder="e.g. Acme Corp"
+                type="text"
+                defaultValue="Acme Corp"
+              />
+              <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
+                <CheckCircle className="h-4 w-4 text-success" aria-hidden="true" />
+              </div>
+            </div>
+          </div>
+
+          {/* Subdomain / Workspace URL */}
+          <div className="space-y-1.5">
+            <label
+              className="block text-sm font-medium text-foreground"
+              htmlFor="subdomain"
+            >
+              Workspace URL
+            </label>
+            <div className="flex rounded-[var(--ui-radius-md)] shadow-sm overflow-hidden border border-border focus-within:ring-2 focus-within:ring-ring">
+              <span className="inline-flex items-center bg-muted/30 px-3 text-sm text-muted-foreground border-r border-border shrink-0">
+                https://
+              </span>
+              <input
+                className="block w-full min-w-0 flex-1 bg-background text-foreground px-3 h-11 text-sm focus:outline-none"
+                id="subdomain"
+                placeholder="acme"
+                type="text"
+                defaultValue="acme-production"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Your team will use this URL to access the platform.
             </p>
           </div>
-          <form className="flex flex-col gap-6" onSubmit={(e) => e.preventDefault()}>
-            {/* Workspace Name */}
-            <div className="space-y-1.5">
-              <label
-                className="block text-sm font-medium text-text-main text-muted-foreground"
-                htmlFor="workspace-name"
-              >
-                Workspace Name
+
+          {/* Tenant Mode */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <label className="block text-sm font-medium text-foreground">
+                Tenant Mode
               </label>
-              <div className="relative">
-                <input
-                  className="form-input block w-full rounded-lg border-border dark:border-border bg-surface-light dark:bg-card text-text-main dark:text-white shadow-sm focus:border-primary focus:ring-primary h-12 px-4 transition-colors placeholder:text-muted-foreground"
-                  id="workspace-name"
-                  placeholder="e.g. Acme Corp"
-                  type="text"
-                  defaultValue="Acme Corp"
-                />
-                <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none text-green-500">
-                  <CheckCircle className="h-5 w-5" />
-                </div>
-              </div>
+              <button type="button" className="text-muted-foreground hover:text-foreground transition-colors" aria-label="Learn about tenant modes">
+                <Info className="h-4 w-4" />
+              </button>
             </div>
-            {/* Subdomain */}
-            <div className="space-y-1.5">
-              <label
-                className="block text-sm font-medium text-text-main text-muted-foreground"
-                htmlFor="subdomain"
-              >
-                Workspace URL
-              </label>
-              <div className="flex rounded-lg shadow-sm">
-                <span className="inline-flex items-center rounded-l-lg border border-r-0 border-border dark:border-border bg-muted/20 dark:bg-background px-3 text-muted-foreground dark:text-muted-foreground sm:text-sm">
-                  https://
-                </span>
-                <input
-                  className="block w-full min-w-0 flex-1 rounded-none rounded-r-lg border-border dark:border-border bg-surface-light dark:bg-card text-text-main dark:text-white focus:border-primary focus:ring-primary sm:text-sm h-12 px-4"
-                  id="subdomain"
-                  placeholder="acme"
-                  type="text"
-                  defaultValue="acme-production"
-                />
-              </div>
-              <p className="text-xs text-text-secondary dark:text-muted-foreground">
-                Your team will use this URL to access the platform.
-              </p>
-            </div>
-            {/* Environment Type Selection */}
-            <div className="space-y-3 pt-2">
-              <div className="flex items-center justify-between">
-                <label className="block text-sm font-medium text-text-main text-muted-foreground">
-                  Tenant Mode
-                </label>
-                <button className="text-primary hover:text-primary-dark">
-                  <Info className="h-5 w-5" />
-                </button>
-              </div>
-              {/* Option 1: Multi-tenant */}
-              <label className="relative flex cursor-pointer rounded-xl border-2 border-primary bg-primary-light/30 dark:bg-primary/10 p-4 shadow-sm focus:outline-none transition-all">
-                <input
-                  aria-describedby="tenant-mode-0-description-0 tenant-mode-0-description-1"
-                  aria-labelledby="tenant-mode-0-label"
-                  defaultChecked
-                  className="sr-only"
-                  name="tenant-mode"
-                  type="radio"
-                  value="multi"
-                />
-                <span className="flex flex-1">
-                  <span className="flex flex-col">
-                    <span
-                      className="block text-sm font-bold text-primary dark:text-blue-400 flex items-center gap-2"
-                      id="tenant-mode-0-label"
-                    >
-                      <Network className="h-5 w-5" />
-                      Shared Environment
-                    </span>
-                    <span
-                      className="mt-1 flex items-center text-sm text-text-secondary dark:text-muted-foreground"
-                      id="tenant-mode-0-description-0"
-                    >
-                      Cost-effective multi-tenant setup. Best for development and staging.
-                    </span>
+
+            {/* Option 1: Shared */}
+            <label className="relative flex cursor-pointer rounded-xl border-2 border-primary bg-primary/8 p-4 transition-all">
+              <input
+                aria-labelledby="tenant-mode-0-label"
+                defaultChecked
+                className="sr-only"
+                name="tenant-mode"
+                type="radio"
+                value="multi"
+              />
+              <span className="flex flex-1">
+                <span className="flex flex-col gap-1">
+                  <span className="text-sm font-bold text-primary flex items-center gap-2" id="tenant-mode-0-label">
+                    <Network className="h-4 w-4" aria-hidden="true" />
+                    Shared Environment
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    Cost-effective multi-tenant setup. Best for development and staging.
                   </span>
                 </span>
-                <CheckCircle
-                  aria-hidden="true"
-                  className="text-primary dark:text-blue-400 h-6 w-6"
-                />
-              </label>
-              {/* Option 2: Dedicated */}
-              <label className="relative flex cursor-pointer rounded-xl border border-border dark:border-border bg-surface-light dark:bg-card p-4 shadow-sm focus:outline-none hover:border-border dark:hover:border-slate-600 transition-all">
-                <input
-                  aria-describedby="tenant-mode-1-description-0 tenant-mode-1-description-1"
-                  aria-labelledby="tenant-mode-1-label"
-                  className="sr-only"
-                  name="tenant-mode"
-                  type="radio"
-                  value="dedicated"
-                />
-                <span className="flex flex-1">
-                  <span className="flex flex-col">
-                    <span
-                      className="block text-sm font-bold text-text-main text-muted-foreground flex items-center gap-2"
-                      id="tenant-mode-1-label"
-                    >
-                      <ShieldCheck className="h-5 w-5" />
-                      Isolated Environment
-                    </span>
-                    <span
-                      className="mt-1 flex items-center text-sm text-text-secondary dark:text-muted-foreground"
-                      id="tenant-mode-1-description-0"
-                    >
-                      Dedicated resources for strict compliance. Best for production.
-                    </span>
+              </span>
+              <CheckCircle className="text-primary h-5 w-5 shrink-0 mt-0.5" aria-hidden="true" />
+            </label>
+
+            {/* Option 2: Isolated */}
+            <label className="relative flex cursor-pointer rounded-xl border border-border bg-card p-4 hover:border-primary/40 transition-all">
+              <input
+                aria-labelledby="tenant-mode-1-label"
+                className="sr-only"
+                name="tenant-mode"
+                type="radio"
+                value="dedicated"
+              />
+              <span className="flex flex-1">
+                <span className="flex flex-col gap-1">
+                  <span className="text-sm font-bold text-foreground flex items-center gap-2" id="tenant-mode-1-label">
+                    <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+                    Isolated Environment
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    Dedicated resources for strict compliance. Best for production.
                   </span>
                 </span>
-                <Circle aria-hidden="true" className="text-muted-foreground dark:text-muted-foreground h-6 w-6" />
-              </label>
-            </div>
-            {/* Compliance Quick Toggles */}
-            <div className="pt-4 border-t border-slate-100 dark:border-border">
-              <h3 className="text-sm font-medium text-text-main dark:text-white mb-4">
-                Audit-Ready Defaults
-              </h3>
-              <div className="flex items-center justify-between mb-4">
-                <div className="flex flex-col">
-                  <span className="text-sm font-medium text-text-main text-muted-foreground">
-                    SOC2 Logging Preset
-                  </span>
-                  <span className="text-xs text-text-secondary dark:text-muted-foreground">
-                    Enables 90-day retention
-                  </span>
+              </span>
+              <Circle className="text-muted-foreground h-5 w-5 shrink-0 mt-0.5" aria-hidden="true" />
+            </label>
+          </div>
+
+          {/* Audit-Ready Defaults */}
+          <div className="pt-2 border-t border-border/60 space-y-4">
+            <h3 className="text-sm font-semibold text-foreground">
+              Audit-Ready Defaults
+            </h3>
+
+            {[
+              {
+                id: "soc2",
+                label: "SOC2 Logging Preset",
+                hint: "Enables 90-day retention",
+                defaultChecked: true,
+              },
+              {
+                id: "2fa",
+                label: "Enforce 2FA",
+                hint: "Require for all admins",
+                defaultChecked: true,
+              },
+            ].map((item) => (
+              <div key={item.id} className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-foreground">{item.label}</p>
+                  <p className="text-xs text-muted-foreground">{item.hint}</p>
                 </div>
                 <label className="relative inline-flex items-center cursor-pointer">
-                  <input defaultChecked className="sr-only peer" type="checkbox" value="" />
-                  <div className="w-11 h-6 bg-slate-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer dark:bg-muted peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-card after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+                  <input
+                    id={item.id}
+                    defaultChecked={item.defaultChecked}
+                    className="sr-only peer"
+                    type="checkbox"
+                  />
+                  <div className="w-10 h-5 rounded-full bg-border peer-focus:ring-2 peer-focus:ring-ring peer-checked:bg-primary transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-5" />
                 </label>
               </div>
-              <div className="flex items-center justify-between">
-                <div className="flex flex-col">
-                  <span className="text-sm font-medium text-text-main text-muted-foreground">
-                    Enforce 2FA
-                  </span>
-                  <span className="text-xs text-text-secondary dark:text-muted-foreground">
-                    Require for all admins
-                  </span>
-                </div>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input defaultChecked className="sr-only peer" type="checkbox" value="" />
-                  <div className="w-11 h-6 bg-slate-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer dark:bg-muted peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-card after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
-                </label>
-              </div>
-            </div>
-          </form>
-        </main>
-        {/* Sticky Footer */}
-        <div className="absolute bottom-0 left-0 right-0 bg-card/90 dark:bg-background/90 backdrop-blur-sm border-t border-border dark:border-border p-4 z-20">
-          <div className="flex gap-3">
-            <button
-              className="flex-1 py-3 px-4 bg-muted/40 hover:bg-slate-200 dark:bg-card dark:hover:bg-muted text-text-main dark:text-white rounded-lg font-semibold text-sm transition-colors"
+            ))}
+          </div>
+
+          {/* Footer actions */}
+          <div className="flex gap-3 pt-2">
+            <Button
               type="button"
+              variant="outline"
+              className="flex-1"
             >
               Save Draft
-            </button>
-            <button
-              className="flex-[2] py-3 px-4 bg-primary hover:bg-primary-dark text-white rounded-lg font-semibold text-sm shadow-lg shadow-primary/30 transition-all flex items-center justify-center gap-2"
+            </Button>
+            <Button
               type="button"
+              className="flex-[2] gap-2"
             >
               Next Step
-              <ArrowRight className="h-5 w-5" />
-            </button>
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Button>
           </div>
-        </div>
+        </form>
       </div>
     </div>
   );

--- a/packages/web/src/app/app/page.tsx
+++ b/packages/web/src/app/app/page.tsx
@@ -109,85 +109,67 @@ export default async function AppPage() {
       <div className="grid gap-6 lg:grid-cols-3">
         {/* Real Metrics Grid */}
         <div className="lg:col-span-2 space-y-6">
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <Card className="panel bg-background/50 backdrop-blur-sm">
-              <CardHeader className="pb-2">
-                <CardDescription className="label-muted">
-                  Integrity Score
-                </CardDescription>
-                <CardTitle className="metric-value font-mono text-2xl">
-                  {stats?.metrics?.integrity_score ?? 100}%
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
+          <div className="stat-strip">
+            {/* Integrity Score */}
+            <Card className="panel bg-background/50">
+              <CardContent className="p-4 pt-3">
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">Integrity</p>
+                  <ShieldCheck className="w-3 h-3 text-primary/60" aria-hidden="true" />
+                </div>
+                <p className="kpi-value text-primary">{stats?.metrics?.integrity_score ?? 100}%</p>
                 <Progress
                   value={stats?.metrics?.integrity_score ?? 100}
-                  className="h-1.5"
+                  className="h-1 mt-2"
                   indicatorClassName="bg-primary"
                 />
               </CardContent>
             </Card>
-            <Card className="panel bg-background/50 backdrop-blur-sm">
-              <CardHeader className="pb-2">
-                <CardDescription className="label-muted">
-                  Total Runs
-                </CardDescription>
-                <CardTitle className="metric-value font-mono text-2xl">
-                  {stats?.metrics?.total_runs ?? 0}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-[10px] text-muted-foreground flex items-center gap-1">
-                  <PieChart className="w-3 h-3" />
-                  Aggregate lifetime
+
+            {/* Total Runs */}
+            <Card className="panel bg-background/50">
+              <CardContent className="p-4 pt-3">
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">Total Runs</p>
+                  <PieChart className="w-3 h-3 text-muted-foreground/60" aria-hidden="true" />
                 </div>
+                <p className="kpi-value">{stats?.metrics?.total_runs ?? 0}</p>
+                <p className="text-[10px] text-muted-foreground mt-1">Aggregate lifetime</p>
               </CardContent>
             </Card>
-            <Card className="panel bg-background/50 backdrop-blur-sm">
-              <CardHeader className="pb-2">
-                <CardDescription className="label-muted text-destructive/80">
-                  Mismatches
-                </CardDescription>
-                <CardTitle className="metric-value font-mono text-2xl text-destructive">
-                  {stats?.metrics?.unmatched_runs ?? 0}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-[10px] text-destructive/70 flex items-center gap-1">
-                  <AlertCircle className="w-3 h-3" />
-                  Requires operator triage
+
+            {/* Mismatches */}
+            <Card className="panel bg-destructive/5 border-destructive/20">
+              <CardContent className="p-4 pt-3">
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-[10px] font-bold uppercase tracking-widest text-destructive/80">Mismatches</p>
+                  <AlertCircle className="w-3 h-3 text-destructive/60" aria-hidden="true" />
                 </div>
+                <p className="kpi-value text-destructive">{stats?.metrics?.unmatched_runs ?? 0}</p>
+                <p className="text-[10px] text-destructive/60 mt-1">Requires triage</p>
               </CardContent>
             </Card>
-            <Card
-              className={`panel backdrop-blur-sm ${(stats?.metrics?.pending_exceptions ?? 0) > 0 ? "bg-amber-50/50 dark:bg-amber-950/20 border-amber-200/60 dark:border-amber-800/40" : "bg-background/50"}`}
-            >
-              <CardHeader className="pb-2">
-                <CardDescription
-                  className={`label-muted ${(stats?.metrics?.pending_exceptions ?? 0) > 0 ? "text-amber-700 dark:text-amber-400" : ""}`}
-                >
-                  Pending Exceptions
-                </CardDescription>
-                <CardTitle
-                  className={`metric-value font-mono text-2xl ${(stats?.metrics?.pending_exceptions ?? 0) > 0 ? "text-amber-700 dark:text-amber-400" : ""}`}
-                >
+
+            {/* Pending Exceptions */}
+            <Card className={`panel ${(stats?.metrics?.pending_exceptions ?? 0) > 0 ? "bg-amber-500/5 border-amber-500/20" : "bg-background/50"}`}>
+              <CardContent className="p-4 pt-3">
+                <div className="flex items-center justify-between mb-2">
+                  <p className={`text-[10px] font-bold uppercase tracking-widest ${(stats?.metrics?.pending_exceptions ?? 0) > 0 ? "text-amber-600" : "text-muted-foreground"}`}>Exceptions</p>
+                  <Zap className={`w-3 h-3 ${(stats?.metrics?.pending_exceptions ?? 0) > 0 ? "text-amber-500/60" : "text-muted-foreground/60"}`} aria-hidden="true" />
+                </div>
+                <p className={`kpi-value ${(stats?.metrics?.pending_exceptions ?? 0) > 0 ? "text-amber-600 dark:text-amber-400" : ""}`}>
                   {stats?.metrics?.pending_exceptions ?? 0}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
+                </p>
                 {(stats?.metrics?.pending_exceptions ?? 0) > 0 ? (
                   <Link
                     href="/console/exceptions"
-                    className="text-[10px] text-amber-700 dark:text-amber-400 font-semibold hover:underline flex items-center gap-1"
+                    className="text-[10px] text-amber-600 dark:text-amber-400 font-semibold hover:underline flex items-center gap-1 mt-1"
                   >
                     <AlertCircle className="w-3 h-3" />
                     Triage now →
                   </Link>
                 ) : (
-                  <div className="text-[10px] text-muted-foreground flex items-center gap-1">
-                    <Zap className="w-3 h-3" />
-                    All exceptions resolved
-                  </div>
+                  <p className="text-[10px] text-muted-foreground mt-1">All resolved</p>
                 )}
               </CardContent>
             </Card>

--- a/packages/web/src/app/app/pipelines/page.tsx
+++ b/packages/web/src/app/app/pipelines/page.tsx
@@ -1,72 +1,63 @@
 "use client";
 
-import { Menu, Bell, Building, ChevronDown } from "lucide-react";
+import { GitBranch, Activity, AlertTriangle, Zap } from "lucide-react";
 import PipelineTable from "@/components/stitch-import/PipelineTable";
 import PipelineDrawer from "@/components/stitch-import/PipelineDrawer";
+import { PageHeader } from "@/components/app/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+
+const quickStats = [
+  { label: "Active", value: "12", icon: Activity, tone: "default" as const },
+  { label: "Error Rate", value: "0.4%", icon: AlertTriangle, tone: "warn" as const },
+  { label: "Throughput", value: "45k/s", icon: Zap, tone: "default" as const },
+];
 
 export default function PipelinesPage() {
   return (
-    <div className="bg-background-light dark:bg-background-dark text-foreground antialiased overflow-x-hidden">
-      <div className="relative flex h-full min-h-screen w-full flex-col overflow-x-hidden">
-        {/* Header & Workspace Selector */}
-        <header className="sticky top-0 z-20 flex flex-col bg-background-light dark:bg-background-dark border-b border-border">
-          <div className="flex items-center justify-between px-4 py-3">
-            <div className="flex items-center gap-3">
-              <button className="flex items-center justify-center w-8 h-8 rounded-full bg-muted text-muted-foreground">
-                <Menu className="h-5 w-5" />
-              </button>
-              <h1 className="text-lg font-bold tracking-tight">Pipelines</h1>
-            </div>
-            <div className="flex items-center gap-2">
-              <button className="relative p-2 text-muted-foreground hover:text-primary dark:hover:text-primary transition-colors">
-                <Bell className="h-6 w-6" />
-                <span className="absolute top-2 right-2 h-2 w-2 rounded-full bg-red-500 ring-2 ring-white dark:ring-[#101922]"></span>
-              </button>
-              <div className="h-8 w-8 rounded-full bg-gradient-to-tr from-primary to-blue-400 flex items-center justify-center text-white text-xs font-bold">
-                JD
+    <div className="space-y-6 pb-8">
+      <PageHeader
+        eyebrow="Execution Infrastructure"
+        title="Pipelines"
+        description="Manage reconciliation pipeline configuration and monitor execution health across all active data flows."
+        icon={GitBranch}
+        variant="hero"
+      />
+
+      {/* Quick stats strip */}
+      <div className="grid grid-cols-3 gap-4">
+        {quickStats.map((stat) => (
+          <Card
+            key={stat.label}
+            className={`panel shadow-none ${stat.tone === "warn" ? "border-amber-500/20 bg-amber-500/5" : ""}`}
+          >
+            <CardContent className="p-4 flex items-center justify-between">
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+                  {stat.label}
+                </p>
+                <p
+                  className={`text-2xl font-bold font-mono mt-0.5 ${
+                    stat.tone === "warn" ? "text-amber-600 dark:text-amber-400" : "text-foreground"
+                  }`}
+                >
+                  {stat.value}
+                </p>
               </div>
-            </div>
-          </div>
-          {/* Workspace Selector */}
-          <div className="px-4 pb-3">
-            <button className="flex w-full items-center justify-between rounded-xl bg-white dark:bg-[#192633] border border-border p-3 shadow-sm active:scale-[0.99] transition-transform">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                  <Building className="h-6 w-6" />
-                </div>
-                <div className="flex flex-col items-start">
-                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                    Workspace
-                  </span>
-                  <span className="text-sm font-semibold text-foreground">
-                    Production - US East
-                  </span>
-                </div>
-              </div>
-              <ChevronDown className="h-6 w-6 text-muted-foreground" />
-            </button>
-          </div>
-          {/* Quick Stats */}
-          <div className="flex gap-4 px-4 pb-4 overflow-x-auto no-scrollbar">
-            <div className="flex flex-col gap-1 min-w-[100px]">
-              <span className="text-xs text-muted-foreground font-medium">Active</span>
-              <span className="text-xl font-bold text-foreground">12</span>
-            </div>
-            <div className="h-8 w-[1px] bg-border self-center"></div>
-            <div className="flex flex-col gap-1 min-w-[100px]">
-              <span className="text-xs text-muted-foreground font-medium">Error Rate</span>
-              <span className="text-xl font-bold text-red-500">0.4%</span>
-            </div>
-            <div className="h-8 w-[1px] bg-border self-center"></div>
-            <div className="flex flex-col gap-1 min-w-[100px]">
-              <span className="text-xs text-muted-foreground font-medium">Throughput</span>
-              <span className="text-xl font-bold text-foreground">45k/s</span>
-            </div>
-          </div>
-        </header>
-        <PipelineTable />
-        <PipelineDrawer />
+              <stat.icon
+                className={`h-5 w-5 ${
+                  stat.tone === "warn" ? "text-amber-500/60" : "text-muted-foreground/40"
+                }`}
+                aria-hidden="true"
+              />
+            </CardContent>
+          </Card>
+        ))}
       </div>
+
+      <div className="panel overflow-hidden">
+        <PipelineTable />
+      </div>
+      <PipelineDrawer />
     </div>
   );
 }

--- a/packages/web/src/app/app/replay/page.tsx
+++ b/packages/web/src/app/app/replay/page.tsx
@@ -98,7 +98,7 @@ export default async function ReplayPage() {
                    <ShieldCheck className="h-4 w-4" />
                    Trusted Replay
                 </h3>
-                <p className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed font-semibold mb-4">
+                <p className="text-xs text-muted-foreground leading-relaxed font-semibold mb-4">
                   Settler guarantees determinism. Replay results are cryptographically checked against 
                   the original execution fingerprint stored in the immutable trust log.
                 </p>

--- a/packages/web/src/app/app/results/page.tsx
+++ b/packages/web/src/app/app/results/page.tsx
@@ -1,5 +1,7 @@
 import { getMatchesList } from "@/lib/domain/runs/runs-reader";
 import ResultsTable from "@/components/ResultsTable";
+import { PageHeader } from "@/components/app/PageHeader";
+import { TableProperties } from "lucide-react";
 
 export const metadata = {
   title: "Transaction Results | Settler",
@@ -11,17 +13,13 @@ export default async function ResultsPage() {
 
   return (
     <div className="space-y-8 pb-8">
-      <div>
-        <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary/70 mb-2">
-          Reconciliation
-        </p>
-        <h1 className="text-4xl font-bold tracking-tight text-foreground">Transaction Results</h1>
-        <p className="mt-4 max-w-2xl text-base text-muted-foreground leading-relaxed">
-          Detailed reconciliation outcomes for matched, unmatched, and flagged transactions. Drill
-          into specific matches to inspect SHA-256 evidence chains.
-        </p>
-      </div>
-
+      <PageHeader
+        eyebrow="Reconciliation"
+        title="Transaction Results"
+        description="Detailed reconciliation outcomes for matched, unmatched, and flagged transactions. Drill into specific matches to inspect SHA-256 evidence chains."
+        icon={TableProperties}
+        variant="hero"
+      />
       <ResultsTable initialMatches={matches} />
     </div>
   );

--- a/packages/web/src/app/app/rules/page.tsx
+++ b/packages/web/src/app/app/rules/page.tsx
@@ -1,41 +1,50 @@
 "use client";
 
-import { ArrowLeft, Clock, Rocket } from "lucide-react";
+import { Rocket, Clock } from "lucide-react";
 import RulesEditor from "@/components/stitch-import/RulesEditor";
+import { PageHeader } from "@/components/app/PageHeader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { FlaskConical } from "lucide-react";
 
 export default function RulesPage() {
   return (
-    <div className="bg-background-light dark:bg-background-dark text-slate-900 dark:text-slate-100 font-display min-h-screen flex flex-col overflow-hidden">
-      <header className="flex-none sticky top-0 z-50 bg-background-dark border-b border-border-dark pt-safe-top">
-        <div className="flex items-center justify-between p-4 pb-3">
-          <button className="text-white flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-surface-dark transition-colors">
-            <ArrowLeft className="h-6 w-6" />
-          </button>
-          <div className="flex flex-col items-center">
-            <h1 className="text-white text-lg font-bold leading-tight tracking-[-0.015em]">
-              Rules &amp; Configuration
-            </h1>
-            <div className="flex items-center gap-1.5">
-              <div className="size-2 rounded-full bg-emerald-500 animate-pulse"></div>
-              <p className="text-text-secondary text-xs font-medium">System Healthy • v2.3.1</p>
+    <div className="space-y-6 pb-8">
+      <PageHeader
+        eyebrow="Execution Infrastructure"
+        title="Rules & Configuration"
+        description="Define and version the tolerance rules that govern reconciliation evaluation. Changes are versioned and hash-locked before deployment."
+        icon={FlaskConical}
+        variant="hero"
+        actions={
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className="h-1.5 w-1.5 rounded-full bg-success animate-pulse" aria-hidden="true" />
+              <span>System Healthy</span>
             </div>
+            <Badge variant="outline" className="font-mono text-[10px]">v2.3.1</Badge>
           </div>
-          <button className="text-white flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-surface-dark transition-colors">
-            <Clock className="h-6 w-6" />
-          </button>
-        </div>
-      </header>
-      <RulesEditor />
-      <div className="fixed bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-background-dark via-background-dark to-transparent z-40 pointer-events-none">
-        <div className="pointer-events-auto">
-          <button
-            className="w-full bg-primary hover:bg-blue-600 disabled:bg-slate-700 disabled:text-slate-400 disabled:cursor-not-allowed text-white font-semibold py-3.5 rounded-xl shadow-lg shadow-primary/20 transition-all flex items-center justify-center gap-2"
-            disabled
-          >
-            <Rocket className="h-6 w-6" />
-            Save &amp; Deploy v2.4
-          </button>
-        </div>
+        }
+      />
+
+      <div className="panel p-0 overflow-hidden">
+        <RulesEditor />
+      </div>
+
+      <div className="flex items-center justify-end gap-3 pt-2">
+        <Button variant="outline" size="sm" className="gap-2">
+          <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+          Version History
+        </Button>
+        <Button
+          size="sm"
+          className="gap-2"
+          disabled
+          title="No pending changes to deploy"
+        >
+          <Rocket className="h-3.5 w-3.5" aria-hidden="true" />
+          Save & Deploy v2.4
+        </Button>
       </div>
     </div>
   );

--- a/packages/web/src/app/app/settings/page.tsx
+++ b/packages/web/src/app/app/settings/page.tsx
@@ -1,38 +1,80 @@
 import Link from "next/link";
 import RoleMatrix from "@/components/RoleMatrix";
 import FreezeToggle from "@/components/FreezeToggle";
+import { PageHeader } from "@/components/app/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Settings, FileSearch, Search, ArrowRight } from "lucide-react";
+
+const auditLinks = [
+  {
+    href: "/app/audit",
+    label: "Audit Surfaces",
+    description: "Inspect all tenant-scoped audit events",
+    icon: FileSearch,
+  },
+  {
+    href: "/app/evidence",
+    label: "Evidence Query Surface",
+    description: "Query cryptographic proof artifacts",
+    icon: Search,
+  },
+];
 
 export default function SettingsPage() {
   return (
-    <div className="space-y-6">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Governance
-        </p>
-        <h1 className="text-2xl font-semibold text-foreground">Tenant Isolation Controls</h1>
-        <p className="text-sm text-muted-foreground">
-          Configure runtime controls and role boundaries used to preserve multi-tenant safety.
-        </p>
-      </div>
-      <div className="rounded-xl border border-border bg-card p-4">
-        <FreezeToggle />
-      </div>
-      <div className="rounded-xl border border-border bg-card p-4">
-        <RoleMatrix />
-      </div>
-      <div className="rounded-xl border border-border bg-card p-4 text-sm text-muted-foreground">
-        Tenant isolation verification artifacts are tracked under{" "}
-        <code className="bg-muted px-1 rounded text-foreground">security/evidence</code> and
-        route-level controls are visible in the audit surfaces.
-        <div className="mt-3 flex flex-wrap gap-4">
-          <Link href="/app/audit" className="font-medium text-primary hover:underline">
-            Open Audit Surfaces →
-          </Link>
-          <Link href="/app/evidence" className="font-medium text-primary hover:underline">
-            Open Evidence Query Surface →
-          </Link>
+    <div className="space-y-8 pb-8">
+      <PageHeader
+        eyebrow="Governance"
+        title="Tenant Isolation Controls"
+        description="Configure runtime controls and role boundaries used to preserve multi-tenant safety. Changes here affect all active reconciliation workflows for this workspace."
+        icon={Settings}
+        variant="hero"
+      />
+
+      {/* Controls */}
+      <div className="space-y-4">
+        <div className="panel p-6">
+          <FreezeToggle />
+        </div>
+        <div className="panel p-6">
+          <RoleMatrix />
         </div>
       </div>
+
+      {/* Audit reference card */}
+      <Card className="border-border/60 shadow-none bg-muted/10">
+        <CardContent className="p-5">
+          <p className="text-sm text-muted-foreground leading-relaxed mb-4">
+            Tenant isolation verification artifacts are tracked under{" "}
+            <code className="code-inline">security/evidence</code>.
+            Route-level controls are visible in the audit surfaces.
+          </p>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {auditLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="group flex items-center justify-between rounded-lg border border-border/60 bg-card p-3.5 hover:border-primary/30 hover:bg-primary/5 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <div className="flex items-center gap-2.5 min-w-0">
+                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted/60 group-hover:bg-primary/10 transition-colors">
+                    <link.icon className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" aria-hidden="true" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold text-foreground group-hover:text-primary transition-colors">
+                      {link.label}
+                    </p>
+                    <p className="text-[10px] text-muted-foreground truncate">
+                      {link.description}
+                    </p>
+                  </div>
+                </div>
+                <ArrowRight className="h-3.5 w-3.5 text-muted-foreground/40 group-hover:text-primary group-hover:translate-x-0.5 transition-all shrink-0 ml-2" aria-hidden="true" />
+              </Link>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/packages/web/src/app/app/traces/page.tsx
+++ b/packages/web/src/app/app/traces/page.tsx
@@ -63,7 +63,7 @@ export default function TracesPage() {
                     </p>
                   </div>
                 </div>
-                <Badge className="bg-emerald-500/10 text-emerald-600 border-emerald-500/20">
+                <Badge variant="success">
                   COMPLETED
                 </Badge>
               </div>
@@ -179,7 +179,7 @@ export default function TracesPage() {
                 <Terminal className="h-4 w-4" />
                 Lineage Discovery
               </h3>
-              <p className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed mb-4">
+              <p className="text-xs text-muted-foreground leading-relaxed mb-4">
                 Settler uses content-addressable storage for all trace payloads, ensuring zero-drift
                 between the log and the actual data states.
               </p>

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -123,6 +123,91 @@
            focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background
            transition-colors duration-100;
   }
+
+  /* Page content shell — consistent max-width + scroll area for app pages */
+  .page-content {
+    @apply space-y-8 pb-12;
+  }
+
+  /* Section title — mid-weight section heading in a content block */
+  .section-title {
+    @apply text-base font-semibold text-foreground tracking-tight;
+  }
+
+  /* Tonal well — inset background surface for secondary content */
+  .surface-well {
+    @apply rounded-xl border border-border/60 bg-muted/20 p-4;
+  }
+
+  /* Alert / notice strip — horizontal status message */
+  .notice-strip {
+    @apply flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm;
+  }
+
+  /* Inline code — for API endpoints, hash values, identifiers */
+  .code-inline {
+    @apply font-mono text-xs rounded bg-muted/60 border border-border/60 px-1.5 py-0.5 text-foreground;
+  }
+
+  /* Evidence/proof block — visual container for audit artifact display */
+  .evidence-block {
+    @apply rounded-xl border border-border/60 bg-card p-5;
+  }
+
+  /* Sidebar nav section heading */
+  .nav-section-label {
+    @apply px-3 mb-1.5 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/60;
+  }
+
+  /* Run status pill — small inline badge for run/job state */
+  .run-status-pill {
+    @apply inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide border;
+  }
+
+  /* Action strip — bottom-of-card or below-header CTA row */
+  .action-strip {
+    @apply flex flex-wrap items-center gap-3 pt-2;
+  }
+
+  /* Stat strip — horizontal row of KPI tiles */
+  .stat-strip {
+    @apply grid gap-4 sm:grid-cols-2 lg:grid-cols-4;
+  }
+
+  /* Highlighted metric number */
+  .kpi-value {
+    @apply text-3xl font-bold font-mono tabular-nums tracking-tight;
+  }
+
+  /* Tinted info notice */
+  .info-well {
+    @apply rounded-lg border border-blue-500/20 bg-blue-500/5 p-4;
+  }
+
+  /* Warning notice */
+  .warn-well {
+    @apply rounded-lg border border-amber-500/20 bg-amber-500/5 p-4;
+  }
+
+  /* Error/critical notice */
+  .error-well {
+    @apply rounded-lg border border-destructive/20 bg-destructive/5 p-4;
+  }
+
+  /* Success notice */
+  .success-well {
+    @apply rounded-lg border border-success/20 bg-success/5 p-4;
+  }
+
+  /* Timeline track — left border + spacing for event streams */
+  .timeline-track {
+    @apply relative pl-5 border-l border-border/60 space-y-5;
+  }
+
+  /* Timeline node dot */
+  .timeline-node {
+    @apply absolute -left-[5px] top-1.5 h-2.5 w-2.5 rounded-full border-2 border-background;
+  }
 }
 
 @layer base {

--- a/packages/web/src/components/ControlPlaneOverview.tsx
+++ b/packages/web/src/components/ControlPlaneOverview.tsx
@@ -56,13 +56,13 @@ const ControlPlaneOverview: React.FC<ControlPlaneOverviewProps> = ({ health }) =
   const getStatusColor = (status: string) => {
     switch (status) {
       case "healthy":
-        return "border-green-200 bg-green-50 text-green-700";
+        return "border-green-500/20 bg-green-500/8 text-green-700 dark:text-green-400";
       case "degraded":
-        return "border-yellow-200 bg-yellow-50 text-yellow-700";
+        return "border-yellow-500/20 bg-yellow-500/8 text-yellow-700 dark:text-yellow-400";
       case "unhealthy":
-        return "border-red-200 bg-red-50 text-red-700";
+        return "border-red-500/20 bg-red-500/8 text-red-700 dark:text-red-400";
       default:
-        return "border-gray-200 bg-gray-50 text-gray-700";
+        return "border-border bg-muted/20 text-muted-foreground";
     }
   };
 
@@ -70,28 +70,28 @@ const ControlPlaneOverview: React.FC<ControlPlaneOverviewProps> = ({ health }) =
     switch (status) {
       case "healthy":
         return (
-          <span className="inline-flex items-center gap-1.5 rounded-md border border-green-200 bg-green-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-green-700 shadow-sm">
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-green-500/25 bg-green-500/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-green-700 dark:text-green-400">
             <span className="h-2 w-2 rounded-full bg-green-500" aria-hidden="true" />
             Healthy
           </span>
         );
       case "degraded":
         return (
-          <span className="inline-flex items-center gap-1.5 rounded-md border border-yellow-200 bg-yellow-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-yellow-700 shadow-sm">
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-yellow-500/25 bg-yellow-500/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-yellow-700 dark:text-yellow-400">
             <span className="h-2 w-2 rounded-full bg-yellow-500" aria-hidden="true" />
             Degraded
           </span>
         );
       case "unhealthy":
         return (
-          <span className="inline-flex items-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-red-700 shadow-sm">
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-red-500/25 bg-red-500/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-red-700 dark:text-red-400">
             <span className="h-2 w-2 rounded-full bg-red-500" aria-hidden="true" />
             Unhealthy
           </span>
         );
       default:
         return (
-          <span className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-gray-700 shadow-sm">
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted/30 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
             Unknown
           </span>
         );
@@ -107,17 +107,17 @@ const ControlPlaneOverview: React.FC<ControlPlaneOverviewProps> = ({ health }) =
       {/* Overall System Status */}
       <div>
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-base font-bold text-slate-900">Overall System Status</h2>
+          <h2 className="text-base font-bold text-foreground">Overall System Status</h2>
           {getStatusBadge(health.status)}
         </div>
 
         {health.status === "unhealthy" && (
-          <div className="rounded-lg border border-red-200 bg-red-50 p-4 mb-4">
+          <div className="error-well mb-4">
             <div className="flex items-start gap-3">
-              <AlertTriangle className="h-5 w-5 text-red-600 mt-0.5" aria-hidden="true" />
+              <AlertTriangle className="h-5 w-5 text-destructive mt-0.5 shrink-0" aria-hidden="true" />
               <div>
-                <h3 className="text-sm font-bold text-red-900">System Degradation Detected</h3>
-                <p className="mt-1 text-xs text-red-700">
+                <h3 className="text-sm font-bold text-foreground">System Degradation Detected</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
                   One or more critical dependencies are unhealthy. Review dependency status below.
                 </p>
               </div>
@@ -128,7 +128,7 @@ const ControlPlaneOverview: React.FC<ControlPlaneOverviewProps> = ({ health }) =
 
       {/* Dependency Health Status */}
       <div>
-        <h2 className="text-base font-bold text-slate-900 mb-3">Service Dependencies</h2>
+        <h2 className="text-base font-bold text-foreground mb-3">Service Dependencies</h2>
         <div className="space-y-3">
           {dependencies.map(([name, check]) => (
             <div key={name} className={`rounded-lg border p-4 ${getStatusColor(check.status)}`}>

--- a/packages/web/src/components/admin/AdminPageHeader.tsx
+++ b/packages/web/src/components/admin/AdminPageHeader.tsx
@@ -1,0 +1,75 @@
+/**
+ * AdminPageHeader — Shared admin page header primitive.
+ *
+ * Wraps the app-level PageHeader with admin-appropriate defaults
+ * (no hero gradient — admin surfaces use a more subdued, operational aesthetic).
+ * Accepts the same props as PageHeader.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { type LucideIcon } from "lucide-react";
+
+export interface AdminPageHeaderProps {
+  /** Small uppercase eyebrow label above the title */
+  eyebrow?: string;
+  /** Main page title */
+  title: string;
+  /** Supplementary description below the title */
+  description?: string;
+  /** Optional Lucide icon shown alongside the title */
+  icon?: LucideIcon;
+  /** Action buttons / controls rendered on the right */
+  actions?: React.ReactNode;
+  /** Additional className applied to the outer wrapper */
+  className?: string;
+  /** Meta/status info rendered below the description */
+  children?: React.ReactNode;
+}
+
+export function AdminPageHeader({
+  eyebrow,
+  title,
+  description,
+  icon: Icon,
+  actions,
+  className,
+  children,
+}: AdminPageHeaderProps) {
+  return (
+    <div className={cn("border-b border-border/60 bg-card/30 px-6 py-5 sm:px-8", className)}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 max-w-2xl">
+          {eyebrow && (
+            <p className="mb-1.5 text-[10px] font-bold uppercase tracking-[0.18em] text-muted-foreground/70">
+              {eyebrow}
+            </p>
+          )}
+          <div className="flex items-center gap-2.5">
+            {Icon && (
+              <div
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10"
+                aria-hidden="true"
+              >
+                <Icon className="h-4 w-4 text-primary" />
+              </div>
+            )}
+            <h1 className="text-xl font-bold tracking-tight text-foreground sm:text-2xl">
+              {title}
+            </h1>
+          </div>
+          {description && (
+            <p className="mt-2 text-sm text-muted-foreground leading-relaxed">{description}</p>
+          )}
+          {children && <div className="mt-2">{children}</div>}
+        </div>
+
+        {actions && (
+          <div className="flex flex-wrap items-center gap-2 shrink-0 pt-1">
+            {actions}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/app/AppNav.tsx
+++ b/packages/web/src/components/app/AppNav.tsx
@@ -2,7 +2,26 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Menu } from "lucide-react";
+import {
+  Menu,
+  LayoutDashboard,
+  Play,
+  ShieldCheck,
+  RefreshCcw,
+  FlaskConical,
+  Bell,
+  BarChart2,
+  Activity,
+  Search,
+  Plug,
+  FileSearch,
+  Settings,
+  ScrollText,
+  BookOpen,
+  Database,
+  GitBranch,
+  type LucideIcon,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SettlerLogo } from "@/components/brand/SettlerLogo";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
@@ -11,28 +30,28 @@ const navSections = [
   {
     label: "Execution Infrastructure",
     items: [
-      { name: "Control Plane", href: "/app", exact: true },
-      { name: "Run Explorer", href: "/app/runs" },
-      { name: "Truth Explorer", href: "/app/proofs" },
-      { name: "Replay Lab", href: "/app/replay" },
-      { name: "Policy Lab", href: "/app/policies" },
+      { name: "Control Plane", href: "/app", exact: true, icon: LayoutDashboard },
+      { name: "Run Explorer", href: "/app/runs", icon: Play },
+      { name: "Truth Explorer", href: "/app/proofs", icon: ShieldCheck },
+      { name: "Replay Lab", href: "/app/replay", icon: RefreshCcw },
+      { name: "Policy Lab", href: "/app/policies", icon: FlaskConical },
     ],
   },
   {
     label: "Operator Intelligence",
     items: [
-      { name: "Live Alerts", href: "/app/alerts" },
-      { name: "Runtime Event Signals", href: "/app/metrics" },
-      { name: "System Telemetry", href: "/app/system-health" },
-      { name: "Evidence Query Surface", href: "/app/evidence" },
-      { name: "Integrations", href: "/app/integrations" },
+      { name: "Live Alerts", href: "/app/alerts", icon: Bell },
+      { name: "Runtime Event Signals", href: "/app/metrics", icon: BarChart2 },
+      { name: "System Telemetry", href: "/app/system-health", icon: Activity },
+      { name: "Evidence Query Surface", href: "/app/evidence", icon: Search },
+      { name: "Integrations", href: "/app/integrations", icon: Plug },
     ],
   },
   {
     label: "Governance",
     items: [
-      { name: "Audit Surfaces", href: "/app/audit" },
-      { name: "Tenant Isolation Controls", href: "/app/settings" },
+      { name: "Audit Surfaces", href: "/app/audit", icon: FileSearch },
+      { name: "Tenant Isolation Controls", href: "/app/settings", icon: Settings },
     ],
   },
 ];
@@ -40,11 +59,12 @@ const navSections = [
 interface NavItemProps {
   href: string;
   name: string;
+  icon: LucideIcon;
   exact?: boolean;
   onClick?: () => void;
 }
 
-function NavItem({ href, name, exact = false, onClick }: NavItemProps) {
+function NavItem({ href, name, icon: Icon, exact = false, onClick }: NavItemProps) {
   const pathname = usePathname();
   const isActive = exact ? pathname === href : pathname === href || pathname.startsWith(href + "/");
 
@@ -54,24 +74,34 @@ function NavItem({ href, name, exact = false, onClick }: NavItemProps) {
       onClick={onClick}
       aria-current={isActive ? "page" : undefined}
       className={cn(
-        "block rounded-[var(--sidebar-item-radius,6px)] px-3 py-2 text-sm transition-colors duration-150",
+        "flex items-center gap-2.5 rounded-[var(--sidebar-item-radius,6px)] px-3 py-2 text-sm transition-all duration-150",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         isActive
-          ? "bg-primary/10 text-foreground font-medium"
+          ? "bg-primary/10 text-primary font-semibold"
           : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
       )}
     >
-      {name}
+      <Icon
+        className={cn(
+          "h-4 w-4 shrink-0 transition-colors",
+          isActive ? "text-primary" : "text-muted-foreground/70"
+        )}
+        aria-hidden="true"
+      />
+      <span className="truncate">{name}</span>
+      {isActive && (
+        <span className="ml-auto h-1.5 w-1.5 rounded-full bg-primary shrink-0" aria-hidden="true" />
+      )}
     </Link>
   );
 }
 
 function NavSections({ onItemClick }: { onItemClick?: () => void }) {
   return (
-    <nav aria-label="App navigation" className="flex-1 space-y-4 overflow-y-auto p-3">
+    <nav aria-label="App navigation" className="flex-1 space-y-5 overflow-y-auto p-3">
       {navSections.map((section) => (
         <div key={section.label}>
-          <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          <p className="mb-1.5 px-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/60">
             {section.label}
           </p>
           <div className="space-y-0.5">
@@ -80,6 +110,7 @@ function NavSections({ onItemClick }: { onItemClick?: () => void }) {
                 key={item.href}
                 href={item.href}
                 name={item.name}
+                icon={item.icon}
                 exact={item.exact}
                 onClick={onItemClick}
               />
@@ -94,11 +125,21 @@ function NavSections({ onItemClick }: { onItemClick?: () => void }) {
 // Sidebar for md+ screens
 export function AppSidebar() {
   return (
-    <aside className="hidden md:flex w-72 flex-col border-r border-border bg-card dark:bg-card">
-      <Link href="/" className="flex border-b border-border p-4">
-        <SettlerLogo variant="horizontal" className="h-8 w-auto" priority />
-      </Link>
+    <aside className="hidden md:flex w-64 flex-col border-r border-border bg-card/80 backdrop-blur-sm">
+      <div className="flex h-14 shrink-0 items-center border-b border-border px-4">
+        <Link href="/" className="flex items-center" aria-label="Settler home">
+          <SettlerLogo variant="horizontal" className="h-7 w-auto" priority />
+        </Link>
+      </div>
       <NavSections />
+      <div className="border-t border-border/60 p-3">
+        <div className="flex items-center gap-2 rounded-md px-3 py-2">
+          <Database className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" aria-hidden="true" />
+          <span className="text-[10px] text-muted-foreground/50 font-medium uppercase tracking-wide">
+            Settler v2
+          </span>
+        </div>
+      </div>
     </aside>
   );
 }
@@ -115,11 +156,11 @@ export function MobileNav() {
           <Menu className="h-5 w-5" aria-hidden="true" />
         </button>
       </SheetTrigger>
-      <SheetContent side="left" className="w-72 p-0 flex flex-col">
-        <SheetHeader className="border-b border-border p-4">
+      <SheetContent side="left" className="w-64 p-0 flex flex-col bg-card/95 backdrop-blur-sm">
+        <SheetHeader className="h-14 flex-row items-center border-b border-border px-4">
           <SheetTitle className="sr-only">Navigation</SheetTitle>
           <Link href="/">
-            <SettlerLogo variant="horizontal" className="h-8 w-auto" priority />
+            <SettlerLogo variant="horizontal" className="h-7 w-auto" priority />
           </Link>
         </SheetHeader>
         <NavSections />

--- a/packages/web/src/components/app/PageHeader.tsx
+++ b/packages/web/src/components/app/PageHeader.tsx
@@ -1,0 +1,100 @@
+/**
+ * PageHeader — Shared operator app page header primitive.
+ *
+ * Handles eyebrow / title / description / actions in a consistent
+ * layout across all /app/* pages. Supports an optional decorative
+ * background icon, an optional hero variant with gradient backdrop,
+ * and slot for action buttons on the right.
+ *
+ * Usage:
+ *   <PageHeader
+ *     eyebrow="Operator Intelligence"
+ *     title="Live Alerts"
+ *     description="Monitor infrastructure-level drift and reconciliation failures."
+ *     icon={Bell}
+ *     actions={<Button>New Run</Button>}
+ *   />
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { type LucideIcon } from "lucide-react";
+
+export interface PageHeaderProps {
+  /** Small uppercase eyebrow label above the title */
+  eyebrow?: string;
+  /** Main page title */
+  title: string;
+  /** Supplementary description below the title */
+  description?: string;
+  /** Optional Lucide icon — renders large and decorative in the background */
+  icon?: LucideIcon;
+  /** Action buttons / controls rendered on the right (desktop) or below description (mobile) */
+  actions?: React.ReactNode;
+  /** Visual variant — 'default' is a plain header, 'hero' adds gradient backdrop */
+  variant?: "default" | "hero";
+  /** Additional className applied to the outer wrapper */
+  className?: string;
+  /** Additional content rendered below the description */
+  children?: React.ReactNode;
+}
+
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  icon: Icon,
+  actions,
+  variant = "default",
+  className,
+  children,
+}: PageHeaderProps) {
+  return (
+    <section
+      className={cn(
+        "relative overflow-hidden",
+        variant === "hero"
+          ? "rounded-2xl border border-primary/10 bg-gradient-to-br from-primary/5 via-background to-background p-6 sm:p-8 shadow-sm"
+          : "pb-6",
+        className
+      )}
+    >
+      {/* Decorative background icon */}
+      {Icon && variant === "hero" && (
+        <div
+          className="pointer-events-none absolute -right-10 -top-10 opacity-[0.03] select-none"
+          aria-hidden="true"
+        >
+          <Icon size={280} className="text-primary" />
+        </div>
+      )}
+
+      <div className="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        {/* Text block */}
+        <div className="max-w-3xl min-w-0">
+          {eyebrow && (
+            <p className="mb-2 text-xs font-bold uppercase tracking-[0.18em] text-primary/70">
+              {eyebrow}
+            </p>
+          )}
+          <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {title}
+          </h1>
+          {description && (
+            <p className="mt-3 max-w-2xl text-base text-muted-foreground leading-relaxed">
+              {description}
+            </p>
+          )}
+          {children && <div className="mt-3">{children}</div>}
+        </div>
+
+        {/* Actions */}
+        {actions && (
+          <div className="flex flex-wrap items-center gap-2 shrink-0">
+            {actions}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
- AppNav: add Lucide icons to all nav items, active dot indicator, tighter section labels, version footer
- App layout: improve header with tenant pill (success dot + truncated ID), alert/settings quick-links
- Create PageHeader component: shared eyebrow/title/description/actions/hero-gradient primitive
- globals.css: add 16 new utility classes (page-content, section-title, evidence-block, timeline-track, notice-strip, info/warn/error/success-well, kpi-value, code-inline, stat-strip, etc.)
- Governance page: fix legacy CSS classes (bg-background-light, dark:bg-background-dark, etc.) that didn't exist in design system; convert to design-system classes + timeline-track
- Evidence page: promote to hero PageHeader, richer query-mode cards with badges, icon containers, improved related-links
- Metrics page: hero PageHeader, proper empty state with icon, LatencyBadge color tiers, role/table accessibility, context note strip
- Connections page: hero PageHeader with icon, consistent panel wrapping
- Integrations page: hero PageHeader with icon + action buttons
- Settings page: hero PageHeader with icon, audit-link grid replacing plain link list
- Admin layout: icons on all nav items, premium sidebar header with tenant dot, consistent section labels, reduced width 64→60
- ControlPlaneOverview: fix hardcoded text-slate-900 → text-foreground; replace hardcoded light-mode colors with dark-mode-safe design-system tokens (status pills, health cards, alert panel)

https://claude.ai/code/session_01T9wzyE9WiN3ZrBRFNrrAd8