### PR TITLE
Unify pricing surfaces around canonical commercial model

### DIFF
--- a/packages/web/src/app/api/user/upgrade/route.ts
+++ b/packages/web/src/app/api/user/upgrade/route.ts
@@ -8,6 +8,7 @@ import { sendPaidWelcomeEmail, LifecycleUser } from "@/lib/stubs/email-lifecycle
 import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
 import { appLogger } from "@/lib/utils/logger";
 import { withSecurity } from "@/lib/middleware/api-security";
+import { mapLegacyPlanId, PlanCode } from "@/domain/billing/planConfig";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs"; // Ensure Node.js runtime for Supabase
@@ -25,18 +26,29 @@ export const POST = withSecurity(
           return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
         }
 
-        const { planType: rawPlanType } = await request.json();
-        const planType = rawPlanType as string;
+        const { planType: rawPlanType, planCode: rawPlanCode } = await request.json();
+        const planType = rawPlanType as string | undefined;
+        const planCode = rawPlanCode as PlanCode | undefined;
 
-        if (!["commercial", "enterprise"].includes(planType)) {
-          return NextResponse.json({ error: "Invalid plan type" }, { status: 400 });
+        const canonicalPlan = planCode ?? (planType ? mapLegacyPlanId(planType) : null);
+        const normalizedProfilePlan =
+          canonicalPlan === "starter"
+            ? "free"
+            : canonicalPlan === "growth"
+              ? "commercial"
+              : canonicalPlan === "scale"
+                ? "enterprise"
+                : canonicalPlan;
+
+        if (!normalizedProfilePlan || !["commercial", "enterprise", "free"].includes(normalizedProfilePlan)) {
+          return NextResponse.json({ error: "Invalid plan type or plan code" }, { status: 400 });
         }
 
         // Update user plan
          
         const { error: updateError } = (await (supabase.from("profiles") as any)
           .update({
-            plan_type: planType,
+            plan_type: normalizedProfilePlan,
             subscription_start_date: new Date().toISOString(),
             updated_at: new Date().toISOString(),
           })
@@ -70,7 +82,12 @@ export const POST = withSecurity(
               firstName: profile.name?.split(" ")[0],
               industry: profile.industry,
               companyName: profile.company_name,
-              planType: planType as "free" | "enterprise" | "trial" | "commercial" | undefined,
+              planType: normalizedProfilePlan as
+                | "free"
+                | "enterprise"
+                | "trial"
+                | "commercial"
+                | undefined,
             };
 
             await sendPaidWelcomeEmail(lifecycleUser);
@@ -80,7 +97,11 @@ export const POST = withSecurity(
           }
         }
 
-        return NextResponse.json({ success: true, planType });
+        return NextResponse.json({
+          success: true,
+          planType: normalizedProfilePlan,
+          planCode: canonicalPlan,
+        });
       } catch (error) {
         appLogger.error("Upgrade error", error);
         // Never return 500 - return graceful error response

--- a/packages/web/src/app/pricing/page.tsx
+++ b/packages/web/src/app/pricing/page.tsx
@@ -5,68 +5,22 @@ import { FeatureComparison } from "@/components/FeatureComparison";
 import { CTASection, Section, SectionHeader } from "@/components/site/primitives";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Check, ArrowRight, Zap, Shield, Globe } from "lucide-react";
+import { Check, ArrowRight, Zap, Shield, Globe, LucideIcon } from "lucide-react";
 import Link from "next/link";
 import { VisualGrid } from "@/components/site/infographics";
+import { COMMERCIAL_OFFERS, OfferCode } from "@/domain/billing/commercialModel";
 
 export const metadata = {
   title: "Pricing | Settler",
   description: "Transparent pricing for high-integrity reconciliation infrastructure.",
 };
 
