### PR TITLE
Unify canonical run proof summary fallback semantics across run surfaces

### DIFF
--- a/packages/api/src/__tests__/services/export-contract.test.ts
+++ b/packages/api/src/__tests__/services/export-contract.test.ts
@@ -37,6 +37,55 @@ jest.mock("@settler/reconciliation-core", () => ({
   unavailableRunProofpackIndex: (reasonCode: string) => ({
     comparison: { state: "unavailable", reasonCodes: [reasonCode] },
   }),
+  resolveRunCompactProofSummary: (input: any) => {
+    const reasonCode = input.fallbackReasonCode ?? "run_proofpack_missing";
+    if (input.compactProofSummary) {
+      return {
+        compactProofSummary: input.compactProofSummary,
+        source: "compact_summary",
+        fallbackReasonCode: null,
+      };
+    }
+    if (input.proofpackIndex) {
+      return {
+        compactProofSummary: {
+          delta: {
+            state: input.proofpackIndex.comparison.state,
+            reasonCodes: input.proofpackIndex.comparison.reasonCodes,
+          },
+          operatorSummary: {
+            signal: "strong",
+            pattern: "stable_pattern",
+            changedSincePreviousRun: "unchanged",
+            proofPosture: "unchanged",
+            primaryReasonCodes: input.proofpackIndex.comparison.reasonCodes,
+            recurringFamilies: [],
+            summary: "stable",
+            explainerCodes: ["signal_strong", "pattern_stable"],
+          },
+        },
+        source: "proofpack_index",
+        fallbackReasonCode: null,
+      };
+    }
+    return {
+      compactProofSummary: {
+        delta: { state: "unavailable", reasonCodes: [reasonCode] },
+        operatorSummary: {
+          signal: "unavailable",
+          pattern: "unavailable",
+          changedSincePreviousRun: "unavailable",
+          proofPosture: "unavailable",
+          primaryReasonCodes: [reasonCode],
+          recurringFamilies: [],
+          summary: "unavailable",
+          explainerCodes: ["signal_unavailable", "pattern_unavailable"],
+        },
+      },
+      source: "fallback_unavailable",
+      fallbackReasonCode: reasonCode,
+    };
+  },
 }));
 
 const queryMock = query as jest.MockedFunction<typeof query>;

--- a/packages/api/src/services/reconciliation/export-contract.ts
+++ b/packages/api/src/services/reconciliation/export-contract.ts
@@ -4,9 +4,8 @@ import {
   validateTenantId,
 } from "../../infrastructure/tenancy/TenantEnforcement";
 import {
+  resolveRunCompactProofSummary,
   resolveOperatorRunDetailForTenants,
-  toRunCompactProofSummary,
-  unavailableRunProofpackIndex,
   type RunCompactProofSummary,
 } from "@settler/reconciliation-core";
 import { prisma } from "../../infrastructure/db/prisma";
