### PR TITLE
Make console webhooks degraded state explicit across API and UI

### DIFF
--- a/packages/web/src/__tests__/api/console-webhooks-route.test.ts
+++ b/packages/web/src/__tests__/api/console-webhooks-route.test.ts
@@ -1,0 +1,86 @@
+/** @jest-environment node */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/console/webhooks/route";
+
+jest.mock("@/middleware/billing-gate-universal", () => ({
+  withUniversalBillingGate: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+const requireAuth = jest.fn();
+const listWebhooks = jest.fn();
+
+jest.mock("@/lib/api/unified-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+jest.mock("@/lib/webhooks/manager", () => ({
+  listWebhooks: (...args: unknown[]) => listWebhooks(...args),
+  createWebhook: jest.fn(),
+}));
+
+const appLoggerError = jest.fn();
+
+jest.mock("@/lib/utils/logger", () => ({
+  appLogger: {
+    error: (...args: unknown[]) => appLoggerError(...args),
+  },
+}));
+
+function makeRequest() {
+  return new NextRequest("http://localhost/api/console/webhooks");
+}
+
+describe("/api/console/webhooks GET truth semantics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns explicit available capability on success", async () => {
+    requireAuth.mockResolvedValue({ userId: "user-1", tenantId: "tenant-1" });
+    listWebhooks.mockResolvedValue([
+      {
+        id: "wh_1",
+        url: "https://example.com/hook",
+        events: ["reconciliation.completed"],
+        secret: "abcdefghijklmnopqrst",
+      },
+    ]);
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.capability).toEqual({ state: "available" });
+    expect(body.webhooks).toHaveLength(1);
+    expect(body.webhooks[0].secret).toBe("abcdefghijkl...");
+  });
+
+  it("returns explicit degraded capability and 503 when list lookup fails", async () => {
+    requireAuth.mockResolvedValue({ userId: "user-1", tenantId: "tenant-1" });
+    listWebhooks.mockRejectedValue(new Error("database timeout"));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.webhooks).toEqual([]);
+    expect(body.capability).toEqual({ state: "degraded", reason: "webhook_list_unavailable" });
+    expect(appLoggerError).toHaveBeenCalled();
+  });
+
+  it("returns explicit unavailable capability when auth context is missing", async () => {
+    requireAuth.mockResolvedValue({ userId: "" });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.capability).toEqual({ state: "unavailable", reason: "auth_required" });
+    expect(body.error).toBe("Unauthorized");
+  });
+});

--- a/packages/web/src/app/api/console/webhooks/route.ts
+++ b/packages/web/src/app/api/console/webhooks/route.ts
@@ -1,86 +1,135 @@
 /**
  * Webhooks API Route
- * 
+ *
  * GET - List webhooks
  * POST - Create webhook
  */
 
-import { NextRequest, NextResponse } from 'next/server';
-import { requireAuth } from '@/lib/api/unified-auth';
-import { createWebhook, listWebhooks, CreateWebhookInput } from '@/lib/webhooks/manager';
-import { withUniversalBillingGate } from '@/middleware/billing-gate-universal';
-import { appLogger } from '@/lib/utils/logger';
-import { withSecurity } from '@/lib/middleware/api-security';
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api/unified-auth";
+import { createWebhook, listWebhooks, CreateWebhookInput } from "@/lib/webhooks/manager";
+import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
+import { appLogger } from "@/lib/utils/logger";
+import { withSecurity } from "@/lib/middleware/api-security";
 
