### PR TITLE
Product truth: Redis prod gate, health guard posture, honest docs

### DIFF
--- a/config/env.schema.ts
+++ b/config/env.schema.ts
@@ -444,6 +444,22 @@ export const ENV_VAR_SCHEMA: EnvVarSpec[] = [
     secret: false,
     platforms: ['github', 'vercel', 'local'],
   },
+  {
+    name: 'REDIS_REQUIRED_FOR_PRODUCTION',
+    description:
+      'When true, API boot fails in NODE_ENV=production if Redis is missing or unreachable (distributed rate limits + webhook replay use Redis first)',
+    type: 'boolean',
+    required: false,
+    scope: 'runtime',
+    exposure: 'server-only',
+    criticality: 'optional',
+    environments: ['staging', 'production'],
+    defaultValue: false,
+    secret: false,
+    platforms: ['github', 'vercel', 'docker'],
+    notes:
+      'Recommended for multi-instance production so limits/replay are not silently per-process. Without Redis the API still falls back to Postgres then in-memory (see distributed-guards).',
+  },
 
   // ============================================================================
   // SECURITY & AUTHENTICATION

--- a/docs/external/product-overview.md
+++ b/docs/external/product-overview.md
@@ -1,7 +1,7 @@
 # Settler Product Overview
 
 **Version:** 1.0  
-**Last Updated:** January 2026  
+**Last Updated:** April 2026  
 **Classification:** External - Public
 
 ---
@@ -14,7 +14,7 @@
 
 ### One-Liner
 
-**Settler automates financial reconciliation across Stripe, Shopify, QuickBooks, and 50+ platforms—reducing hours of manual work with automatic matching and exception supervision.**
+**Settler is a reconciliation control plane: ingest normalized transactions (CSV and supported API paths), run deterministic matching, supervise exceptions with audit-grade evidence, and export proof-oriented artifacts—without claiming connectors or schedules that the runtime does not provide.**
 
 ---
 
@@ -37,16 +37,16 @@ Settler is reconciliation-as-a-service—a single API that normalizes, validates
 
 **How it works:**
 
-1. Connect your platforms (Stripe, Shopify, QuickBooks, etc.) via adapters
-2. Ingest transaction data (automatic normalization)
-3. Automatic reconciliation runs continuously (no configuration required)
-4. Review exceptions and export audit trails
+1. Bring transaction data via **CSV upload** and **supported API/ingestion paths** (see current adapter and integration docs—not a closed catalog of “50+” live connectors)
+2. Normalize and validate ingested rows against your run configuration
+3. Execute reconciliation on **demand** (console/API); **cron-style scheduled reconciliation runs are not a shipped product surface yet**
+4. Review exceptions, capture adjudications, and export deterministic evidence / proof-oriented bundles where enabled
 
 ### Key Benefits
 
 - ⚡ **5-minute integration** vs. weeks of custom code
 - 🔄 **Automatic reconciliation** vs. manual matching
-- 🔌 **Standard adapters** for 50+ platforms
+- 🔌 **Integration paths** that match what is implemented today (CSV-first; API ingestion where documented—verify before buying)
 - 🔒 **Compliance built-in** (SOC 2 planned Q3 2026, GDPR/CCPA compliant)
 - 📊 **Comprehensive reporting** with audit trails
 - 🚀 **Scalable** from 10K to 1M+ transactions/month
@@ -57,11 +57,11 @@ Settler is reconciliation-as-a-service—a single API that normalizes, validates
 
 ### Core Features
 
-**Multi-Platform Reconciliation**
+**Multi-source reconciliation (as implemented)**
 
-- Connect 50+ platforms (Stripe, Shopify, QuickBooks, PayPal, Square, Xero, NetSuite, etc.)
-- Normalize data across different formats
-- Real-time or scheduled reconciliation
+- Ingest via **CSV** and **documented API/integration surfaces** (no promise of a fixed “50+” pre-built connector catalog in this document)
+- Normalize data across supported formats for your configured run
+- **On-demand** reconciliation (manual trigger via console/API); scheduled/cron reconciliation runs are **not** marketed here as generally available
 
 **Deterministic Matching**
 