@@ -203,9 +202,10 @@ async function buildHistoricalIntelligence(tenantId: string, runId: string): Pro
     const resolved = await resolveOperatorRunDetailForTenants(prisma, [tenantId], runId);
     if (resolved.kind !== "ok") {
       return {
-        summary: toRunCompactProofSummary(
-          unavailableRunProofpackIndex(`export_run_detail_${resolved.kind}`)
-        ),
+        summary: resolveRunCompactProofSummary({
+          runKind: "recon_job",
+          fallbackReasonCode: `export_run_detail_${resolved.kind}`,
+        }).compactProofSummary,
         context: {
           runId,
           runKind: "unknown",
@@ -215,28 +215,28 @@ async function buildHistoricalIntelligence(tenantId: string, runId: string): Pro
       };
     }
 
-    const fallbackReason =
-      resolved.detail.runKind === "ingestion_run"
-        ? "ingestion_run_history_not_comparable"
-        : "export_run_proofpack_missing";
-    const fallbackSummary = toRunCompactProofSummary(
-      resolved.detail.proofpackIndex ?? unavailableRunProofpackIndex(fallbackReason)
-    );
+    const summaryResolution = resolveRunCompactProofSummary({
+      runKind: resolved.detail.runKind,
+      compactProofSummary: resolved.detail.compactProofSummary,
+      proofpackIndex: resolved.detail.proofpackIndex,
+      fallbackReasonCode:
+        resolved.detail.runKind === "ingestion_run" ? "ingestion_run_history_not_comparable" : "run_proofpack_missing",
+    });
     return {
-      summary: resolved.detail.compactProofSummary ?? fallbackSummary,
+      summary: summaryResolution.compactProofSummary,
       context: {
         runId: resolved.detail.id,
         runKind: resolved.detail.runKind,
         source: "operator_run_detail",
-        reason:
-          resolved.detail.compactProofSummary || resolved.detail.proofpackIndex
-            ? null
-            : fallbackReason,
+        reason: summaryResolution.fallbackReasonCode,
       },
     };
   } catch {
     return {
-      summary: toRunCompactProofSummary(unavailableRunProofpackIndex("export_run_detail_error")),
+      summary: resolveRunCompactProofSummary({
+        runKind: "recon_job",
+        fallbackReasonCode: "export_run_detail_error",
+      }).compactProofSummary,
       context: {
         runId,
         runKind: "unknown",

--- a/packages/api/src/services/support/support-intake-service.ts
+++ b/packages/api/src/services/support/support-intake-service.ts
@@ -5,9 +5,8 @@ import { supportIntakeSubmissionSchema, SupportIntakeSubmission } from "./suppor
 import { eventBus } from "../events/event-bus";
 import { prisma } from "../../infrastructure/db/prisma";
 import {
+  resolveRunCompactProofSummary,
   resolveOperatorRunDetailForTenants,
-  toRunCompactProofSummary,
-  unavailableRunProofpackIndex,
 } from "@settler/reconciliation-core";
 
 export interface StoredSupportIntake {
@@ -120,23 +119,26 @@ async function buildSupportRunContext(
         state: "unavailable",
         reason: outcome.kind,
         runId,
-        compactProofSummary: toRunCompactProofSummary(
-          unavailableRunProofpackIndex("support_run_detail_unavailable")
-        ),
+        compactProofSummary: resolveRunCompactProofSummary({
+          runKind: "recon_job",
+          fallbackReasonCode: "support_run_detail_unavailable",
+        }).compactProofSummary,
       };
     }
+
+    const summaryResolution = resolveRunCompactProofSummary({
+      runKind: outcome.detail.runKind,
+      compactProofSummary: outcome.detail.compactProofSummary,
+      proofpackIndex: outcome.detail.proofpackIndex,
+    });
 
     return {
       state: "ok",
       runId: outcome.detail.id,
       runKind: outcome.detail.runKind,
       status: outcome.detail.status,
-      compactProofSummary:
-        outcome.detail.compactProofSummary ??
-        toRunCompactProofSummary(
-          outcome.detail.proofpackIndex ??
-            unavailableRunProofpackIndex("support_run_proofpack_missing")
-        ),
+      compactProofSummary: summaryResolution.compactProofSummary,
+      fallbackReason: summaryResolution.fallbackReasonCode,
     };
   } catch (error) {
     logError("Failed to derive run intelligence for support intake", error, { tenantId, runId });
@@ -144,9 +146,10 @@ async function buildSupportRunContext(
       state: "degraded",
       reason: "support_run_context_error",
       runId,
-      compactProofSummary: toRunCompactProofSummary(
-        unavailableRunProofpackIndex("support_run_context_error")
-      ),
+      compactProofSummary: resolveRunCompactProofSummary({
+        runKind: "recon_job",
+        fallbackReasonCode: "support_run_context_error",
+      }).compactProofSummary,
     };
   }
 }

--- a/packages/reconciliation-core/src/operator-run-detail.ts
+++ b/packages/reconciliation-core/src/operator-run-detail.ts
@@ -12,8 +12,7 @@ import type { RunStatus } from "@settler/types";
 import type { CanonicalReconciliationRunDetail } from "./canonical-reconciliation.js";
 import type { AdapterDriftSignal } from "./canonical-run-result.js";
 import {
-  toRunCompactProofSummary,
-  unavailableRunProofpackIndex,
+  resolveRunCompactProofSummary,
   type RunCompactProofSummary,
   type RunProofpackIndex,
 } from "./run-proofpack-index.js";
@@ -190,15 +189,7 @@ function buildCompactProofSummaryForRunDetail(
   runKind: OperatorRunDetail["runKind"],
   proofpackIndex?: RunProofpackIndex
 ): RunCompactProofSummary {
-  if (proofpackIndex) {
-    return toRunCompactProofSummary(proofpackIndex);
-  }
-
-  return toRunCompactProofSummary(
-    unavailableRunProofpackIndex(
-      runKind === "ingestion_run" ? "ingestion_run_history_not_comparable" : "run_proofpack_missing"
-    )
-  );
+  return resolveRunCompactProofSummary({ runKind, proofpackIndex }).compactProofSummary;
 }
 
 function baseFromCanonical(

--- a/packages/reconciliation-core/src/run-proofpack-index.test.ts
+++ b/packages/reconciliation-core/src/run-proofpack-index.test.ts
@@ -1,5 +1,7 @@
 import {
   buildRunProofpackIndexByRunId,
+  canonicalMissingProofpackReasonForRunKind,
+  resolveRunCompactProofSummary,
   toRunCompactProofSummary,
   unavailableRunProofpackIndex,
 } from "./run-proofpack-index.js";
@@ -226,6 +228,29 @@ describe("run proofpack index", () => {
     const compact = toRunCompactProofSummary(byRun.get("job-1")!);
     expect(compact.operatorSummary.explainerCodes).toEqual(
       expect.arrayContaining(["signal_degraded", "history_lookup_failed", "history_unavailable"])
+    );
+  });
+
+  it("uses canonical fallback reason codes by run kind when no summary/index exists", () => {
+    const reconSummary = resolveRunCompactProofSummary({ runKind: "recon_job" });
+    expect(reconSummary.source).toBe("fallback_unavailable");
+    expect(reconSummary.fallbackReasonCode).toBe("run_proofpack_missing");
+    expect(reconSummary.compactProofSummary.operatorSummary.primaryReasonCodes).toContain(
+      "run_proofpack_missing"
+    );
+
+    const ingestionSummary = resolveRunCompactProofSummary({ runKind: "ingestion_run" });
+    expect(ingestionSummary.source).toBe("fallback_unavailable");
+    expect(ingestionSummary.fallbackReasonCode).toBe("ingestion_run_history_not_comparable");
+    expect(ingestionSummary.compactProofSummary.operatorSummary.primaryReasonCodes).toContain(
+      "ingestion_run_history_not_comparable"
+    );
+  });
+
+  it("exposes deterministic run-kind-to-fallback-reason mapping", () => {
+    expect(canonicalMissingProofpackReasonForRunKind("recon_job")).toBe("run_proofpack_missing");
+    expect(canonicalMissingProofpackReasonForRunKind("ingestion_run")).toBe(
+      "ingestion_run_history_not_comparable"
     );
   });
 });