-export const dynamic = 'force-dynamic';
-export const runtime = 'nodejs';
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
 export const GET = withSecurity(
-  withUniversalBillingGate(async function GET(request: NextRequest) {
-  try {
-    const authContext = await requireAuth(request);
-    
-    if (!authContext.userId) {
-      return NextResponse.json({ webhooks: [] });
-    }
+  withUniversalBillingGate(
+    async function GET(request: NextRequest) {
+      try {
+        const authContext = await requireAuth(request);
 
-    const webhooks = await listWebhooks(authContext.userId, authContext.tenantId || authContext.userId);
+        if (!authContext.userId) {
+          return NextResponse.json(
+            {
+              error: "Unauthorized",
+              capability: {
+                state: "unavailable",
+                reason: "auth_required",
+              },
+            },
+            { status: 401 }
+          );
+        }
 
-    // Don't expose secrets in list
-    const safeWebhooks = webhooks.map((w) => ({
-      ...w,
-      secret: w.secret.substring(0, 12) + '...', // Show only prefix
-    }));
+        const webhooks = await listWebhooks(
+          authContext.userId,
+          authContext.tenantId || authContext.userId
+        );
 
-    return NextResponse.json({ webhooks: safeWebhooks });
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('Unauthorized')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    appLogger.error('[Webhooks API] Error', error);
-    return NextResponse.json({ webhooks: [] });
-  }
-}, { feature: 'GET API' }),
+        // Don't expose secrets in list
+        const safeWebhooks = webhooks.map((w) => ({
+          ...w,
+          secret: w.secret.substring(0, 12) + "...", // Show only prefix
+        }));
+
+        return NextResponse.json({
+          webhooks: safeWebhooks,
+          capability: {
+            state: "available",
+          },
+        });
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("Unauthorized")) {
+          return NextResponse.json(
+            {
+              error: "Unauthorized",
+              capability: {
+                state: "unavailable",
+                reason: "auth_required",
+              },
+            },
+            { status: 401 }
+          );
+        }
+        appLogger.error("[Webhooks API] Error", error);
+        return NextResponse.json(
+          {
+            error: "Webhook list is currently unavailable",
+            webhooks: [],
+            capability: {
+              state: "degraded",
+              reason: "webhook_list_unavailable",
+            },
+          },
+          { status: 503 }
+        );
+      }
+    },
+    { feature: "GET API" }
+  ),
   { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: true }
 );
 
 export const POST = withSecurity(
-  withUniversalBillingGate(async function POST(request: NextRequest) {
-  try {
-    const authContext = await requireAuth(request);
-    
-    if (!authContext.userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+  withUniversalBillingGate(
+    async function POST(request: NextRequest) {
+      try {
+        const authContext = await requireAuth(request);
 
-    const body = await request.json().catch(() => ({}));
-    
-    // Validate inputs
-    if (!body.url || typeof body.url !== 'string') {
-      return NextResponse.json({ error: 'URL is required and must be a string' }, { status: 400 });
-    }
+        if (!authContext.userId) {
+          return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
 
-    if (!body.events || !Array.isArray(body.events)) {
-      return NextResponse.json({ error: 'Events must be an array' }, { status: 400 });
-    }
+        const body = await request.json().catch(() => ({}));
 
-    const input: CreateWebhookInput = {
-      url: body.url,
-      events: body.events,
-      secret: body.secret,
-    };
+        // Validate inputs
+        if (!body.url || typeof body.url !== "string") {
+          return NextResponse.json(
+            { error: "URL is required and must be a string" },
+            { status: 400 }
+          );
+        }
 
-    const webhook = await createWebhook(authContext.userId, authContext.tenantId || authContext.userId, input);
+        if (!body.events || !Array.isArray(body.events)) {
+          return NextResponse.json({ error: "Events must be an array" }, { status: 400 });
+        }
 
-    // Return full secret only on creation
-    return NextResponse.json({ webhook }, { status: 201 });
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('Unauthorized')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    const errorMessage = error instanceof Error ? error.message : 'Failed to create webhook';
-    return NextResponse.json({ error: errorMessage }, { status: 400 });
-  }
-}, { feature: 'POST API' }),
+        const input: CreateWebhookInput = {
+          url: body.url,
+          events: body.events,
+          secret: body.secret,
+        };
+
+        const webhook = await createWebhook(
+          authContext.userId,
+          authContext.tenantId || authContext.userId,
+          input
+        );
+
+        // Return full secret only on creation
+        return NextResponse.json({ webhook }, { status: 201 });
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("Unauthorized")) {
+          return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const errorMessage = error instanceof Error ? error.message : "Failed to create webhook";
+        return NextResponse.json({ error: errorMessage }, { status: 400 });
+      }
+    },
+    { feature: "POST API" }
+  ),
   { rateLimit: { windowMs: 60000, maxRequests: 20 }, requireAuth: true }
 );

--- a/packages/web/src/app/console/webhooks/page.tsx
+++ b/packages/web/src/app/console/webhooks/page.tsx
@@ -52,6 +52,16 @@ interface Webhook {
   failureCount: number;
 }
 
+interface WebhooksCapability {
+  state?: "available" | "degraded" | "unavailable";
+  reason?: string;
+}
+
+interface WebhooksListResponse {
+  webhooks?: Webhook[];
+  error?: string;
+  capability?: WebhooksCapability;
+}
 const availableEvents = [
   "reconciliation.completed",
   "reconciliation.failed",
@@ -70,6 +80,10 @@ export default function WebhooksPage() {
   const [newWebhookEvents, setNewWebhookEvents] = useState<string[]>([]);
   const [formError, setFormError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [capabilityState, setCapabilityState] = useState<"available" | "degraded" | "unavailable">(
+    "available"
+  );
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [togglingId, setTogglingId] = useState<string | null>(null);
@@ -81,13 +95,23 @@ export default function WebhooksPage() {
   const fetchWebhooks = async () => {
     try {
       setLoading(true);
+      setLoadError(null);
       const res = await fetch("/api/console/webhooks");
-      if (res.ok) {
-        const data = await res.json();
-        setWebhooks(data.webhooks || []);
+      const data = (await res.json().catch(() => ({}))) as WebhooksListResponse;
+
+      if (!res.ok) {
+        setCapabilityState(data.capability?.state === "unavailable" ? "unavailable" : "degraded");
+        setLoadError(data.error || "Webhook endpoints are currently unavailable.");
+        setWebhooks([]);
+        return;
       }
+
+      setWebhooks(Array.isArray(data.webhooks) ? data.webhooks : []);
+      setCapabilityState(data.capability?.state || "available");
     } catch {
-      // Silent — empty list is a safe degraded state
+      setCapabilityState("degraded");
+      setLoadError("Network error while loading webhooks. Check connectivity and try again.");
+      setWebhooks([]);
     } finally {
       setLoading(false);
     }
@@ -198,6 +222,28 @@ export default function WebhooksPage() {
           </div>
         </div>
 
+        {loadError && (
+          <div className="flex items-start gap-3 rounded-lg border border-amber-400/30 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/30 dark:text-amber-100">
+            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" aria-hidden="true" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium">
+                {capabilityState === "unavailable"
+                  ? "Webhook management is unavailable for this session."
+                  : "Webhook data is currently degraded."}
+              </p>
+              <p className="text-sm">{loadError}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-1"
+                onClick={() => void fetchWebhooks()}
+              >
+                Retry
+              </Button>
+            </div>
+          </div>
+        )}
+
         {actionError && (
           <div className="flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
             <AlertCircle
@@ -299,8 +345,12 @@ export default function WebhooksPage() {
             <CardContent className="p-0">
               <EmptyState
                 icon={Plus}
-                title="No webhooks configured"
-                description="Create a webhook to receive real-time event notifications."
+                title={loadError ? "Webhook data unavailable" : "No webhooks configured"}
+                description={
+                  loadError
+                    ? "Settler could not load webhook state. Resolve connectivity or auth issues and retry."
+                    : "Create a webhook to receive real-time event notifications."
+                }
                 action={{
                   label: "Create Webhook",
                   onClick: () => {


### PR DESCRIPTION
### Motivation
- Close an operator-trust gap where webhook-list failures were silently rendered as an empty healthy state, violating the repo’s requirement for machine-visible degraded states and tenant-truthful responses. 
- Ensure the console surfaces explicit capability/truth semantics so operators can triage auth, degraded, and unavailable conditions rather than assuming “no webhooks” is normal. 
- Keep the smallest scoped change that centralizes degraded-capability semantics at the route and surfaces it in the UI while preserving tenant isolation and secret-safety.

### Description
- API: `GET /api/console/webhooks` now returns a machine-visible `capability` envelope (`state: "available" | "degraded" | "unavailable"`, optional `reason`) and uses appropriate HTTP statuses (`200` for success, `503` for degraded list failures, `401` when auth is missing), while still redacting webhook secrets; file changed: `packages/web/src/app/api/console/webhooks/route.ts`.
- UI: Console Webhooks page now consumes the `capability` envelope and shows an explicit degraded/unavailable alert with retry and contextual copy instead of silently falling back to an empty-state-only view; it also adds local `loadError` and `capabilityState` handling; file changed: `packages/web/src/app/console/webhooks/page.tsx`.
- Tests: added contract/regression tests that assert explicit capability semantics for success, backend failure (degraded + 503), and missing-auth (unavailable + 401); new test: `packages/web/src/__tests__/api/console-webhooks-route.test.ts`.

### Testing
- Ran the targeted unit test: `pnpm --filter @settler/web test -- --runInBand src/__tests__/api/console-webhooks-route.test.ts`, and the test suite passed (3/3 tests). ✅
- Ran lint for the web package with `pnpm --filter @settler/web lint`; lint completed (warnings exist elsewhere in the repo but are unrelated to this change). ✅
- Per-repo typecheck/build: a full `pnpm --filter @settler/web typecheck` and `pnpm --filter @settler/web build` cannot complete in this environment due to pre-existing workspace issues (missing/broken `@settler/reconciliation-core` type resolution and required build env vars such as `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and DB URL), so full package/typecheck/build are marked with environment/preceding-issue warnings; a scoped `tsc --noEmit --skipLibCheck` over the changed files completed for verification of the edited surfaces. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdc161b2f483288d7ed13c8c84e1c8)