@@ -94,12 +94,14 @@ Settler is reconciliation-as-a-service—a single API that normalizes, validates
 
 ### Advanced Features (Growth+)
 
-- **Multi-Currency Support:** Reconcile transactions across different currencies
-- **Custom Adapters:** Build custom adapters for proprietary systems
-- **Scheduled Jobs:** Automated reconciliation on schedule
-- **Advanced Matching Rules:** Complex matching logic with custom rules
-- **Custom Webhooks:** Real-time notifications for reconciliation events
-- **Multi-Entity Support:** Manage multiple entities/accounts (Scale+)
+Positioning below is **aspirational or partial** unless your contract explicitly lists it as delivered for your tenant. Verify against [INTENTIONAL_BOUNDARIES.md](../getting-started/INTENTIONAL_BOUNDARIES.md) and live docs.
+
+- **Multi-Currency Support:** Partial—single-currency runs are the supported default; cross-currency scenarios need explicit validation
+- **Custom adapters / proprietary systems:** Engineering engagement—not a self-serve “unlimited adapters” claim without a statement of work
+- **Scheduled reconciliation runs:** Not a first-class product surface yet (use external schedulers calling the API if needed)
+- **Advanced Matching Rules:** Available where exposed in product/API—confirm for your plan
+- **Custom Webhooks:** Where enabled in your environment
+- **Multi-Entity Support:** Where contractually enabled (Scale+ / enterprise)
 
 ### Enterprise Features
 
@@ -149,7 +151,7 @@ Settler is reconciliation-as-a-service—a single API that normalizes, validates
 | API Rate Limit  | 500 requests/15 min      |
 | Webhooks        | ✅ Included              |
 | Reports         | JSON + CSV export        |
-| Scheduled Jobs  | ✅ Included              |
+| Scheduled reconciliation (cron) | ❌ Not included — use API + your scheduler |
 
 **Use Case:** Small e-commerce stores (100-1,000 orders/month), early-stage SaaS companies, freelancers managing multiple clients.
 
@@ -172,9 +174,9 @@ Settler is reconciliation-as-a-service—a single API that normalizes, validates
 | API Rate Limit          | 2,000 requests/15 min            |
 | Webhooks                | ✅ Included                      |
 | Reports                 | JSON + CSV + PDF export          |
-| Scheduled Jobs          | ✅ Included                      |
+| Scheduled reconciliation (cron) | ❌ Not included — use API + your scheduler |
 | Advanced Matching Rules | ✅ Included                      |
-| Multi-Currency          | ✅ Included                      |
+| Multi-Currency          | ⚠️ Partial — validate with your currencies |
 | Custom Webhooks         | ✅ Included                      |
 
 **Use Case:** Mid-market SaaS companies, growing e-commerce (1,000-10,000 orders/month), multi-platform operations, need for advanced features.
@@ -198,7 +200,7 @@ Settler is reconciliation-as-a-service—a single API that normalizes, validates
 | API Rate Limit           | 10,000 requests/15 min        |
 | Webhooks                 | ✅ Included                   |
 | Reports                  | All formats + White-label     |
-| Scheduled Jobs           | ✅ Included                   |
+| Scheduled reconciliation (cron) | ❌ Not included — use API + your scheduler |
 | Advanced Matching Rules  | ✅ Included                   |
 | Multi-Currency           | ✅ Included                   |
 | Custom Webhooks          | ✅ Included                   |
@@ -228,7 +230,7 @@ _Typically $1,000-$10,000+/month_
 | API Rate Limit           | Custom                                 |
 | Webhooks                 | ✅ Included                            |
 | Reports                  | All formats + White-label + Custom     |
