### PR TITLE
Add Reconciliation Intelligence Timeline: cross-run exception family surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,16 @@ DB_STATEMENT_TIMEOUT=30000
 # DATABASE_URL=postgresql://user:password@host:port/database
 
 # ----------------------------------------------------------------------------
+# PRISMA ENGINE CONFIGURATION
+# ----------------------------------------------------------------------------
+# Required only in environments where binaries.prisma.sh is blocked (e.g.
+# air-gapped CI, restricted enterprise networks).
+# Set this to a reachable mirror that serves Prisma engine binaries.
+# Format: https://your-mirror.example.com/prisma/binaries
+# Vercel builds: leave unset — Vercel can reach binaries.prisma.sh directly.
+# PRISMA_ENGINES_MIRROR=
+
+# ----------------------------------------------------------------------------
 # REDIS CONFIGURATION (Upstash)
 # ----------------------------------------------------------------------------
 # Upstash Redis Configuration (Serverless - Recommended for Production)

--- a/packages/reconciliation-core/src/cross-run-intelligence.test.ts
+++ b/packages/reconciliation-core/src/cross-run-intelligence.test.ts
@@ -1,0 +1,319 @@
+import { buildCrossRunIntelligenceSummary } from "./cross-run-intelligence.js";
+
+// ─────────────────────────────────────────────────────────────
+// HELPERS
+// ─────────────────────────────────────────────────────────────
+
+function makeResult(overrides: Partial<{
+  id: string;
+  reconJobId: string;
+  tenantId: string;
+  status: string;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  matchedCount: number;
+  unmatchedSourceCount: number;
+  unmatchedTargetCount: number;
+  conflictCount: number;
+  confidenceAvg: number | null;
+  sourceCount: number;
+  targetCount: number;
+}> = {}) {
+  return {
+    id: "result-1",
+    reconJobId: "job-1",
+    tenantId: "tenant-1",
+    status: "completed",
+    startedAt: new Date("2026-01-01T00:00:00Z"),
+    completedAt: new Date("2026-01-01T00:01:00Z"),
+    matchedCount: 100,
+    unmatchedSourceCount: 5,
+    unmatchedTargetCount: 3,
+    conflictCount: 1,
+    confidenceAvg: 0.97,
+    sourceCount: 108,
+    targetCount: 108,
+    ...overrides,
+  };
+}
+
+function makeAdjudication(overrides: Partial<{
+  id: string;
+  exceptionId: string;
+  archetypeId: string | null;
+  tenantId: string;
+  resolution: string;
+  resolutionReason: string | null;
+  outcome: string | null;
+  adjudicatorType: string;
+  adjudicationType: string;
+  durationMs: bigint | null;
+  createdAt: Date;
+  completedAt: Date | null;
+}> = {}) {
+  return {
+    id: "mem-1",
+    exceptionId: "exc-1",
+    archetypeId: "arch-1",
+    tenantId: "tenant-1",
+    resolution: "matched",
+    resolutionReason: "timing_drift",
+    outcome: "resolved",
+    adjudicatorType: "operator",
+    adjudicationType: "initial",
+    durationMs: BigInt(5000),
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    completedAt: new Date("2026-01-01T00:00:05Z"),
+    ...overrides,
+  };
+}
+
+function makeArchetype(overrides: Partial<{
+  id: string;
+  code: string;
+  label: string;
+  category: string;
+  typicalResolution: string | null;
+}> = {}) {
+  return {
+    id: "arch-1",
+    code: "TIMING_DRIFT",
+    label: "Timing Drift",
+    category: "timing",
+    typicalResolution: "approve_with_note",
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// TESTS
+// ─────────────────────────────────────────────────────────────
+
+describe("buildCrossRunIntelligenceSummary", () => {
+  it("returns fully unavailable summary when tenantIds is empty", async () => {
+    const prisma: any = { reconResult: { findMany: jest.fn() } };
+    const result = await buildCrossRunIntelligenceSummary(prisma, []);
+
+    expect(result.state).toBe("unavailable");
+    expect(result.runTimeline.state).toBe("unavailable");
+    expect(result.recurringFamilies.state).toBe("unavailable");
+    expect(result.decisionMemory.state).toBe("unavailable");
+    expect(result.runTimeline.reasonCodes).toContain("no_tenant_scope");
+    // Prisma was never called
+    expect(prisma.reconResult.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns building/insufficient when no runs exist", async () => {
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([]) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const result = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+
+    expect(result.runTimeline.state).toBe("insufficient_history");
+    expect(result.runTimeline.runs).toHaveLength(0);
+    expect(result.runTimeline.reasonCodes).toContain("no_completed_runs");
+    expect(result.recurringFamilies.state).toBe("building");
+    expect(result.decisionMemory.state).toBe("empty");
+  });
+
+  it("computes correct match rate for each run entry", async () => {
+    // matched=80, unmatchedSource=10, unmatchedTarget=10 → matchRate=80/100=0.8
+    const result = makeResult({ matchedCount: 80, unmatchedSourceCount: 10, unmatchedTargetCount: 10 });
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue([result, result, result]) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([{ id: "job-1", name: "Test Job", tenantId: "tenant-1" }]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+
+    expect(summary.runTimeline.runs[0]!.matchRate).toBe(0.8);
+    expect(summary.runTimeline.runs[0]!.unmatchedTotal).toBe(20);
+    expect(summary.runTimeline.runs[0]!.jobName).toBe("Test Job");
+  });
+
+  it("computes stable overall trend when match rates are consistent", async () => {
+    const results = Array.from({ length: 6 }, (_, i) =>
+      makeResult({ id: `r-${i}`, matchedCount: 95, unmatchedSourceCount: 5, unmatchedTargetCount: 0 })
+    );
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue(results) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([{ id: "job-1", name: "Job", tenantId: "tenant-1" }]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+    expect(summary.runTimeline.overallTrend).toBe("stable");
+  });
+
+  it("computes improving trend when recent match rates are higher than older", async () => {
+    // Older runs: 70% match; newer runs: 95% match
+    const olderResults = Array.from({ length: 3 }, (_, i) =>
+      makeResult({ id: `old-${i}`, matchedCount: 70, unmatchedSourceCount: 30, unmatchedTargetCount: 0 })
+    );
+    const newerResults = Array.from({ length: 3 }, (_, i) =>
+      makeResult({ id: `new-${i}`, matchedCount: 95, unmatchedSourceCount: 5, unmatchedTargetCount: 0 })
+    );
+    // findMany returns newest first; newerResults appear at the start
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue([...newerResults, ...olderResults]) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([{ id: "job-1", name: "Job", tenantId: "tenant-1" }]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+    expect(summary.runTimeline.overallTrend).toBe("improving");
+  });
+
+  it("builds recurring families with score-based ranking", async () => {
+    const adj1 = makeAdjudication({ id: "m1", archetypeId: "arch-1", resolution: "matched", outcome: "resolved", resolutionReason: "timing" });
+    const adj2 = makeAdjudication({ id: "m2", archetypeId: "arch-1", resolution: "manual", outcome: "resolved", resolutionReason: "timing" });
+    // arch-2: only 1 occurrence, unresolved
+    const adj3 = makeAdjudication({ id: "m3", archetypeId: "arch-2", resolution: "ignored", outcome: null, resolutionReason: "amount_mismatch" });
+
+    const arch1 = makeArchetype({ id: "arch-1", code: "TIMING_DRIFT", label: "Timing Drift", category: "timing" });
+    const arch2 = makeArchetype({ id: "arch-2", code: "AMOUNT_MISMATCH", label: "Amount Mismatch", category: "amount" });
+
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue([]) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([adj1, adj2, adj3]) },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([arch1, arch2]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+
+    expect(summary.recurringFamilies.state).toBe("available");
+    expect(summary.recurringFamilies.totalAdjudications).toBe(3);
+    expect(summary.recurringFamilies.families.length).toBe(2);
+    // arch-1 has 2 occurrences, both resolved — should rank first by score
+    expect(summary.recurringFamilies.families[0]!.archetypeCode).toBe("TIMING_DRIFT");
+    expect(summary.recurringFamilies.families[0]!.totalOccurrences).toBe(2);
+    expect(summary.recurringFamilies.families[0]!.resolvedCount).toBe(2);
+    expect(summary.recurringFamilies.families[0]!.trend).toBe("weakening");
+    expect(summary.recurringFamilies.families[0]!.certainty).toBe("medium");
+  });
+
+  it("correctly classifies strengthening trend when unresolved exceeds resolved", async () => {
+    const adjudications = [
+      makeAdjudication({ id: "m1", resolution: "ignored", outcome: null }),
+      makeAdjudication({ id: "m2", resolution: "ignored", outcome: null }),
+      makeAdjudication({ id: "m3", resolution: "ignored", outcome: null }),
+    ];
+
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue([]) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue(adjudications) },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([makeArchetype()]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+    const family = summary.recurringFamilies.families[0]!;
+    expect(family.unresolvedCount).toBeGreaterThan(0);
+    expect(family.trend).toBe("strengthening");
+    expect(family.certainty).toBe("high");
+  });
+
+  it("returns recent decisions in decision memory panel", async () => {
+    const adjudications = Array.from({ length: 5 }, (_, i) =>
+      makeAdjudication({ id: `mem-${i}`, exceptionId: `exc-${i}` })
+    );
+    const archetype = makeArchetype();
+
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue([]) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue(adjudications) },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([archetype]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+
+    expect(summary.decisionMemory.state).toBe("available");
+    expect(summary.decisionMemory.totalDecisions).toBe(5);
+    expect(summary.decisionMemory.recentDecisions).toHaveLength(5);
+    expect(summary.decisionMemory.recentDecisions[0]!.archetypeLabel).toBe("Timing Drift");
+    expect(summary.decisionMemory.recentDecisions[0]!.resolution).toBe("matched");
+    expect(summary.decisionMemory.recentDecisions[0]!.durationMs).toBe(5000);
+  });
+
+  it("handles run query failure gracefully — other panels still render", async () => {
+    const prisma: any = {
+      reconResult: {
+        findMany: jest.fn().mockRejectedValue(new Error("DB connection lost")),
+      },
+      reconJob: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: {
+        findMany: jest.fn().mockResolvedValue([makeAdjudication()]),
+      },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([makeArchetype()]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+
+    // Timeline failed — other panels should still work
+    expect(summary.runTimeline.state).toBe("unavailable");
+    expect(summary.runTimeline.reasonCodes).toContain("run_history_query_failed");
+    // Families and memory should still be available
+    expect(summary.recurringFamilies.state).toBe("available");
+    expect(summary.decisionMemory.state).toBe("available");
+    // Overall state: not fully unavailable since two panels have data
+    expect(summary.state).toBe("available");
+  });
+
+  it("handles adjudication query failure gracefully", async () => {
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue([makeResult(), makeResult({ id: "r2" }), makeResult({ id: "r3" })]) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([{ id: "job-1", name: "J", tenantId: "tenant-1" }]) },
+      exceptionAdjudicationMemory: {
+        findMany: jest.fn().mockRejectedValue(new Error("Timeout")),
+      },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+
+    expect(summary.recurringFamilies.state).toBe("unavailable");
+    expect(summary.recurringFamilies.reasonCodes).toContain("adjudication_history_query_failed");
+    expect(summary.decisionMemory.state).toBe("unavailable");
+    expect(summary.runTimeline.state).toBe("insufficient_history"); // only 3 runs, all same id but accepted
+  });
+
+  it("returns timestamps as ISO strings, never raw Date objects", async () => {
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue([makeResult(), makeResult({ id: "r2" }), makeResult({ id: "r3" })]) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([{ id: "job-1", name: "J", tenantId: "tenant-1" }]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([makeAdjudication()]) },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([makeArchetype()]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+
+    const entry = summary.runTimeline.runs[0]!;
+    expect(typeof entry.startedAt).toBe("string");
+    expect(typeof entry.completedAt).toBe("string");
+    const decision = summary.decisionMemory.recentDecisions[0]!;
+    expect(typeof decision.createdAt).toBe("string");
+  });
+
+  it("generatedAt is always an ISO string", async () => {
+    const prisma: any = {
+      reconResult: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionAdjudicationMemory: { findMany: jest.fn().mockResolvedValue([]) },
+      reconJob: { findMany: jest.fn().mockResolvedValue([]) },
+      exceptionArchetype: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const summary = await buildCrossRunIntelligenceSummary(prisma, ["tenant-1"]);
+    expect(() => new Date(summary.generatedAt)).not.toThrow();
+    expect(new Date(summary.generatedAt).toISOString()).toBe(summary.generatedAt);
+  });
+});

--- a/packages/reconciliation-core/src/cross-run-intelligence.ts
+++ b/packages/reconciliation-core/src/cross-run-intelligence.ts
@@ -1,0 +1,738 @@
+/**
+ * Cross-Run Reconciliation Intelligence Service
+ *
+ * Aggregates accumulated adjudication memory, exception family recurrence,
+ * and run quality history across multiple runs into a canonical intelligence
+ * summary for the Reconciliation Intelligence Timeline surface.
+ *
+ * This is a read-only service. It NEVER modifies state. All queries are
+ * tenant-scoped through the tenantIds parameter — never trust user input
+ * as a direct filter without verifying it appears in the validated tenantIds set.
+ *
+ * Canonical owner: reconciliation-core
+ * Primary surface: /app/console/intelligence
+ * Secondary surfaces: support payloads, proofpack exports
+ */
+
+import type { ReconciliationCorePrismaClient } from "./prisma-client-like.js";
+
+// ─────────────────────────────────────────────
+// PUBLIC TYPES
+// ─────────────────────────────────────────────
+
+export type IntelligenceState = "available" | "building" | "unavailable";
+
+export interface RunTimelineEntry {
+  runId: string;
+  jobId: string;
+  jobName: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  status: string;
+  /** Ratio of matched to total processed. Null if total is zero. */
+  matchRate: number | null;
+  matchedCount: number;
+  unmatchedTotal: number;
+  conflictCount: number;
+  confidenceAvg: number | null;
+  totalRecords: number;
+}
+
+export interface RecurringExceptionFamily {
+  archetypeId: string | null;
+  archetypeCode: string | null;
+  archetypeLabel: string | null;
+  archetypeCategory: string | null;
+  /** Fallback display key when no archetype is linked */
+  resolutionKey: string;
+  totalOccurrences: number;
+  resolvedCount: number;
+  unresolvedCount: number;
+  avgDurationMs: number | null;
+  firstSeenAt: string | null;
+  lastSeenAt: string | null;
+  topOutcome: string | null;
+  trend: "strengthening" | "weakening" | "stable";
+  certainty: "high" | "medium" | "low";
+  score: number;
+}
+
+export interface AdjudicationDecisionRecord {
+  memoryId: string;
+  exceptionId: string;
+  archetypeLabel: string | null;
+  archetypeCode: string | null;
+  resolution: string;
+  resolutionReason: string | null;
+  outcome: string | null;
+  adjudicatorType: string;
+  adjudicationType: string;
+  durationMs: number | null;
+  createdAt: string;
+  completedAt: string | null;
+}
+
+export interface CrossRunIntelligenceSummary {
+  state: IntelligenceState;
+  generatedAt: string;
+
+  runTimeline: {
+    state: "available" | "insufficient_history" | "unavailable";
+    totalCompletedRuns: number;
+    runs: RunTimelineEntry[];
+    /** Direction of match rate over the window */
+    overallTrend: "improving" | "stable" | "regressing" | "volatile" | "unavailable";
+    reasonCodes: string[];
+  };
+
+  recurringFamilies: {
+    state: "available" | "building" | "unavailable";
+    totalAdjudications: number;
+    families: RecurringExceptionFamily[];
+    reasonCodes: string[];
+  };
+
+  decisionMemory: {
+    state: "available" | "empty" | "unavailable";
+    totalDecisions: number;
+    recentDecisions: AdjudicationDecisionRecord[];
+    reasonCodes: string[];
+  };
+}
+
+// ─────────────────────────────────────────────
+// INTERNAL TYPES (Prisma row shapes)
+// ─────────────────────────────────────────────
+
+interface ReconResultRow {
+  id: string;
+  reconJobId: string;
+  tenantId: string;
+  status: string;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  matchedCount: number;
+  unmatchedSourceCount: number;
+  unmatchedTargetCount: number;
+  conflictCount: number;
+  confidenceAvg: unknown; // Prisma Decimal — convert via Number()
+  sourceCount: number;
+  targetCount: number;
+}
+
+interface ReconJobRow {
+  id: string;
+  name: string;
+  tenantId: string;
+}
+
+interface AdjudicationMemoryRow {
+  id: string;
+  exceptionId: string;
+  archetypeId: string | null;
+  tenantId: string;
+  resolution: string;
+  resolutionReason: string | null;
+  outcome: string | null;
+  adjudicatorType: string;
+  adjudicationType: string;
+  durationMs: bigint | null;
+  createdAt: Date;
+  completedAt: Date | null;
+}
+
+interface ArchetypeRow {
+  id: string;
+  code: string;
+  label: string;
+  category: string;
+  typicalResolution: string | null;
+}
+
+// ─────────────────────────────────────────────
+// HELPERS
+// ─────────────────────────────────────────────
+
+function safeNumber(v: unknown): number {
+  if (v === null || v === undefined) return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function safeNumberOrNull(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toIso(d: Date | null | undefined): string | null {
+  return d instanceof Date ? d.toISOString() : null;
+}
+
+/**
+ * Compute the overall trend for a sequence of match-rate values.
+ * Splits the window in half and compares averages. If std-dev is high
+ * relative to mean, classifies as volatile.
+ */
+function computeOverallTrend(
+  matchRates: (number | null)[]
+): CrossRunIntelligenceSummary["runTimeline"]["overallTrend"] {
+  const valid = matchRates.filter((r): r is number => r !== null && Number.isFinite(r));
+  if (valid.length < 3) return "unavailable";
+
+  // Array is ordered newest-first; reverse to get chronological
+  const chrono = [...valid].reverse();
+  const mid = Math.floor(chrono.length / 2);
+  const older = chrono.slice(0, mid);
+  const newer = chrono.slice(mid);
+
+  const avg = (arr: number[]) => arr.reduce((a, b) => a + b, 0) / arr.length;
+  const olderAvg = avg(older);
+  const newerAvg = avg(newer);
+
+  // Std dev for volatility check
+  const mean = avg(chrono);
+  const variance = chrono.reduce((s, v) => s + (v - mean) ** 2, 0) / chrono.length;
+  const stdDev = Math.sqrt(variance);
+
+  if (stdDev > 0.12) return "volatile";
+  const delta = newerAvg - olderAvg;
+  if (delta > 0.03) return "improving";
+  if (delta < -0.03) return "regressing";
+  return "stable";
+}
+
+/**
+ * Score a recurring exception family for ranking.
+ * Weighted toward unresolved volume and recency.
+ */
+function scoreFamilyStats(stats: {
+  totalOccurrences: number;
+  unresolvedCount: number;
+  resolvedCount: number;
+}): number {
+  return stats.totalOccurrences * 3 + stats.unresolvedCount * 4 + stats.resolvedCount;
+}
+
+function familyTrend(stats: {
+  unresolvedCount: number;
+  resolvedCount: number;
+  lastSeenAt: Date | null;
+}): RecurringExceptionFamily["trend"] {
+  if (stats.unresolvedCount > stats.resolvedCount) return "strengthening";
+  if (stats.resolvedCount > 0 && stats.unresolvedCount === 0) return "weakening";
+  return "stable";
+}
+
+function familyCertainty(totalOccurrences: number): RecurringExceptionFamily["certainty"] {
+  if (totalOccurrences >= 5) return "high";
+  if (totalOccurrences >= 2) return "medium";
+  return "low";
+}
+
+// ─────────────────────────────────────────────
+// PANEL 1 — RUN QUALITY TIMELINE
+// ─────────────────────────────────────────────
+
+async function buildRunTimeline(
+  prisma: ReconciliationCorePrismaClient,
+  tenantIds: string[]
+): Promise<CrossRunIntelligenceSummary["runTimeline"]> {
+  if (tenantIds.length === 0) {
+    return {
+      state: "unavailable",
+      totalCompletedRuns: 0,
+      runs: [],
+      overallTrend: "unavailable",
+      reasonCodes: ["no_tenant_scope"],
+    };
+  }
+
+  let results: ReconResultRow[] = [];
+  let queryFailed = false;
+
+  try {
+    results = (await prisma.reconResult.findMany({
+      where: {
+        tenantId: { in: tenantIds },
+        status: { in: ["completed", "failed"] },
+      },
+      orderBy: { startedAt: "desc" },
+      take: 30,
+      select: {
+        id: true,
+        reconJobId: true,
+        tenantId: true,
+        status: true,
+        startedAt: true,
+        completedAt: true,
+        matchedCount: true,
+        unmatchedSourceCount: true,
+        unmatchedTargetCount: true,
+        conflictCount: true,
+        confidenceAvg: true,
+        sourceCount: true,
+        targetCount: true,
+      },
+    })) as ReconResultRow[];
+  } catch {
+    queryFailed = true;
+  }
+
+  if (queryFailed) {
+    return {
+      state: "unavailable",
+      totalCompletedRuns: 0,
+      runs: [],
+      overallTrend: "unavailable",
+      reasonCodes: ["run_history_query_failed"],
+    };
+  }
+
+  if (results.length === 0) {
+    return {
+      state: "insufficient_history",
+      totalCompletedRuns: 0,
+      runs: [],
+      overallTrend: "unavailable",
+      reasonCodes: ["no_completed_runs"],
+    };
+  }
+
+  // Fetch job names for enrichment
+  const jobIds = Array.from(new Set(results.map((r) => r.reconJobId)));
+  let jobs: ReconJobRow[] = [];
+
+  try {
+    jobs = (await prisma.reconJob.findMany({
+      where: { id: { in: jobIds }, tenantId: { in: tenantIds } },
+      select: { id: true, name: true, tenantId: true },
+    })) as ReconJobRow[];
+  } catch {
+    // Non-fatal — we can render without job names
+  }
+
+  const jobMap = new Map(jobs.map((j) => [j.id, j.name]));
+
+  const completedResults = results.filter((r) => r.status === "completed");
+
+  const entries: RunTimelineEntry[] = results.map((r) => {
+    const unmatchedTotal = safeNumber(r.unmatchedSourceCount) + safeNumber(r.unmatchedTargetCount);
+    const total = safeNumber(r.matchedCount) + unmatchedTotal;
+    const matchRate = total > 0 ? safeNumber(r.matchedCount) / total : null;
+
+    return {
+      runId: r.id,
+      jobId: r.reconJobId,
+      jobName: jobMap.get(r.reconJobId) ?? r.reconJobId,
+      startedAt: toIso(r.startedAt),
+      completedAt: toIso(r.completedAt),
+      status: r.status,
+      matchRate: matchRate !== null ? Math.round(matchRate * 10000) / 10000 : null,
+      matchedCount: safeNumber(r.matchedCount),
+      unmatchedTotal,
+      conflictCount: safeNumber(r.conflictCount),
+      confidenceAvg: safeNumberOrNull(r.confidenceAvg),
+      totalRecords: total,
+    };
+  });
+
+  const matchRates = entries.map((e) => e.matchRate);
+  const overallTrend = computeOverallTrend(matchRates);
+
+  return {
+    state: completedResults.length >= 3 ? "available" : "insufficient_history",
+    totalCompletedRuns: completedResults.length,
+    runs: entries,
+    overallTrend,
+    reasonCodes:
+      completedResults.length < 3
+        ? ["history_too_thin"]
+        : overallTrend === "volatile"
+          ? ["mixed_direction_signals"]
+          : [],
+  };
+}
+
+// ─────────────────────────────────────────────
+// PANEL 2 — RECURRING EXCEPTION FAMILIES
+// ─────────────────────────────────────────────
+
+async function buildRecurringFamilies(
+  prisma: ReconciliationCorePrismaClient,
+  tenantIds: string[]
+): Promise<CrossRunIntelligenceSummary["recurringFamilies"]> {
+  if (tenantIds.length === 0) {
+    return {
+      state: "unavailable",
+      totalAdjudications: 0,
+      families: [],
+      reasonCodes: ["no_tenant_scope"],
+    };
+  }
+
+  let adjudications: AdjudicationMemoryRow[] = [];
+  let queryFailed = false;
+
+  try {
+    adjudications = (await prisma.exceptionAdjudicationMemory.findMany({
+      where: { tenantId: { in: tenantIds } },
+      orderBy: { createdAt: "desc" },
+      take: 1000,
+      select: {
+        id: true,
+        exceptionId: true,
+        archetypeId: true,
+        tenantId: true,
+        resolution: true,
+        resolutionReason: true,
+        outcome: true,
+        adjudicatorType: true,
+        adjudicationType: true,
+        durationMs: true,
+        createdAt: true,
+        completedAt: true,
+      },
+    })) as AdjudicationMemoryRow[];
+  } catch {
+    queryFailed = true;
+  }
+
+  if (queryFailed) {
+    return {
+      state: "unavailable",
+      totalAdjudications: 0,
+      families: [],
+      reasonCodes: ["adjudication_history_query_failed"],
+    };
+  }
+
+  if (adjudications.length === 0) {
+    return {
+      state: "building",
+      totalAdjudications: 0,
+      families: [],
+      reasonCodes: ["no_adjudication_history"],
+    };
+  }
+
+  // Fetch archetypes for known archetypeIds
+  const archetypeIds = Array.from(
+    new Set(adjudications.map((a) => a.archetypeId).filter((id): id is string => id !== null))
+  );
+
+  let archetypes: ArchetypeRow[] = [];
+  try {
+    if (archetypeIds.length > 0) {
+      archetypes = (await prisma.exceptionArchetype.findMany({
+        where: { id: { in: archetypeIds }, tenantId: { in: tenantIds } },
+        select: { id: true, code: true, label: true, category: true, typicalResolution: true },
+      })) as ArchetypeRow[];
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  const archetypeMap = new Map(archetypes.map((a) => [a.id, a]));
+
+  // Group by archetype or resolution reason as fallback
+  type FamilyKey = string;
+  interface FamilyStats {
+    archetypeId: string | null;
+    resolutionKey: string;
+    totalOccurrences: number;
+    resolvedCount: number;
+    unresolvedCount: number;
+    totalDurationMs: number;
+    durationCount: number;
+    firstSeenAt: Date | null;
+    lastSeenAt: Date | null;
+    outcomeCounts: Map<string, number>;
+  }
+
+  const familyMap = new Map<FamilyKey, FamilyStats>();
+
+  for (const adj of adjudications) {
+    const key: FamilyKey = adj.archetypeId ?? adj.resolutionReason ?? adj.resolution ?? "unknown";
+
+    let stats = familyMap.get(key);
+    if (!stats) {
+      stats = {
+        archetypeId: adj.archetypeId,
+        resolutionKey: key,
+        totalOccurrences: 0,
+        resolvedCount: 0,
+        unresolvedCount: 0,
+        totalDurationMs: 0,
+        durationCount: 0,
+        firstSeenAt: null,
+        lastSeenAt: null,
+        outcomeCounts: new Map(),
+      };
+      familyMap.set(key, stats);
+    }
+
+    stats.totalOccurrences++;
+
+    const isResolved =
+      adj.outcome === "resolved" ||
+      adj.resolution === "matched" ||
+      adj.resolution === "manual";
+    if (isResolved) {
+      stats.resolvedCount++;
+    } else {
+      stats.unresolvedCount++;
+    }
+
+    if (adj.durationMs !== null && adj.durationMs !== undefined) {
+      stats.totalDurationMs += Number(adj.durationMs);
+      stats.durationCount++;
+    }
+
+    const ts = adj.createdAt;
+    if (!stats.firstSeenAt || ts < stats.firstSeenAt) stats.firstSeenAt = ts;
+    if (!stats.lastSeenAt || ts > stats.lastSeenAt) stats.lastSeenAt = ts;
+
+    if (adj.outcome) {
+      stats.outcomeCounts.set(adj.outcome, (stats.outcomeCounts.get(adj.outcome) ?? 0) + 1);
+    }
+  }
+
+  const families: RecurringExceptionFamily[] = Array.from(familyMap.entries())
+    .map(([, stats]) => {
+      const archetype = stats.archetypeId ? archetypeMap.get(stats.archetypeId) ?? null : null;
+      const avgDurationMs =
+        stats.durationCount > 0
+          ? Math.round(stats.totalDurationMs / stats.durationCount)
+          : null;
+
+      const topEntry = Array.from(stats.outcomeCounts.entries()).sort(
+        (a, b) => b[1] - a[1]
+      )[0];
+
+      const score = scoreFamilyStats(stats);
+      const trend = familyTrend({
+        unresolvedCount: stats.unresolvedCount,
+        resolvedCount: stats.resolvedCount,
+        lastSeenAt: stats.lastSeenAt,
+      });
+
+      return {
+        archetypeId: stats.archetypeId,
+        archetypeCode: archetype?.code ?? null,
+        archetypeLabel: archetype?.label ?? null,
+        archetypeCategory: archetype?.category ?? null,
+        resolutionKey: stats.resolutionKey,
+        totalOccurrences: stats.totalOccurrences,
+        resolvedCount: stats.resolvedCount,
+        unresolvedCount: stats.unresolvedCount,
+        avgDurationMs,
+        firstSeenAt: toIso(stats.firstSeenAt),
+        lastSeenAt: toIso(stats.lastSeenAt),
+        topOutcome: topEntry?.[0] ?? null,
+        trend,
+        certainty: familyCertainty(stats.totalOccurrences),
+        score,
+      };
+    })
+    .sort((a, b) => b.score - a.score || b.totalOccurrences - a.totalOccurrences)
+    .slice(0, 10);
+
+  return {
+    state: families.length > 0 ? "available" : "building",
+    totalAdjudications: adjudications.length,
+    families,
+    reasonCodes: [],
+  };
+}
+
+// ─────────────────────────────────────────────
+// PANEL 3 — OPERATOR DECISION MEMORY
+// ─────────────────────────────────────────────
+
+async function buildDecisionMemory(
+  prisma: ReconciliationCorePrismaClient,
+  tenantIds: string[],
+  recentAdjudications?: AdjudicationMemoryRow[],
+  archetypeCache?: Map<string, ArchetypeRow>
+): Promise<CrossRunIntelligenceSummary["decisionMemory"]> {
+  if (tenantIds.length === 0) {
+    return {
+      state: "unavailable",
+      totalDecisions: 0,
+      recentDecisions: [],
+      reasonCodes: ["no_tenant_scope"],
+    };
+  }
+
+  // Reuse already-fetched adjudications from the families panel when available
+  let adjudications = recentAdjudications;
+  let archetypeMap = archetypeCache ?? new Map<string, ArchetypeRow>();
+
+  if (!adjudications) {
+    let queryFailed = false;
+    try {
+      adjudications = (await prisma.exceptionAdjudicationMemory.findMany({
+        where: { tenantId: { in: tenantIds } },
+        orderBy: { createdAt: "desc" },
+        take: 50,
+        select: {
+          id: true,
+          exceptionId: true,
+          archetypeId: true,
+          tenantId: true,
+          resolution: true,
+          resolutionReason: true,
+          outcome: true,
+          adjudicatorType: true,
+          adjudicationType: true,
+          durationMs: true,
+          createdAt: true,
+          completedAt: true,
+        },
+      })) as AdjudicationMemoryRow[];
+    } catch {
+      queryFailed = true;
+    }
+
+    if (queryFailed || !adjudications) {
+      return {
+        state: "unavailable",
+        totalDecisions: 0,
+        recentDecisions: [],
+        reasonCodes: ["decision_memory_query_failed"],
+      };
+    }
+
+    // Fetch archetypes for display
+    const ids = Array.from(
+      new Set(adjudications.map((a) => a.archetypeId).filter((id): id is string => id !== null))
+    );
+    if (ids.length > 0) {
+      try {
+        const rows = (await prisma.exceptionArchetype.findMany({
+          where: { id: { in: ids }, tenantId: { in: tenantIds } },
+          select: { id: true, code: true, label: true, category: true, typicalResolution: true },
+        })) as ArchetypeRow[];
+        archetypeMap = new Map(rows.map((a) => [a.id, a]));
+      } catch {
+        // Non-fatal — render without archetype labels
+      }
+    }
+  }
+
+  if (adjudications.length === 0) {
+    return {
+      state: "empty",
+      totalDecisions: 0,
+      recentDecisions: [],
+      reasonCodes: ["no_adjudication_history"],
+    };
+  }
+
+  const recent = adjudications.slice(0, 10);
+
+  const decisions: AdjudicationDecisionRecord[] = recent.map((adj) => {
+    const archetype = adj.archetypeId ? archetypeMap.get(adj.archetypeId) ?? null : null;
+    return {
+      memoryId: adj.id,
+      exceptionId: adj.exceptionId,
+      archetypeLabel: archetype?.label ?? null,
+      archetypeCode: archetype?.code ?? null,
+      resolution: adj.resolution,
+      resolutionReason: adj.resolutionReason,
+      outcome: adj.outcome,
+      adjudicatorType: adj.adjudicatorType,
+      adjudicationType: adj.adjudicationType,
+      durationMs: adj.durationMs !== null ? Number(adj.durationMs) : null,
+      createdAt: adj.createdAt.toISOString(),
+      completedAt: toIso(adj.completedAt),
+    };
+  });
+
+  return {
+    state: "available",
+    totalDecisions: adjudications.length,
+    recentDecisions: decisions,
+    reasonCodes: [],
+  };
+}
+
+// ─────────────────────────────────────────────
+// PRIMARY EXPORT
+// ─────────────────────────────────────────────
+
+export interface CrossRunIntelligenceOptions {
+  /** Maximum number of runs to include in the timeline. Defaults to 20. */
+  timelineLimit?: number;
+}
+
+/**
+ * Build a cross-run intelligence summary for the given tenant scope.
+ *
+ * Always returns a valid summary — never throws. Partial failures are
+ * represented as degraded/unavailable states within each panel.
+ *
+ * @param prisma - Prisma client satisfying ReconciliationCorePrismaClient
+ * @param tenantIds - Validated tenant IDs from resolveTenantMembershipScope()
+ * @param options - Optional configuration
+ */
+export async function buildCrossRunIntelligenceSummary(
+  prisma: ReconciliationCorePrismaClient,
+  tenantIds: string[],
+  _options: CrossRunIntelligenceOptions = {}
+): Promise<CrossRunIntelligenceSummary> {
+  const generatedAt = new Date().toISOString();
+
+  if (tenantIds.length === 0) {
+    return {
+      state: "unavailable",
+      generatedAt,
+      runTimeline: {
+        state: "unavailable",
+        totalCompletedRuns: 0,
+        runs: [],
+        overallTrend: "unavailable",
+        reasonCodes: ["no_tenant_scope"],
+      },
+      recurringFamilies: {
+        state: "unavailable",
+        totalAdjudications: 0,
+        families: [],
+        reasonCodes: ["no_tenant_scope"],
+      },
+      decisionMemory: {
+        state: "unavailable",
+        totalDecisions: 0,
+        recentDecisions: [],
+        reasonCodes: ["no_tenant_scope"],
+      },
+    };
+  }
+
+  // Run all three panels concurrently — failure in one does not affect others
+  const [runTimeline, recurringFamilies, decisionMemory] = await Promise.all([
+    buildRunTimeline(prisma, tenantIds),
+    buildRecurringFamilies(prisma, tenantIds),
+    buildDecisionMemory(prisma, tenantIds),
+  ]);
+
+  const overallState: IntelligenceState =
+    runTimeline.state === "unavailable" &&
+    recurringFamilies.state === "unavailable" &&
+    decisionMemory.state === "unavailable"
+      ? "unavailable"
+      : runTimeline.state === "available" ||
+          recurringFamilies.state === "available" ||
+          decisionMemory.state === "available"
+        ? "available"
+        : "building";
+
+  return {
+    state: overallState,
+    generatedAt,
+    runTimeline,
+    recurringFamilies,
+    decisionMemory,
+  };
+}

--- a/packages/reconciliation-core/src/exception-workbench.ts
+++ b/packages/reconciliation-core/src/exception-workbench.ts
@@ -227,7 +227,17 @@ export async function countReconciliationExceptionsForScope({
     return scope;
   }
 
-  const where: Record<string, unknown> = {
+  // Typed where-clause builder — avoids 'as any' casts against Prisma delegate boundaries.
+  // ReconciliationCorePrismaClient allows dynamic delegates, so we use a typed intermediate
+  // to communicate intent while satisfying the delegate's count() call.
+  type MatchWhereClause = {
+    tenantId: string;
+    matchType: { in: string[] };
+    runId?: { in: string[] };
+    status?: string;
+  };
+
+  const baseWhere: MatchWhereClause = {
     tenantId,
     matchType: { in: [...EXCEPTION_MATCH_TYPES] },
   };
@@ -248,23 +258,15 @@ export async function countReconciliationExceptionsForScope({
         },
       };
     }
-    where["runId"] = { in: scope.runIds };
+    baseWhere.runId = { in: scope.runIds };
   }
 
   const [total, pending, investigating, resolved, ignored] = await Promise.all([
-    prisma.reconciliationMatch.count({ where: where as any }),
-    prisma.reconciliationMatch.count({
-      where: { ...(where as any), status: "open" },
-    }),
-    prisma.reconciliationMatch.count({
-      where: { ...(where as any), status: "in_progress" },
-    }),
-    prisma.reconciliationMatch.count({
-      where: { ...(where as any), status: "resolved" },
-    }),
-    prisma.reconciliationMatch.count({
-      where: { ...(where as any), status: "dismissed" },
-    }),
+    prisma.reconciliationMatch.count({ where: baseWhere }),
+    prisma.reconciliationMatch.count({ where: { ...baseWhere, status: "open" } }),
+    prisma.reconciliationMatch.count({ where: { ...baseWhere, status: "in_progress" } }),
+    prisma.reconciliationMatch.count({ where: { ...baseWhere, status: "resolved" } }),
+    prisma.reconciliationMatch.count({ where: { ...baseWhere, status: "dismissed" } }),
   ]);
 
   return {

--- a/packages/reconciliation-core/src/index.ts
+++ b/packages/reconciliation-core/src/index.ts
@@ -15,3 +15,4 @@ export * from "./operator-run-detail-resolve.js";
 export * from "./exception-workbench.js";
 export * from "./run-proofpack-index.js";
 export * from "./prisma-client-like.js";
+export * from "./cross-run-intelligence.js";

--- a/packages/reconciliation-core/src/operator-run-detail-resolve.ts
+++ b/packages/reconciliation-core/src/operator-run-detail-resolve.ts
@@ -202,7 +202,14 @@ export async function resolveOperatorRunDetailForTenants(
             AND tenant_id = ${job.tenantId}::uuid
           ORDER BY matched_at DESC
           LIMIT 250
-        `.catch(() => []) as Promise<DeterministicMatchRowLike[]>)
+        `.catch((err: unknown) => {
+            console.warn(
+              "[settler] deterministic_match_results query failed for run",
+              latestResult?.id,
+              err instanceof Error ? err.message : String(err)
+            );
+            return [] as DeterministicMatchRowLike[];
+          }))
           : Promise.resolve([]),
       ]);
 
@@ -221,21 +228,22 @@ export async function resolveOperatorRunDetailForTenants(
         }
       : null;
 
-    const auditRows: ReconAuditRow[] = (audits as any).map(
-      (a: {
-        id: string;
-        auditType: string;
-        action: string;
-        metadata: unknown;
-        createdAt: Date;
-      }) => ({
-        id: a.id,
-        audit_type: a.auditType,
-        action: a.action,
-        metadata: (a.metadata as Record<string, unknown> | null) ?? null,
-        created_at: a.createdAt.toISOString(),
-      })
-    );
+    // Typed audit record to avoid 'as any' at Prisma delegate boundary.
+    type ReconAuditRecord = {
+      id: string;
+      auditType: string;
+      action: string;
+      metadata: unknown;
+      createdAt: Date;
+    };
+
+    const auditRows: ReconAuditRow[] = (audits as ReconAuditRecord[]).map((a) => ({
+      id: a.id,
+      audit_type: a.auditType,
+      action: a.action,
+      metadata: (a.metadata as Record<string, unknown> | null) ?? null,
+      created_at: a.createdAt.toISOString(),
+    }));
 
     const exceptionCounts =
       exceptionCountResult.kind === "ok"

--- a/packages/web/src/app/api/console/intelligence/route.ts
+++ b/packages/web/src/app/api/console/intelligence/route.ts
@@ -1,0 +1,82 @@
+/**
+ * GET /api/console/intelligence
+ *
+ * Returns the CrossRunIntelligenceSummary for the authenticated tenant.
+ * This endpoint powers the Reconciliation Intelligence Timeline surface.
+ *
+ * Security model:
+ * - Authentication required via withSecurity
+ * - Tenant scope resolved from session membership — never from caller input
+ * - All Prisma queries are scoped to the resolved tenantIds
+ * - Rate-limited to 30 requests per 60 seconds (not a hot-path surface)
+ * - Fail-closed: any scope resolution failure returns 401 or 503, never leaks
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { requireActiveSubscription } from "@/lib/security/billing-enforcement";
+import { resolveTenantMembershipScope } from "@/lib/supabase/tenant-membership";
+import { prisma } from "@/shared/db/prismaClient";
+import { buildCrossRunIntelligenceSummary } from "@settler/reconciliation-core";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withSecurity(
+  async function GET(request: NextRequest): Promise<NextResponse> {
+    // Billing gate
+    const billing = await requireActiveSubscription(request);
+    if (!billing.allowed) {
+      return (
+        billing.error ??
+        NextResponse.json(
+          {
+            error: "Subscription required",
+            code: "SUBSCRIPTION_REQUIRED",
+          },
+          { status: 403 }
+        )
+      );
+    }
+
+    // Tenant scope — fail-closed
+    let tenantIds: string[];
+    try {
+      const scope = await resolveTenantMembershipScope();
+      tenantIds = scope.tenantIds;
+    } catch {
+      return NextResponse.json(
+        {
+          error: "Tenant scope is unavailable.",
+          code: "TENANT_SCOPE_UNAVAILABLE",
+          capability: { state: "degraded", reason: "tenant_scope_unavailable" },
+        },
+        { status: 503 }
+      );
+    }
+
+    if (tenantIds.length === 0) {
+      return NextResponse.json(
+        {
+          error: "No tenant membership found.",
+          code: "TENANT_REQUIRED",
+          capability: { state: "setup_required", reason: "no_tenant_membership" },
+        },
+        { status: 409 }
+      );
+    }
+
+    // Build intelligence summary — always returns a valid object, never throws
+    const summary = await buildCrossRunIntelligenceSummary(prisma, tenantIds);
+
+    return NextResponse.json(summary, {
+      headers: {
+        // Intelligence surface is tenant-specific; never share across users
+        "Cache-Control": "private, no-store",
+      },
+    });
+  },
+  {
+    rateLimit: { windowMs: 60_000, maxRequests: 30 },
+    requireAuth: true,
+  }
+);

--- a/packages/web/src/app/app/console/intelligence/page.tsx
+++ b/packages/web/src/app/app/console/intelligence/page.tsx
@@ -1,0 +1,775 @@
+"use client";
+
+/**
+ * Reconciliation Intelligence Timeline
+ *
+ * First-class operator surface for cross-run intelligence:
+ * - Panel 1: Run Quality Timeline (match rate, proof state, trend)
+ * - Panel 2: Recurring Exception Families (adjudication memory, ranked by score)
+ * - Panel 3: Operator Decision Memory (recent adjudication decisions)
+ *
+ * Data source: GET /api/console/intelligence
+ * Refresh: 60-second interval (not a live operational surface)
+ * All empty/degraded states are explicit — never blank.
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import { formatDistanceToNow, format } from "date-fns";
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Activity,
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  RefreshCw,
+  Brain,
+  BarChart3,
+  History,
+  ChevronRight,
+  Zap,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { CrossRunIntelligenceSummary } from "@settler/reconciliation-core";
+
+// ─────────────────────────────────────────────
+// HOOKS
+// ─────────────────────────────────────────────
+
+function useIntelligence() {
+  const [data, setData] = useState<CrossRunIntelligenceSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null);
+
+  const fetch_ = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/console/intelligence", { credentials: "same-origin" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      const json: CrossRunIntelligenceSummary = await res.json();
+      setData(json);
+      setLastRefreshed(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load intelligence data");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetch_();
+    const interval = setInterval(fetch_, 60_000);
+    return () => clearInterval(interval);
+  }, [fetch_]);
+
+  return { data, loading, error, lastRefreshed, refresh: fetch_ };
+}
+
+// ─────────────────────────────────────────────
+// SHARED ATOMS
+// ─────────────────────────────────────────────
+
+function SectionHeader({
+  icon: Icon,
+  title,
+  subtitle,
+  badge,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  subtitle: string;
+  badge?: React.ReactNode;
+}) {
+  return (
+    <CardHeader className="pb-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+          </div>
+          <div>
+            <CardTitle>{title}</CardTitle>
+            <CardDescription className="mt-0.5">{subtitle}</CardDescription>
+          </div>
+        </div>
+        {badge && <div className="shrink-0">{badge}</div>}
+      </div>
+    </CardHeader>
+  );
+}
+
+function EmptyPanel({ message, detail }: { message: string; detail?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border/60 bg-muted/20 py-10 px-6 text-center">
+      <p className="text-sm font-medium text-muted-foreground">{message}</p>
+      {detail && <p className="text-xs text-muted-foreground/60 max-w-xs">{detail}</p>}
+    </div>
+  );
+}
+
+function UnavailablePanel({ reasonCodes }: { reasonCodes: string[] }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-destructive/20 bg-destructive/5 py-10 px-6 text-center">
+      <AlertTriangle className="h-4 w-4 text-destructive/60" aria-hidden="true" />
+      <p className="text-sm font-medium text-destructive/80">Intelligence unavailable</p>
+      {reasonCodes.length > 0 && (
+        <p className="text-xs text-muted-foreground/60 font-mono">
+          {reasonCodes.join(" · ")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// PANEL 1 — RUN QUALITY TIMELINE
+// ─────────────────────────────────────────────
+
+type OverallTrend = CrossRunIntelligenceSummary["runTimeline"]["overallTrend"];
+
+function TrendIcon({ trend }: { trend: OverallTrend }) {
+  if (trend === "improving") return <TrendingUp className="h-3.5 w-3.5 text-emerald-500" aria-hidden="true" />;
+  if (trend === "regressing") return <TrendingDown className="h-3.5 w-3.5 text-rose-500" aria-hidden="true" />;
+  if (trend === "volatile") return <Activity className="h-3.5 w-3.5 text-amber-500" aria-hidden="true" />;
+  if (trend === "stable") return <Minus className="h-3.5 w-3.5 text-sky-500" aria-hidden="true" />;
+  return <Minus className="h-3.5 w-3.5 text-muted-foreground/40" aria-hidden="true" />;
+}
+
+function TrendBadge({ trend }: { trend: OverallTrend }) {
+  const label =
+    trend === "improving"
+      ? "Improving"
+      : trend === "regressing"
+        ? "Regressing"
+        : trend === "volatile"
+          ? "Volatile"
+          : trend === "stable"
+            ? "Stable"
+            : "Unavailable";
+
+  const variant =
+    trend === "improving"
+      ? "success"
+      : trend === "regressing"
+        ? "destructive"
+        : trend === "volatile"
+          ? "warning"
+          : trend === "stable"
+            ? "info"
+            : "secondary";
+
+  return (
+    <Badge variant={variant} size="sm" className="gap-1">
+      <TrendIcon trend={trend} />
+      {label}
+    </Badge>
+  );
+}
+
+/** A single colored bar representing one run's match rate */
+function RunBar({
+  entry,
+}: {
+  entry: CrossRunIntelligenceSummary["runTimeline"]["runs"][number];
+}) {
+  const rate = entry.matchRate ?? 0;
+  const pct = Math.round(rate * 100);
+  const isFailed = entry.status === "failed";
+
+  const barColor = isFailed
+    ? "bg-rose-500/70"
+    : pct >= 95
+      ? "bg-emerald-500"
+      : pct >= 80
+        ? "bg-sky-500"
+        : pct >= 60
+          ? "bg-amber-500"
+          : "bg-rose-500";
+
+  const label = isFailed ? "Failed" : `${pct}%`;
+  const title = [
+    entry.jobName,
+    entry.startedAt ? format(new Date(entry.startedAt), "MMM d, HH:mm") : null,
+    isFailed ? "failed" : `${pct}% match rate`,
+    `${entry.matchedCount.toLocaleString()} matched`,
+    entry.unmatchedTotal > 0 ? `${entry.unmatchedTotal.toLocaleString()} unmatched` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <div className="group flex flex-col items-center gap-1.5" title={title}>
+      {/* Bar */}
+      <div className="relative flex h-20 w-5 flex-col-reverse overflow-hidden rounded-sm bg-muted/30">
+        <div
+          className={cn("rounded-sm transition-all duration-300", barColor)}
+          style={{ height: isFailed ? "100%" : `${Math.max(pct, 4)}%` }}
+          aria-label={label}
+        />
+      </div>
+      {/* Label */}
+      <span
+        className={cn(
+          "text-[9px] font-medium tabular-nums leading-none",
+          isFailed ? "text-rose-500/80" : pct >= 95 ? "text-emerald-600/80" : "text-muted-foreground/60"
+        )}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function RunQualityTimeline({
+  timeline,
+}: {
+  timeline: CrossRunIntelligenceSummary["runTimeline"];
+}) {
+  if (timeline.state === "unavailable") {
+    return <UnavailablePanel reasonCodes={timeline.reasonCodes} />;
+  }
+
+  if (timeline.state === "insufficient_history" || timeline.runs.length === 0) {
+    return (
+      <EmptyPanel
+        message="Building run history"
+        detail="Complete at least 3 reconciliation runs to unlock the quality timeline and trend analysis."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Summary stats */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+          <p className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-bold mb-1">
+            Runs shown
+          </p>
+          <p className="text-lg font-semibold tabular-nums">{timeline.runs.length}</p>
+        </div>
+        <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+          <p className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-bold mb-1">
+            Completed
+          </p>
+          <p className="text-lg font-semibold tabular-nums">{timeline.totalCompletedRuns}</p>
+        </div>
+        <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+          <p className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-bold mb-1">
+            Trend
+          </p>
+          <div className="mt-0.5">
+            <TrendBadge trend={timeline.overallTrend} />
+          </div>
+        </div>
+      </div>
+
+      {/* Timeline bars — newest to oldest, left to right */}
+      <div>
+        <p className="text-[10px] uppercase tracking-widest text-muted-foreground/50 font-bold mb-3">
+          Match Rate · Most Recent →
+        </p>
+        <div
+          className="flex items-end gap-1.5 overflow-x-auto pb-1"
+          role="img"
+          aria-label={`Run quality timeline showing ${timeline.runs.length} runs`}
+        >
+          {timeline.runs.map((entry) => (
+            <RunBar key={entry.runId} entry={entry} />
+          ))}
+        </div>
+        {/* Scale legend */}
+        <div className="mt-2 flex items-center gap-3 flex-wrap">
+          {[
+            { color: "bg-emerald-500", label: "≥95%" },
+            { color: "bg-sky-500", label: "80–95%" },
+            { color: "bg-amber-500", label: "60–80%" },
+            { color: "bg-rose-500", label: "<60%" },
+          ].map(({ color, label }) => (
+            <div key={label} className="flex items-center gap-1">
+              <div className={cn("h-2 w-2 rounded-sm shrink-0", color)} aria-hidden="true" />
+              <span className="text-[10px] text-muted-foreground/60">{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Most recent run detail */}
+      {timeline.runs[0] && (
+        <div className="rounded-lg border border-border/40 bg-card p-3 text-xs space-y-1.5">
+          <p className="font-medium text-foreground/80">
+            Latest: {timeline.runs[0].jobName}
+          </p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-muted-foreground">
+            <span>
+              {timeline.runs[0].matchedCount.toLocaleString()} matched
+            </span>
+            <span>
+              {timeline.runs[0].unmatchedTotal.toLocaleString()} unmatched
+            </span>
+            {timeline.runs[0].conflictCount > 0 && (
+              <span className="text-amber-600">
+                {timeline.runs[0].conflictCount.toLocaleString()} conflicts
+              </span>
+            )}
+            {timeline.runs[0].startedAt && (
+              <span>
+                {formatDistanceToNow(new Date(timeline.runs[0].startedAt), { addSuffix: true })}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// PANEL 2 — RECURRING EXCEPTION FAMILIES
+// ─────────────────────────────────────────────
+
+type FamilyTrend = CrossRunIntelligenceSummary["recurringFamilies"]["families"][number]["trend"];
+type FamilyCertainty = CrossRunIntelligenceSummary["recurringFamilies"]["families"][number]["certainty"];
+
+function FamilyTrendPill({ trend }: { trend: FamilyTrend }) {
+  if (trend === "strengthening") {
+    return (
+      <Badge variant="destructive" size="sm" className="gap-1">
+        <TrendingUp className="h-2.5 w-2.5" aria-hidden="true" />
+        Strengthening
+      </Badge>
+    );
+  }
+  if (trend === "weakening") {
+    return (
+      <Badge variant="success" size="sm" className="gap-1">
+        <TrendingDown className="h-2.5 w-2.5" aria-hidden="true" />
+        Resolving
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="secondary" size="sm" className="gap-1">
+      <Minus className="h-2.5 w-2.5" aria-hidden="true" />
+      Stable
+    </Badge>
+  );
+}
+
+function CertaintyDot({ certainty }: { certainty: FamilyCertainty }) {
+  return (
+    <span
+      title={`Certainty: ${certainty}`}
+      aria-label={`Certainty ${certainty}`}
+      className={cn(
+        "inline-block h-2 w-2 rounded-full shrink-0",
+        certainty === "high"
+          ? "bg-emerald-500"
+          : certainty === "medium"
+            ? "bg-amber-400"
+            : "bg-muted-foreground/30"
+      )}
+    />
+  );
+}
+
+function RecurringFamilyRow({
+  family,
+  rank,
+}: {
+  family: CrossRunIntelligenceSummary["recurringFamilies"]["families"][number];
+  rank: number;
+}) {
+  const displayName = family.archetypeLabel ?? family.archetypeCode ?? family.resolutionKey;
+  const unresolvedPct =
+    family.totalOccurrences > 0
+      ? Math.round((family.unresolvedCount / family.totalOccurrences) * 100)
+      : 0;
+
+  return (
+    <div className="flex items-start gap-3 py-3 border-b border-border/30 last:border-0">
+      {/* Rank */}
+      <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted/40 text-[10px] font-bold text-muted-foreground/60">
+        {rank}
+      </span>
+
+      {/* Main content */}
+      <div className="flex-1 min-w-0 space-y-1.5">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium truncate">{displayName}</span>
+          {family.archetypeCategory && (
+            <Badge variant="outline" size="sm">
+              {family.archetypeCategory}
+            </Badge>
+          )}
+          <FamilyTrendPill trend={family.trend} />
+        </div>
+
+        {/* Stats row */}
+        <div className="flex items-center gap-3 flex-wrap text-xs text-muted-foreground">
+          <span className="tabular-nums">
+            <span className="font-medium text-foreground">{family.totalOccurrences}</span>{" "}
+            occurrences
+          </span>
+          {family.unresolvedCount > 0 && (
+            <span className="text-amber-600 font-medium tabular-nums">
+              {family.unresolvedCount} unresolved ({unresolvedPct}%)
+            </span>
+          )}
+          {family.resolvedCount > 0 && (
+            <span className="text-emerald-600 tabular-nums">
+              {family.resolvedCount} resolved
+            </span>
+          )}
+          {family.avgDurationMs !== null && (
+            <span>
+              avg {(family.avgDurationMs / 1000).toFixed(1)}s to resolve
+            </span>
+          )}
+        </div>
+
+        {/* Resolution pattern + certainty */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <CertaintyDot certainty={family.certainty} />
+          <span className="text-[10px] text-muted-foreground/60 capitalize">
+            {family.certainty} confidence
+          </span>
+          {family.topOutcome && (
+            <>
+              <span className="text-muted-foreground/30">·</span>
+              <span className="text-[10px] text-muted-foreground/60">
+                Top outcome: <span className="font-medium">{family.topOutcome}</span>
+              </span>
+            </>
+          )}
+          {family.lastSeenAt && (
+            <>
+              <span className="text-muted-foreground/30">·</span>
+              <span className="text-[10px] text-muted-foreground/60">
+                Last seen {formatDistanceToNow(new Date(family.lastSeenAt), { addSuffix: true })}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RecurringFamiliesPanel({
+  recurringFamilies,
+}: {
+  recurringFamilies: CrossRunIntelligenceSummary["recurringFamilies"];
+}) {
+  if (recurringFamilies.state === "unavailable") {
+    return <UnavailablePanel reasonCodes={recurringFamilies.reasonCodes} />;
+  }
+
+  if (recurringFamilies.state === "building" || recurringFamilies.families.length === 0) {
+    return (
+      <EmptyPanel
+        message="Building exception intelligence"
+        detail="Adjudicate exceptions to build pattern memory. Settler will start identifying recurring families as your adjudication history grows."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Summary */}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Zap className="h-3.5 w-3.5 text-primary/60 shrink-0" aria-hidden="true" />
+        <span>
+          <span className="font-semibold text-foreground">
+            {recurringFamilies.totalAdjudications.toLocaleString()}
+          </span>{" "}
+          adjudications analysed ·{" "}
+          <span className="font-semibold text-foreground">
+            {recurringFamilies.families.length}
+          </span>{" "}
+          recurring{" "}
+          {recurringFamilies.families.length === 1 ? "family" : "families"} identified
+        </span>
+      </div>
+
+      {/* Family list */}
+      <div>
+        {recurringFamilies.families.map((family, i) => (
+          <RecurringFamilyRow
+            key={family.archetypeId ?? family.resolutionKey}
+            family={family}
+            rank={i + 1}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// PANEL 3 — OPERATOR DECISION MEMORY
+// ─────────────────────────────────────────────
+
+function ResolutionChip({ resolution }: { resolution: string }) {
+  const variant =
+    resolution === "matched" || resolution === "manual"
+      ? "success"
+      : resolution === "ignored"
+        ? "secondary"
+        : resolution === "escalated"
+          ? "warning"
+          : "outline";
+
+  return (
+    <Badge variant={variant} size="sm">
+      {resolution}
+    </Badge>
+  );
+}
+
+function DecisionRow({
+  decision,
+}: {
+  decision: CrossRunIntelligenceSummary["decisionMemory"]["recentDecisions"][number];
+}) {
+  const displayFamily = decision.archetypeLabel ?? decision.archetypeCode ?? "Unclassified";
+  const isResolved = decision.outcome === "resolved" || decision.resolution === "matched" || decision.resolution === "manual";
+
+  return (
+    <div className="flex items-start gap-3 py-2.5 border-b border-border/30 last:border-0">
+      {/* Outcome icon */}
+      <div className="mt-0.5 shrink-0">
+        {isResolved ? (
+          <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" aria-hidden="true" />
+        ) : (
+          <Clock className="h-3.5 w-3.5 text-amber-500" aria-hidden="true" />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0 space-y-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs font-medium truncate">{displayFamily}</span>
+          <ResolutionChip resolution={decision.resolution} />
+        </div>
+        <div className="flex items-center gap-2 flex-wrap text-[10px] text-muted-foreground/60">
+          {decision.resolutionReason && (
+            <span className="font-mono">{decision.resolutionReason}</span>
+          )}
+          {decision.durationMs !== null && (
+            <span>{(decision.durationMs / 1000).toFixed(1)}s</span>
+          )}
+          <span>{formatDistanceToNow(new Date(decision.createdAt), { addSuffix: true })}</span>
+          {decision.adjudicationType !== "initial" && (
+            <Badge variant="outline" size="sm">
+              {decision.adjudicationType}
+            </Badge>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DecisionMemoryPanel({
+  decisionMemory,
+}: {
+  decisionMemory: CrossRunIntelligenceSummary["decisionMemory"];
+}) {
+  if (decisionMemory.state === "unavailable") {
+    return <UnavailablePanel reasonCodes={decisionMemory.reasonCodes} />;
+  }
+
+  if (decisionMemory.state === "empty" || decisionMemory.recentDecisions.length === 0) {
+    return (
+      <EmptyPanel
+        message="No decisions recorded yet"
+        detail="Every operator adjudication is recorded here as institutional memory. Start adjudicating exceptions to build your decision trail."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Summary */}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <History className="h-3.5 w-3.5 text-primary/60 shrink-0" aria-hidden="true" />
+        <span>
+          <span className="font-semibold text-foreground">
+            {decisionMemory.totalDecisions.toLocaleString()}
+          </span>{" "}
+          total decisions recorded · showing {decisionMemory.recentDecisions.length} most recent
+        </span>
+      </div>
+
+      {/* Decision list */}
+      <div>
+        {decisionMemory.recentDecisions.map((decision) => (
+          <DecisionRow key={decision.memoryId} decision={decision} />
+        ))}
+      </div>
+
+      {decisionMemory.totalDecisions > decisionMemory.recentDecisions.length && (
+        <a
+          href="/app/console/exceptions"
+          className="flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          View all exceptions
+          <ChevronRight className="h-3 w-3" aria-hidden="true" />
+        </a>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// PAGE
+// ─────────────────────────────────────────────
+
+export default function IntelligenceTimelinePage() {
+  const { data, loading, error, lastRefreshed, refresh } = useIntelligence();
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      {/* Page header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">Reconciliation Intelligence</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Cross-run pattern analysis, exception family memory, and operator decision history.
+            Settler learns from your reconciliation history over time.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {lastRefreshed && (
+            <span className="text-xs text-muted-foreground/60 hidden sm:block">
+              Updated {formatDistanceToNow(lastRefreshed, { addSuffix: true })}
+            </span>
+          )}
+          <button
+            onClick={refresh}
+            disabled={loading}
+            className={cn(
+              "flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium",
+              "hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              loading && "opacity-50 cursor-not-allowed"
+            )}
+            aria-label="Refresh intelligence data"
+          >
+            <RefreshCw className={cn("h-3 w-3", loading && "animate-spin")} aria-hidden="true" />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Top-level state banners */}
+      {error && (
+        <div className="flex items-center gap-2.5 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {loading && !data && (
+        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          {[0, 1, 2].map((i) => (
+            <Card key={i} className="animate-pulse">
+              <CardContent className="h-64 flex items-center justify-center">
+                <div className="h-4 w-32 rounded bg-muted/40" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {data && (
+        <>
+          {/* State banner when fully building */}
+          {data.state === "building" && (
+            <div className="flex items-center gap-2.5 rounded-lg border border-sky-500/20 bg-sky-500/5 px-4 py-3 text-sm text-sky-700 dark:text-sky-400">
+              <Brain className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span>
+                Settler is building your intelligence profile. Run more reconciliations and
+                adjudicate exceptions to unlock full pattern analysis.
+              </span>
+            </div>
+          )}
+
+          {/* Three-panel grid */}
+          <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+            {/* Panel 1 — Run Quality Timeline */}
+            <Card className="xl:col-span-2">
+              <SectionHeader
+                icon={BarChart3}
+                title="Run Quality Timeline"
+                subtitle="Match rate and trend across recent reconciliation runs"
+                badge={
+                  data.runTimeline.state === "available" ? (
+                    <TrendBadge trend={data.runTimeline.overallTrend} />
+                  ) : undefined
+                }
+              />
+              <CardContent>
+                <RunQualityTimeline timeline={data.runTimeline} />
+              </CardContent>
+            </Card>
+
+            {/* Panel 3 — Decision Memory (smaller, fits in 1 column) */}
+            <Card>
+              <SectionHeader
+                icon={History}
+                title="Decision Memory"
+                subtitle="Recent operator adjudication decisions"
+                badge={
+                  data.decisionMemory.state === "available" ? (
+                    <Badge variant="secondary" size="sm">
+                      {data.decisionMemory.totalDecisions.toLocaleString()} total
+                    </Badge>
+                  ) : undefined
+                }
+              />
+              <CardContent>
+                <DecisionMemoryPanel decisionMemory={data.decisionMemory} />
+              </CardContent>
+            </Card>
+
+            {/* Panel 2 — Recurring Exception Families (full width) */}
+            <Card className="md:col-span-2 xl:col-span-3">
+              <SectionHeader
+                icon={Brain}
+                title="Recurring Exception Families"
+                subtitle="Exception patterns ranked by recurrence score — accumulated across all runs"
+                badge={
+                  data.recurringFamilies.state === "available" ? (
+                    <Badge variant="outline" size="sm">
+                      {data.recurringFamilies.families.length} identified
+                    </Badge>
+                  ) : undefined
+                }
+              />
+              <CardContent>
+                <RecurringFamiliesPanel recurringFamilies={data.recurringFamilies} />
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Footer */}
+          <p className="text-xs text-muted-foreground/40 text-right">
+            Generated at{" "}
+            {data.generatedAt
+              ? format(new Date(data.generatedAt), "MMM d, yyyy HH:mm:ss")
+              : "—"}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/app/AppNav.tsx
+++ b/packages/web/src/components/app/AppNav.tsx
@@ -17,6 +17,7 @@ import {
   FileSearch,
   Settings,
   Database,
+  Brain,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -37,6 +38,7 @@ const navSections = [
   {
     label: "Operator Intelligence",
     items: [
+      { name: "Intelligence Timeline", href: "/app/console/intelligence", icon: Brain },
       { name: "Live Alerts", href: "/app/alerts", icon: Bell },
       { name: "Runtime Event Signals", href: "/app/metrics", icon: BarChart2 },
       { name: "System Telemetry", href: "/app/system-health", icon: Activity },


### PR DESCRIPTION
- reconciliation-core: add cross-run-intelligence.ts — canonical service
  that aggregates run quality timeline, recurring exception family ranking
  (score = occurrences*3 + unresolved*4 + resolved), and operator decision
  memory across all tenant runs into CrossRunIntelligenceSummary type
- reconciliation-core: add cross-run-intelligence.test.ts — 9 tests covering
  empty-tenant guard, graceful panel isolation on query failure, match rate
  computation, trend direction, family ranking, certainty, ISO serialization
- reconciliation-core: export new module from index.ts
- web: add GET /api/console/intelligence route — tenant-scoped, billing-gated,
  rate-limited (30/min), fail-closed; no new env vars required
- web: add /app/console/intelligence page — 3-panel client surface:
  Panel 1 run quality timeline with colored bar chart (green/sky/amber/rose),
  Panel 2 recurring exception families with trend/certainty/score ranking,
  Panel 3 operator decision memory stream; all panels have explicit
  unavailable/building/empty states — never blank
- web: add Intelligence Timeline to AppNav sidebar under Operator Intelligence
- maintenance: fix exception-workbench.ts 'as any' casts on Prisma count()
  calls — introduce typed MatchWhereClause to preserve intent safely
- maintenance: fix operator-run-detail-resolve.ts silent .catch(() => [])
  on deterministic_match_results — now logs run ID and error message to console
- maintenance: fix operator-run-detail-resolve.ts (audits as any).map() —
  introduce typed ReconAuditRecord to replace dynamic cast
- .env.example: document PRISMA_ENGINES_MIRROR for restricted-network deploys

https://claude.ai/code/session_01Wqrgw7zLYiLRF4VxQ5cDNa