--- a/packages/reconciliation-core/src/run-proofpack-index.ts
+++ b/packages/reconciliation-core/src/run-proofpack-index.ts
@@ -157,6 +157,14 @@ export type RunCompactProofSummary = {
   };
 };
 
+type RunKindForSummary = "recon_job" | "ingestion_run";
+
+export type RunCompactProofSummaryResolution = {
+  compactProofSummary: RunCompactProofSummary;
+  source: "compact_summary" | "proofpack_index" | "fallback_unavailable";
+  fallbackReasonCode: RunOperatorReasonCode | null;
+};
+
 type LatestPriorResultRow = {
   recon_job_id: string;
   rn: number;
@@ -415,6 +423,44 @@ export function toRunCompactProofSummary(index: RunProofpackIndex): RunCompactPr
       summary,
       explainerCodes,
     },
+  };
+}
+
+export function canonicalMissingProofpackReasonForRunKind(
+  runKind: RunKindForSummary
+): RunOperatorReasonCode {
+  return runKind === "ingestion_run" ? "ingestion_run_history_not_comparable" : "run_proofpack_missing";
+}
+
+export function resolveRunCompactProofSummary(input: {
+  runKind: RunKindForSummary;
+  compactProofSummary?: RunCompactProofSummary;
+  proofpackIndex?: RunProofpackIndex;
+  fallbackReasonCode?: RunOperatorReasonCode;
+}): RunCompactProofSummaryResolution {
+  if (input.compactProofSummary) {
+    return {
+      compactProofSummary: input.compactProofSummary,
+      source: "compact_summary",
+      fallbackReasonCode: null,
+    };
+  }
+
+  if (input.proofpackIndex) {
+    return {
+      compactProofSummary: toRunCompactProofSummary(input.proofpackIndex),
+      source: "proofpack_index",
+      fallbackReasonCode: null,
+    };
+  }
+
+  const fallbackReasonCode =
+    input.fallbackReasonCode ?? canonicalMissingProofpackReasonForRunKind(input.runKind);
+
+  return {
+    compactProofSummary: toRunCompactProofSummary(unavailableRunProofpackIndex(fallbackReasonCode)),
+    source: "fallback_unavailable",
+    fallbackReasonCode,
   };
 }
 

