### PR TITLE
Canonical run proofpack index and deterministic prior-run delta; wire into list/detail/export

### DIFF
--- a/packages/reconciliation-core/src/index.ts
+++ b/packages/reconciliation-core/src/index.ts
@@ -13,3 +13,4 @@ export * from "./run-configuration-summary.js";
 export * from "./recon-audit-stages.js";
 export * from "./operator-run-detail-resolve.js";
 export * from "./exception-workbench.js";
+export * from "./run-proofpack-index.js";

--- a/packages/reconciliation-core/src/operator-run-detail-resolve.ts
+++ b/packages/reconciliation-core/src/operator-run-detail-resolve.ts
@@ -30,6 +30,7 @@ import {
   type RunConfigurationSummary,
 } from "./run-configuration-summary.js";
 import { toStageRows, type ReconAuditRow } from "./recon-audit-stages.js";
+import { buildRunProofpackIndexByRunId } from "./run-proofpack-index.js";
 
 export type OperatorRunDetailResolution =
   | { kind: "ok"; detail: OperatorRunDetail }
@@ -139,6 +140,7 @@ export async function resolveOperatorRunDetailForTenants(
       detail: buildOperatorIngestionRunDetailJson({
         detail: resolved.detail,
         stages: buildIngestionStages(resolved),
+        proofpackIndex: undefined,
       }),
     };
   }
@@ -309,6 +311,12 @@ export async function resolveOperatorRunDetailForTenants(
       new Set(contract.rowResults.map((row) => row.rationale.code))
     );
 