-| Scheduled Jobs           | ✅ Included                            |
+| Scheduled reconciliation (cron) | ❌ Not included — use API + your scheduler |
 | Advanced Matching Rules  | ✅ Included                            |
 | Multi-Currency           | ✅ Included                            |
 | Custom Webhooks          | ✅ Included                            |

--- a/docs/getting-started/INTENTIONAL_BOUNDARIES.md
+++ b/docs/getting-started/INTENTIONAL_BOUNDARIES.md
@@ -1,6 +1,6 @@
 # Intentional Boundaries
 
-**Last Updated:** 2026-03-18  
+**Last Updated:** 2026-04-04  
 **Purpose:** Document what is intentionally not production-complete and why.
 
 ---
@@ -50,11 +50,11 @@ Basic multi-currency support exists, but advanced scenarios are incomplete.
 
 ### Advanced Scheduling / Cron
 
-**Status:** Not yet built
+**Status:** Not yet built (reconciliation runs)
 
-Automated scheduling of reconciliation runs is not implemented.
+Workflow templates and some internal job queues may store `schedule_cron`-style fields or enqueue delayed work, but **there is no operator-facing, per-tenant cron that starts reconciliation runs on a cadence** with last-run / next-run truth in the product surface.
 
-**Workaround:** Trigger reconciliation manually via console or API.
+**Workaround:** Trigger reconciliation manually via console, API, or your own scheduler calling the API.
 
 ---
 
@@ -64,24 +64,25 @@ Automated scheduling of reconciliation runs is not implemented.
 
 **What's implemented:**
 - Basic error logging
-- Health check endpoints
+- Health check endpoints (`/health`, `/health/detailed`, `/health/ready`) including dependency checks
+- Detailed health exposes **distributed guard posture**: API rate limiting and webhook replay deduplication are `distributed_shared` only when Redis is healthy; otherwise guarantees are explicitly **degraded** (Postgres ledger / in-memory fallbacks may apply—see API code)
 
 **What's missing:**
 - Custom dashboards
-- Alerting thresholds
+- Alerting thresholds (beyond what you wire to health/metrics)
 - SLI/SLO tracking
 
 ---
 
 ### Rate Limiting
 
-**Status:** Fallback mode
+**Status:** Tiered guarantees (Redis → Postgres → in-memory)
 
-Rate limiting falls back to in-memory storage if Redis is unavailable.
+The API prefers **Redis** for shared rate limits and webhook replay keys. If Redis is down or unset, it attempts a **Postgres-backed** counter / replay ledger (`rate_limit_counters`, `webhook_replay_keys`). If that fails, it falls back to **per-process memory** (limits do not hold across instances).
 
 **Implication:**
-- Rate limits reset on server restart
-- Rate limits are per-instance
+- Without healthy Redis, limits are not reliably shared across horizontally scaled instances (Postgres path helps when migrations/tables exist; memory path is last resort).
+- For **production** deployments that must not boot without shared Redis, set `REDIS_REQUIRED_FOR_PRODUCTION=true` (API fails startup in `NODE_ENV=production` if Redis is missing or unreachable).
 
 ---
 

