### PR TITLE
Harden run/exception list truth signals and add exception proofpack + activation support bundle

### DIFF
--- a/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
+++ b/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
@@ -48,8 +48,13 @@ jest.mock("@/lib/logger", () => ({
 }));
 
 jest.mock("@/shared/db/prismaClient", () => ({
-  prisma: {},
+  prisma: {
+    reconciliationMatch: { findMany: jest.fn() },
+    exceptionAdjudicationMemory: { findMany: jest.fn() },
+    proofPackage: { findMany: jest.fn() },
+  },
 }));
+import { prisma } from "@/shared/db/prismaClient";
 
 function req(url: string) {
   return {
@@ -127,6 +132,9 @@ describe("GET /api/runs", () => {
     fetchMergedReconciliationRunsPageMock.mockReset();
     decodeMergedRunsCursorMock.mockReset();
     mapCanonicalListItemToApiRunsLegacyRowMock.mockReset();
+    (prisma as any).reconciliationMatch.findMany.mockReset();
+    (prisma as any).exceptionAdjudicationMemory.findMany.mockReset();
+    (prisma as any).proofPackage.findMany.mockReset();
 
     requireAuthMock.mockResolvedValue({ tenantId: "tenant-1", userId: "u1", type: "session" });
     resolveTenantMembershipScopeMock.mockResolvedValue({
@@ -194,6 +202,9 @@ describe("GET /api/runs", () => {
         targetAdapter: row.adapters.targetAdapter,
       })
     );
+    (prisma as any).reconciliationMatch.findMany.mockResolvedValue([]);
+    (prisma as any).exceptionAdjudicationMemory.findMany.mockResolvedValue([]);
+    (prisma as any).proofPackage.findMany.mockResolvedValue([]);
   });
 
   it("returns 400 for invalid run_kind", async () => {
@@ -225,6 +236,7 @@ describe("GET /api/runs", () => {
     expect(body.items[0].id).toBe("job-1");
     expect(body.items[0].runKind).toBe("recon_job");
     expect(body.items[0].sourceModel).toBe("recon_jobs");
+    expect(body.items[0].compactProofSummary.proofPackages.state).toBe("setup_required");
     expect(body.items[0].detailHref).toBe("/console/runs/job-1");
     expect(body.next_cursor).toBe("next");
     expect(body.response_meta.pagination_mode).toBe("merged_cursor");

--- a/packages/web/src/__tests__/api/console-activation-route.test.ts
+++ b/packages/web/src/__tests__/api/console-activation-route.test.ts
@@ -1,0 +1,70 @@
+/** @jest-environment node */
+
+const getConsoleActivationOverviewMock = jest.fn();
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+jest.mock("@/middleware/billing-gate-universal", () => ({
+  withUniversalBillingGate: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/server/console/activation-overview", () => ({
+  getConsoleActivationOverview: (...args: unknown[]) => getConsoleActivationOverviewMock(...args),
+}));
+
+import { GET as getActivation } from "@/app/api/console/activation/route";
+
+describe("GET /api/console/activation", () => {
+  beforeEach(() => {
+    getConsoleActivationOverviewMock.mockReset();
+  });
+
+  it("returns support bundle with explicit blockers", async () => {
+    getConsoleActivationOverviewMock.mockResolvedValue({
+      generatedAt: "2026-04-03T00:00:00.000Z",
+      overallState: "degraded",
+      authState: "authenticated",
+      counts: {
+        workspaces: 1,
+        activeWorkspaces: 1,
+        connectedIntegrations: 0,
+        reconciliationRuns: 0,
+        unresolvedExceptions: 0,
+        adjudicationMemories: 0,
+        evidenceArtifacts: 0,
+        degradedEvidenceArtifacts: 0,
+        finalizedProofPackages: 0,
+      },
+      workspaces: [],
+      systemChecks: [],
+      journeyChecks: [],
+      tasks: [],
+      supportBundle: {
+        generatedAt: "2026-04-03T00:00:00.000Z",
+        summary: "1 activation blocker requires follow-up.",
+        blockers: [
+          {
+            id: "integration_readiness",
+            label: "Integration readiness",
+            state: "setup_required",
+            summary: "No integration connected",
+            detail: "Connect data source",
+            actionLabel: "Connect data",
+            href: "/console/onboarding",
+          },
+        ],
+        recommendedNextActions: ["Connect data: Integration readiness"],
+      },
+      lastRunAt: null,
+      lastDecisionAt: null,
+    });
+
+    const response = await getActivation();
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.data.supportBundle.blockers).toHaveLength(1);
+    expect(payload.data.supportBundle.blockers[0].state).toBe("setup_required");
+  });
+});

--- a/packages/web/src/__tests__/api/exceptions-runtime-integrity.test.ts
+++ b/packages/web/src/__tests__/api/exceptions-runtime-integrity.test.ts
@@ -65,6 +65,7 @@ jest.mock("@/lib/utils/logger", () => ({
 
 import { GET as getExceptions } from "@/app/api/exceptions/route";
 import { GET as getExceptionDetail } from "@/app/api/exceptions/[exceptionId]/route";
+import { GET as getExceptionProofpack } from "@/app/api/exceptions/[exceptionId]/proofpack/route";
 
 function req(url: string) {
   return {
@@ -136,6 +137,32 @@ describe("exceptions runtime integrity", () => {
             runId: RUN_ID,
             assignedTo: "user-a",
             resolutionReason: "ignored_in_workbench",
+            compactSummary: {
+              recurrence: {
+                memoryCount: 1,
+                recurringResolutionReason: "ignored_in_workbench",
+                state: "ready",
+              },
+              evidence: {
+                total: 1,
+                degraded: 0,
+                attested: 1,
+                state: "ready",
+              },
+              proof: {
+                total: 1,
+                finalized: 1,
+                bestCompletenessScore: 1,
+                missingEvidenceCount: 0,
+                state: "ready",
+                changedSincePreviousRun: "unavailable",
+                changeSummary: "Delta unavailable",
+              },
+              supportability: {
+                degradedReasons: [],
+                nextStep: "Proceed with export.",
+              },
+            },
           },
         ],
         total: 1,
@@ -158,6 +185,11 @@ describe("exceptions runtime integrity", () => {
       id: EXCEPTION_ID,
       status: "ignored",
       runId: RUN_ID,
+      compactSummary: expect.objectContaining({
+        recurrence: expect.objectContaining({ memoryCount: expect.any(Number) }),
+        evidence: expect.objectContaining({ total: expect.any(Number) }),
+        proof: expect.objectContaining({ state: expect.any(String) }),
+      }),
     });
     expect(listReconciliationWorkbenchExceptionsMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -168,6 +200,95 @@ describe("exceptions runtime integrity", () => {
         status: "ignored",
       })
     );
+  });
+
+  test("returns productized proofpack artifact with explicit completeness and unavailable delta semantics", async () => {
+    getReconciliationWorkbenchExceptionDetailMock.mockResolvedValue({
+      id: EXCEPTION_ID,
+      type: "amount_mismatch",
+      matchType: "unmatched",
+      status: "resolved",
+      canonicalStatus: "resolved",
+      severity: "high",
+      detectedAt: "2026-01-01T00:00:00.000Z",
+      description: "Settlement amount mismatch",
+      runId: RUN_ID,
+      statusDetail: "Resolved",
+      reasonTags: [],
+      confidenceScore: 0.92,
+      sourceTransactionId: "src-1",
+      targetTransactionId: "tgt-1",
+      suggestedActions: ["Export proof package."],
+      adjudicationMemories: [],
+      evidenceSummary: {
+        total: 1,
+        degraded: 1,
+        attested: 0,
+        latestCapturedAt: "2026-01-01T00:05:00.000Z",
+        items: [
+          {
+            id: "ev-1",
+            artifactType: "operator_annotation",
+            artifactKey: "k",
+            capturedAt: "2026-01-01T00:05:00.000Z",
+            capturedBy: "operator",
+            degraded: true,
+            degradedReasons: ["source_unavailable"],
+            attested: false,
+            reliabilityScore: 0.6,
+          },
+        ],
+      },
+      proofSummary: {
+        total: 1,
+        finalized: 0,
+        latestCreatedAt: "2026-01-01T00:06:00.000Z",
+        items: [
+          {
+            id: "proof-1",
+            packageType: "exception_resolution",
+            packageKey: "exception:proof",
+            status: "draft",
+            completenessScore: 0.5,
+            missingEvidence: ["bank_statement"],
+            completenessFlags: [],
+            evidenceIds: ["ev-1"],
+            createdAt: "2026-01-01T00:06:00.000Z",
+            finalizedAt: null,
+          },
+        ],
+      },
+      operatorSummary: {
+        whatHappened: "Resolved with degraded evidence.",
+        whyItMatters: "Evidence is not complete.",
+        nextStep: "Attach evidence.",
+        evidenceState: "degraded",
+        proofState: "degraded",
+        memoryState: "setup_required",
+        evidenceCount: 1,
+        attestedEvidenceCount: 0,
+        degradedEvidenceCount: 1,
+        proofPackageCount: 1,
+        finalizedProofPackageCount: 0,
+        bestCompletenessScore: 0.5,
+        missingEvidenceCount: 1,
+        memoryCount: 0,
+        recurringResolutionReason: null,
+        latestResolution: null,
+      },
+    });
+
+    const response = await getExceptionProofpack(
+      req(`http://localhost/api/exceptions/${EXCEPTION_ID}/proofpack`),
+      { params: Promise.resolve({ exceptionId: EXCEPTION_ID }) } as any
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.artifact.completeness.isExportReady).toBe(false);
+    expect(payload.artifact.changeSincePreviousRun.available).toBe(false);
+    expect(payload.artifact.changeSincePreviousRun.state).toBe("unavailable");
+    expect(payload.artifact.completeness.degradedEvidenceReasons).toContain("source_unavailable");
   });
 
   test("returns 404 when a requested run scope does not exist", async () => {

--- a/packages/web/src/app/api/exceptions/[exceptionId]/proofpack/route.ts
+++ b/packages/web/src/app/api/exceptions/[exceptionId]/proofpack/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/shared/db/prismaClient";
+import {
+  resolveTenantForMutation,
+  resolveTenantMembershipScope,
+  TenantMembershipError,
+} from "@/lib/supabase/tenant-membership";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
+import { getReconciliationWorkbenchExceptionDetail } from "@/lib/server/exceptions/reconciliation-workbench";
+
+export const runtime = "nodejs";
+
+const paramsSchema = z.object({
+  exceptionId: z.string().uuid("Invalid exception ID format"),
+});
+
+export const GET = withSecurity(
+  withUniversalBillingGate(
+    async function GET(
+      request: NextRequest,
+      { params }: { params: Promise<{ exceptionId: string }> }
+    ) {
+      try {
+        const parsed = paramsSchema.safeParse(await params);
+        if (!parsed.success) {
+          return NextResponse.json(
+            { error: "Invalid exception ID", details: parsed.error.issues },
+            { status: 400 }
+          );
+        }
+
+        const { tenantIds } = await resolveTenantMembershipScope();
+        const requestedTenantId =
+          request.nextUrl.searchParams.get("workspace_id")?.trim() ||
+          request.nextUrl.searchParams.get("tenant_id")?.trim() ||
+          null;
+        const tenantId = resolveTenantForMutation(tenantIds, requestedTenantId);
+
+        const detail = await getReconciliationWorkbenchExceptionDetail(
+          prisma,
+          tenantId,
+          parsed.data.exceptionId
+        );
+
+        if (!detail) {
+          return NextResponse.json({ error: "Exception not found" }, { status: 404 });
+        }
+
+        const missingEvidence = detail.proofSummary.items.flatMap((item) => item.missingEvidence);
+        const degradedEvidenceReasons = detail.evidenceSummary.items
+          .filter((item) => item.degraded)
+          .flatMap((item) => item.degradedReasons);
+
+        const changeComparison = {
+          available: false,
+          state: "unavailable" as const,
+          summary:
+            "Prior-run proof comparison is not available from exception list context. Use run detail lineage for deterministic baseline diff.",
+        };
+
+        const artifact = {
+          schemaVersion: "proofpack.exception.v2",
+          generatedAt: new Date().toISOString(),
+          tenantScoped: true,
+          exception: {
+            id: detail.id,
+            runId: detail.runId,
+            type: detail.type,
+            status: detail.status,
+            severity: detail.severity,
+            description: detail.description,
+          },
+          completeness: {
+            proofPackageCount: detail.proofSummary.total,
+            finalizedProofPackageCount: detail.proofSummary.finalized,
+            bestCompletenessScore: detail.operatorSummary.bestCompletenessScore,
+            missingEvidenceCount: detail.operatorSummary.missingEvidenceCount,
+            missingEvidence,
+            degradedEvidenceCount: detail.evidenceSummary.degraded,
+            degradedEvidenceReasons,
+            isExportReady:
+              detail.operatorSummary.proofState === "ready" &&
+              detail.operatorSummary.evidenceState === "ready",
+          },
+          lineage: {
+            evidenceArtifactIds: detail.evidenceSummary.items.map((item) => item.id),
+            proofPackageIds: detail.proofSummary.items.map((item) => item.id),
+            adjudicationMemoryIds: detail.adjudicationMemories.map((item) => item.id),
+            latestEvidenceCapturedAt: detail.evidenceSummary.latestCapturedAt,
+            latestProofCreatedAt: detail.proofSummary.latestCreatedAt,
+            latestDecisionAt: detail.operatorSummary.latestResolution?.completedAt ?? null,
+          },
+          confidence: {
+            exceptionConfidence: detail.confidenceScore,
+            bestProofCompleteness: detail.operatorSummary.bestCompletenessScore,
+            boundedCertainty:
+              detail.operatorSummary.proofState === "ready"
+                ? "high"
+                : detail.operatorSummary.proofState === "degraded"
+                  ? "bounded"
+                  : "low",
+          },
+          changeSincePreviousRun: changeComparison,
+          recurringContext: {
+            memoryCount: detail.operatorSummary.memoryCount,
+            recurringResolutionReason: detail.operatorSummary.recurringResolutionReason,
+          },
+          operatorAction: {
+            nextStep: detail.operatorSummary.nextStep,
+            supportabilityCaveats: [
+              ...new Set([
+                ...detail.suggestedActions,
+                changeComparison.summary,
+                ...(detail.operatorSummary.proofState !== "ready"
+                  ? ["Proof package is not yet fully complete or finalized."]
+                  : []),
+              ]),
+            ],
+          },
+          humanSummary: {
+            title: `Exception proofpack: ${detail.type.replaceAll("_", " ")}`,
+            summary: detail.operatorSummary.whatHappened,
+            whyItMatters: detail.operatorSummary.whyItMatters,
+            nextStep: detail.operatorSummary.nextStep,
+          },
+        };
+
+        return NextResponse.json({ data: artifact, artifact });
+      } catch (error) {
+        if (error instanceof TenantMembershipError) {
+          return NextResponse.json(
+            { error: error.message, code: error.code },
+            { status: error.status }
+          );
+        }
+
+        return NextResponse.json({ error: "Failed to build proofpack artifact" }, { status: 500 });
+      }
+    },
+    { feature: "GET Exception Proofpack" }
+  ),
+  { rateLimit: { windowMs: 60000, maxRequests: 60 }, requireAuth: true }
+);

--- a/packages/web/src/app/api/runs/route.ts
+++ b/packages/web/src/app/api/runs/route.ts
@@ -35,6 +35,28 @@ import {
 
 export const runtime = "nodejs";
 
+type RunListItemWithSignals = ReturnType<typeof mapCanonicalListItemToApiRunsLegacyRow> & {
+  compactProofSummary?: {
+    proofPackages: {
+      total: number;
+      finalized: number;
+      bestCompletenessScore: number | null;
+      missingEvidenceCount: number;
+      latestCreatedAt: string | null;
+      state: "ready" | "degraded" | "setup_required" | "unavailable";
+    };
+    recurrence: {
+      exceptionsWithMemories: number;
+      repeatedResolutionReasons: string[];
+      state: "ready" | "degraded" | "setup_required" | "unavailable";
+    };
+    delta: {
+      changedSincePreviousRun: "changed" | "unchanged" | "unavailable";
+      summary: string;
+    };
+  };
+};
+
 function resolveTenantIdForRuns(
   authContext: UnifiedAuthContext,
   tenantIds: string[],
@@ -63,6 +85,172 @@ function matchesSearchFilter(searchFilter: string | undefined, id: string, name:
 }
 
 const MAX_FILTER_SCAN_PAGES = 30;
+
+async function withRunCompactProofSignals(
+  tenantId: string,
+  items: ReturnType<typeof mapCanonicalListItemToApiRunsLegacyRow>[]
+): Promise<RunListItemWithSignals[]> {
+  const reconRunIds = items.filter((item) => item.runKind === "recon_job").map((item) => item.id);
+  if (reconRunIds.length === 0) {
+    return items;
+  }
+
+  const matches = await prisma.reconciliationMatch.findMany({
+    where: {
+      tenantId,
+      runId: { in: reconRunIds },
+      matchType: { in: ["unmatched", "conflict"] },
+    },
+    select: { id: true, runId: true },
+  });
+
+  const runByExceptionId = new Map<string, string>();
+  for (const match of matches) {
+    runByExceptionId.set(match.id, match.runId);
+  }
+
+  const reasonCountsByRun = new Map<string, Map<string, number>>();
+  const exceptionIds = matches.map((match: { id: string }) => match.id);
+  if (exceptionIds.length > 0) {
+    const memories = await prisma.exceptionAdjudicationMemory.findMany({
+      where: {
+        tenantId,
+        exceptionId: { in: exceptionIds },
+      },
+      select: { exceptionId: true, resolutionReason: true },
+    });
+    for (const memory of memories) {
+      const runId = runByExceptionId.get(memory.exceptionId);
+      if (!runId) continue;
+      const reason = memory.resolutionReason?.trim();
+      if (!reason) continue;
+      const runReasons = reasonCountsByRun.get(runId) ?? new Map<string, number>();
+      runReasons.set(reason, (runReasons.get(reason) ?? 0) + 1);
+      reasonCountsByRun.set(runId, runReasons);
+    }
+  }
+
+  const proofPackages =
+    exceptionIds.length > 0
+      ? await prisma.proofPackage.findMany({
+          where: {
+            tenantId,
+            OR: exceptionIds.map((exceptionId: string) => ({
+              packageKey: { startsWith: `exception:${exceptionId}:` },
+            })),
+          },
+          select: {
+            packageKey: true,
+            status: true,
+            completenessScore: true,
+            missingEvidence: true,
+            createdAt: true,
+          },
+          orderBy: { createdAt: "desc" },
+        })
+      : [];
+
+  const proofByRun = new Map<
+    string,
+    {
+      total: number;
+      finalized: number;
+      missingEvidenceCount: number;
+      bestCompletenessScore: number | null;
+      latestCreatedAt: string | null;
+    }
+  >();
+  const runExceptionCounts = new Map<string, number>();
+  for (const match of matches) {
+    runExceptionCounts.set(match.runId, (runExceptionCounts.get(match.runId) ?? 0) + 1);
+  }
+  for (const proof of proofPackages) {
+    const packageKeyParts = proof.packageKey.split(":");
+    const exceptionId = packageKeyParts.length >= 2 ? packageKeyParts[1] : null;
+    if (!exceptionId) continue;
+    const runId = runByExceptionId.get(exceptionId);
+    if (!runId) continue;
+    const state = proofByRun.get(runId) ?? {
+      total: 0,
+      finalized: 0,
+      missingEvidenceCount: 0,
+      bestCompletenessScore: null,
+      latestCreatedAt: null,
+    };
+    state.total += 1;
+    if (proof.status === "finalized") state.finalized += 1;
+    state.missingEvidenceCount += Array.isArray(proof.missingEvidence)
+      ? proof.missingEvidence.length
+      : 0;
+    const completenessScore = Number(proof.completenessScore);
+    state.bestCompletenessScore =
+      state.bestCompletenessScore == null
+        ? completenessScore
+        : Math.max(state.bestCompletenessScore, completenessScore);
+    if (!state.latestCreatedAt) {
+      state.latestCreatedAt = proof.createdAt.toISOString();
+    }
+    proofByRun.set(runId, state);
+  }
+
+  return items.map((item) => {
+    const proof = proofByRun.get(item.id) ?? {
+      total: 0,
+      finalized: 0,
+      missingEvidenceCount: 0,
+      bestCompletenessScore: null,
+      latestCreatedAt: null,
+    };
+    const repeatedReasons = Array.from(reasonCountsByRun.get(item.id)?.entries() ?? [])
+      .filter(([, count]) => count > 1)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 2)
+      .map(([reason]) => reason);
+    const exceptionsWithMemories = Array.from(
+      reasonCountsByRun.get(item.id)?.values() ?? []
+    ).reduce((total, count) => total + (count > 0 ? 1 : 0), 0);
+    const proofState =
+      proof.total === 0
+        ? "setup_required"
+        : proof.finalized > 0 && proof.missingEvidenceCount === 0
+          ? "ready"
+          : "degraded";
+
+    return {
+      ...item,
+      compactProofSummary: {
+        proofPackages: {
+          ...proof,
+          state: proofState,
+        },
+        recurrence: {
+          exceptionsWithMemories,
+          repeatedResolutionReasons: repeatedReasons,
+          state:
+            exceptionsWithMemories > 0
+              ? "ready"
+              : runExceptionCounts.get(item.id)
+                ? "degraded"
+                : "setup_required",
+        },
+        delta: {
+          changedSincePreviousRun:
+            item.configDrift?.status === "detected"
+              ? "changed"
+              : item.configDrift?.status === "none"
+                ? "unchanged"
+                : "unavailable",
+          summary:
+            item.configDrift?.status === "detected"
+              ? "Configuration drift detected since prior run."
+              : item.configDrift?.status === "none"
+                ? "No configuration drift detected in canonical run metadata."
+                : "Prior-run delta unavailable in this list view.",
+        },
+      },
+    };
+  });
+}
 
 export const GET = withSecurity(
   withUniversalBillingGate(
@@ -130,7 +318,8 @@ export const GET = withSecurity(
             encodeCursor: encodeMergedRunsCursor,
           });
 
-          const items = page.runs.map(mapCanonicalListItemToApiRunsLegacyRow);
+          const baseItems = page.runs.map(mapCanonicalListItemToApiRunsLegacyRow);
+          const items = await withRunCompactProofSignals(tenantId, baseItems);
 
           return NextResponse.json({
             items,
@@ -211,7 +400,7 @@ export const GET = withSecurity(
           truncated = true;
         }
 
-        const items = collected.slice(0, limit);
+        const items = await withRunCompactProofSignals(tenantId, collected.slice(0, limit));
 
         return NextResponse.json({
           items,

--- a/packages/web/src/app/console/exceptions/page.tsx
+++ b/packages/web/src/app/console/exceptions/page.tsx
@@ -31,6 +31,32 @@ interface Exception {
   targetTransactionId?: string;
   runId?: string;
   fieldPath?: string;
+  compactSummary?: {
+    recurrence: {
+      memoryCount: number;
+      recurringResolutionReason: string | null;
+      state: "ready" | "degraded" | "setup_required" | "unavailable";
+    };
+    evidence: {
+      total: number;
+      degraded: number;
+      attested: number;
+      state: "ready" | "degraded" | "setup_required" | "unavailable";
+    };
+    proof: {
+      total: number;
+      finalized: number;
+      bestCompletenessScore: number | null;
+      missingEvidenceCount: number;
+      state: "ready" | "degraded" | "setup_required" | "unavailable";
+      changedSincePreviousRun: "changed" | "unchanged" | "unavailable";
+      changeSummary: string;
+    };
+    supportability: {
+      degradedReasons: string[];
+      nextStep: string;
+    };
+  };
 }
 
 interface ExceptionFilters {
@@ -99,6 +125,21 @@ function buildColumns(_runId: string | null): DataTableColumn<Exception>[] {
               ))}
             </div>
           )}
+          {row.compactSummary ? (
+            <div className="flex flex-wrap gap-1.5 pt-1">
+              <Badge variant="outline" size="sm">
+                Memory {row.compactSummary.recurrence.memoryCount}
+              </Badge>
+              <Badge variant="outline" size="sm">
+                Proof {row.compactSummary.proof.finalized}/{row.compactSummary.proof.total}
+              </Badge>
+              {row.compactSummary.evidence.degraded > 0 ? (
+                <Badge variant="warning" size="sm">
+                  Evidence degraded
+                </Badge>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       ),
     },
@@ -110,6 +151,16 @@ function buildColumns(_runId: string | null): DataTableColumn<Exception>[] {
         <div>
           <p className="line-clamp-2">{row.description}</p>
           {row.statusDetail && <p className="mt-1 text-[11px] opacity-70">{row.statusDetail}</p>}
+          {row.compactSummary?.recurrence.recurringResolutionReason ? (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Recurring pattern: {row.compactSummary.recurrence.recurringResolutionReason}
+            </p>
+          ) : null}
+          {row.compactSummary?.supportability.degradedReasons?.length ? (
+            <p className="mt-1 text-[11px] text-warning">
+              {row.compactSummary.supportability.degradedReasons[0]}
+            </p>
+          ) : null}
         </div>
       ),
     },

--- a/packages/web/src/app/console/runs/page.tsx
+++ b/packages/web/src/app/console/runs/page.tsx
@@ -61,6 +61,25 @@ interface RunListItem {
   configDrift?: {
     status?: "none" | "detected" | "indeterminate";
   };
+  compactProofSummary?: {
+    proofPackages: {
+      total: number;
+      finalized: number;
+      bestCompletenessScore: number | null;
+      missingEvidenceCount: number;
+      latestCreatedAt: string | null;
+      state: "ready" | "degraded" | "setup_required" | "unavailable";
+    };
+    recurrence: {
+      exceptionsWithMemories: number;
+      repeatedResolutionReasons: string[];
+      state: "ready" | "degraded" | "setup_required" | "unavailable";
+    };
+    delta: {
+      changedSincePreviousRun: "changed" | "unchanged" | "unavailable";
+      summary: string;
+    };
+  };
 }
 
 interface RunsListApiResponse {
@@ -317,10 +336,7 @@ export default function RunsPage() {
       <ConsolePageHeader
         title="Runs"
         description="Merged reconciliation activity: scheduled recon jobs and ingestion-triggered reconciliation runs share one list. Use the run kind filter to narrow the stream."
-        breadcrumbs={[
-          { label: "Console", href: "/console" },
-          { label: "Runs" },
-        ]}
+        breadcrumbs={[{ label: "Console", href: "/console" }, { label: "Runs" }]}
         actions={
           <div className="flex flex-wrap items-center gap-3">
             <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
@@ -528,160 +544,209 @@ export default function RunsPage() {
               </p>
             ) : null}
             {runs.map((run) => (
-                <div
-                  key={run.id}
-                  className="rounded-xl border border-border/80 bg-card/50 p-5 shadow-sm transition-colors hover:border-primary/30 hover:bg-card/80 hover:shadow-md"
-                >
-                  <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-                    <div className="min-w-0 flex-1 space-y-4">
-                      {/* Row 1: Name + status badges */}
-                      <div className="flex flex-wrap items-center gap-2">
-                        <h2 className="truncate text-base font-semibold text-foreground" title={run.name}>
-                          {run.name}
-                        </h2>
-                        <Badge variant="outline" className="text-xs font-normal">
-                          {run.runKind === "ingestion_run" ? "Ingestion run" : "Recon job"}
-                        </Badge>
-                        <StatusBadge
-                          status={toStatusType(run.status)}
-                          label={run.statusLabel || undefined}
-                        />
-                        {run.configDrift?.status === "detected" && (
-                          <StatusBadge status="warning" label="Config drift" size="sm" />
-                        )}
-                      </div>
-
-                      {/* Row 2: Metadata grid */}
-                      <div className="grid gap-x-6 gap-y-1 text-sm md:grid-cols-4">
-                        <div>
-                          <span className="text-xs text-muted-foreground">Run ID</span>
-                          <div
-                            className="truncate font-mono text-xs text-foreground"
-                            title={run.id}
-                          >
-                            {run.id}
-                          </div>
-                        </div>
-                        {run.ingestionId ? (
-                          <div>
-                            <span className="text-xs text-muted-foreground">Ingestion</span>
-                            <div
-                              className="truncate font-mono text-xs text-foreground"
-                              title={run.ingestionId}
-                            >
-                              {run.ingestionId}
-                            </div>
-                          </div>
-                        ) : null}
-                        {(run.sourceAdapter || run.targetAdapter) && (
-                          <div className="md:col-span-2">
-                            <span className="text-xs text-muted-foreground">Adapters</span>
-                            <div className="text-sm text-foreground">
-                              {[run.sourceAdapter, run.targetAdapter].filter(Boolean).join(" → ") ||
-                                "—"}
-                            </div>
-                          </div>
-                        )}
-                        <div>
-                          <span className="text-xs text-muted-foreground">Started</span>
-                          <div className="text-foreground">{new Date(run.startedAt).toLocaleString()}</div>
-                        </div>
-                        <div>
-                          <span className="text-xs text-muted-foreground">Completed</span>
-                          <div className="text-foreground">
-                            {run.completedAt
-                              ? new Date(run.completedAt).toLocaleString()
-                              : "Still running"}
-                          </div>
-                        </div>
-                        <div>
-                          <span className="text-xs text-muted-foreground">Duration</span>
-                          <div className="font-mono text-foreground">{formatDuration(run.startedAt, run.completedAt)}</div>
-                        </div>
-                      </div>
-
-                      {/* Row 3: Metric chips */}
-                      <div className="grid gap-2 sm:grid-cols-3 xl:grid-cols-6">
-                        <div className="metric-chip">
-                          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Matched</div>
-                          <div className="mt-0.5 text-lg font-semibold text-success tabular-nums">
-                            {formatCount(run.summary.matched)}
-                          </div>
-                        </div>
-                        <div className="metric-chip">
-                          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Unmatched</div>
-                          <div className="mt-0.5 text-lg font-semibold text-warning tabular-nums">
-                            {formatCount(run.summary.unmatched)}
-                          </div>
-                        </div>
-                        <div className="metric-chip">
-                          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Conflicts</div>
-                          <div className="mt-0.5 text-lg font-semibold text-error tabular-nums">
-                            {formatCount(run.summary.conflicts)}
-                          </div>
-                        </div>
-                        <div className="metric-chip">
-                          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Exceptions</div>
-                          <div className="mt-0.5 text-lg font-semibold tabular-nums">
-                            {formatCount(run.summarySemantics.exceptioned)}
-                          </div>
-                        </div>
-                        <div className="metric-chip">
-                          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Review</div>
-                          <div className="mt-0.5 text-lg font-semibold tabular-nums">
-                            {formatCount(run.summarySemantics.unresolved)}
-                          </div>
-                        </div>
-                        <div className="metric-chip">
-                          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">In-tolerance</div>
-                          <div className="mt-0.5 text-lg font-semibold tabular-nums">
-                            {formatCount(run.summarySemantics.matchedWithTolerance)}
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* Row 4: Summary state + record counts */}
-                      <div className="flex flex-wrap items-center gap-3 text-sm">
-                        <StatusBadge
-                          status={summaryToStatusType(run.summaryState)}
-                          label={run.summaryState.replaceAll("_", " ").replace(/\b\w/g, (c) => c.toUpperCase())}
-                          size="sm"
-                        />
-                        <span className="text-muted-foreground">
-                          {formatCount(run.summarySemantics.processed)} / {formatCount(run.summary.total)} records
-                        </span>
-                        <span className="text-muted-foreground text-xs">
-                          Source {formatCount(run.summary.sourceCount)} &middot; Target {formatCount(run.summary.targetCount)}
-                        </span>
-                      </div>
-                    </div>
-
-                    {/* Actions */}
-                    <div className="flex flex-wrap gap-2 xl:w-48 xl:flex-col xl:gap-2">
-                      <Button asChild size="sm">
-                        <Link href={`/console/runs/${run.id}`}>Open detail</Link>
-                      </Button>
-                      {run.runKind === "recon_job" ? (
-                        <>
-                          <Button asChild variant="outline" size="sm">
-                            <Link href={`/console/reconciliations?runId=${run.id}`}>
-                              Reconciliation
-                            </Link>
-                          </Button>
-                          <Button asChild variant="ghost" size="sm">
-                            <Link href={`/console/exceptions?runId=${run.id}`}>Exceptions</Link>
-                          </Button>
-                        </>
-                      ) : (
-                        <p className="text-xs text-muted-foreground xl:px-1">
-                          Results and exceptions UIs are recon-job keyed today; open detail for
-                          ingestion run truth.
-                        </p>
+              <div
+                key={run.id}
+                className="rounded-xl border border-border/80 bg-card/50 p-5 shadow-sm transition-colors hover:border-primary/30 hover:bg-card/80 hover:shadow-md"
+              >
+                <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                  <div className="min-w-0 flex-1 space-y-4">
+                    {/* Row 1: Name + status badges */}
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2
+                        className="truncate text-base font-semibold text-foreground"
+                        title={run.name}
+                      >
+                        {run.name}
+                      </h2>
+                      <Badge variant="outline" className="text-xs font-normal">
+                        {run.runKind === "ingestion_run" ? "Ingestion run" : "Recon job"}
+                      </Badge>
+                      <StatusBadge
+                        status={toStatusType(run.status)}
+                        label={run.statusLabel || undefined}
+                      />
+                      {run.configDrift?.status === "detected" && (
+                        <StatusBadge status="warning" label="Config drift" size="sm" />
                       )}
                     </div>
+
+                    {/* Row 2: Metadata grid */}
+                    <div className="grid gap-x-6 gap-y-1 text-sm md:grid-cols-4">
+                      <div>
+                        <span className="text-xs text-muted-foreground">Run ID</span>
+                        <div className="truncate font-mono text-xs text-foreground" title={run.id}>
+                          {run.id}
+                        </div>
+                      </div>
+                      {run.ingestionId ? (
+                        <div>
+                          <span className="text-xs text-muted-foreground">Ingestion</span>
+                          <div
+                            className="truncate font-mono text-xs text-foreground"
+                            title={run.ingestionId}
+                          >
+                            {run.ingestionId}
+                          </div>
+                        </div>
+                      ) : null}
+                      {(run.sourceAdapter || run.targetAdapter) && (
+                        <div className="md:col-span-2">
+                          <span className="text-xs text-muted-foreground">Adapters</span>
+                          <div className="text-sm text-foreground">
+                            {[run.sourceAdapter, run.targetAdapter].filter(Boolean).join(" → ") ||
+                              "—"}
+                          </div>
+                        </div>
+                      )}
+                      <div>
+                        <span className="text-xs text-muted-foreground">Started</span>
+                        <div className="text-foreground">
+                          {new Date(run.startedAt).toLocaleString()}
+                        </div>
+                      </div>
+                      <div>
+                        <span className="text-xs text-muted-foreground">Completed</span>
+                        <div className="text-foreground">
+                          {run.completedAt
+                            ? new Date(run.completedAt).toLocaleString()
+                            : "Still running"}
+                        </div>
+                      </div>
+                      <div>
+                        <span className="text-xs text-muted-foreground">Duration</span>
+                        <div className="font-mono text-foreground">
+                          {formatDuration(run.startedAt, run.completedAt)}
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Row 3: Metric chips */}
+                    <div className="grid gap-2 sm:grid-cols-3 xl:grid-cols-6">
+                      <div className="metric-chip">
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                          Matched
+                        </div>
+                        <div className="mt-0.5 text-lg font-semibold text-success tabular-nums">
+                          {formatCount(run.summary.matched)}
+                        </div>
+                      </div>
+                      <div className="metric-chip">
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                          Unmatched
+                        </div>
+                        <div className="mt-0.5 text-lg font-semibold text-warning tabular-nums">
+                          {formatCount(run.summary.unmatched)}
+                        </div>
+                      </div>
+                      <div className="metric-chip">
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                          Conflicts
+                        </div>
+                        <div className="mt-0.5 text-lg font-semibold text-error tabular-nums">
+                          {formatCount(run.summary.conflicts)}
+                        </div>
+                      </div>
+                      <div className="metric-chip">
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                          Exceptions
+                        </div>
+                        <div className="mt-0.5 text-lg font-semibold tabular-nums">
+                          {formatCount(run.summarySemantics.exceptioned)}
+                        </div>
+                      </div>
+                      <div className="metric-chip">
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                          Review
+                        </div>
+                        <div className="mt-0.5 text-lg font-semibold tabular-nums">
+                          {formatCount(run.summarySemantics.unresolved)}
+                        </div>
+                      </div>
+                      <div className="metric-chip">
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                          In-tolerance
+                        </div>
+                        <div className="mt-0.5 text-lg font-semibold tabular-nums">
+                          {formatCount(run.summarySemantics.matchedWithTolerance)}
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Row 4: Summary state + record counts */}
+                    <div className="flex flex-wrap items-center gap-3 text-sm">
+                      <StatusBadge
+                        status={summaryToStatusType(run.summaryState)}
+                        label={run.summaryState
+                          .replaceAll("_", " ")
+                          .replace(/\b\w/g, (c) => c.toUpperCase())}
+                        size="sm"
+                      />
+                      <span className="text-muted-foreground">
+                        {formatCount(run.summarySemantics.processed)} /{" "}
+                        {formatCount(run.summary.total)} records
+                      </span>
+                      <span className="text-muted-foreground text-xs">
+                        Source {formatCount(run.summary.sourceCount)} &middot; Target{" "}
+                        {formatCount(run.summary.targetCount)}
+                      </span>
+                      {run.compactProofSummary ? (
+                        <>
+                          <Badge variant="outline" size="sm">
+                            Proof {run.compactProofSummary.proofPackages.finalized}/
+                            {run.compactProofSummary.proofPackages.total}
+                          </Badge>
+                          <Badge
+                            variant={
+                              run.compactProofSummary.delta.changedSincePreviousRun === "changed"
+                                ? "warning"
+                                : "outline"
+                            }
+                            size="sm"
+                          >
+                            {run.compactProofSummary.delta.changedSincePreviousRun === "changed"
+                              ? "Changed since prior run"
+                              : run.compactProofSummary.delta.changedSincePreviousRun ===
+                                  "unchanged"
+                                ? "No run config drift"
+                                : "Delta unavailable"}
+                          </Badge>
+                          {run.compactProofSummary.recurrence.exceptionsWithMemories > 0 ? (
+                            <Badge variant="info" size="sm">
+                              {run.compactProofSummary.recurrence.exceptionsWithMemories} recurring
+                              families
+                            </Badge>
+                          ) : null}
+                        </>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  {/* Actions */}
+                  <div className="flex flex-wrap gap-2 xl:w-48 xl:flex-col xl:gap-2">
+                    <Button asChild size="sm">
+                      <Link href={`/console/runs/${run.id}`}>Open detail</Link>
+                    </Button>
+                    {run.runKind === "recon_job" ? (
+                      <>
+                        <Button asChild variant="outline" size="sm">
+                          <Link href={`/console/reconciliations?runId=${run.id}`}>
+                            Reconciliation
+                          </Link>
+                        </Button>
+                        <Button asChild variant="ghost" size="sm">
+                          <Link href={`/console/exceptions?runId=${run.id}`}>Exceptions</Link>
+                        </Button>
+                      </>
+                    ) : (
+                      <p className="text-xs text-muted-foreground xl:px-1">
+                        Results and exceptions UIs are recon-job keyed today; open detail for
+                        ingestion run truth.
+                      </p>
+                    )}
                   </div>
                 </div>
-              ))}
+              </div>
+            ))}
             {!filters.status && !filters.search && nextCursor ? (
               <div className="flex justify-center pt-2">
                 <Button

--- a/packages/web/src/lib/activation/overview.ts
+++ b/packages/web/src/lib/activation/overview.ts
@@ -44,6 +44,20 @@ export interface ConsoleActivationOverview {
   systemChecks: ReadinessCheck[];
   journeyChecks: ReadinessCheck[];
   tasks: ConsoleActivationTask[];
+  supportBundle: {
+    generatedAt: string;
+    summary: string;
+    blockers: Array<{
+      id: string;
+      label: string;
+      state: ReadinessState;
+      summary: string;
+      detail: string;
+      actionLabel: string;
+      href: string;
+    }>;
+    recommendedNextActions: string[];
+  };
   lastRunAt: string | null;
   lastDecisionAt: string | null;
 }

--- a/packages/web/src/lib/server/console/activation-overview.ts
+++ b/packages/web/src/lib/server/console/activation-overview.ts
@@ -51,6 +51,34 @@ function buildTask(args: {
   };
 }
 
+function buildSupportBundle(args: {
+  generatedAt: string;
+  checks: ReadinessCheck[];
+}): ConsoleActivationOverview["supportBundle"] {
+  const blockers = args.checks.filter((check) => check.state !== "ready");
+  const recommendedNextActions = blockers.slice(0, 5).map((check) => {
+    const action = check.actionLabel?.trim() || "Review";
+    return `${action}: ${check.label}`;
+  });
+  return {
+    generatedAt: args.generatedAt,
+    summary:
+      blockers.length === 0
+        ? "No activation blockers are currently reported."
+        : `${blockers.length} activation blocker${blockers.length === 1 ? "" : "s"} require operator or support follow-up.`,
+    blockers: blockers.map((check) => ({
+      id: check.id,
+      label: check.label,
+      state: check.state,
+      summary: check.summary,
+      detail: check.detail,
+      actionLabel: check.actionLabel || "Open diagnostics",
+      href: check.href || "/console/setup-check",
+    })),
+    recommendedNextActions,
+  };
+}
+
 export async function getConsoleActivationOverview(): Promise<ConsoleActivationOverview> {
   const generatedAt = new Date().toISOString();
   const envValidation = validateSupabaseEnv();
@@ -128,6 +156,10 @@ export async function getConsoleActivationOverview(): Promise<ConsoleActivationO
           actionLabel: "Open diagnostics",
         }),
       ],
+      supportBundle: buildSupportBundle({
+        generatedAt,
+        checks: [...systemChecks, ...journeyChecks],
+      }),
       lastRunAt: null,
       lastDecisionAt: null,
     };
@@ -170,6 +202,10 @@ export async function getConsoleActivationOverview(): Promise<ConsoleActivationO
           actionLabel: "Inspect diagnostics",
         }),
       ],
+      supportBundle: buildSupportBundle({
+        generatedAt,
+        checks: [...systemChecks, ...journeyChecks],
+      }),
       lastRunAt: null,
       lastDecisionAt: null,
     };
@@ -210,6 +246,10 @@ export async function getConsoleActivationOverview(): Promise<ConsoleActivationO
           actionLabel: "Sign in",
         }),
       ],
+      supportBundle: buildSupportBundle({
+        generatedAt,
+        checks: [...systemChecks],
+      }),
       lastRunAt: null,
       lastDecisionAt: null,
     };
@@ -564,6 +604,10 @@ export async function getConsoleActivationOverview(): Promise<ConsoleActivationO
     systemChecks,
     journeyChecks,
     tasks,
+    supportBundle: buildSupportBundle({
+      generatedAt,
+      checks: allChecks,
+    }),
     lastRunAt,
     lastDecisionAt,
   };

--- a/packages/web/src/lib/server/exceptions/reconciliation-workbench.ts
+++ b/packages/web/src/lib/server/exceptions/reconciliation-workbench.ts
@@ -40,6 +40,32 @@ export type ReconciliationWorkbenchListItem = {
   runId: string;
   assignedTo?: string | null;
   resolutionReason?: string | null;
+  compactSummary?: {
+    recurrence: {
+      memoryCount: number;
+      recurringResolutionReason: string | null;
+      state: ReadinessState;
+    };
+    evidence: {
+      total: number;
+      degraded: number;
+      attested: number;
+      state: ReadinessState;
+    };
+    proof: {
+      total: number;
+      finalized: number;
+      bestCompletenessScore: number | null;
+      missingEvidenceCount: number;
+      state: ReadinessState;
+      changedSincePreviousRun: "changed" | "unchanged" | "unavailable";
+      changeSummary: string;
+    };
+    supportability: {
+      degradedReasons: string[];
+      nextStep: string;
+    };
+  };
 };
 
 export type ReconciliationWorkbenchDetail = ReconciliationWorkbenchListItem & {
@@ -714,25 +740,99 @@ export async function listReconciliationWorkbenchExceptions(
   ]);
 
   const exceptionIds = rows.map((row: { id: string }) => row.id);
-  const [topArchetypes, latestMemories] = await Promise.all([
-    loadTopArchetypes(prisma, filters.tenantId, exceptionIds),
-    prisma.exceptionAdjudicationMemory.findMany({
-      where: {
-        tenantId: filters.tenantId,
-        exceptionId: { in: exceptionIds },
-      },
-      select: {
-        exceptionId: true,
-        resolutionReason: true,
-        operatorNotes: true,
-        completedAt: true,
-        createdAt: true,
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-    }),
-  ]);
+  const [topArchetypes, latestMemories, allMemories, evidenceArtifacts, proofPackages] =
+    await Promise.all([
+      loadTopArchetypes(prisma, filters.tenantId, exceptionIds),
+      prisma.exceptionAdjudicationMemory.findMany({
+        where: {
+          tenantId: filters.tenantId,
+          exceptionId: { in: exceptionIds },
+        },
+        select: {
+          exceptionId: true,
+          resolutionReason: true,
+          operatorNotes: true,
+          completedAt: true,
+          createdAt: true,
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+      }),
+      prisma.exceptionAdjudicationMemory.findMany({
+        where: {
+          tenantId: filters.tenantId,
+          exceptionId: { in: exceptionIds },
+        },
+        select: {
+          id: true,
+          exceptionId: true,
+          resolution: true,
+          resolutionReason: true,
+          adjudicationType: true,
+          adjudicatorId: true,
+          adjudicatorType: true,
+          outcome: true,
+          confidence: true,
+          sourceTrustScore: true,
+          operatorNotes: true,
+          systemNotes: true,
+          evidenceIds: true,
+          createdAt: true,
+          completedAt: true,
+          parentMemoryId: true,
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+      }),
+      prisma.evidenceArtifact.findMany({
+        where: {
+          tenantId: filters.tenantId,
+          exceptionId: { in: exceptionIds },
+        },
+        select: {
+          id: true,
+          exceptionId: true,
+          artifactType: true,
+          artifactKey: true,
+          capturedAt: true,
+          capturedBy: true,
+          degraded: true,
+          degradedReasons: true,
+          attested: true,
+          reliabilityScore: true,
+        },
+        orderBy: {
+          capturedAt: "desc",
+        },
+      }),
+      exceptionIds.length > 0
+        ? prisma.proofPackage.findMany({
+            where: {
+              tenantId: filters.tenantId,
+              OR: exceptionIds.map((exceptionId: string) => ({
+                packageKey: { startsWith: `exception:${exceptionId}:` },
+              })),
+            },
+            select: {
+              id: true,
+              packageType: true,
+              packageKey: true,
+              status: true,
+              completenessScore: true,
+              missingEvidence: true,
+              completenessFlags: true,
+              evidenceIds: true,
+              createdAt: true,
+              finalizedAt: true,
+            },
+            orderBy: {
+              createdAt: "desc",
+            },
+          })
+        : Promise.resolve([]),
+    ]);
 
   const latestMemoryByException = new Map<
     string,
@@ -748,8 +848,8 @@ export async function listReconciliationWorkbenchExceptions(
     }
   }
 
-  const items = rows.map((row: (typeof rows)[number]) =>
-    mapListItem({
+  const items = rows.map((row: (typeof rows)[number]) => {
+    const mapped = mapListItem({
       id: row.id,
       runId: row.runId,
       matchType: row.matchType,
@@ -773,8 +873,144 @@ export async function listReconciliationWorkbenchExceptions(
         : null,
       latestMemory: latestMemoryByException.get(row.id) ?? null,
       topArchetype: topArchetypes.get(row.id) ?? null,
-    })
-  );
+    });
+
+    const memories = allMemories
+      .filter((memory: (typeof allMemories)[number]) => memory.exceptionId === row.id)
+      .map((memory: (typeof allMemories)[number]) => ({
+        ...memory,
+        resolutionReason: memory.resolutionReason ?? null,
+        outcome: memory.outcome ?? null,
+        confidence: memory.confidence != null ? Number(memory.confidence) : null,
+        sourceTrustScore: memory.sourceTrustScore != null ? Number(memory.sourceTrustScore) : null,
+        operatorNotes: memory.operatorNotes ?? null,
+        systemNotes: memory.systemNotes ?? null,
+        evidenceIds: Array.isArray(memory.evidenceIds) ? memory.evidenceIds.filter(isString) : [],
+        createdAt: memory.createdAt.toISOString(),
+        completedAt: memory.completedAt?.toISOString() ?? null,
+        parentMemoryId: memory.parentMemoryId ?? null,
+      }));
+
+    const evidenceSummary = {
+      total: 0,
+      degraded: 0,
+      attested: 0,
+      latestCapturedAt: null as string | null,
+      items: [] as ReconciliationWorkbenchDetail["evidenceSummary"]["items"],
+    };
+
+    for (const evidence of evidenceArtifacts.filter(
+      (artifact: (typeof evidenceArtifacts)[number]) => artifact.exceptionId === row.id
+    )) {
+      evidenceSummary.total += 1;
+      if (evidence.degraded) evidenceSummary.degraded += 1;
+      if (evidence.attested) evidenceSummary.attested += 1;
+      if (!evidenceSummary.latestCapturedAt) {
+        evidenceSummary.latestCapturedAt = evidence.capturedAt.toISOString();
+      }
+      evidenceSummary.items.push({
+        id: evidence.id,
+        artifactType: evidence.artifactType,
+        artifactKey: evidence.artifactKey,
+        capturedAt: evidence.capturedAt.toISOString(),
+        capturedBy: evidence.capturedBy,
+        degraded: evidence.degraded,
+        degradedReasons: Array.isArray(evidence.degradedReasons)
+          ? evidence.degradedReasons.filter(isString)
+          : [],
+        attested: evidence.attested,
+        reliabilityScore:
+          evidence.reliabilityScore != null ? Number(evidence.reliabilityScore) : null,
+      });
+    }
+
+    const proofSummary = {
+      total: 0,
+      finalized: 0,
+      latestCreatedAt: null as string | null,
+      items: [] as ReconciliationWorkbenchDetail["proofSummary"]["items"],
+    };
+
+    for (const proof of proofPackages.filter((item: (typeof proofPackages)[number]) =>
+      item.packageKey.startsWith(`exception:${row.id}:`)
+    )) {
+      proofSummary.total += 1;
+      if (proof.status === "finalized") {
+        proofSummary.finalized += 1;
+      }
+      if (!proofSummary.latestCreatedAt) {
+        proofSummary.latestCreatedAt = proof.createdAt.toISOString();
+      }
+      proofSummary.items.push({
+        id: proof.id,
+        packageType: proof.packageType,
+        packageKey: proof.packageKey,
+        status: proof.status,
+        completenessScore: Number(proof.completenessScore),
+        missingEvidence: Array.isArray(proof.missingEvidence)
+          ? proof.missingEvidence.filter(isString)
+          : [],
+        completenessFlags: Array.isArray(proof.completenessFlags)
+          ? proof.completenessFlags.filter(isString)
+          : [],
+        evidenceIds: Array.isArray(proof.evidenceIds) ? proof.evidenceIds.filter(isString) : [],
+        createdAt: proof.createdAt.toISOString(),
+        finalizedAt: proof.finalizedAt?.toISOString() ?? null,
+      });
+    }
+
+    const operatorSummary = buildExceptionOperatorSummary({
+      status: mapped.canonicalStatus,
+      severity: mapped.severity,
+      description: mapped.description,
+      suggestedActions: buildSuggestedActions(mapped.canonicalStatus, evidenceSummary.total > 0),
+      adjudicationMemories: memories,
+      evidenceSummary,
+      proofSummary,
+    });
+
+    const supportDegradedReasons: string[] = [];
+    if (operatorSummary.evidenceState !== "ready") {
+      supportDegradedReasons.push("Evidence is incomplete or degraded.");
+    }
+    if (operatorSummary.proofState !== "ready") {
+      supportDegradedReasons.push("Proof package is not finalized and complete.");
+    }
+    if (operatorSummary.memoryState === "setup_required") {
+      supportDegradedReasons.push("Recurring adjudication memory has not been established.");
+    }
+
+    return {
+      ...mapped,
+      compactSummary: {
+        recurrence: {
+          memoryCount: operatorSummary.memoryCount,
+          recurringResolutionReason: operatorSummary.recurringResolutionReason,
+          state: operatorSummary.memoryState,
+        },
+        evidence: {
+          total: operatorSummary.evidenceCount,
+          degraded: operatorSummary.degradedEvidenceCount,
+          attested: operatorSummary.attestedEvidenceCount,
+          state: operatorSummary.evidenceState,
+        },
+        proof: {
+          total: operatorSummary.proofPackageCount,
+          finalized: operatorSummary.finalizedProofPackageCount,
+          bestCompletenessScore: operatorSummary.bestCompletenessScore,
+          missingEvidenceCount: operatorSummary.missingEvidenceCount,
+          state: operatorSummary.proofState,
+          changedSincePreviousRun: "unavailable",
+          changeSummary:
+            "Run-over-run proof delta is unavailable in list context; open detail for canonical lineage.",
+        },
+        supportability: {
+          degradedReasons: supportDegradedReasons,
+          nextStep: operatorSummary.nextStep,
+        },
+      },
+    };
+  });
 
   return {
     kind: "ok",


### PR DESCRIPTION
### Motivation
- Ensure list surfaces surface backend-owned, tenant-scoped compact proof/memory/recurrence signals so operators can triage before opening detail.  
- Productize a shareable, operator/buyer-grade proofpack artifact that includes explicit completeness, lineage, degraded reasons, and clear “change unavailable” semantics.  
- Improve activation/support diagnostics by returning a runbook-grade `supportBundle` that enumerates blockers and recommended next actions for support/operator handoff.

### Description
- Added backend-run enrichment `withRunCompactProofSignals` to `GET /api/runs` so the run list now includes `compactProofSummary` (proof package posture, recurrence cues, and explicit prior-run delta availability semantics). (`packages/web/src/app/api/runs/route.ts`)  
- Extended reconciliation workbench list contract to include optional server-owned `compactSummary` on each exception row and implemented list-side aggregation from adjudication memories, evidence artifacts, and proof packages. (`packages/web/src/lib/server/exceptions/reconciliation-workbench.ts`)  
- Introduced a tenant-scoped proofpack artifact endpoint `GET /api/exceptions/[exceptionId]/proofpack` that returns a versioned artifact (`schemaVersion: proofpack.exception.v2`) with completeness, degraded reasons, lineage IDs, confidence bounds, recurring context, operator next-step framing, and explicit change-availability semantics. (`packages/web/src/app/api/exceptions/[exceptionId]/proofpack/route.ts`)  
- Added `supportBundle` to the activation overview contract and implemented `buildSupportBundle` to produce a shareable list of blockers + recommended actions for runbook-grade diagnostics. (`packages/web/src/lib/activation/overview.ts`, `packages/web/src/lib/server/console/activation-overview.ts`)  
- Updated console UI to render the new truthful compact signals on runs and exceptions list rows (badges and inline supportability cues). (`packages/web/src/app/console/runs/page.tsx`, `packages/web/src/app/console/exceptions/page.tsx`)  
- Tests: added/updated route-level contract tests to assert new payload fields and artifact semantics. (`packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts`, `packages/web/src/__tests__/api/exceptions-runtime-integrity.test.ts`, `packages/web/src/__tests__/api/console-activation-route.test.ts`)  
- Kept all enrichment and export behavior tenant-scoped and read-only for list surfaces; explicit degraded/unavailable states are returned instead of silent fallbacks.

### Testing
- ✅ Ran the targeted route/unit suites under Node 24 and verified success with `pnpm --filter @settler/web test -- --runInBand src/__tests__/api/api-runs-list-route.contract.test.ts src/__tests__/api/exceptions-runtime-integrity.test.ts src/__tests__/api/console-activation-route.test.ts`, all tests passed.  
- ✅ Ran lint for the web package with `pnpm --filter @settler/web lint` and the staged lint checks completed successfully.  
- ⚠️ Ran typecheck `pnpm --filter @settler/web typecheck` which surfaced pre-existing workspace/module-resolution and TS errors (not introduced by this pass) related to `@settler/reconciliation-core` and other baseline issues; those remain a separate repo maintenance task.  
- Environment: verification executed under `node v24.12.0` (switched via `nvm use 24.12.0`) and `pnpm install` was run to restore workspace deps before tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf0b675e7483289f247f5afdffcb9a)