### PR TITLE
Unify canonical run proof intelligence across API list and proofpack surfaces

### DIFF
--- a/packages/api/src/routes/__tests__/runs.test.ts
+++ b/packages/api/src/routes/__tests__/runs.test.ts
@@ -35,6 +35,8 @@ jest.mock(
   () => ({
     scanMergedRunsForLegacyPage: jest.fn(),
     resolveOperatorRunDetailForTenants: jest.fn(),
+    buildRunProofpackIndexByRunId: jest.fn(),
+    toRunCompactProofSummary: jest.fn((value: unknown) => value),
   }),
   { virtual: true }
 );
@@ -45,6 +47,8 @@ const mockReconResult = mockedPrisma.reconResult;
 const {
   scanMergedRunsForLegacyPage: mockScanMergedRunsForLegacyPage,
   resolveOperatorRunDetailForTenants: mockResolveOperatorRunDetail,
+  buildRunProofpackIndexByRunId: mockBuildRunProofpackIndexByRunId,
+  toRunCompactProofSummary: mockToRunCompactProofSummary,
 } = require("@settler/reconciliation-core");
 
 // Mock governance middleware
@@ -154,10 +158,64 @@ describe("Runs Routes", () => {
     jest.clearAllMocks();
     mockScanMergedRunsForLegacyPage.mockReset();
     mockResolveOperatorRunDetail.mockReset();
+    mockBuildRunProofpackIndexByRunId.mockReset();
+    mockBuildRunProofpackIndexByRunId.mockResolvedValue(new Map());
+    mockToRunCompactProofSummary.mockClear();
   });
 
   describe("GET /api/runs", () => {
     it("should return merged canonical runs adapted into the Express envelope", async () => {
+      mockBuildRunProofpackIndexByRunId.mockResolvedValueOnce(
+        new Map([
+          [
+            "run-1",
+            {
+              proofPackages: {
+                total: 1,
+                finalized: 1,
+                bestCompletenessScore: 1,
+                missingEvidenceCount: 0,
+                latestCreatedAt: "2026-03-17T10:10:00.000Z",
+                state: "ready",
+                degradedEvidenceReasons: [],
+              },
+              recurrence: {
+                exceptionsWithMemories: 1,
+                repeatedResolutionReasons: ["bank_window"],
+                state: "ready",
+                topRecurringFamilies: [],
+              },
+              comparison: {
+                state: "available",
+                changedSincePriorRun: "changed",
+                certainty: "high",
+                reasonCodes: ["history_window_evaluated"],
+                summary:
+                  "Deterministic run-over-run differences detected versus the most recent comparable baseline.",
+                baseline: {
+                  priorResultId: "prior-1",
+                  priorResultStartedAt: "2026-03-16T10:00:00.000Z",
+                },
+                history: {
+                  lookbackWindow: 2,
+                  comparableWindowCount: 2,
+                  certainty: "high",
+                  trend: "improving",
+                  reasonCodes: ["history_window_evaluated"],
+                  summary: "Recent comparable history shows improving reconciliation posture.",
+                },
+                deltas: {
+                  matched: 2,
+                  unmatched: -2,
+                  conflicts: -1,
+                  proofCompleteness: "improved",
+                  recurringFamilyConcentration: "stronger",
+                },
+              },
+            },
+          ],
+        ])
+      );
       mockScanMergedRunsForLegacyPage.mockResolvedValueOnce({
         data: [
           {
@@ -221,6 +279,7 @@ describe("Runs Routes", () => {
         sourceModel: "recon_jobs",
         summary: { total: 100, matched: 95, unmatched: 5, conflicts: 0 },
       });
+      expect(res.body.data[0].compactProofSummary).toBeDefined();
 
       expect(mockScanMergedRunsForLegacyPage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -230,6 +289,12 @@ describe("Runs Routes", () => {
           limit: 50,
           batchSize: 100,
           filters: { status: undefined, search: undefined },
+        })
+      );
+      expect(mockBuildRunProofpackIndexByRunId).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: "tenant-123",
+          runs: [{ id: "run-1", runKind: "recon_job" }],
         })
       );
     });

--- a/packages/api/src/routes/runs.ts
+++ b/packages/api/src/routes/runs.ts
@@ -23,6 +23,8 @@ import { enforceFreezeState } from "../middleware/governance";
 import {
   scanMergedRunsForLegacyPage,
   resolveOperatorRunDetailForTenants,
+  buildRunProofpackIndexByRunId,
+  toRunCompactProofSummary,
 } from "@settler/reconciliation-core";
 import { handleRouteError } from "../utils/error-handler";
 import {
@@ -80,11 +82,25 @@ router.get(
         batchSize: MERGED_LIST_BATCH_SIZE,
       });
 
+      const indexByRun = await buildRunProofpackIndexByRunId({
+        prisma,
+        tenantId,
+        runs: result.data.map((row) => ({ id: row.id, runKind: row.runKind })),
+      });
+
+      const rowsWithSignals = result.data.map((row) => {
+        const index = indexByRun.get(row.id);
+        return {
+          ...row,
+          compactProofSummary: index ? toRunCompactProofSummary(index) : undefined,
+        };
+      });
+
       logInfo("Runs listed", {
         tenantId,
         status: result.filters.status,
         search: result.filters.search,
-        count: result.data.length,
+        count: rowsWithSignals.length,
         total: result.pagination.total,
         page,
         limit,
@@ -92,7 +108,7 @@ router.get(
       });
 
       res.json({
-        data: result.data,
+        data: rowsWithSignals,
         pagination: result.pagination,
       });
     } catch (error: unknown) {

--- a/packages/reconciliation-core/src/run-proofpack-index.test.ts
+++ b/packages/reconciliation-core/src/run-proofpack-index.test.ts
@@ -1,4 +1,8 @@
-import { buildRunProofpackIndexByRunId } from "./run-proofpack-index.js";
+import {
+  buildRunProofpackIndexByRunId,
+  toRunCompactProofSummary,
+  unavailableRunProofpackIndex,
+} from "./run-proofpack-index.js";
 import type { CanonicalReconciliationListItem } from "./canonical-reconciliation.js";
 
 const baseRun: CanonicalReconciliationListItem = {
@@ -31,7 +35,12 @@ const baseRun: CanonicalReconciliationListItem = {
     ignored: 0,
     resolved: 0,
   },
-  provenance: { sourceModel: "recon_jobs", runKind: "recon_job", ingestionId: null, reconJobId: "job-1" },
+  provenance: {
+    sourceModel: "recon_jobs",
+    runKind: "recon_job",
+    ingestionId: null,
+    reconJobId: "job-1",
+  },
   adapters: { sourceAdapter: "a", targetAdapter: "b" },
   timestamps: {
     createdAt: "2026-01-01T00:00:00.000Z",
@@ -111,7 +120,11 @@ describe("run proofpack index", () => {
       ]),
     };
 
-    const byRun = await buildRunProofpackIndexByRunId({ prisma, tenantId: "tenant-1", runs: [baseRun] });
+    const byRun = await buildRunProofpackIndexByRunId({
+      prisma,
+      tenantId: "tenant-1",
+      runs: [baseRun],
+    });
     const index = byRun.get("job-1");
     expect(index?.comparison.state).toBe("available");
     expect(index?.comparison.changedSincePriorRun).toBe("changed");
@@ -141,9 +154,40 @@ describe("run proofpack index", () => {
       ]),
     };
 
-    const byRun = await buildRunProofpackIndexByRunId({ prisma, tenantId: "tenant-1", runs: [baseRun] });
+    const byRun = await buildRunProofpackIndexByRunId({
+      prisma,
+      tenantId: "tenant-1",
+      runs: [baseRun],
+    });
     expect(byRun.get("job-1")?.comparison.state).toBe("unavailable");
     expect(byRun.get("job-1")?.comparison.reasonCodes).toContain("baseline_missing");
     expect(byRun.get("job-1")?.comparison.history.trend).toBe("unavailable");
+  });
+
+  it("builds canonical compact proof summary from full index", async () => {
+    const prisma: any = {
+      reconciliationMatch: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([]) },
+      proofPackage: { findMany: jest.fn().mockResolvedValue([]) },
+      $queryRaw: jest.fn().mockResolvedValue([]),
+    };
+
+    const byRun = await buildRunProofpackIndexByRunId({
+      prisma,
+      tenantId: "tenant-1",
+      runs: [baseRun],
+    });
+    const index = byRun.get("job-1");
+    expect(index).toBeDefined();
+    const compact = toRunCompactProofSummary(index!);
+    expect(compact.delta.changedSincePreviousRun).toBe("unavailable");
+    expect(compact.recurrence.state).toBe("setup_required");
+  });
+
+  it("returns explicit unavailable index contract for unsupported run types", () => {
+    const unavailable = unavailableRunProofpackIndex();
+    expect(unavailable.proofPackages.state).toBe("unavailable");
+    expect(unavailable.comparison.reasonCodes).toEqual(["proofpack_index_unavailable"]);
+    expect(unavailable.comparison.history.reasonCodes).toEqual(["proofpack_index_unavailable"]);
   });
 });

