### PR TITLE
Canonicalize run-history semantics across proof index, export, and support intake

### DIFF
--- a/packages/api/src/__tests__/services/support-intake-service.test.ts
+++ b/packages/api/src/__tests__/services/support-intake-service.test.ts
@@ -1,0 +1,101 @@
+import { submitSupportIntake } from "../../services/support/support-intake-service";
+
+jest.mock("../../db", () => ({
+  query: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("../../services/events/event-bus", () => ({
+  eventBus: {
+    emitEvent: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock("../../infrastructure/db/prisma", () => ({
+  prisma: {},
+}));
+
+jest.mock("@settler/reconciliation-core", () => ({
+  resolveOperatorRunDetailForTenants: jest.fn(),
+  toRunCompactProofSummary: jest.fn((value: unknown) => value),
+  unavailableRunProofpackIndex: jest.fn((reasonCode: string) => ({
+    comparison: { reasonCodes: [reasonCode] },
+  })),
+}));
+
+const { query } = require("../../db");
+const { eventBus } = require("../../services/events/event-bus");
+const { resolveOperatorRunDetailForTenants } = require("@settler/reconciliation-core");
+
+describe("support-intake-service run intelligence context", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("embeds canonical run intelligence in audit/event payload when run_id is provided", async () => {
+    resolveOperatorRunDetailForTenants.mockResolvedValue({
+      kind: "resolved",
+      detail: {
+        id: "run-1",
+        runKind: "recon_job",
+        status: "completed",
+        proofpackIndex: {
+          comparison: { reasonCodes: ["history_window_evaluated"] },
+        },
+      },
+    });
+
+    await submitSupportIntake({
+      userId: "user-1",
+      tenantId: "tenant-1",
+      path: "/api/v1/support/intake",
+      body: {
+        category: "run_failure",
+        description: "This is a long enough support description for validation.",
+        run_id: "run-1",
+      },
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const metadata = JSON.parse(query.mock.calls[0][1][4]);
+    expect(metadata.run_context).toMatchObject({
+      state: "resolved",
+      runId: "run-1",
+      runKind: "recon_job",
+      status: "completed",
+    });
+
+    expect(eventBus.emitEvent).toHaveBeenCalledWith(
+      "support.issue.created",
+      "tenant-1",
+      expect.objectContaining({
+        runId: "run-1",
+        runIntelligence: expect.objectContaining({ state: "resolved", runId: "run-1" }),
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it("records explicit unavailable semantics when run lookup fails", async () => {
+    resolveOperatorRunDetailForTenants.mockResolvedValue({
+      kind: "not_found",
+    });
+
+    await submitSupportIntake({
+      userId: "user-1",
+      tenantId: "tenant-1",
+      path: "/api/v1/support/intake",
+      body: {
+        category: "run_failure",
+        description: "This is a long enough support description for validation.",
+        run_id: "missing-run",
+      },
+    });
+
+    const metadata = JSON.parse(query.mock.calls[0][1][4]);
+    expect(metadata.run_context).toMatchObject({
+      state: "unavailable",
+      reason: "not_found",
+      runId: "missing-run",
+    });
+  });
+});

--- a/packages/api/src/services/reconciliation/export-contract.ts
+++ b/packages/api/src/services/reconciliation/export-contract.ts
@@ -4,6 +4,11 @@ import {
   validateTenantId,
 } from "../../infrastructure/tenancy/TenantEnforcement";
 import {
+  toRunCompactProofSummary,
+  unavailableRunProofpackIndex,
+  type RunCompactProofSummary,
+} from "@settler/reconciliation-core";
+import {
   computeReconciliationHash,
   verifyIntegrityChain,
   ReconciliationMatchForIntegrity,
@@ -32,6 +37,7 @@ export interface ReconciliationExportDocument {
     chain: IntegrityChainEntry[];
     chainValid: boolean;
   };
+  historicalIntelligence: RunCompactProofSummary;
 }
 
 export interface ExportPaginationOptions {
@@ -168,6 +174,9 @@ export async function buildReconciliationExport(
       chain,
       chainValid: chainVerification.valid,
     },
+    historicalIntelligence: toRunCompactProofSummary(
+      unavailableRunProofpackIndex("ingestion_run_history_not_comparable")
+    ),
     pagination: {
       limit: matchLimit,
       offset: matchOffset,

--- a/packages/api/src/services/support/support-intake-service.ts
+++ b/packages/api/src/services/support/support-intake-service.ts
@@ -3,6 +3,12 @@ import { query } from "../../db";
 import { logError } from "../../utils/logger";
 import { supportIntakeSubmissionSchema, SupportIntakeSubmission } from "./support-intake-contract";
 import { eventBus } from "../events/event-bus";
+import { prisma } from "../../infrastructure/db/prisma";
+import {
+  resolveOperatorRunDetailForTenants,
+  toRunCompactProofSummary,
+  unavailableRunProofpackIndex,
+} from "@settler/reconciliation-core";
 
 export interface StoredSupportIntake {
   submissionId: string;
@@ -22,6 +28,10 @@ export async function submitSupportIntake(params: {
   });
 
   const submissionId = crypto.randomUUID();
+  const runContext =
+    parsed.run_id && parsed.run_id.trim().length > 0
+      ? await buildSupportRunContext(params.tenantId, parsed.run_id)
+      : null;
 
   try {
     await persistSupportIntakeToAuditLog({
@@ -30,6 +40,7 @@ export async function submitSupportIntake(params: {
       path: params.path,
       submissionId,
       payload: parsed,
+      runContext,
     });
 
     await eventBus.emitEvent(
@@ -39,6 +50,7 @@ export async function submitSupportIntake(params: {
         submissionId,
         category: parsed.category,
         runId: parsed.run_id ?? null,
+        runIntelligence: runContext,
         route: parsed.route ?? null,
         module: parsed.module ?? null,
       },
@@ -73,6 +85,7 @@ async function persistSupportIntakeToAuditLog(params: {
   tenantId: string;
   path: string;
   payload: SupportIntakeSubmission;
+  runContext: Record<string, unknown> | null;
 }): Promise<void> {
   await query(
     `INSERT INTO audit_logs (event, user_id, tenant_id, path, metadata)
@@ -90,7 +103,47 @@ async function persistSupportIntakeToAuditLog(params: {
         module: params.payload.module ?? null,
         description: params.payload.description,
         contact: params.payload.contact ?? {},
+        run_context: params.runContext,
       }),
     ]
   );
+}
+
+async function buildSupportRunContext(
+  tenantId: string,
+  runId: string
+): Promise<Record<string, unknown>> {
+  try {
+    const outcome = await resolveOperatorRunDetailForTenants(prisma, [tenantId], runId);
+    if (outcome.kind !== "resolved") {
+      return {
+        state: "unavailable",
+        reason: outcome.kind,
+        runId,
+        compactProofSummary: toRunCompactProofSummary(
+          unavailableRunProofpackIndex("support_run_detail_unavailable")
+        ),
+      };
+    }
+
+    return {
+      state: "resolved",
+      runId: outcome.detail.id,
+      runKind: outcome.detail.runKind,
+      status: outcome.detail.status,
+      compactProofSummary: toRunCompactProofSummary(
+        outcome.detail.proofpackIndex ?? unavailableRunProofpackIndex("support_run_proofpack_missing")
+      ),
+    };
+  } catch (error) {
+    logError("Failed to derive run intelligence for support intake", error, { tenantId, runId });
+    return {
+      state: "degraded",
+      reason: "support_run_context_error",
+      runId,
+      compactProofSummary: toRunCompactProofSummary(
+        unavailableRunProofpackIndex("support_run_context_error")
+      ),
+    };
+  }
 }

--- a/packages/reconciliation-core/src/run-proofpack-index.test.ts
+++ b/packages/reconciliation-core/src/run-proofpack-index.test.ts
@@ -131,6 +131,7 @@ describe("run proofpack index", () => {
     expect(index?.comparison.deltas.matched).toBe(2);
     expect(index?.comparison.baseline.priorResultId).toBe("result-1");
     expect(index?.comparison.history.trend).toBe("improving");
+    expect(index?.comparison.history.pattern).toBe("recovering_pattern");
     expect(index?.recurrence.topRecurringFamilies[0]?.family).toBe("bank_window");
   });
 
@@ -162,6 +163,7 @@ describe("run proofpack index", () => {
     expect(byRun.get("job-1")?.comparison.state).toBe("unavailable");
     expect(byRun.get("job-1")?.comparison.reasonCodes).toContain("baseline_missing");
     expect(byRun.get("job-1")?.comparison.history.trend).toBe("unavailable");
+    expect(byRun.get("job-1")?.comparison.history.pattern).toBe("thin_history");
   });
 
   it("builds canonical compact proof summary from full index", async () => {
@@ -189,5 +191,24 @@ describe("run proofpack index", () => {
     expect(unavailable.proofPackages.state).toBe("unavailable");
     expect(unavailable.comparison.reasonCodes).toEqual(["proofpack_index_unavailable"]);
     expect(unavailable.comparison.history.reasonCodes).toEqual(["proofpack_index_unavailable"]);
+    expect(unavailable.comparison.history.pattern).toBe("unavailable");
+  });
+
+  it("returns explicit degraded comparison semantics when prior history query fails", async () => {
+    const prisma: any = {
+      reconciliationMatch: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([]) },
+      proofPackage: { findMany: jest.fn().mockResolvedValue([]) },
+      $queryRaw: jest.fn().mockRejectedValue(new Error("db unavailable")),
+    };
+
+    const byRun = await buildRunProofpackIndexByRunId({
+      prisma,
+      tenantId: "tenant-1",
+      runs: [baseRun],
+    });
+
+    expect(byRun.get("job-1")?.comparison.state).toBe("degraded");
+    expect(byRun.get("job-1")?.comparison.reasonCodes).toContain("history_query_failed");
   });
 });

--- a/packages/reconciliation-core/src/run-proofpack-index.ts
+++ b/packages/reconciliation-core/src/run-proofpack-index.ts
@@ -6,6 +6,12 @@ export type RunDeltaChangeState = "changed" | "unchanged" | "unavailable";
 
 type RunCertainty = "high" | "medium" | "low";
 type RunTrend = "improving" | "regressing" | "stable" | "volatile" | "unavailable";
+type RunPattern =
+  | "worsening_pattern"
+  | "recovering_pattern"
+  | "stable_pattern"
+  | "thin_history"
+  | "unavailable";
 
 export interface RunProofpackIndex {
   proofPackages: {
@@ -50,6 +56,7 @@ export interface RunProofpackIndex {
       comparableWindowCount: number;
       certainty: RunCertainty;
       trend: RunTrend;
+      pattern: RunPattern;
       reasonCodes: string[];
       summary: string;
     };
@@ -130,6 +137,7 @@ function defaultIndex(): RunProofpackIndex {
         comparableWindowCount: 0,
         certainty: "low",
         trend: "unavailable",
+        pattern: "unavailable",
         reasonCodes: ["history_missing"],
         summary: "History window is unavailable.",
       },
@@ -182,6 +190,7 @@ export function unavailableRunProofpackIndex(
       summary: "Run-level proofpack index is unavailable for this run type.",
       history: {
         ...base.comparison.history,
+        pattern: "unavailable",
         reasonCodes: [reasonCode],
         summary: "Run history intelligence is unavailable for this run type.",
       },
@@ -231,6 +240,7 @@ function buildHistorySummary(
       comparableWindowCount: comparableRows.length,
       certainty: "low",
       trend: "unavailable",
+      pattern: "thin_history",
       reasonCodes: ["history_too_thin"],
       summary: "Fewer than two comparable completed results are available in the history window.",
     };
@@ -240,8 +250,8 @@ function buildHistorySummary(
   let regressingSignals = 0;
   let volatileSignals = 0;
   for (let i = 0; i < comparableRows.length - 1; i += 1) {
-    const current = comparableRows[i];
-    const prior = comparableRows[i + 1];
+    const current = comparableRows[i]!;
+    const prior = comparableRows[i + 1]!;
     const matchedDelta = current.matched_count - prior.matched_count;
     const unmatchedDelta = totalUnmatched(current) - totalUnmatched(prior);
     const conflictsDelta = current.conflict_count - prior.conflict_count;
@@ -272,11 +282,19 @@ function buildHistorySummary(
             ? "stable"
             : "stable";
 
+  const pattern: RunPattern =
+    trend === "improving"
+      ? "recovering_pattern"
+      : trend === "regressing"
+        ? "worsening_pattern"
+        : "stable_pattern";
+
   return {
     lookbackWindow: Math.min(rows.length, HISTORY_WINDOW),
     comparableWindowCount: comparableRows.length,
     certainty,
     trend,
+    pattern,
     reasonCodes: [trend === "volatile" ? "mixed_direction_signals" : "history_window_evaluated"],
     summary:
       trend === "improving"
@@ -336,7 +354,7 @@ export async function buildRunProofpackIndexByRunId(input: {
     >
   >();
 
-  const exceptionIds = matches.map((match) => match.id);
+  const exceptionIds = matches.map((match: MatchRow) => match.id);
   if (exceptionIds.length > 0) {
     const memories = await prisma.exceptionAdjudicationMemory.findMany({
       where: {
@@ -387,7 +405,7 @@ export async function buildRunProofpackIndexByRunId(input: {
       ? await prisma.proofPackage.findMany({
           where: {
             tenantId,
-            OR: exceptionIds.map((exceptionId) => ({
+            OR: exceptionIds.map((exceptionId: string) => ({
               packageKey: { startsWith: `exception:${exceptionId}:` },
             })),
           },
@@ -402,24 +420,30 @@ export async function buildRunProofpackIndexByRunId(input: {
         })
       : [];
 
-  const results = (await prisma.$queryRaw`
-    SELECT
-      recon_job_id,
-      id,
-      started_at,
-      status,
-      matched_count,
-      unmatched_source_count,
-      unmatched_target_count,
-      conflict_count,
-      ROW_NUMBER() OVER (
-        PARTITION BY recon_job_id
-        ORDER BY started_at DESC NULLS LAST, id::text DESC
-      ) as rn
-    FROM recon_results
-    WHERE tenant_id = ${tenantId}::uuid
-      AND recon_job_id = ANY(${runIds}::uuid[])
-  `.catch(() => [])) as LatestPriorResultRow[];
+  let results: LatestPriorResultRow[] = [];
+  let historyQueryFailed = false;
+  try {
+    results = (await prisma.$queryRaw`
+      SELECT
+        recon_job_id,
+        id,
+        started_at,
+        status,
+        matched_count,
+        unmatched_source_count,
+        unmatched_target_count,
+        conflict_count,
+        ROW_NUMBER() OVER (
+          PARTITION BY recon_job_id
+          ORDER BY started_at DESC NULLS LAST, id::text DESC
+        ) as rn
+      FROM recon_results
+      WHERE tenant_id = ${tenantId}::uuid
+        AND recon_job_id = ANY(${runIds}::uuid[])
+    `) as LatestPriorResultRow[];
+  } catch {
+    historyQueryFailed = true;
+  }
 
   const resultsByRun = new Map<string, LatestPriorResultRow[]>();
   for (const row of results) {
@@ -547,7 +571,13 @@ export async function buildRunProofpackIndexByRunId(input: {
     let unmatchedDelta: number | null = null;
     let conflictsDelta: number | null = null;
 
-    if (!latest) {
+    if (historyQueryFailed) {
+      comparisonState = "degraded";
+      reasonCodes.push("history_query_failed");
+      summary =
+        "Prior-run comparison is degraded because run history could not be loaded from persistence.";
+      certainty = "low";
+    } else if (!latest) {
       reasonCodes.push("latest_result_missing");
       summary = "Run has no persisted result, so prior-run comparison is unavailable.";
     } else if (!prior) {


### PR DESCRIPTION
### Motivation
- Close a repo-truth seam where run-list/detail surfaces had canonical run-history intelligence but export and support artifacts lacked the same shared framing and degraded-state truth. 
- Make prior-run comparison outcomes deterministic, explainable, and explicit when persistence queries fail, enabling safer operator/support workflows and exports that preserve historical intelligence.

### Description
- Extended the run proofpack index contract with an explicit `history.pattern` classification (`worsening_pattern`, `recovering_pattern`, `stable_pattern`, `thin_history`, `unavailable`) and propagated it through default and unavailable index paths for deterministic pattern semantics. 
- Added explicit degraded semantics when run-history reads fail (`comparison.state = "degraded"`, reason code `history_query_failed`) instead of treating query failures as normal unavailability. 
- Added `historicalIntelligence: RunCompactProofSummary` to reconciliation export documents and populated ingestion-backed exports with an explicit unavailable compact index via `unavailableRunProofpackIndex("ingestion_run_history_not_comparable")`. 
- Integrated tenant-scoped canonical run intelligence into support intake: support persistence now includes `run_context` in audit metadata and support events emit `runIntelligence`; resolved/degraded/unavailable fallbacks are explicit and tenant-scoped. 

### Testing
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json parse ok')"` ✅ pass (package.json parsed). 
- `pnpm --filter @settler/reconciliation-core test -- run-proofpack-index.test.ts` ❌ fail (blocked by default Node `v22.21.1` vs repo engines `>=24.0.0 <25.0.0`). 
- `pnpm --filter @settler/api test -- support-intake-service.test.ts` ❌ fail (same Node engine mismatch). 
- `source ~/.nvm/nvm.sh && nvm use 24.12.0 && pnpm --filter @settler/reconciliation-core test -- run-proofpack-index.test.ts` ⚠️ environment-limited (Node switched to `v24.12.0` but `jest`/workspace deps not installed so test runner not found). 
- `source ~/.nvm/nvm.sh && nvm use 24.12.0 && pnpm --filter @settler/reconciliation-core typecheck && pnpm --filter @settler/api typecheck` ⚠️ environment-limited (typecheck surfaced local TS diagnostics but execution blocked by missing workspace `node_modules` and type definition packages). 

Files changed (high level): `packages/reconciliation-core/src/run-proofpack-index.ts` (+tests), `packages/api/src/services/reconciliation/export-contract.ts`, `packages/api/src/services/support/support-intake-service.ts`, and new test `packages/api/src/__tests__/services/support-intake-service.test.ts`.

Notes: full test and typecheck verification require installing workspace dependencies under Node 24.12.0 (`pnpm install` under the correct Node) and then re-running the scoped tests; until then some runtime/typecheck evidence is environment-limited.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfcaa9b2e08328b58b9c65f8d732f1)