--- a/packages/web/src/app/api/runs/[id]/proofpack/route.ts
+++ b/packages/web/src/app/api/runs/[id]/proofpack/route.ts
@@ -7,8 +7,9 @@ import {
 } from "@/lib/supabase/tenant-membership";
 import { prisma } from "@/shared/db/prismaClient";
 import {
+  canonicalMissingProofpackReasonForRunKind,
+  resolveRunCompactProofSummary,
   resolveOperatorRunDetailForTenants,
-  toRunCompactProofSummary,
   unavailableRunProofpackIndex,
 } from "@settler/reconciliation-core";
 
@@ -40,8 +41,14 @@ export const GET = withSecurity(
       }
 
       const detail = outcome.detail;
-      const proofpackIndex = detail.proofpackIndex ?? unavailableRunProofpackIndex();
-      const compactProofSummary = detail.compactProofSummary ?? toRunCompactProofSummary(proofpackIndex);
+      const proofpackIndex =
+        detail.proofpackIndex ??
+        unavailableRunProofpackIndex(canonicalMissingProofpackReasonForRunKind(detail.runKind));
+      const compactProofSummary = resolveRunCompactProofSummary({
+        runKind: detail.runKind,
+        compactProofSummary: detail.compactProofSummary,
+        proofpackIndex,
+      }).compactProofSummary;
       const artifact = {
         schemaVersion: "proofpack.run.v1",
         generatedAt: new Date().toISOString(),


### PR DESCRIPTION
### Motivation
- Eliminate semantic drift where multiple surfaces independently invented missing-proofpack fallbacks and reason codes, causing export/support/operator mismatch. 
- Establish a single canonical owner for compact-proof-summary resolution and deterministic fallback reason mapping. 
- Ensure support/export/proofpack artifacts and operator detail share identical, auditable fallback semantics. 
- Reduce duplication and maintenance cost while preserving ingestion-run non-comparable semantics.

### Description
- Added `resolveRunCompactProofSummary` and `canonicalMissingProofpackReasonForRunKind` to `packages/reconciliation-core/src/run-proofpack-index.ts` to centralize compact-summary resolution and run-kind fallback mapping. 
- Replaced route/service-local fallback logic with the canonical resolver in `operator-run-detail`, the API export shaping (`packages/api/src/services/reconciliation/export-contract.ts`), the support intake service (`packages/api/src/services/support/support-intake-service.ts`), and the web proofpack route (`packages/web/src/app/api/runs/[id]/proofpack/route.ts`). 
- Updated unit test mocks and added reconciliation-core tests that assert deterministic run-kind-to-fallback-reason behavior. 
- Committed changes that standardize recon-job fallback to `run_proofpack_missing` and keep ingestion-run fallback as `ingestion_run_history_not_comparable`.

### Testing
- `pnpm --filter @settler/reconciliation-core test -- run-proofpack-index.test.ts` — ✅ passed (reconciliation-core unit tests including new fallback tests). 
- `pnpm --filter @settler/reconciliation-core typecheck` — ✅ passed. 
- `pnpm --filter @settler/reconciliation-core build` — ✅ passed. 
- `pnpm --filter @settler/web typecheck` — ✅ passed. 
- `pnpm --filter @settler/api test -- src/__tests__/services/export-contract.test.ts` — ❌ failed due to package-scoped Jest module resolution in this harness (`Cannot find module '@settler/reconciliation-core'`). 
- `pnpm --filter @settler/api typecheck` — ❌ blocked by external Prisma engine checksum fetch (postinstall/prisma generate classified as `blocked_external/prisma_engine_checksum_forbidden`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00b511ff08328a872b2dcb1f2102c)