-const plans = [
-  {
-    name: "Open Source",
-    price: "$0",
-    description: "Self-hosted reconciliation for small teams and developers.",
-    features: [
-      "Core Reconciliation Engine",
-      "Standard Platform Adapters",
-      "Local Result Export",
-      "Community Support",
-      "Self-managed Infrastructure",
-    ],
-    cta: "Download OSS",
-    href: "/docs/getting-started",
-    icon: Globe,
-    popular: false,
-  },
-  {
-    name: "Commercial",
-    price: "$99",
-    period: "/mo",
-    description: "Cloud-hosted with high-availability and advanced drift detection.",
-    features: [
-      "Everything in OSS",
-      "Managed Cloud Deployment",
-      "SSO & RBAC Security",
-      "Priority Email Support",
-      "Unlimited Platform Adapters",
-      "30-day History Retention",
-    ],
-    cta: "Start Free Trial",
-    href: "/signup",
-    icon: Zap,
-    popular: true,
-  },
-  {
-    name: "Enterprise",
-    price: "Custom",
-    description: "Tailored infrastructure for high-volume financial flows.",
-    features: [
-      "Everything in Commercial",
-      "Custom Adapter Development",
-      "Dedicated Infrastructure",
-      "Infinite History Retention",
-      "24/7 SLA & Incident Response",
-      "On-premise Deployment Option",
-    ],
-    cta: "Contact Sales",
-    href: "/contact",
-    icon: Shield,
-    popular: false,
-  },
-];
+const iconByOffer: Record<OfferCode, LucideIcon> = {
+  oss: Globe,
+  cloud: Zap,
+  managed: Shield,
+  enterprise: Shield,
+};
 
 export default function PricingPage() {
   return (
@@ -83,41 +37,46 @@ export default function PricingPage() {
       {/* Pricing Cards */}
       <Section className="py-16 sm:py-20">
         <div className="mx-auto max-w-7xl">
-          <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
-            {plans.map((plan) => (
-              <Card
-                key={plan.name}
-                className={`relative flex h-full flex-col border-border/40 transition-all duration-300 hover:shadow-xl motion-reduce:transition-none motion-reduce:hover:translate-y-0 hover:-translate-y-1 ${plan.popular ? "border-primary shadow-lg ring-1 ring-primary/20" : ""}`}
-              >
-                {plan.popular && (
-                  <div className="absolute top-0 right-1/2 translate-x-1/2 -translate-y-1/2 px-4 py-1.5 rounded-full bg-primary text-primary-foreground text-xs font-bold uppercase tracking-widest shadow-lg">
-                    Most Popular
-                  </div>
-                )}
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-4">
+            {COMMERCIAL_OFFERS.map((offer) => {
+              const Icon = iconByOffer[offer.code];
+              const features = [offer.evidencePosture, offer.deployment, offer.supportModel];
+              const popular = offer.code === "cloud";
 
-                <CardHeader className="p-8">
+              return (
+                <Card
+                  key={offer.name}
+                  className={`relative flex h-full flex-col border-border/40 transition-all duration-300 hover:shadow-xl motion-reduce:transition-none motion-reduce:hover:translate-y-0 hover:-translate-y-1 ${popular ? "border-primary shadow-lg ring-1 ring-primary/20" : ""}`}
+                >
+                  {popular && (
+                    <div className="absolute top-0 right-1/2 translate-x-1/2 -translate-y-1/2 px-4 py-1.5 rounded-full bg-primary text-primary-foreground text-xs font-bold uppercase tracking-widest shadow-lg">
+                      Canonical Self-Serve
+                    </div>
+                  )}
+
+                  <CardHeader className="p-8">
                   <div className="flex items-center gap-2 mb-4">
                     <div className="p-2 rounded-lg bg-primary/10 text-primary">
-                      <plan.icon className="h-5 w-5" />
+                      <Icon className="h-5 w-5" />
                     </div>
-                    <CardTitle className="text-xl font-bold">{plan.name}</CardTitle>
+                    <CardTitle className="text-xl font-bold">{offer.name}</CardTitle>
                   </div>
                   <div className="flex items-baseline gap-1 mt-2">
-                    <span className="text-4xl font-bold tracking-tight">{plan.price}</span>
-                    {plan.period && (
+                    <span className="text-4xl font-bold tracking-tight">{offer.headlinePrice}</span>
+                    {offer.period && (
                       <span className="text-sm font-medium text-muted-foreground">
-                        {plan.period}
+                        {offer.period}
                       </span>
                     )}
                   </div>
                   <CardDescription className="mt-4 leading-relaxed font-medium min-h-[3rem]">
-                    {plan.description}
+                    {offer.description}
                   </CardDescription>
-                </CardHeader>
+                  </CardHeader>
 
-                <CardContent className="flex-1 flex flex-col p-8 pt-0">
+                  <CardContent className="flex-1 flex flex-col p-8 pt-0">
                   <div className="space-y-4 mb-8 flex-1">
-                    {plan.features.map((feature) => (
+                    {features.map((feature) => (
                       <div key={feature} className="flex items-start gap-3">
                         <div className="mt-1 rounded-full bg-primary/10 p-1">
                           <Check className="h-3 w-3 text-primary" />
@@ -129,17 +88,18 @@ export default function PricingPage() {
 
                   <Button
                     asChild
-                    variant={plan.popular ? "default" : "outline"}
-                    className={`w-full h-12 font-bold group ${plan.popular ? "text-lg" : ""}`}
+                    variant={popular ? "default" : "outline"}
+                    className={`w-full h-12 font-bold group ${popular ? "text-lg" : ""}`}
                   >
-                    <Link href={plan.href} className="flex items-center justify-center gap-2">
-                      {plan.cta}
+                    <Link href={offer.ctaHref} className="flex items-center justify-center gap-2">
+                      {offer.ctaLabel}
                       <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
                     </Link>
                   </Button>
-                </CardContent>
-              </Card>
-            ))}
+                  </CardContent>
+                </Card>
+              );
+            })}
           </div>
         </div>
       </Section>
@@ -159,7 +119,7 @@ export default function PricingPage() {
               <h3 className="text-lg font-semibold text-foreground">Can I switch plans later?</h3>
               <p className="text-sm leading-relaxed text-muted-foreground">
                 Absolutely. Our cloud infrastructure supports seamless migration between plans.
-                Downgrading from Commercial to OSS requires setting up your own hosting environment.
+                Downgrading from Cloud API to OSS requires moving to self-managed deployment.
               </p>
             </div>
             <div className="space-y-2">
@@ -168,7 +128,7 @@ export default function PricingPage() {
               </h3>
               <p className="text-sm leading-relaxed text-muted-foreground">
                 A run is any triggered execution that compares a source and target dataset. Our
-                pricing is based on volume and required data retention rather than just run counts.
+                pricing is based on reconciliation volume and exception supervision load.
               </p>
             </div>
             <div className="space-y-2">

--- a/packages/web/src/components/FeatureComparison.tsx
+++ b/packages/web/src/components/FeatureComparison.tsx
@@ -4,24 +4,53 @@ import { SectionHeader } from "@/components/site/primitives";
 
 interface Feature {
   name: string;
-  free: boolean | string;
-  commercial: boolean | string;
+  oss: boolean | string;
+  cloud: boolean | string;
+  managed: boolean | string;
   enterprise: boolean | string;
 }
 
 const features: Feature[] = [
-  { name: "Monthly Reconciliations", free: "1,000", commercial: "100,000", enterprise: "Unlimited" },
-  { name: "Platform Adapters", free: "2", commercial: "Unlimited", enterprise: "Unlimited" },
-  { name: "Log Retention", free: "7 days", commercial: "30 days", enterprise: "Unlimited" },
-  { name: "Real-time Webhooks", free: false, commercial: true, enterprise: true },
-  { name: "API Access", free: true, commercial: true, enterprise: true },
-  { name: "Community Support", free: true, commercial: false, enterprise: false },
-  { name: "Email Support", free: false, commercial: true, enterprise: false },
-  { name: "Priority Support", free: false, commercial: false, enterprise: true },
-  { name: "SSO / SAML", free: false, commercial: false, enterprise: true },
-  { name: "RBAC", free: false, commercial: false, enterprise: true },
-  { name: "White-label", free: false, commercial: false, enterprise: true },
-  { name: "On-premise Deployment", free: false, commercial: false, enterprise: true },
+  {
+    name: "Monthly Reconciliations",
+    oss: "10,000",
+    cloud: "100,000",
+    managed: "1,000,000+",
+    enterprise: "Contractual",
+  },
+  {
+    name: "Exception supervision",
+    oss: "Self-run",
+    cloud: "Usage-based",
+    managed: "Operator-assisted",
+    enterprise: "Custom policy",
+  },
+  {
+    name: "Deployment model",
+    oss: "Self-hosted",
+    cloud: "Multi-tenant cloud",
+    managed: "Cloud + managed operator",
+    enterprise: "Dedicated/VPC/on-prem",
+  },
+  {
+    name: "Evidence retention",
+    oss: "Local",
+    cloud: "Hosted",
+    managed: "Hosted + monthly packets",
+    enterprise: "Custom retention",
+  },
+  { name: "API access", oss: true, cloud: true, managed: true, enterprise: true },
+  { name: "Escalation queue", oss: false, cloud: false, managed: true, enterprise: true },
+  { name: "SLA", oss: false, cloud: false, managed: "Business-hours", enterprise: "Contractual" },
+  {
+    name: "SSO / policy controls",
+    oss: false,
+    cloud: false,
+    managed: "Optional",
+    enterprise: true,
+  },
+  { name: "Audit export support", oss: false, cloud: true, managed: true, enterprise: true },
+  { name: "Named operator coverage", oss: false, cloud: false, managed: true, enterprise: "Optional" },
 ];
 
 export function FeatureComparison() {
@@ -40,7 +69,7 @@ export function FeatureComparison() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <SectionHeader
           title="Compare plans"
-          description="Feature coverage across OSS, Commercial, and Enterprise."
+          description="Canonical offer coverage across OSS, Cloud API, Managed Operations, and Enterprise Dedicated."
         />
         <Card className="mt-10 overflow-x-auto border-border/60 bg-card">
           <CardContent className="p-0">
@@ -52,19 +81,25 @@ export function FeatureComparison() {
                       Feature
                     </th>
                     <th scope="col" className="p-4 text-center font-semibold text-foreground">
-                      <div>Free</div>
+                      <div>Open Source</div>
                       <Badge variant="secondary" className="mt-2">
                         OSS
                       </Badge>
                     </th>
                     <th scope="col" className="p-4 text-center font-semibold text-foreground">
-                      <div>Commercial</div>
+                      <div>Cloud API</div>
                       <Badge variant="secondary" className="mt-2">
-                        $99/mo
+                        Usage-based
                       </Badge>
                     </th>
                     <th scope="col" className="p-4 text-center font-semibold text-foreground">
-                      <div>Enterprise</div>
+                      <div>Managed Ops</div>
+                      <Badge variant="secondary" className="mt-2">
+                        Operator-led
+                      </Badge>
+                    </th>
+                    <th scope="col" className="p-4 text-center font-semibold text-foreground">
+                      <div>Enterprise Dedicated</div>
                       <Badge variant="secondary" className="mt-2">
                         Custom
                       </Badge>
@@ -80,8 +115,9 @@ export function FeatureComparison() {
                       <th scope="row" className="p-4 font-medium text-foreground">
                         {feature.name}
                       </th>
-                      <td className="p-4 text-center">{renderValue(feature.free)}</td>
-                      <td className="p-4 text-center">{renderValue(feature.commercial)}</td>
+                      <td className="p-4 text-center">{renderValue(feature.oss)}</td>
+                      <td className="p-4 text-center">{renderValue(feature.cloud)}</td>
+                      <td className="p-4 text-center">{renderValue(feature.managed)}</td>
                       <td className="p-4 text-center">{renderValue(feature.enterprise)}</td>
                     </tr>
                   ))}

--- a/packages/web/src/domain/billing/commercialModel.ts
+++ b/packages/web/src/domain/billing/commercialModel.ts
@@ -1,0 +1,77 @@
+import { PlanCode, planConfigs } from "@/domain/billing/planConfig";
+
+export type OfferCode = "oss" | "cloud" | "managed" | "enterprise";
+
+export interface CommercialOffer {
+  code: OfferCode;
+  name: string;
+  headlinePrice: string;
+  period?: string;
+  description: string;
+  ctaLabel: string;
+  ctaHref: string;
+  evidencePosture: string;
+  deployment: string;
+  supportModel: string;
+  planCode?: PlanCode;
+}
+
+/**
+ * Canonical commercial model: OSS → Cloud API → Managed Ops → Enterprise Dedicated.
+ *
+ * Keep all marketing and console-adjacent pricing surfaces aligned to this owner.
+ */
+export const COMMERCIAL_OFFERS: CommercialOffer[] = [
+  {
+    code: "oss",
+    name: "Open Source",
+    headlinePrice: "$0",
+    description: "Self-hosted engine for teams validating deterministic reconciliation flows.",
+    ctaLabel: "Run OSS",
+    ctaHref: "/docs/getting-started",
+    evidencePosture: "Local evidence artifacts and replay traces",
+    deployment: "Self-managed",
+    supportModel: "Community",
+    planCode: "starter",
+  },
+  {
+    code: "cloud",
+    name: "Cloud API",
+    headlinePrice: `$${planConfigs.growth.monthlyPrice.toLocaleString()}`,
+    period: "/mo",
+    description: "Usage-based control plane with metered reconciliation volume and exception supervision.",
+    ctaLabel: "Start Cloud",
+    ctaHref: "/signup",
+    evidencePosture: "Hosted run evidence, replay detail, and usage telemetry",
+    deployment: "Multi-tenant cloud",
+    supportModel: "Email",
+    planCode: "growth",
+  },
+  {
+    code: "managed",
+    name: "Managed Operations",
+    headlinePrice: `$${planConfigs.scale.monthlyPrice.toLocaleString()}+`,
+    period: "/mo",
+    description:
+      "Operator-assisted reconciliation operations: onboarding, exception triage, monthly close, and audit packet prep.",
+    ctaLabel: "Discuss Managed Ops",
+    ctaHref: "/contact",
+    evidencePosture: "Shared operator proofpacks, escalation ledger, and monthly close evidence",
+    deployment: "Hosted with human-in-the-loop",
+    supportModel: "Named operator + escalation",
+    planCode: "scale",
+  },
+  {
+    code: "enterprise",
+    name: "Enterprise Dedicated",
+    headlinePrice: "Custom",
+    description: "Dedicated/VPC/on-prem deployment with contractual controls and custom policy envelope.",
+    ctaLabel: "Contact Enterprise",
+    ctaHref: "/contact",
+    evidencePosture: "Audit export controls, retention controls, and architecture review",
+    deployment: "Dedicated, VPC, or on-prem",
+    supportModel: "SLA + security review",
+    planCode: "enterprise",
+  },
+];
+


### PR DESCRIPTION
### Motivation
- Remove drift between internal plan config and public-facing pricing/upgrade surfaces by introducing a single canonical commercial owner. 
- Make the buying motion explicit: OSS → Cloud API (usage-based) → Managed Operations (operator-assisted) → Enterprise Dedicated, and surface managed-service differentiators.
- Harden the upgrade API to accept canonical plan codes while preserving legacy persisted `plan_type` semantics.

### Description
- Add `packages/web/src/domain/billing/commercialModel.ts` which defines `COMMERCIAL_OFFERS` as the canonical offer spine (oss, cloud, managed, enterprise) and links to existing `planConfigs` for price evidence. 
- Refactor `/pricing` page (`packages/web/src/app/pricing/page.tsx`) to render cards from `COMMERCIAL_OFFERS` rather than hard-coded plan objects and to adopt consistent IA/copy for the canonical spine. 
- Update the feature matrix (`packages/web/src/components/FeatureComparison.tsx`) to a 4-column comparison reflecting OSS / Cloud API / Managed Ops / Enterprise Dedicated and to surface operator/managed-service distinctions. 
- Harden `POST /api/user/upgrade` (`packages/web/src/app/api/user/upgrade/route.ts`) to accept a canonical `planCode` (or legacy `planType`), normalize to storage-compatible `plan_type` (`free`/`commercial`/`enterprise`), and return the resolved `planCode` in the response.

### Testing
- ⚠️ `pnpm --filter @settler/web lint` — blocked by environment Node engine mismatch (`expected >=24 <25`, current v22.21.1). Full lint not run in this environment.
- ⚠️ `pnpm typecheck` — blocked by Node engine mismatch; typecheck not completed here.
- ⚠️ `pnpm --filter @settler/web test -- --runInBand` — blocked by Node engine mismatch; package tests were not executed.
- ⚠️ `node scripts/verify-routes.mjs` — blocked by Node engine mismatch; route verification not completed.
- ✅ `git diff --check` and commit were performed locally in the branch and show the changes staged and committed (commit message: "Unify pricing surfaces around canonical commercial model").

Note: verification commands were selected per the repo verification matrix but could not be completed due to the Node engine constraint in this environment; follow-up should rerun the above commands on Node.js 24.x to produce full lint/type/test/route verification evidence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d06d11a4108328a9bb2db4a0d4925c)