+    const proofpackIndexByRun = await buildRunProofpackIndexByRunId({
+      prisma,
+      tenantId: job.tenantId,
+      runs: [resolved.detail],
+    });
+
     const detailJson = buildOperatorReconRunDetailJson({
       detail: resolved.detail,
       status: truth.status,
@@ -337,6 +345,7 @@ export async function resolveOperatorRunDetailForTenants(
       rowRationaleCodes,
       rowResultsPreview: contract.rowResults.slice(0, 100),
       stages: toStageRows(auditRows),
+      proofpackIndex: proofpackIndexByRun.get(resolved.detail.id),
       runDelta: runDeltaRecord
         ? {
             inputChanged: runDeltaRecord.inputChanged,

--- a/packages/reconciliation-core/src/operator-run-detail.ts
+++ b/packages/reconciliation-core/src/operator-run-detail.ts
@@ -11,6 +11,7 @@
 import type { RunStatus } from "@settler/types";
 import type { CanonicalReconciliationRunDetail } from "./canonical-reconciliation.js";
 import type { AdapterDriftSignal } from "./canonical-run-result.js";
+import type { RunProofpackIndex } from "./run-proofpack-index.js";
 
 function legacyAdapterDriftLabel(
   signal: AdapterDriftSignal
@@ -173,6 +174,7 @@ export interface OperatorRunDetailBase {
     resolvedPatterns: string[];
     confidenceDelta: number | null;
   } | null;
+  proofpackIndex?: RunProofpackIndex;
   kindDetail: OperatorKindDetail;
 }
 
@@ -236,6 +238,7 @@ function baseFromCanonical(
 export function buildOperatorIngestionRunDetailJson(input: {
   detail: CanonicalReconciliationRunDetail;
   stages: OperatorRunStageRow[];
+  proofpackIndex?: RunProofpackIndex;
 }): OperatorRunDetail {
   const startedAt = input.detail.timestamps.startedAt ?? input.detail.timestamps.createdAt;
   const completedAt = input.detail.timestamps.completedAt;
@@ -294,6 +297,7 @@ export function buildOperatorIngestionRunDetailJson(input: {
     stages: input.stages,
     metadata: input.detail.metadata,
     traceId: input.detail.traceId,
+    proofpackIndex: input.proofpackIndex,
     kindDetail: {
       kind: "ingestion_run",
       ingestionRun: {
@@ -319,6 +323,7 @@ export function buildOperatorReconRunDetailJson(input: {
   rowRationaleCodes: string[];
   rowResultsPreview: unknown[];
   stages: OperatorRunStageRow[];
+  proofpackIndex?: RunProofpackIndex;
   runDelta?: OperatorRunDetail["runDelta"];
 }): OperatorRunDetail {
   const base = baseFromCanonical(input.detail, input.startedAt, input.completedAt);
@@ -348,6 +353,7 @@ export function buildOperatorReconRunDetailJson(input: {
     stages: input.stages,
     metadata: input.detail.metadata,
     traceId: input.detail.traceId,
+    proofpackIndex: input.proofpackIndex,
     runDelta: input.runDelta,
     kindDetail: {
       kind: "recon_job",

--- a/packages/reconciliation-core/src/run-proofpack-index.test.ts
+++ b/packages/reconciliation-core/src/run-proofpack-index.test.ts
@@ -1,0 +1,123 @@
+import { buildRunProofpackIndexByRunId } from "./run-proofpack-index.js";
+import type { CanonicalReconciliationListItem } from "./canonical-reconciliation.js";
+
+const baseRun: CanonicalReconciliationListItem = {
+  runKind: "recon_job",
+  id: "job-1",
+  tenantId: "tenant-1",
+  name: "Run",
+  reconResultId: "result-1",
+  lifecycle: {
+    status: "completed",
+    statusLabel: "Completed",
+    isTerminal: true,
+    progressPercent: 100,
+    progressState: "completed",
+  },
+  summaryState: "success",
+  summary: {
+    total: 1,
+    sourceCount: 1,
+    targetCount: 1,
+    processed: 1,
+    matched: 1,
+    matchedWithTolerance: 0,
+    unmatched: 0,
+    unmatchedSourceCount: 0,
+    unmatchedTargetCount: 0,
+    conflicts: 0,
+    exceptioned: 0,
+    unresolved: 0,
+    ignored: 0,
+    resolved: 0,
+  },
+  provenance: { sourceModel: "recon_jobs", runKind: "recon_job", ingestionId: null, reconJobId: "job-1" },
+  adapters: { sourceAdapter: "a", targetAdapter: "b" },
+  timestamps: {
+    createdAt: "2026-01-01T00:00:00.000Z",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:01:00.000Z",
+    updatedAt: "2026-01-01T00:01:00.000Z",
+  },
+  configDrift: {
+    status: "none",
+    strategyChanged: false,
+    templateChanged: false,
+    validationRulesChanged: false,
+    adapter: {
+      status: "none",
+      comparisonMode: "unavailable",
+      sourceChanged: null,
+      targetChanged: null,
+      sourceHashPresent: false,
+      targetHashPresent: false,
+    },
+    notes: [],
+  },
+};
+
+describe("run proofpack index", () => {
+  it("returns deterministic available comparison when latest+prior completed results exist", async () => {
+    const prisma: any = {
+      reconciliationMatch: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([]) },
+      proofPackage: { findMany: jest.fn().mockResolvedValue([]) },
+      $queryRaw: jest.fn().mockResolvedValue([
+        {
+          recon_job_id: "job-1",
+          rn: 1,
+          id: "result-2",
+          started_at: new Date("2026-01-02T00:00:00.000Z"),
+          status: "completed",
+          matched_count: 10,
+          unmatched_source_count: 1,
+          unmatched_target_count: 0,
+          conflict_count: 1,
+        },
+        {
+          recon_job_id: "job-1",
+          rn: 2,
+          id: "result-1",
+          started_at: new Date("2026-01-01T00:00:00.000Z"),
+          status: "completed",
+          matched_count: 8,
+          unmatched_source_count: 1,
+          unmatched_target_count: 1,
+          conflict_count: 0,
+        },
+      ]),
+    };
+
+    const byRun = await buildRunProofpackIndexByRunId({ prisma, tenantId: "tenant-1", runs: [baseRun] });
+    const index = byRun.get("job-1");
+    expect(index?.comparison.state).toBe("available");
+    expect(index?.comparison.changedSincePriorRun).toBe("changed");
+    expect(index?.comparison.deltas.matched).toBe(2);
+    expect(index?.comparison.baseline.priorResultId).toBe("result-1");
+  });
+
+  it("returns unavailable comparison when baseline is missing", async () => {
+    const prisma: any = {
+      reconciliationMatch: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([]) },
+      proofPackage: { findMany: jest.fn().mockResolvedValue([]) },
+      $queryRaw: jest.fn().mockResolvedValue([
+        {
+          recon_job_id: "job-1",
+          rn: 1,
+          id: "result-2",
+          started_at: new Date("2026-01-02T00:00:00.000Z"),
+          status: "completed",
+          matched_count: 10,
+          unmatched_source_count: 1,
+          unmatched_target_count: 0,
+          conflict_count: 1,
+        },
+      ]),
+    };
+
+    const byRun = await buildRunProofpackIndexByRunId({ prisma, tenantId: "tenant-1", runs: [baseRun] });
+    expect(byRun.get("job-1")?.comparison.state).toBe("unavailable");
+    expect(byRun.get("job-1")?.comparison.reasonCodes).toContain("baseline_missing");
+  });
+});

--- a/packages/reconciliation-core/src/run-proofpack-index.ts
+++ b/packages/reconciliation-core/src/run-proofpack-index.ts
@@ -1,0 +1,362 @@
+import type { CanonicalReconciliationListItem } from "./canonical-reconciliation.js";
+
+export type RunComparisonState = "available" | "unavailable" | "not_comparable" | "degraded";
+export type RunDeltaChangeState = "changed" | "unchanged" | "unavailable";
+
+export interface RunProofpackIndex {
+  proofPackages: {
+    total: number;
+    finalized: number;
+    bestCompletenessScore: number | null;
+    missingEvidenceCount: number;
+    latestCreatedAt: string | null;
+    state: "ready" | "degraded" | "setup_required" | "unavailable";
+    degradedEvidenceReasons: string[];
+  };
+  recurrence: {
+    exceptionsWithMemories: number;
+    repeatedResolutionReasons: string[];
+    state: "ready" | "degraded" | "setup_required" | "unavailable";
+  };
+  comparison: {
+    state: RunComparisonState;
+    changedSincePriorRun: RunDeltaChangeState;
+    certainty: "high" | "medium" | "low";
+    reasonCodes: string[];
+    summary: string;
+    baseline: {
+      priorResultId: string | null;
+      priorResultStartedAt: string | null;
+    };
+    deltas: {
+      matched: number | null;
+      unmatched: number | null;
+      conflicts: number | null;
+      proofCompleteness: "improved" | "regressed" | "unchanged" | "unavailable";
+      recurringFamilyConcentration: "stronger" | "weaker" | "stable" | "unavailable";
+    };
+  };
+}
+
+type LatestPriorResultRow = {
+  recon_job_id: string;
+  rn: number;
+  id: string;
+  started_at: Date | null;
+  status: string;
+  matched_count: number;
+  unmatched_source_count: number;
+  unmatched_target_count: number;
+  conflict_count: number;
+};
+
+function defaultIndex(): RunProofpackIndex {
+  return {
+    proofPackages: {
+      total: 0,
+      finalized: 0,
+      bestCompletenessScore: null,
+      missingEvidenceCount: 0,
+      latestCreatedAt: null,
+      state: "setup_required",
+      degradedEvidenceReasons: [],
+    },
+    recurrence: {
+      exceptionsWithMemories: 0,
+      repeatedResolutionReasons: [],
+      state: "setup_required",
+    },
+    comparison: {
+      state: "unavailable",
+      changedSincePriorRun: "unavailable",
+      certainty: "low",
+      reasonCodes: ["baseline_missing"],
+      summary: "No prior comparable run result is available yet.",
+      baseline: {
+        priorResultId: null,
+        priorResultStartedAt: null,
+      },
+      deltas: {
+        matched: null,
+        unmatched: null,
+        conflicts: null,
+        proofCompleteness: "unavailable",
+        recurringFamilyConcentration: "unavailable",
+      },
+    },
+  };
+}
+
+type RunProofpackPrisma = {
+  reconciliationMatch: { findMany: (args: unknown) => Promise<Array<{ id: string; runId: string }>> };
+  exceptionAdjudicationMemory: {
+    findMany: (args: unknown) => Promise<Array<{ exceptionId: string; resolutionReason: string | null }>>;
+  };
+  proofPackage: {
+    findMany: (args: unknown) => Promise<
+      Array<{
+        packageKey: string;
+        status: string;
+        completenessScore: unknown;
+        missingEvidence: unknown;
+        createdAt: Date;
+      }>
+    >;
+  };
+  $queryRaw: (query: TemplateStringsArray, ...values: unknown[]) => Promise<unknown>;
+};
+
+export async function buildRunProofpackIndexByRunId(input: {
+  prisma: RunProofpackPrisma;
+  tenantId: string;
+  runs: CanonicalReconciliationListItem[];
+}): Promise<Map<string, RunProofpackIndex>> {
+  const { prisma, tenantId, runs } = input;
+  const byRun = new Map<string, RunProofpackIndex>();
+  for (const run of runs) byRun.set(run.id, defaultIndex());
+
+  const reconRuns = runs.filter((item) => item.runKind === "recon_job");
+  if (reconRuns.length === 0) {
+    return byRun;
+  }
+
+  const runIds = reconRuns.map((item) => item.id);
+  const matches = await prisma.reconciliationMatch.findMany({
+    where: {
+      tenantId,
+      runId: { in: runIds },
+      matchType: { in: ["unmatched", "conflict"] },
+    },
+    select: { id: true, runId: true },
+  });
+
+  const runByExceptionId = new Map<string, string>();
+  const runExceptionCounts = new Map<string, number>();
+  for (const match of matches) {
+    runByExceptionId.set(match.id, match.runId);
+    runExceptionCounts.set(match.runId, (runExceptionCounts.get(match.runId) ?? 0) + 1);
+  }
+
+  const reasonCountsByRun = new Map<string, Map<string, number>>();
+  const exceptionIds = matches.map((match: { id: string }) => match.id);
+  if (exceptionIds.length > 0) {
+    const memories = await prisma.exceptionAdjudicationMemory.findMany({
+      where: {
+        tenantId,
+        exceptionId: { in: exceptionIds },
+      },
+      select: { exceptionId: true, resolutionReason: true },
+    });
+
+    for (const memory of memories) {
+      const runId = runByExceptionId.get(memory.exceptionId);
+      if (!runId) continue;
+      const reason = memory.resolutionReason?.trim();
+      if (!reason) continue;
+      const runReasons = reasonCountsByRun.get(runId) ?? new Map<string, number>();
+      runReasons.set(reason, (runReasons.get(reason) ?? 0) + 1);
+      reasonCountsByRun.set(runId, runReasons);
+    }
+  }
+
+  const proofPackages =
+    exceptionIds.length > 0
+      ? await prisma.proofPackage.findMany({
+          where: {
+            tenantId,
+            OR: exceptionIds.map((exceptionId: string) => ({
+              packageKey: { startsWith: `exception:${exceptionId}:` },
+            })),
+          },
+          select: {
+            packageKey: true,
+            status: true,
+            completenessScore: true,
+            missingEvidence: true,
+            createdAt: true,
+          },
+          orderBy: { createdAt: "desc" },
+        })
+      : [];
+
+  const results = (await prisma.$queryRaw`
+    SELECT
+      recon_job_id,
+      id,
+      started_at,
+      status,
+      matched_count,
+      unmatched_source_count,
+      unmatched_target_count,
+      conflict_count,
+      ROW_NUMBER() OVER (
+        PARTITION BY recon_job_id
+        ORDER BY started_at DESC NULLS LAST, id::text DESC
+      ) as rn
+    FROM recon_results
+    WHERE tenant_id = ${tenantId}::uuid
+      AND recon_job_id = ANY(${runIds}::uuid[])
+  `.catch(() => [])) as LatestPriorResultRow[];
+
+  const latestByRun = new Map<string, LatestPriorResultRow>();
+  const priorByRun = new Map<string, LatestPriorResultRow>();
+  for (const row of results) {
+    if (row.rn === 1) latestByRun.set(row.recon_job_id, row);
+    if (row.rn === 2) priorByRun.set(row.recon_job_id, row);
+  }
+
+  const proofByRun = new Map<string, RunProofpackIndex["proofPackages"]>();
+  for (const proof of proofPackages) {
+    const exceptionId = proof.packageKey.split(":")[1];
+    if (!exceptionId) continue;
+    const runId = runByExceptionId.get(exceptionId);
+    if (!runId) continue;
+    const state =
+      proofByRun.get(runId) ??
+      ({
+        total: 0,
+        finalized: 0,
+        missingEvidenceCount: 0,
+        bestCompletenessScore: null,
+        latestCreatedAt: null,
+        state: "setup_required",
+        degradedEvidenceReasons: [],
+      } satisfies RunProofpackIndex["proofPackages"]);
+
+    state.total += 1;
+    if (proof.status === "finalized") state.finalized += 1;
+    state.missingEvidenceCount += Array.isArray(proof.missingEvidence) ? proof.missingEvidence.length : 0;
+    const completenessScore = Number(proof.completenessScore);
+    state.bestCompletenessScore =
+      state.bestCompletenessScore == null
+        ? completenessScore
+        : Math.max(state.bestCompletenessScore, completenessScore);
+    if (!state.latestCreatedAt) state.latestCreatedAt = proof.createdAt.toISOString();
+    if (Array.isArray(proof.missingEvidence)) {
+      for (const reason of proof.missingEvidence) {
+        if (typeof reason === "string" && !state.degradedEvidenceReasons.includes(reason)) {
+          state.degradedEvidenceReasons.push(reason);
+        }
+      }
+    }
+    proofByRun.set(runId, state);
+  }
+
+  for (const run of reconRuns) {
+    const base = byRun.get(run.id) ?? defaultIndex();
+    const proof =
+      proofByRun.get(run.id) ??
+      ({ ...base.proofPackages, state: "setup_required", degradedEvidenceReasons: [] } as const);
+
+    const repeatedReasons = Array.from(reasonCountsByRun.get(run.id)?.entries() ?? [])
+      .filter(([, count]) => count > 1)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([reason]) => reason);
+
+    const exceptionsWithMemories = Array.from(reasonCountsByRun.get(run.id)?.values() ?? []).reduce(
+      (total, count) => total + (count > 0 ? 1 : 0),
+      0
+    );
+
+    const proofState =
+      proof.total === 0
+        ? "setup_required"
+        : proof.finalized > 0 && proof.missingEvidenceCount === 0
+          ? "ready"
+          : "degraded";
+
+    const recurrenceState =
+      exceptionsWithMemories > 0
+        ? "ready"
+        : (runExceptionCounts.get(run.id) ?? 0) > 0
+          ? "degraded"
+          : "setup_required";
+
+    const latest = latestByRun.get(run.id);
+    const prior = priorByRun.get(run.id);
+    const reasonCodes: string[] = [];
+
+    let comparisonState: RunComparisonState = "unavailable";
+    let changedSincePriorRun: RunDeltaChangeState = "unavailable";
+    let summary = "No prior comparable run result is available yet.";
+    let certainty: "high" | "medium" | "low" = "low";
+    let matchedDelta: number | null = null;
+    let unmatchedDelta: number | null = null;
+    let conflictsDelta: number | null = null;
+
+    if (!latest) {
+      reasonCodes.push("latest_result_missing");
+      summary = "Run has no persisted result, so prior-run comparison is unavailable.";
+    } else if (!prior) {
+      reasonCodes.push("baseline_missing");
+    } else {
+      const statusesComparable = latest.status === "completed" && prior.status === "completed";
+      if (!statusesComparable) {
+        comparisonState = "not_comparable";
+        reasonCodes.push("non_terminal_baseline");
+        summary = "Baseline exists but one or both run results are not completed, so deterministic deltas are not comparable.";
+        certainty = "medium";
+      } else {
+        comparisonState = "available";
+        certainty = "high";
+        matchedDelta = latest.matched_count - prior.matched_count;
+        unmatchedDelta =
+          latest.unmatched_source_count +
+          latest.unmatched_target_count -
+          (prior.unmatched_source_count + prior.unmatched_target_count);
+        conflictsDelta = latest.conflict_count - prior.conflict_count;
+        changedSincePriorRun =
+          matchedDelta !== 0 || unmatchedDelta !== 0 || conflictsDelta !== 0 ? "changed" : "unchanged";
+        summary =
+          changedSincePriorRun === "changed"
+            ? "Deterministic run-over-run differences detected versus the most recent comparable baseline."
+            : "No deterministic run-over-run differences detected versus the most recent comparable baseline.";
+      }
+    }
+
+    byRun.set(run.id, {
+      proofPackages: {
+        ...proof,
+        state: proofState,
+      },
+      recurrence: {
+        exceptionsWithMemories,
+        repeatedResolutionReasons: repeatedReasons,
+        state: recurrenceState,
+      },
+      comparison: {
+        state: comparisonState,
+        changedSincePriorRun,
+        certainty,
+        reasonCodes,
+        summary,
+        baseline: {
+          priorResultId: prior?.id ?? null,
+          priorResultStartedAt: prior?.started_at?.toISOString() ?? null,
+        },
+        deltas: {
+          matched: matchedDelta,
+          unmatched: unmatchedDelta,
+          conflicts: conflictsDelta,
+          proofCompleteness:
+            proof.bestCompletenessScore == null
+              ? "unavailable"
+              : proof.bestCompletenessScore >= 0.9
+                ? "improved"
+                : proof.bestCompletenessScore >= 0.7
+                  ? "unchanged"
+                  : "regressed",
+          recurringFamilyConcentration:
+            repeatedReasons.length === 0
+              ? "unavailable"
+              : repeatedReasons.length === 1
+                ? "stronger"
+                : "stable",
+        },
+      },
+    });
+  }
+
+  return byRun;
+}

--- a/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
+++ b/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
@@ -8,6 +8,7 @@ const resolveTenantMembershipScopeMock = jest.fn();
 const fetchMergedReconciliationRunsPageMock = jest.fn();
 const decodeMergedRunsCursorMock = jest.fn();
 const mapCanonicalListItemToApiRunsLegacyRowMock = jest.fn();
+const buildRunProofpackIndexByRunIdMock = jest.fn();
 
 jest.mock("@/lib/middleware/api-security", () => ({
   withSecurity: (handler: unknown) => handler,
@@ -36,6 +37,7 @@ jest.mock("@settler/reconciliation-core", () => {
     decodeMergedRunsCursor: (...args: unknown[]) => decodeMergedRunsCursorMock(...args),
     mapCanonicalListItemToApiRunsLegacyRow: (...args: unknown[]) =>
       mapCanonicalListItemToApiRunsLegacyRowMock(...args),
+    buildRunProofpackIndexByRunId: (...args: unknown[]) => buildRunProofpackIndexByRunIdMock(...args),
   };
 });
 
@@ -132,6 +134,7 @@ describe("GET /api/runs", () => {
     fetchMergedReconciliationRunsPageMock.mockReset();
     decodeMergedRunsCursorMock.mockReset();
     mapCanonicalListItemToApiRunsLegacyRowMock.mockReset();
+    buildRunProofpackIndexByRunIdMock.mockReset();
     (prisma as any).reconciliationMatch.findMany.mockReset();
     (prisma as any).exceptionAdjudicationMemory.findMany.mockReset();
     (prisma as any).proofPackage.findMany.mockReset();
@@ -205,6 +208,47 @@ describe("GET /api/runs", () => {
     (prisma as any).reconciliationMatch.findMany.mockResolvedValue([]);
     (prisma as any).exceptionAdjudicationMemory.findMany.mockResolvedValue([]);
     (prisma as any).proofPackage.findMany.mockResolvedValue([]);
+    buildRunProofpackIndexByRunIdMock.mockResolvedValue(
+      new Map([
+        [
+          "job-1",
+          {
+            proofPackages: {
+              total: 0,
+              finalized: 0,
+              bestCompletenessScore: null,
+              missingEvidenceCount: 0,
+              latestCreatedAt: null,
+              state: "setup_required",
+              degradedEvidenceReasons: [],
+            },
+            recurrence: {
+              exceptionsWithMemories: 0,
+              repeatedResolutionReasons: [],
+              state: "setup_required",
+            },
+            comparison: {
+              state: "unavailable",
+              changedSincePriorRun: "unavailable",
+              certainty: "low",
+              reasonCodes: ["baseline_missing"],
+              summary: "No prior comparable run result is available yet.",
+              baseline: {
+                priorResultId: null,
+                priorResultStartedAt: null,
+              },
+              deltas: {
+                matched: null,
+                unmatched: null,
+                conflicts: null,
+                proofCompleteness: "unavailable",
+                recurringFamilyConcentration: "unavailable",
+              },
+            },
+          },
+        ],
+      ])
+    );
   });
 
   it("returns 400 for invalid run_kind", async () => {
@@ -237,6 +281,7 @@ describe("GET /api/runs", () => {
     expect(body.items[0].runKind).toBe("recon_job");
     expect(body.items[0].sourceModel).toBe("recon_jobs");
     expect(body.items[0].compactProofSummary.proofPackages.state).toBe("setup_required");
+    expect(body.items[0].compactProofSummary.delta.state).toBe("unavailable");
     expect(body.items[0].detailHref).toBe("/console/runs/job-1");
     expect(body.next_cursor).toBe("next");
     expect(body.response_meta.pagination_mode).toBe("merged_cursor");

--- a/packages/web/src/__tests__/api/run-proofpack-route.contract.test.ts
+++ b/packages/web/src/__tests__/api/run-proofpack-route.contract.test.ts
@@ -1,0 +1,121 @@
+/** @jest-environment node */
+
+import { GET as getRunProofpack } from "@/app/api/runs/[id]/proofpack/route";
+
+const resolveTenantMembershipScopeMock = jest.fn();
+const resolveOperatorRunDetailForTenantsMock = jest.fn();
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+jest.mock("@/middleware/billing-gate-universal", () => ({
+  withUniversalBillingGate: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/supabase/tenant-membership", () => {
+  class TenantMembershipError extends Error {
+    status: number;
+    code: string;
+    constructor(status: number, code: string, message: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  }
+
+  return {
+    resolveTenantMembershipScope: (...args: unknown[]) => resolveTenantMembershipScopeMock(...args),
+    TenantMembershipError,
+  };
+});
+
+jest.mock("@settler/reconciliation-core", () => ({
+  resolveOperatorRunDetailForTenants: (...args: unknown[]) =>
+    resolveOperatorRunDetailForTenantsMock(...args),
+}));
+
+jest.mock("@/shared/db/prismaClient", () => ({ prisma: {} }));
+
+function req(url: string) {
+  return {
+    url,
+    method: "GET",
+    headers: new Headers(),
+    nextUrl: new URL(url),
+  } as any;
+}
+
+describe("GET /api/runs/[id]/proofpack", () => {
+  beforeEach(() => {
+    resolveTenantMembershipScopeMock.mockReset();
+    resolveOperatorRunDetailForTenantsMock.mockReset();
+    resolveTenantMembershipScopeMock.mockResolvedValue({ tenantIds: ["tenant-a"] });
+  });
+
+  it("returns canonical run-level proofpack artifact with deterministic comparison state", async () => {
+    resolveOperatorRunDetailForTenantsMock.mockResolvedValue({
+      kind: "ok",
+      detail: {
+        id: "run-1",
+        runKind: "recon_job",
+        status: "completed",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        completedAt: "2026-01-01T00:01:00.000Z",
+        detailHref: "/console/runs/run-1",
+        proofpackIndex: {
+          proofPackages: {
+            total: 1,
+            finalized: 1,
+            bestCompletenessScore: 1,
+            missingEvidenceCount: 0,
+            latestCreatedAt: "2026-01-01T00:05:00.000Z",
+            state: "ready",
+            degradedEvidenceReasons: [],
+          },
+          recurrence: {
+            exceptionsWithMemories: 1,
+            repeatedResolutionReasons: ["known_bank_window"],
+            state: "ready",
+          },
+          comparison: {
+            state: "available",
+            changedSincePriorRun: "changed",
+            certainty: "high",
+            reasonCodes: [],
+            summary: "Deterministic run-over-run differences detected versus the most recent comparable baseline.",
+            baseline: {
+              priorResultId: "result-1",
+              priorResultStartedAt: "2025-12-31T00:00:00.000Z",
+            },
+            deltas: {
+              matched: 2,
+              unmatched: -1,
+              conflicts: 0,
+              proofCompleteness: "improved",
+              recurringFamilyConcentration: "stronger",
+            },
+          },
+        },
+      },
+    });
+
+    const response = await getRunProofpack(req("http://localhost/api/runs/run-1/proofpack"), {
+      params: { id: "run-1" },
+    } as any);
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.artifact.schemaVersion).toBe("proofpack.run.v1");
+    expect(payload.artifact.proofpackIndex.comparison.state).toBe("available");
+    expect(payload.artifact.supportability.shareable).toBe(true);
+  });
+
+  it("returns 404 for inaccessible run ids", async () => {
+    resolveOperatorRunDetailForTenantsMock.mockResolvedValue({ kind: "not_found" });
+    const response = await getRunProofpack(req("http://localhost/api/runs/other/proofpack"), {
+      params: { id: "other" },
+    } as any);
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/web/src/app/api/runs/[id]/proofpack/route.ts
+++ b/packages/web/src/app/api/runs/[id]/proofpack/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
+import {
+  resolveTenantMembershipScope,
+  TenantMembershipError,
+} from "@/lib/supabase/tenant-membership";
+import { prisma } from "@/shared/db/prismaClient";
+import { resolveOperatorRunDetailForTenants } from "@settler/reconciliation-core";
+
+export const runtime = "nodejs";
+
+export const GET = withSecurity(
+  withUniversalBillingGate(async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+    try {
+      const { tenantIds } = await resolveTenantMembershipScope();
+      const outcome = await resolveOperatorRunDetailForTenants(prisma, tenantIds, params.id);
+
+      if (outcome.kind === "ambiguous_uuid_collision") {
+        return NextResponse.json({ error: "Ambiguous run identifier", code: "RUN_ID_COLLISION" }, { status: 409 });
+      }
+      if (outcome.kind === "not_found") {
+        return NextResponse.json({ error: "Run not found" }, { status: 404 });
+      }
+      if (outcome.kind === "recon_enrichment_failed") {
+        return NextResponse.json({ error: "Failed to build run proofpack artifact" }, { status: 500 });
+      }
+
+      const detail = outcome.detail;
+      const proofpackIndex = detail.proofpackIndex;
+      const artifact = {
+        schemaVersion: "proofpack.run.v1",
+        generatedAt: new Date().toISOString(),
+        run: {
+          id: detail.id,
+          runKind: detail.runKind,
+          status: detail.status,
+          startedAt: detail.startedAt,
+          completedAt: detail.completedAt,
+          detailHref: detail.detailHref,
+        },
+        proofpackIndex: proofpackIndex ?? {
+          comparison: {
+            state: "unavailable",
+            changedSincePriorRun: "unavailable",
+            certainty: "low",
+            reasonCodes: ["proofpack_index_unavailable"],
+            summary: "Run-level proofpack index is unavailable for this run type.",
+          },
+        },
+        supportability: {
+          shareable: Boolean(
+            proofpackIndex &&
+              proofpackIndex.proofPackages.state === "ready" &&
+              proofpackIndex.comparison.state === "available"
+          ),
+          notes:
+            proofpackIndex?.comparison.state === "available"
+              ? []
+              : ["Prior comparable baseline is unavailable or not comparable."],
+        },
+      };
+
+      return NextResponse.json({ artifact });
+    } catch (error) {
+      if (error instanceof TenantMembershipError) {
+        return NextResponse.json({ error: error.message, code: error.code }, { status: error.status });
+      }
+      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+  }),
+  { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: true }
+);

--- a/packages/web/src/app/api/runs/route.ts
+++ b/packages/web/src/app/api/runs/route.ts
@@ -25,6 +25,7 @@ import {
   fetchMergedReconciliationRunsPage,
   mapCanonicalListItemToApiRunsLegacyRow,
   MergedRunsCursorError,
+  buildRunProofpackIndexByRunId,
   type MergedRunsCursorV1,
 } from "@settler/reconciliation-core";
 import {
@@ -36,26 +37,24 @@ import {
 export const runtime = "nodejs";
 
 type RunListItemWithSignals = ReturnType<typeof mapCanonicalListItemToApiRunsLegacyRow> & {
-  compactProofSummary?: {
-    proofPackages: {
-      total: number;
-      finalized: number;
-      bestCompletenessScore: number | null;
-      missingEvidenceCount: number;
-      latestCreatedAt: string | null;
-      state: "ready" | "degraded" | "setup_required" | "unavailable";
-    };
-    recurrence: {
-      exceptionsWithMemories: number;
-      repeatedResolutionReasons: string[];
-      state: "ready" | "degraded" | "setup_required" | "unavailable";
-    };
-    delta: {
-      changedSincePreviousRun: "changed" | "unchanged" | "unavailable";
-      summary: string;
-    };
-  };
+  compactProofSummary?: ReturnType<typeof toCompactProofSummary>;
 };
+
+function toCompactProofSummary(index: import("@settler/reconciliation-core").RunProofpackIndex) {
+  return {
+    proofPackages: index.proofPackages,
+    recurrence: index.recurrence,
+    delta: {
+      changedSincePreviousRun: index.comparison.changedSincePriorRun,
+      summary: index.comparison.summary,
+      state: index.comparison.state,
+      certainty: index.comparison.certainty,
+      reasonCodes: index.comparison.reasonCodes,
+      baseline: index.comparison.baseline,
+      deltas: index.comparison.deltas,
+    },
+  };
+}
 
 function resolveTenantIdForRuns(
   authContext: UnifiedAuthContext,
@@ -88,166 +87,15 @@ const MAX_FILTER_SCAN_PAGES = 30;
 
 async function withRunCompactProofSignals(
   tenantId: string,
-  items: ReturnType<typeof mapCanonicalListItemToApiRunsLegacyRow>[]
+  rows: import("@settler/reconciliation-core").CanonicalReconciliationListItem[]
 ): Promise<RunListItemWithSignals[]> {
-  const reconRunIds = items.filter((item) => item.runKind === "recon_job").map((item) => item.id);
-  if (reconRunIds.length === 0) {
-    return items;
-  }
-
-  const matches = await prisma.reconciliationMatch.findMany({
-    where: {
-      tenantId,
-      runId: { in: reconRunIds },
-      matchType: { in: ["unmatched", "conflict"] },
-    },
-    select: { id: true, runId: true },
-  });
-
-  const runByExceptionId = new Map<string, string>();
-  for (const match of matches) {
-    runByExceptionId.set(match.id, match.runId);
-  }
-
-  const reasonCountsByRun = new Map<string, Map<string, number>>();
-  const exceptionIds = matches.map((match: { id: string }) => match.id);
-  if (exceptionIds.length > 0) {
-    const memories = await prisma.exceptionAdjudicationMemory.findMany({
-      where: {
-        tenantId,
-        exceptionId: { in: exceptionIds },
-      },
-      select: { exceptionId: true, resolutionReason: true },
-    });
-    for (const memory of memories) {
-      const runId = runByExceptionId.get(memory.exceptionId);
-      if (!runId) continue;
-      const reason = memory.resolutionReason?.trim();
-      if (!reason) continue;
-      const runReasons = reasonCountsByRun.get(runId) ?? new Map<string, number>();
-      runReasons.set(reason, (runReasons.get(reason) ?? 0) + 1);
-      reasonCountsByRun.set(runId, runReasons);
-    }
-  }
-
-  const proofPackages =
-    exceptionIds.length > 0
-      ? await prisma.proofPackage.findMany({
-          where: {
-            tenantId,
-            OR: exceptionIds.map((exceptionId: string) => ({
-              packageKey: { startsWith: `exception:${exceptionId}:` },
-            })),
-          },
-          select: {
-            packageKey: true,
-            status: true,
-            completenessScore: true,
-            missingEvidence: true,
-            createdAt: true,
-          },
-          orderBy: { createdAt: "desc" },
-        })
-      : [];
-
-  const proofByRun = new Map<
-    string,
-    {
-      total: number;
-      finalized: number;
-      missingEvidenceCount: number;
-      bestCompletenessScore: number | null;
-      latestCreatedAt: string | null;
-    }
-  >();
-  const runExceptionCounts = new Map<string, number>();
-  for (const match of matches) {
-    runExceptionCounts.set(match.runId, (runExceptionCounts.get(match.runId) ?? 0) + 1);
-  }
-  for (const proof of proofPackages) {
-    const packageKeyParts = proof.packageKey.split(":");
-    const exceptionId = packageKeyParts.length >= 2 ? packageKeyParts[1] : null;
-    if (!exceptionId) continue;
-    const runId = runByExceptionId.get(exceptionId);
-    if (!runId) continue;
-    const state = proofByRun.get(runId) ?? {
-      total: 0,
-      finalized: 0,
-      missingEvidenceCount: 0,
-      bestCompletenessScore: null,
-      latestCreatedAt: null,
-    };
-    state.total += 1;
-    if (proof.status === "finalized") state.finalized += 1;
-    state.missingEvidenceCount += Array.isArray(proof.missingEvidence)
-      ? proof.missingEvidence.length
-      : 0;
-    const completenessScore = Number(proof.completenessScore);
-    state.bestCompletenessScore =
-      state.bestCompletenessScore == null
-        ? completenessScore
-        : Math.max(state.bestCompletenessScore, completenessScore);
-    if (!state.latestCreatedAt) {
-      state.latestCreatedAt = proof.createdAt.toISOString();
-    }
-    proofByRun.set(runId, state);
-  }
-
-  return items.map((item) => {
-    const proof = proofByRun.get(item.id) ?? {
-      total: 0,
-      finalized: 0,
-      missingEvidenceCount: 0,
-      bestCompletenessScore: null,
-      latestCreatedAt: null,
-    };
-    const repeatedReasons = Array.from(reasonCountsByRun.get(item.id)?.entries() ?? [])
-      .filter(([, count]) => count > 1)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 2)
-      .map(([reason]) => reason);
-    const exceptionsWithMemories = Array.from(
-      reasonCountsByRun.get(item.id)?.values() ?? []
-    ).reduce((total, count) => total + (count > 0 ? 1 : 0), 0);
-    const proofState =
-      proof.total === 0
-        ? "setup_required"
-        : proof.finalized > 0 && proof.missingEvidenceCount === 0
-          ? "ready"
-          : "degraded";
-
+  const indexByRun = await buildRunProofpackIndexByRunId({ prisma, tenantId, runs: rows });
+  return rows.map((row) => {
+    const legacy = mapCanonicalListItemToApiRunsLegacyRow(row);
+    const index = indexByRun.get(row.id);
     return {
-      ...item,
-      compactProofSummary: {
-        proofPackages: {
-          ...proof,
-          state: proofState,
-        },
-        recurrence: {
-          exceptionsWithMemories,
-          repeatedResolutionReasons: repeatedReasons,
-          state:
-            exceptionsWithMemories > 0
-              ? "ready"
-              : runExceptionCounts.get(item.id)
-                ? "degraded"
-                : "setup_required",
-        },
-        delta: {
-          changedSincePreviousRun:
-            item.configDrift?.status === "detected"
-              ? "changed"
-              : item.configDrift?.status === "none"
-                ? "unchanged"
-                : "unavailable",
-          summary:
-            item.configDrift?.status === "detected"
-              ? "Configuration drift detected since prior run."
-              : item.configDrift?.status === "none"
-                ? "No configuration drift detected in canonical run metadata."
-                : "Prior-run delta unavailable in this list view.",
-        },
-      },
+      ...legacy,
+      compactProofSummary: index ? toCompactProofSummary(index) : undefined,
     };
   });
 }
@@ -318,8 +166,7 @@ export const GET = withSecurity(
             encodeCursor: encodeMergedRunsCursor,
           });
 
-          const baseItems = page.runs.map(mapCanonicalListItemToApiRunsLegacyRow);
-          const items = await withRunCompactProofSignals(tenantId, baseItems);
+          const items = await withRunCompactProofSignals(tenantId, page.runs);
 
           return NextResponse.json({
             items,
@@ -354,7 +201,7 @@ export const GET = withSecurity(
         }
 
         let walkCursor: MergedRunsCursorV1 | null = null;
-        const collected: ReturnType<typeof mapCanonicalListItemToApiRunsLegacyRow>[] = [];
+        const collected: import("@settler/reconciliation-core").CanonicalReconciliationListItem[] = [];
         let pagesScanned = 0;
         let lastPagePagination = null as
           | Awaited<ReturnType<typeof fetchMergedReconciliationRunsPage>>["pagination"]
@@ -377,7 +224,7 @@ export const GET = withSecurity(
             const legacy = mapCanonicalListItemToApiRunsLegacyRow(row);
             if (!matchesStatusFilter(statusFilter, legacy.status)) continue;
             if (!matchesSearchFilter(searchFilter, legacy.id, legacy.name)) continue;
-            collected.push(legacy);
+            collected.push(row);
             if (collected.length >= limit) break;
           }
 


### PR DESCRIPTION
### Motivation

- Centralize run-level proof posture and prior-run delta computation so list/detail/export share one canonical truth instead of route-local heuristics. 
- Make prior-run comparability and degraded states explicit and machine-visible with deterministic baseline selection rules. 
- Provide a shareable run-level proofpack artifact with explicit supportability framing for operators and buyers.

### Description

- Added a canonical `RunProofpackIndex` and `buildRunProofpackIndexByRunId` service in `@settler/reconciliation-core` that computes proof-package posture, recurrence signals, and deterministic prior-run deltas using tenant-scoped `recon_results` windowing. 
- Exported the new service from `packages/reconciliation-core/src/index.ts` and extended the canonical operator run detail contract to include `proofpackIndex` (updated serializers and resolver to inject the index). 
- Replaced route-local proof/delta heuristics in the runs list with calls to the canonical service and emit a compact proof summary on each list row (`packages/web/src/app/api/runs/route.ts`). 
- Added a run-level proofpack artifact endpoint `GET /api/runs/[id]/proofpack` that returns `proofpack.run.v1` with explicit `supportability.shareable` and degraded-state reasons (`packages/web/src/app/api/runs/[id]/proofpack/route.ts`). 
- Tests added and updated to cover deterministic baseline-available and baseline-missing cases and to assert contract wiring between core and web packages (`packages/reconciliation-core/src/run-proofpack-index.test.ts`, web route contract tests). 

### Testing

- Ran `npx node@24.12.0 $(which pnpm) install` — ✅ completed (non-fatal Prisma postinstall checksum warning surfaced in this environment). 
- Ran reconciliation-core unit tests: `npx node@24.12.0 $(which pnpm) --filter @settler/reconciliation-core test -- run-proofpack-index` — ✅ passed. 
- Ran web contract tests: `npx node@24.12.0 $(which pnpm) --filter @settler/web test -- run-proofpack-route.contract api-runs-list-route.contract` — ✅ passed. 
- Attempted workspace/package typecheck: `npx node@24.12.0 $(which pnpm) --filter @settler/reconciliation-core typecheck` and `--filter @settler/web typecheck` — ⚠️ surfaced pre-existing type/module-resolution issues (Prisma v7 `@prisma/client` typing export and web ↔ reconciliation-core resolution drift) that remain and are tracked as the next follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1988b5808328bae2ad6c03519a97)