### PR TITLE
web: expose machine-readable degraded state on legacy support routes

### DIFF
--- a/packages/web/src/__tests__/api/support-billing-operator-tenant-boundary.test.ts
+++ b/packages/web/src/__tests__/api/support-billing-operator-tenant-boundary.test.ts
@@ -119,6 +119,9 @@ describe("support/billing/operator boundary coverage", () => {
     );
     expect(response.status).toBe(410);
     const payload = await response.json();
+    expect(payload.status).toBe("deprecated");
+    expect(payload.trustState).toBe("unavailable");
+    expect(payload.degradedReasonCode).toBe("legacy_support_tickets_route_removed");
     expect(JSON.stringify(payload)).not.toContain("tenant-b");
   });
 

--- a/packages/web/src/app/api/console/support/triage/route.ts
+++ b/packages/web/src/app/api/console/support/triage/route.ts
@@ -11,6 +11,9 @@ function legacyTriageDeprecated() {
       message:
         "Legacy support triage endpoint is deprecated. Use /api/console/support/tickets for canonical intake queue reads.",
       canonicalOperatorRoute: "/api/console/support/tickets",
+      trustState: "unavailable",
+      degradedReasonCode: "legacy_support_triage_route_removed",
+      status: "deprecated",
     },
     { status: 410 }
   );

--- a/packages/web/src/app/api/support/report-issue/route.ts
+++ b/packages/web/src/app/api/support/report-issue/route.ts
@@ -65,6 +65,8 @@ export const POST = withSecurity(
         created_at: stored.createdAt,
         deprecated_route: true,
         canonical_route: "/api/v1/support/intake",
+        trust_state: "degraded",
+        degraded_reason_code: "legacy_report_issue_route_translated",
       },
       { status: 202 }
     );

--- a/packages/web/src/app/api/support/tickets/route.ts
+++ b/packages/web/src/app/api/support/tickets/route.ts
@@ -18,6 +18,9 @@ function deprecated() {
         "Legacy support ticket endpoints are deprecated. Use /api/v1/support/intake for submission and /api/console/support/tickets for operator triage.",
       canonicalSubmissionRoute: "/api/v1/support/intake",
       canonicalOperatorRoute: "/api/console/support/tickets",
+      trustState: "unavailable",
+      degradedReasonCode: "legacy_support_tickets_route_removed",
+      status: "deprecated",
     },
     { status: 410 }
   );


### PR DESCRIPTION
### Motivation
- Legacy support/ticket endpoints only returned human-readable deprecation text which led to ambiguity for operator tooling and clients about whether those endpoints were safe to consume programmatically.
- Make the legacy support surface explicitly machine-visible as degraded/unavailable so downstream systems and operators can treat them differently from the canonical intake surface.

### Description
- Added machine-visible degraded/trust metadata to legacy support endpoints by adding `trustState`, `degradedReasonCode`, and `status` to the deprecation payload in `packages/web/src/app/api/support/tickets/route.ts` and `packages/web/src/app/api/console/support/triage/route.ts`.
- Added `trust_state` and `degraded_reason_code` to the legacy translator response in `packages/web/src/app/api/support/report-issue/route.ts` so translated requests are visibly degraded.
- Strengthened the operator/boundary test in `packages/web/src/__tests__/api/support-billing-operator-tenant-boundary.test.ts` to assert the new degraded/trust fields while preserving tenant-leak checks.

### Testing
- `pnpm --config.engine-strict=false --filter @settler/web exec jest --runInBand src/__tests__/api/support-billing-operator-tenant-boundary.test.ts` ✅ pass
- `pnpm --config.engine-strict=false --filter @settler/web exec jest --runInBand src/__tests__/api/run-proofpack-route.contract.test.ts src/__tests__/api/run-domain-trust-invariants.test.ts` ✅ pass
- `pnpm --config.engine-strict=false --filter @settler/web exec jest --runInBand src/__tests__/content/visual-proof-registry.test.ts src/__tests__/api/run-proofpack-route.contract.test.ts src/__tests__/api/run-domain-trust-invariants.test.ts src/__tests__/middleware/app-auth-gating.test.ts src/__tests__/app/marketing-route-boundary.test.ts` ✅ pass
- `pnpm lint` ⚠️ blocked by environment Node version mismatch (repo requires `node >=24 <25`, current runtime `v22.21.1`), so full root verification (`pnpm typecheck`, `pnpm build`, `pnpm test`) was environment-limited and not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1153979d48328977165c4cd471c90)