--- a/packages/api/src/infrastructure/observability/__tests__/health-guarantees.test.ts
+++ b/packages/api/src/infrastructure/observability/__tests__/health-guarantees.test.ts
@@ -1,0 +1,66 @@
+import { HealthCheckService } from "../health";
+
+const getDistributedGuaranteesMock = jest.fn();
+
+jest.mock("../../../services/distributed-guards", () => ({
+  getDistributedGuarantees: (...args: unknown[]) => getDistributedGuaranteesMock(...args),
+}));
+
+jest.mock("../../../db", () => ({
+  query: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock("../../../utils/cache", () => ({
+  getRedisClient: jest.fn(() => null),
+}));
+
+jest.mock("../../../domain/services/LedgerService", () => ({
+  getLedgerService: () => ({
+    isEnabled: () => false,
+  }),
+}));
+
+jest.mock("../../../services/authz/openfga-authorization-service", () => ({
+  getOpenFgaAuthorizationService: () => ({
+    status: async () => ({ state: "disabled", reason: "test" }),
+  }),
+}));
+
+jest.mock("../../../infrastructure/supabase/client", () => ({
+  checkSupabaseHealth: async () => ({ healthy: true, latency: 1 }),
+}));
+
+describe("HealthCheckService distributed guard visibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("surfaces healthy guarantees when Redis-backed distributed_shared", async () => {
+    getDistributedGuaranteesMock.mockResolvedValue({
+      rateLimiting: "distributed_shared",
+      webhookReplayDedup: "distributed_shared",
+    });
+
+    const svc = new HealthCheckService();
+    const health = await svc.checkAll();
+
+    expect(health.checks.rate_limit_guarantee?.status).toBe("healthy");
+    expect(health.checks.webhook_replay_guarantee?.status).toBe("healthy");
+    expect(health.degraded).not.toContain("rate_limit_guarantee");
+  });
+
+  it("marks guarantee checks degraded when not distributed_shared", async () => {
+    getDistributedGuaranteesMock.mockResolvedValue({
+      rateLimiting: "degraded",
+      webhookReplayDedup: "degraded",
+    });
+
+    const svc = new HealthCheckService();
+    const health = await svc.checkAll();
+
+    expect(health.checks.rate_limit_guarantee?.status).toBe("degraded");
+    expect(health.checks.webhook_replay_guarantee?.status).toBe("degraded");
+    expect(health.degraded).toContain("rate_limit_guarantee");
+    expect(health.degraded).toContain("webhook_replay_guarantee");
+  });
+});

--- a/packages/api/src/infrastructure/observability/health.ts
+++ b/packages/api/src/infrastructure/observability/health.ts
@@ -4,6 +4,7 @@
  */
 
 import { query } from "../../db";
+import { getDistributedGuarantees } from "../../services/distributed-guards";
 import { getRedisClient } from "../../utils/cache";
 import { getLedgerService } from "../../domain/services/LedgerService";
 import { getOpenFgaAuthorizationService } from "../../services/authz/openfga-authorization-service";