--- a/packages/reconciliation-core/src/run-proofpack-index.ts
+++ b/packages/reconciliation-core/src/run-proofpack-index.ts
@@ -63,6 +63,21 @@ export interface RunProofpackIndex {
   };
 }
 
+export type RunCompactProofSummary = {
+  proofPackages: RunProofpackIndex["proofPackages"];
+  recurrence: RunProofpackIndex["recurrence"];
+  delta: {
+    changedSincePreviousRun: RunProofpackIndex["comparison"]["changedSincePriorRun"];
+    summary: RunProofpackIndex["comparison"]["summary"];
+    state: RunProofpackIndex["comparison"]["state"];
+    certainty: RunProofpackIndex["comparison"]["certainty"];
+    reasonCodes: RunProofpackIndex["comparison"]["reasonCodes"];
+    baseline: RunProofpackIndex["comparison"]["baseline"];
+    history: RunProofpackIndex["comparison"]["history"];
+    deltas: RunProofpackIndex["comparison"]["deltas"];
+  };
+};
+
 type LatestPriorResultRow = {
   recon_job_id: string;
   rn: number;
@@ -129,10 +144,57 @@ function defaultIndex(): RunProofpackIndex {
   };
 }
 
+export function toRunCompactProofSummary(index: RunProofpackIndex): RunCompactProofSummary {
+  return {
+    proofPackages: index.proofPackages,
+    recurrence: index.recurrence,
+    delta: {
+      changedSincePreviousRun: index.comparison.changedSincePriorRun,
+      summary: index.comparison.summary,
+      state: index.comparison.state,
+      certainty: index.comparison.certainty,
+      reasonCodes: index.comparison.reasonCodes,
+      baseline: index.comparison.baseline,
+      history: index.comparison.history,
+      deltas: index.comparison.deltas,
+    },
+  };
+}
+
+export function unavailableRunProofpackIndex(
+  reasonCode = "proofpack_index_unavailable"
+): RunProofpackIndex {
+  const base = defaultIndex();
+  return {
+    ...base,
+    proofPackages: {
+      ...base.proofPackages,
+      state: "unavailable",
+      degradedEvidenceReasons: [reasonCode],
+    },
+    recurrence: {
+      ...base.recurrence,
+      state: "unavailable",
+    },
+    comparison: {
+      ...base.comparison,
+      reasonCodes: [reasonCode],
+      summary: "Run-level proofpack index is unavailable for this run type.",
+      history: {
+        ...base.comparison.history,
+        reasonCodes: [reasonCode],
+        summary: "Run history intelligence is unavailable for this run type.",
+      },
+    },
+  };
+}
+
 type RunProofpackPrisma = {
   reconciliationMatch: { findMany: (args: unknown) => Promise<MatchRow[]> };
   exceptionAdjudicationMemory: {
-    findMany: (args: unknown) => Promise<Array<{ exceptionId: string; resolutionReason: string | null }>>;
+    findMany: (
+      args: unknown
+    ) => Promise<Array<{ exceptionId: string; resolutionReason: string | null }>>;
   };
   proofPackage: {
     findMany: (args: unknown) => Promise<
@@ -159,7 +221,9 @@ function toComparableHistory(rows: LatestPriorResultRow[]) {
   return ordered.filter((row) => row.status === "completed").slice(0, HISTORY_WINDOW);
 }
 
-function buildHistorySummary(rows: LatestPriorResultRow[]): RunProofpackIndex["comparison"]["history"] {
+function buildHistorySummary(
+  rows: LatestPriorResultRow[]
+): RunProofpackIndex["comparison"]["history"] {
   const comparableRows = toComparableHistory(rows);
   if (comparableRows.length < 2) {
     return {
@@ -194,7 +258,8 @@ function buildHistorySummary(rows: LatestPriorResultRow[]): RunProofpackIndex["c
   const transitions = comparableRows.length - 1;
   const dominant = Math.max(improvingSignals, regressingSignals, volatileSignals);
   const dominanceRatio = dominant / transitions;
-  const certainty: RunCertainty = transitions >= 4 && dominanceRatio >= 0.75 ? "high" : dominanceRatio >= 0.5 ? "medium" : "low";
+  const certainty: RunCertainty =
+    transitions >= 4 && dominanceRatio >= 0.75 ? "high" : dominanceRatio >= 0.5 ? "medium" : "low";
 
   const trend: RunTrend =
     improvingSignals === regressingSignals && improvingSignals > 0
@@ -227,7 +292,7 @@ function buildHistorySummary(rows: LatestPriorResultRow[]): RunProofpackIndex["c
 export async function buildRunProofpackIndexByRunId(input: {
   prisma: ReconciliationCorePrismaClient;
   tenantId: string;
-  runs: CanonicalReconciliationListItem[];
+  runs: Array<Pick<CanonicalReconciliationListItem, "id" | "runKind">>;
 }): Promise<Map<string, RunProofpackIndex>> {
   const { prisma, tenantId, runs } = input;
   const byRun = new Map<string, RunProofpackIndex>();
@@ -285,13 +350,29 @@ export async function buildRunProofpackIndexByRunId(input: {
       const runId = runByExceptionId.get(memory.exceptionId);
       const match = matchByExceptionId.get(memory.exceptionId);
       if (!runId || !match) continue;
-      const reason = memory.resolutionReason?.trim() || match.resolutionReason?.trim() || "unclassified";
+      const reason =
+        memory.resolutionReason?.trim() || match.resolutionReason?.trim() || "unclassified";
       const runReasons = reasonCountsByRun.get(runId) ?? new Map<string, number>();
       runReasons.set(reason, (runReasons.get(reason) ?? 0) + 1);
       reasonCountsByRun.set(runId, runReasons);
 
-      const runFamilyStats = familyStatsByRun.get(runId) ?? new Map<string, { occurrences: number; unresolvedCount: number; adjudicationTouches: number; highSeverityCount: number; }>();
-      const family = runFamilyStats.get(reason) ?? { occurrences: 0, unresolvedCount: 0, adjudicationTouches: 0, highSeverityCount: 0 };
+      const runFamilyStats =
+        familyStatsByRun.get(runId) ??
+        new Map<
+          string,
+          {
+            occurrences: number;
+            unresolvedCount: number;
+            adjudicationTouches: number;
+            highSeverityCount: number;
+          }
+        >();
+      const family = runFamilyStats.get(reason) ?? {
+        occurrences: 0,
+        unresolvedCount: 0,
+        adjudicationTouches: 0,
+        highSeverityCount: 0,
+      };
       family.occurrences += 1;
       family.adjudicationTouches += 1;
       if (match.status !== "resolved") family.unresolvedCount += 1;
@@ -374,7 +455,9 @@ export async function buildRunProofpackIndexByRunId(input: {
 
     state.total += 1;
     if (proof.status === "finalized") state.finalized += 1;
-    state.missingEvidenceCount += Array.isArray(proof.missingEvidence) ? proof.missingEvidence.length : 0;
+    state.missingEvidenceCount += Array.isArray(proof.missingEvidence)
+      ? proof.missingEvidence.length
+      : 0;
     const completenessScore = Number(proof.completenessScore);
     state.bestCompletenessScore =
       state.bestCompletenessScore == null
@@ -421,7 +504,8 @@ export async function buildRunProofpackIndexByRunId(input: {
             : stats.unresolvedCount === 0 && stats.adjudicationTouches > 0
               ? "weakening"
               : "stable";
-        const certainty: RunCertainty = stats.occurrences >= 3 ? "high" : stats.occurrences >= 2 ? "medium" : "low";
+        const certainty: RunCertainty =
+          stats.occurrences >= 3 ? "high" : stats.occurrences >= 2 ? "medium" : "low";
         return {
           family,
           trend,
@@ -473,7 +557,8 @@ export async function buildRunProofpackIndexByRunId(input: {
       if (!statusesComparable) {
         comparisonState = "not_comparable";
         reasonCodes.push("non_terminal_baseline");
-        summary = "Baseline exists but one or both run results are not completed, so deterministic deltas are not comparable.";
+        summary =
+          "Baseline exists but one or both run results are not completed, so deterministic deltas are not comparable.";
         certainty = "medium";
       } else {
         comparisonState = "available";
@@ -482,7 +567,9 @@ export async function buildRunProofpackIndexByRunId(input: {
         unmatchedDelta = totalUnmatched(latest) - totalUnmatched(prior);
         conflictsDelta = latest.conflict_count - prior.conflict_count;
         changedSincePriorRun =
-          matchedDelta !== 0 || unmatchedDelta !== 0 || conflictsDelta !== 0 ? "changed" : "unchanged";
+          matchedDelta !== 0 || unmatchedDelta !== 0 || conflictsDelta !== 0
+            ? "changed"
+            : "unchanged";
         summary =
           changedSincePriorRun === "changed"
             ? "Deterministic run-over-run differences detected versus the most recent comparable baseline."

--- a/packages/web/src/app/api/runs/[id]/proofpack/route.ts
+++ b/packages/web/src/app/api/runs/[id]/proofpack/route.ts
@@ -6,24 +6,36 @@ import {
   TenantMembershipError,
 } from "@/lib/supabase/tenant-membership";
 import { prisma } from "@/shared/db/prismaClient";
-import { resolveOperatorRunDetailForTenants } from "@settler/reconciliation-core";
+import {
+  resolveOperatorRunDetailForTenants,
+  unavailableRunProofpackIndex,
+} from "@settler/reconciliation-core";
 
 export const runtime = "nodejs";
 
 export const GET = withSecurity(
-  withUniversalBillingGate(async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  withUniversalBillingGate(async function GET(
+    _request: NextRequest,
+    { params }: { params: { id: string } }
+  ) {
     try {
       const { tenantIds } = await resolveTenantMembershipScope();
       const outcome = await resolveOperatorRunDetailForTenants(prisma, tenantIds, params.id);
 
       if (outcome.kind === "ambiguous_uuid_collision") {
-        return NextResponse.json({ error: "Ambiguous run identifier", code: "RUN_ID_COLLISION" }, { status: 409 });
+        return NextResponse.json(
+          { error: "Ambiguous run identifier", code: "RUN_ID_COLLISION" },
+          { status: 409 }
+        );
       }
       if (outcome.kind === "not_found") {
         return NextResponse.json({ error: "Run not found" }, { status: 404 });
       }
       if (outcome.kind === "recon_enrichment_failed") {
-        return NextResponse.json({ error: "Failed to build run proofpack artifact" }, { status: 500 });
+        return NextResponse.json(
+          { error: "Failed to build run proofpack artifact" },
+          { status: 500 }
+        );
       }
 
       const detail = outcome.detail;
@@ -39,54 +51,12 @@ export const GET = withSecurity(
           completedAt: detail.completedAt,
           detailHref: detail.detailHref,
         },
-        proofpackIndex: proofpackIndex ?? {
-          proofPackages: {
-            total: 0,
-            finalized: 0,
-            bestCompletenessScore: null,
-            missingEvidenceCount: 0,
-            latestCreatedAt: null,
-            state: "unavailable",
-            degradedEvidenceReasons: ["proofpack_index_unavailable"],
-          },
-          recurrence: {
-            exceptionsWithMemories: 0,
-            repeatedResolutionReasons: [],
-            state: "unavailable",
-            topRecurringFamilies: [],
-          },
-          comparison: {
-            state: "unavailable",
-            changedSincePriorRun: "unavailable",
-            certainty: "low",
-            reasonCodes: ["proofpack_index_unavailable"],
-            summary: "Run-level proofpack index is unavailable for this run type.",
-            baseline: {
-              priorResultId: null,
-              priorResultStartedAt: null,
-            },
-            history: {
-              lookbackWindow: 0,
-              comparableWindowCount: 0,
-              certainty: "low",
-              trend: "unavailable",
-              reasonCodes: ["proofpack_index_unavailable"],
-              summary: "Run history intelligence is unavailable for this run type.",
-            },
-            deltas: {
-              matched: null,
-              unmatched: null,
-              conflicts: null,
-              proofCompleteness: "unavailable",
-              recurringFamilyConcentration: "unavailable",
-            },
-          },
-        },
+        proofpackIndex: proofpackIndex ?? unavailableRunProofpackIndex(),
         supportability: {
           shareable: Boolean(
             proofpackIndex &&
-              proofpackIndex.proofPackages.state === "ready" &&
-              proofpackIndex.comparison.state === "available"
+            proofpackIndex.proofPackages.state === "ready" &&
+            proofpackIndex.comparison.state === "available"
           ),
           notes:
             proofpackIndex?.comparison.state === "available"
@@ -98,7 +68,10 @@ export const GET = withSecurity(
       return NextResponse.json({ artifact });
     } catch (error) {
       if (error instanceof TenantMembershipError) {
-        return NextResponse.json({ error: error.message, code: error.code }, { status: error.status });
+        return NextResponse.json(
+          { error: error.message, code: error.code },
+          { status: error.status }
+        );
       }
       return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }

--- a/packages/web/src/app/api/runs/route.ts
+++ b/packages/web/src/app/api/runs/route.ts
@@ -26,6 +26,7 @@ import {
   mapCanonicalListItemToApiRunsLegacyRow,
   MergedRunsCursorError,
   buildRunProofpackIndexByRunId,
+  toRunCompactProofSummary,
   type MergedRunsCursorV1,
 } from "@settler/reconciliation-core";
 import {
@@ -37,25 +38,8 @@ import {
 export const runtime = "nodejs";
 
 type RunListItemWithSignals = ReturnType<typeof mapCanonicalListItemToApiRunsLegacyRow> & {
-  compactProofSummary?: ReturnType<typeof toCompactProofSummary>;
+  compactProofSummary?: ReturnType<typeof toRunCompactProofSummary>;
 };
-
-function toCompactProofSummary(index: import("@settler/reconciliation-core").RunProofpackIndex) {
-  return {
-    proofPackages: index.proofPackages,
-    recurrence: index.recurrence,
-    delta: {
-      changedSincePreviousRun: index.comparison.changedSincePriorRun,
-      summary: index.comparison.summary,
-      state: index.comparison.state,
-      certainty: index.comparison.certainty,
-      reasonCodes: index.comparison.reasonCodes,
-      baseline: index.comparison.baseline,
-      history: index.comparison.history,
-      deltas: index.comparison.deltas,
-    },
-  };
-}
 
 function resolveTenantIdForRuns(
   authContext: UnifiedAuthContext,
@@ -96,7 +80,7 @@ async function withRunCompactProofSignals(
     const index = indexByRun.get(row.id);
     return {
       ...legacy,
-      compactProofSummary: index ? toCompactProofSummary(index) : undefined,
+      compactProofSummary: index ? toRunCompactProofSummary(index) : undefined,
     };
   });
 }
@@ -202,7 +186,8 @@ export const GET = withSecurity(
         }
 
         let walkCursor: MergedRunsCursorV1 | null = null;
-        const collected: import("@settler/reconciliation-core").CanonicalReconciliationListItem[] = [];
+        const collected: import("@settler/reconciliation-core").CanonicalReconciliationListItem[] =
+          [];
         let pagesScanned = 0;
         let lastPagePagination = null as
           | Awaited<ReturnType<typeof fetchMergedReconciliationRunsPage>>["pagination"]


### PR DESCRIPTION
### Motivation
- Eliminate route-local duplication and contract drift for run-level proof/history intelligence by centralizing shaping in a single canonical owner. 
- Make degraded/unavailable semantics explicit and machine-visible instead of duplicated ad-hoc objects in routes. 
- Ensure both list and proofpack surfaces expose the same compact intelligence summary so operators see consistent trend/recurrence signals. 

### Description
- Added `RunCompactProofSummary`, `toRunCompactProofSummary`, and `unavailableRunProofpackIndex()` helpers to `packages/reconciliation-core/src/run-proofpack-index.ts` and relaxed the `buildRunProofpackIndexByRunId` input to accept minimal run identity (`id` + `runKind`).
- Updated Express `GET /api/runs` (`packages/api/src/routes/runs.ts`) to call `buildRunProofpackIndexByRunId` tenant-scoped and attach a canonical `compactProofSummary` per run. 
- Replaced route-local compact shaping and unavailable fallback with canonical helpers in Next list (`packages/web/src/app/api/runs/route.ts`) and proofpack export (`packages/web/src/app/api/runs/[id]/proofpack/route.ts`).
- Added/updated unit tests to assert canonical compact projection and explicit unavailable contract (`packages/reconciliation-core/src/run-proofpack-index.test.ts` and `packages/api/src/routes/__tests__/runs.test.ts`), and ran `prettier` formatting across changed files.

### Testing
- Ran `npx prettier --write` on the modified files (succeeded). 
- Verified repository/manifest checks with `node` scripts (root `package.json` parses OK and `.nvmrc` / `engines` show Node 24.x requirement). 
- Attempted to run scoped `pnpm` Jest runs (e.g. `pnpm --filter @settler/reconciliation-core exec jest src/run-proofpack-index.test.ts --runInBand` and similar for `@settler/api` / `@settler/web`), but these were blocked by the environment Node version (`v22.21.1`) while the workspace enforces `engines.node >=24 <25`; full test/lint/typecheck verification must be run under Node `24.12.0` to complete automated validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb732e91c83288d548a7cac5c4aed)