@@ -236,7 +237,7 @@ export class HealthCheckService {
 
   async checkAll(): Promise<HealthStatus> {
     const redisClient = this.getRedisClient();
-    const [database, redis, sentry, supabase, ledger, openfga] = await Promise.all([
+    const [database, redis, sentry, supabase, ledger, openfga, guarantees] = await Promise.all([
       this.checkDatabase(),
       redisClient
         ? this.checkRedis()
@@ -249,7 +250,26 @@ export class HealthCheckService {
       this.checkSupabase(),
       this.checkTigerBeetle(),
       this.checkOpenFga(),
+      getDistributedGuarantees(),
     ]);
+
+    const ts = new Date().toISOString();
+    const rateLimitGuaranteeCheck: HealthCheck =
+      guarantees.rateLimiting === "distributed_shared"
+        ? { status: "healthy", timestamp: ts }
+        : {
+            status: "degraded",
+            error: `API rate limiting guarantee is "${guarantees.rateLimiting}" (not shared across instances unless Redis is healthy; Postgres bucket or in-memory fallback may apply)`,
+            timestamp: ts,
+          };
+    const webhookReplayGuaranteeCheck: HealthCheck =
+      guarantees.webhookReplayDedup === "distributed_shared"
+        ? { status: "healthy", timestamp: ts }
+        : {
+            status: "degraded",
+            error: `Webhook replay deduplication guarantee is "${guarantees.webhookReplayDedup}" (not shared across instances unless Redis is healthy; Postgres or in-memory fallback may apply)`,
+            timestamp: ts,
+          };
 
     const checks = {
       database,
@@ -258,6 +278,8 @@ export class HealthCheckService {
       supabase,
       tigerbeetle: ledger,
       openfga,
+      rate_limit_guarantee: rateLimitGuaranteeCheck,
+      webhook_replay_guarantee: webhookReplayGuaranteeCheck,
     };
 
     const classification = this.classifyChecks(checks);

--- a/packages/api/src/utils/__tests__/startup-validation-redis-gate.test.ts
+++ b/packages/api/src/utils/__tests__/startup-validation-redis-gate.test.ts
@@ -1,0 +1,69 @@
+/**
+ * REDIS_REQUIRED_FOR_PRODUCTION startup gate
+ */
+
+const getRedisClientMock = jest.fn();
+
+jest.mock("../cache", () => ({
+  getRedisClient: (...args: unknown[]) => getRedisClientMock(...args),
+}));
+
+jest.mock("../../db", () => ({
+  initDatabase: jest.fn(),
+  query: jest.fn(() => Promise.resolve([{ "?column?": 1 }])),
+}));
+
+jest.mock("../schema-validation", () => ({
+  validateSchema: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock("../../../../../config/env.schema", () => ({
+  getRequiredEnvVars: () => [],
+  validateEnvVar: () => ({ valid: true }),
+}));
+
+jest.mock("../../config", () => ({
+  config: {
+    nodeEnv: "production",
+    encryption: { key: "x".repeat(32) },
+    jwt: { secret: "y".repeat(32) },
+    logging: { level: "error" },
+  },
+}));
+
+describe("validateRedisProductionRequirement", () => {
+  const orig = process.env.REDIS_REQUIRED_FOR_PRODUCTION;
+
+  afterEach(() => {
+    if (orig === undefined) {
+      delete process.env.REDIS_REQUIRED_FOR_PRODUCTION;
+    } else {
+      process.env.REDIS_REQUIRED_FOR_PRODUCTION = orig;
+    }
+    jest.clearAllMocks();
+  });
+
+  it("returns null when gate is off", async () => {
+    delete process.env.REDIS_REQUIRED_FOR_PRODUCTION;
+    const { validateRedisProductionRequirement } = await import("../startup-validation");
+    expect(await validateRedisProductionRequirement()).toBeNull();
+  });
+
+  it("errors when gate is on and Redis client is missing", async () => {
+    process.env.REDIS_REQUIRED_FOR_PRODUCTION = "true";
+    getRedisClientMock.mockReturnValue(null);
+    const { validateRedisProductionRequirement } = await import("../startup-validation");
+    const r = await validateRedisProductionRequirement();
+    expect(r?.status).toBe("error");
+    expect(r?.name).toBe("redis_production_requirement");
+    expect(r?.message).toMatch(/not configured/);
+  });
+
+  it("ok when gate is on and Redis pings", async () => {
+    process.env.REDIS_REQUIRED_FOR_PRODUCTION = "1";
+    getRedisClientMock.mockReturnValue({ ping: jest.fn(() => Promise.resolve("PONG")) });
+    const { validateRedisProductionRequirement } = await import("../startup-validation");
+    const r = await validateRedisProductionRequirement();
+    expect(r?.status).toBe("ok");
+  });
+});

--- a/packages/api/src/utils/startup-validation.ts
+++ b/packages/api/src/utils/startup-validation.ts
@@ -124,6 +124,47 @@ async function validateRedis(): Promise<ValidationResult> {
   }
 }
 
+function redisRequiredForProduction(): boolean {
+  const v = process.env.REDIS_REQUIRED_FOR_PRODUCTION;
+  return v === "true" || v === "1";
+}
+
+/**
+ * Production gate: optional fail-closed boot when Redis is mandatory for your deployment.
+ * See `REDIS_REQUIRED_FOR_PRODUCTION` in config/env.schema.ts.
+ */
+export async function validateRedisProductionRequirement(): Promise<ValidationResult | null> {
+  if (config.nodeEnv !== "production" || !redisRequiredForProduction()) {
+    return null;
+  }
+
+  const redis = getRedisClient();
+  if (!redis) {
+    return {
+      name: "redis_production_requirement",
+      status: "error",
+      message:
+        "REDIS_REQUIRED_FOR_PRODUCTION is enabled but Redis is not configured (set UPSTASH_REDIS_REST_URL + TOKEN or REDIS_URL)",
+    };
+  }
+
+  try {
+    await redis.ping();
+    return {
+      name: "redis_production_requirement",
+      status: "ok",
+      message: "Redis reachable (production requirement satisfied)",
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      name: "redis_production_requirement",
+      status: "error",
+      message: `REDIS_REQUIRED_FOR_PRODUCTION is enabled but Redis ping failed: ${message}`,
+    };
+  }
+}
+
 /**
  * Validate encryption key format
  */
@@ -238,6 +279,10 @@ export async function validateStartup(): Promise<StartupValidation> {
   try {
     const redisResult = await validateRedis();
     results.push(redisResult);
+    const redisProdGate = await validateRedisProductionRequirement();
+    if (redisProdGate) {
+      results.push(redisProdGate);
+    }
   } catch (error: unknown) {
     results.push({
       name: "redis",

--- a/packages/web/src/types/database.types.ts
+++ b/packages/web/src/types/database.types.ts
@@ -1,13 +1,16 @@
 /**
- * Supabase Database Types
+ * Supabase `Database` shape for the Next.js / Supabase client.
  *
- * CTO Mode: Type Safety
- * - Generated from Supabase schema
- * - Use these types instead of 'any'
- * - Run: supabase gen types typescript --project-id <project-ref> > src/types/database.types.ts
+ * This file is the **canonical hand-maintained contract** for tables the web app
+ * touches (profiles, jobs, receipts, etc.). It is intentionally not a full dump of
+ * every Postgres table in the monorepo (the API uses Prisma for most reconciliation
+ * data). When you add or rename Supabase-backed columns, update this file and run
+ * `pnpm --filter @settler/web typecheck`.
  *
- * TODO: Generate actual types from Supabase schema
- * For now, this is a placeholder structure
+ * Optional: to diff against a live Supabase project (does not replace this file
+ * wholesale without review):
+ *   pnpm run db:types
+ * (requires `SUPABASE_PROJECT_REF` and the Supabase CLI.)
  */
 
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes gaps between **marketing/product copy** and **runtime truth**, and makes **distributed rate-limit / webhook replay posture** visible to operators.

## Changes

- **API health (`/health/detailed`)**: Adds `rate_limit_guarantee` and `webhook_replay_guarantee` checks derived from `getDistributedGuarantees()` so Redis vs degraded (Postgres / in-memory fallback) is machine-visible.
- **Optional production gate**: New env `REDIS_REQUIRED_FOR_PRODUCTION` (documented in `config/env.schema.ts`). When `true` and `NODE_ENV=production`, startup validation **errors** if Redis is missing or ping fails—operators can fail-closed for multi-instance deployments.
- **Docs**: Updates `INTENTIONAL_BOUNDARIES.md` for rate-limit tiers, scheduling nuance, observability/health. Narrows `docs/external/product-overview.md` (removes “50+ platforms” / GA scheduled reconciliation claims; flags multi-currency as partial).
- **Web types**: Replaces the misleading “TODO generate from Supabase” header on `packages/web/src/types/database.types.ts` with an accurate **hand-maintained Supabase contract** note (API reconciliation data remains Prisma).

## Verification

- `pnpm lint` — pass  
- `pnpm typecheck` — pass  
- `pnpm build` — pass  
- `pnpm run verify:docs` — pass  
- `pnpm --filter @settler/api exec jest --runInBand` (new test files) — pass  

## Operator note

Set `REDIS_REQUIRED_FOR_PRODUCTION=true` in production when horizontal scale requires shared Redis-backed limits/replay; otherwise defaults preserve current behavior (Postgres then memory fallback).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dd3759c-bd73-4529-9d8e-069716024f9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dd3759c-bd73-4529-9d8e-069716024f9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

