### PR TITLE
Productization: pillar IA, premium packs, honest operator console, plan alignment

### DIFF
--- a/packages/web/src/__tests__/billing/plan-config-legacy-map.test.ts
+++ b/packages/web/src/__tests__/billing/plan-config-legacy-map.test.ts
@@ -1,0 +1,12 @@
+import { mapLegacyPlanId } from "@/domain/billing/planConfig";
+
+describe("mapLegacyPlanId", () => {
+  it("maps enterprise subscription ids to enterprise plan code", () => {
+    expect(mapLegacyPlanId("enterprise")).toBe("enterprise");
+  });
+
+  it("passes through modern plan codes", () => {
+    expect(mapLegacyPlanId("growth")).toBe("growth");
+    expect(mapLegacyPlanId("scale")).toBe("scale");
+  });
+});

--- a/packages/web/src/__tests__/productization/console-route-pillars.test.ts
+++ b/packages/web/src/__tests__/productization/console-route-pillars.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  CONSOLE_ROUTE_REGISTRY,
+  type ConsoleNavSection,
+} from "@/lib/console/route-maturity";
+import { COMMERCIAL_OFFERS } from "@/domain/billing/commercialModel";
+import { planConfigs, type PlanCode } from "@/domain/billing/planConfig";
+import { PREMIUM_PACKS } from "@/domain/billing/premiumPacks";
+
+const PILLARS: ConsoleNavSection[] = [
+  "Reconciliation core",
+  "Exception ops",
+  "Evidence + audit",
+  "Control plane",
+  "Administration",
+];
+
+describe("product IA and billing alignment", () => {
+  it("places every console nav entry under the four product pillars (+ admin)", () => {
+    for (const route of CONSOLE_ROUTE_REGISTRY) {
+      expect(PILLARS).toContain(route.section);
+    }
+  });
+
+  it("lists /console/schedules in the route registry (nav discoverability)", () => {
+    expect(CONSOLE_ROUTE_REGISTRY.some((r) => r.href === "/console/schedules")).toBe(true);
+  });
+
+  it("keeps COMMERCIAL_OFFERS plan codes on defined planConfigs entries", () => {
+    for (const offer of COMMERCIAL_OFFERS) {
+      const code = offer.planCode;
+      expect(code).toBeDefined();
+      expect(planConfigs[code as PlanCode]).toBeDefined();
+    }
+  });
+
+  it("maps premium pack console routes to registry hrefs when non-empty", () => {
+    const hrefs = new Set(CONSOLE_ROUTE_REGISTRY.map((r) => r.href));
+    for (const pack of PREMIUM_PACKS) {
+      for (const href of pack.consoleRoutes) {
+        expect(hrefs.has(href)).toBe(true);
+      }
+    }
+  });
+
+  it("documents planConfig as canonical owner in route-maturity (drift guard)", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/lib/console/route-maturity.ts"),
+      "utf-8"
+    );
+    expect(source).toContain("COMMERCIAL_OFFERS");
+  });
+});

--- a/packages/web/src/app/console/operator/page.tsx
+++ b/packages/web/src/app/console/operator/page.tsx
@@ -1,226 +1,99 @@
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Activity, Layers, Globe, Cpu, Terminal, Search, HardDrive } from "lucide-react";
-import ControlPlaneOverview from "@/components/ControlPlaneOverview";
+import Link from "next/link";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Activity, AlertTriangle, Headphones, LayoutDashboard, Shield } from "lucide-react";
 
 export const metadata = {
   title: "Operator Console | Settler",
-  description: "Real-time fleet monitoring and control-plane health for Settler infrastructure.",
+  description:
+    "Honest operator routing: tenant workbench, diagnostics, and admin-only ops surfaces — no synthetic fleet telemetry.",
 };
 
 export default function OperatorPage() {
-  const healthData = {
-    status: "healthy" as const,
-    checks: {
-      database: { status: "healthy" as const, latency: 4, timestamp: new Date().toISOString() },
-      reconciliation: {
-        status: "healthy" as const,
-        latency: 12,
-        timestamp: new Date().toISOString(),
-      },
-      "trust-graph": {
-        status: "healthy" as const,
-        latency: 8,
-        timestamp: new Date().toISOString(),
-      },
-      storage: { status: "healthy" as const, timestamp: new Date().toISOString() },
-    },
-    timestamp: new Date().toISOString(),
-  };
-
   return (
-    <div className="space-y-8 pb-12">
-      <div className="flex items-end justify-between">
-        <div className="max-w-4xl">
-          <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary/70 mb-2">
-            Infrastructure Fleet Control
-          </p>
-          <h1 className="text-4xl font-bold tracking-tight text-foreground italic">
-            Operator Interface
-          </h1>
-          <p className="mt-4 text-base text-muted-foreground leading-relaxed">
-            Direct access to the Settler control plane. Monitor engine orchestration, agent health,
-            and global synchronization state across your multi-region reconciliation deployment.
-          </p>
-        </div>
+    <div className="space-y-8 pb-12 max-w-4xl">
+      <div>
+        <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary/70 mb-2">
+          Solo-operator routing
+        </p>
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">Operator console</h1>
+        <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
+          This route is a control-plane index. It does not render live multi-region fleet health,
+          fabricated latencies, or storage efficiency — those were removed because they were not
+          backed by repository contracts. Use the links below for real surfaces.
+        </p>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Fleet Integrity Card */}
-        <div className="lg:col-span-2 space-y-8">
-          <Card className="border-border/40 shadow-xl overflow-hidden glass border-l-4 border-l-primary/60">
-            <CardHeader className="bg-primary/5 pb-6 border-b border-border/40">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <Activity className="h-5 w-5 text-primary" />
-                  <div>
-                    <CardTitle className="text-lg font-bold">Orchestration Health</CardTitle>
-                    <CardDescription className="text-xs font-medium">
-                      Global control-plane status and latency
-                    </CardDescription>
-                  </div>
-                </div>
-                <Badge className="bg-success/10 text-success border-success/20 px-3 py-1 font-bold text-xs uppercase tracking-widest">
-                  FLEET NOMINAL
-                </Badge>
-              </div>
-            </CardHeader>
-            <CardContent className="p-8">
-              <ControlPlaneOverview health={healthData} />
-            </CardContent>
-          </Card>
+      <Alert variant="default" className="border-amber-500/40 bg-amber-500/5">
+        <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-500" aria-hidden="true" />
+        <AlertTitle>No synthetic health theatre</AlertTitle>
+        <AlertDescription>
+          Tenant-scoped run and exception truth lives in the workbench and run detail routes.
+          Super-admin fleet views live under Ops and Support inbox — both require elevated role.
+        </AlertDescription>
+      </Alert>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <Card className="border-border/40 bg-card/50">
-              <CardHeader className="pb-4 border-b border-border/20">
-                <div className="flex items-center gap-3">
-                  <Globe className="h-4 w-4 text-primary" />
-                  <CardTitle className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
-                    Regional Synchronization
-                  </CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent className="p-6 space-y-4">
-                {[
-                  { region: "US-EAST-1", status: "In-Sync", RTT: "4ms" },
-                  { region: "EU-WEST-2", status: "In-Sync", RTT: "62ms" },
-                  { region: "AP-SOUTH-1", status: "Lagged", RTT: "241ms", warning: true },
-                ].map((item) => (
-                  <div key={item.region} className="flex items-center justify-between">
-                    <span className="text-xs font-bold font-mono text-muted-foreground">
-                      {item.region}
-                    </span>
-                    <div className="flex items-center gap-4">
-                      <span className="text-[10px] font-mono opacity-60">RTT: {item.RTT}</span>
-                      <Badge
-                        variant="outline"
-                        className={`text-[10px] font-black tracking-widest h-5 ${item.warning ? "text-warning border-warning/30 bg-warning/5 animate-pulse" : "text-success border-success/30 bg-success/5"}`}
-                      >
-                        {item.status}
-                      </Badge>
-                    </div>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-            <Card className="border-border/40 bg-card/50">
-              <CardHeader className="pb-4 border-b border-border/20">
-                <div className="flex items-center gap-3 text-muted-foreground">
-                  <HardDrive className="h-4 w-4 text-primary" />
-                  <CardTitle className="text-xs font-bold uppercase tracking-widest">
-                    Proof Persistence
-                  </CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent className="p-6">
-                <div className="flex flex-col gap-4">
-                  <div className="space-y-2">
-                    <div className="flex justify-between text-[10px] font-bold uppercase">
-                      <span>S3 Cold Archive</span>
-                      <span className="text-primary tracking-widest">94% EFFICIENCY</span>
-                    </div>
-                    <div className="h-1.5 w-full bg-muted rounded-full overflow-hidden">
-                      <div className="h-full bg-primary w-[94%]" />
-                    </div>
-                  </div>
-                  <div className="space-y-2">
-                    <div className="flex justify-between text-[10px] font-bold uppercase">
-                      <span>Redis Mirror Lag</span>
-                      <span className="text-primary tracking-widest">0.02ms</span>
-                    </div>
-                    <div className="h-1.5 w-full bg-muted rounded-full overflow-hidden">
-                      <div className="h-full bg-primary w-[2%]" />
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card className="border-border/60">
+          <CardHeader className="pb-2">
+            <div className="flex items-center gap-2">
+              <LayoutDashboard className="h-4 w-4 text-primary" aria-hidden="true" />
+              <CardTitle className="text-base">Tenant command center</CardTitle>
+            </div>
+            <CardDescription>Open exceptions, runs, and activation readiness for the current scope.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="secondary" className="w-full sm:w-auto">
+              <Link href="/console">Open workbench</Link>
+            </Button>
+          </CardContent>
+        </Card>
 
-        {/* Sidebar Diagnostics */}
-        <div className="space-y-8">
-          <Card className="border-border/40 bg-card/50 shadow-none overflow-hidden h-full flex flex-col">
-            <CardHeader className="bg-muted/10 border-b border-border/20 relative overflow-hidden">
-              <div className="absolute right-0 top-0 opacity-10 -mr-6 -mt-6">
-                <Terminal className="h-24 w-24 text-primary" />
-              </div>
-              <div className="relative z-10 flex flex-col space-y-1">
-                <CardTitle className="text-xs font-black uppercase tracking-[0.2em] text-primary">
-                  Live Diagnostics
-                </CardTitle>
-              </div>
-            </CardHeader>
-            <CardContent className="flex-1 p-6 space-y-6">
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest">
-                    Active Orchestrator Nodes
-                  </p>
-                  <div className="flex flex-wrap gap-2">
-                    {[1, 2, 3, 4].map((i) => (
-                      <div
-                        key={i}
-                        className="flex items-center gap-2 px-2 py-1 rounded bg-success/5 border border-success/20 text-success"
-                      >
-                        <div className="h-1.5 w-1.5 rounded-full bg-success animate-pulse" />
-                        <span className="text-[10px] font-mono font-bold tracking-tight text-success uppercase italic">
-                          NODE-0{i}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-                <div className="space-y-2 pt-4">
-                  <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest">
-                    Recent Fleet Events
-                  </p>
-                  <div className="space-y-3 font-mono text-[10px] leading-relaxed text-muted-foreground bg-slate-950 p-4 rounded-xl border border-white/5">
-                    <p>
-                      <span className="text-primary">02:31:12</span> [PROG] Deploy V2.4.1 Fleet
-                      wide...
-                    </p>
-                    <p>
-                      <span className="text-primary">02:35:01</span> [FLEET] NODE-01 Rollout
-                      Verified.
-                    </p>
-                    <p>
-                      <span className="text-primary">02:35:45</span> [FLEET] NODE-02 Rollout
-                      Verified.
-                    </p>
-                    <p>
-                      <span className="text-success">02:38:00</span> [SUCCESS] Health Gradients
-                      Balanced.
-                    </p>
-                  </div>
-                </div>
-              </div>
+        <Card className="border-border/60">
+          <CardHeader className="pb-2">
+            <div className="flex items-center gap-2">
+              <Activity className="h-4 w-4 text-primary" aria-hidden="true" />
+              <CardTitle className="text-base">Diagnostics</CardTitle>
+            </div>
+            <CardDescription>Explicit missing-env and contract disclosure for this deployment.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="secondary" className="w-full sm:w-auto">
+              <Link href="/console/diagnostics">Open diagnostics</Link>
+            </Button>
+          </CardContent>
+        </Card>
 
-              <div className="pt-6 border-t border-border/40 space-y-4">
-                <div className="flex items-center justify-between group cursor-pointer hover:bg-primary/5 p-2 rounded-lg transition-colors">
-                  <span className="text-xs font-bold text-slate-600 dark:text-slate-400 group-hover:text-primary transition-colors flex items-center gap-2">
-                    <Search size={14} className="opacity-40" />
-                    View Full Diagnostics
-                  </span>
-                </div>
-                <div className="flex items-center justify-between group cursor-pointer hover:bg-primary/5 p-2 rounded-lg transition-colors">
-                  <span className="text-xs font-bold text-slate-600 dark:text-slate-400 group-hover:text-primary transition-colors flex items-center gap-2">
-                    <Layers size={14} className="opacity-40" />
-                    Memory Snapshot
-                  </span>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+        <Card className="border-border/60">
+          <CardHeader className="pb-2">
+            <div className="flex items-center gap-2">
+              <Shield className="h-4 w-4 text-primary" aria-hidden="true" />
+              <CardTitle className="text-base">Ops command center</CardTitle>
+            </div>
+            <CardDescription>Super-admin monitoring and management (gated).</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline" className="w-full sm:w-auto">
+              <Link href="/console/ops">Open ops</Link>
+            </Button>
+          </CardContent>
+        </Card>
 
-          <section className="p-6 rounded-2xl bg-primary/5 border border-primary/10 flex flex-col items-center text-center space-y-4">
-            <Cpu className="h-10 w-10 text-primary opacity-40" />
-            <h4 className="text-sm font-bold tracking-tight italic">Engine Version: 2.4.1</h4>
-            <p className="text-[10px] text-muted-foreground font-medium max-w-[200px] leading-relaxed italic uppercase tracking-widest">
-              High-integrity reconciliation core v2.4.1 is verified for production workloads.
-            </p>
-          </section>
-        </div>
+        <Card className="border-border/60">
+          <CardHeader className="pb-2">
+            <div className="flex items-center gap-2">
+              <Headphones className="h-4 w-4 text-primary" aria-hidden="true" />
+              <CardTitle className="text-base">Support inbox</CardTitle>
+            </div>
+            <CardDescription>Evidence-oriented intake queue for elevated operators.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline" className="w-full sm:w-auto">
+              <Link href="/console/support">Open support inbox</Link>
+            </Button>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -72,12 +72,12 @@ export default function HomePage() {
           actions={
             <>
               <Button asChild>
-                <UiLink href="/app/runs">
-                  Open Console <ArrowRight className="ml-1 h-4 w-4" />
+                <UiLink href="/console">
+                  Open console <ArrowRight className="ml-1 h-4 w-4" />
                 </UiLink>
               </Button>
               <Button variant="outline" asChild>
-                <UiLink href="/docs">Read docs</UiLink>
+                <UiLink href="/docs/quickstart">15-minute quickstart</UiLink>
               </Button>
             </>
           }
@@ -123,9 +123,9 @@ export default function HomePage() {
             <div className="space-y-8">
               <h2 className="text-3xl font-bold tracking-tight">Operator-Grade Triage</h2>
               <p className="text-lg text-muted-foreground leading-relaxed">
-                Settler doesn't just find mismatches; it empowers operators to resolve them with
-                institutional-grade confidence. AI-assisted review compresses resolution time by
-                surfacing the exact context needed for every decision.
+                Exceptions carry deterministic &quot;why&quot; context and operator decisions stay
+                auditable. Where AI is enabled, it is advisory, evidence-linked, and bounded — humans
+                keep final authority.
               </p>
               <Button asChild variant="outline">
                 <UiLink href="/platform">
@@ -160,8 +160,8 @@ export default function HomePage() {
                 },
                 {
                   role: "Operator",
-                  href: "/app/runs",
-                  desc: "Exception handling, controls, and run operations.",
+                  href: "/console",
+                  desc: "Workbench, exceptions, runs, and billing in one console.",
                 },
                 {
                   role: "Architecture reviewer",

--- a/packages/web/src/app/pricing/page.tsx
+++ b/packages/web/src/app/pricing/page.tsx
@@ -9,6 +9,7 @@ import { Check, ArrowRight, Zap, Shield, Globe, LucideIcon } from "lucide-react"
 import Link from "next/link";
 import { VisualGrid } from "@/components/site/infographics";
 import { COMMERCIAL_OFFERS, OfferCode } from "@/domain/billing/commercialModel";
+import { PREMIUM_PACKS } from "@/domain/billing/premiumPacks";
 
 export const metadata = {
   title: "Pricing | Settler",
@@ -108,6 +109,46 @@ export default function PricingPage() {
 
       {/* Feature Comparison */}
       <FeatureComparison />
+
+      <Section className="border-t border-border/40 py-16 sm:py-20 bg-muted/10">
+        <div className="mx-auto max-w-7xl">
+          <SectionHeader
+            title="Capability packs"
+            description="Additive overlays on volume plans — each maps to real console routes today. Managed reliability is contractual (Managed / Enterprise), not a UI toggle."
+          />
+          <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {PREMIUM_PACKS.map((pack) => (
+              <Card key={pack.code} className="border-border/50 h-full flex flex-col">
+                <CardHeader>
+                  <CardTitle className="text-lg">{pack.name}</CardTitle>
+                  <CardDescription className="leading-relaxed">{pack.summary}</CardDescription>
+                </CardHeader>
+                <CardContent className="flex-1 flex flex-col justify-end pt-0">
+                  {pack.consoleRoutes.length > 0 ? (
+                    <div>
+                      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                        Console surfaces
+                      </p>
+                      <ul className="text-xs text-muted-foreground space-y-1 font-mono">
+                        {pack.consoleRoutes.map((r) => (
+                          <li key={r}>{r}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : (
+                    <p className="text-xs text-muted-foreground italic">
+                      Delivered via contract / operator engagement — no dedicated pack page in-app.
+                    </p>
+                  )}
+                  <p className="text-[11px] text-muted-foreground/80 mt-4">
+                    Typical base: <span className="font-medium">{pack.suggestedBasePlan}</span>
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </Section>
 
       {/* FAQ */}
       <Section className="border-t border-border/40 py-16 sm:py-20">

--- a/packages/web/src/app/product/page.tsx
+++ b/packages/web/src/app/product/page.tsx
@@ -43,6 +43,46 @@ export default function ProductPage() {
           }
         />
 
+        <div id="product-pillars" className="scroll-mt-24">
+          <Section className="py-16 lg:py-24 border-t border-border/40">
+            <div className="text-center space-y-3 max-w-3xl mx-auto mb-12">
+              <h2 className="text-2xl font-bold tracking-tight">Product pillars</h2>
+              <p className="text-muted-foreground text-sm leading-relaxed">
+                How the console and docs are organized: reconciliation core, exception operations,
+                evidence and audit, and the control plane (API, webhooks, billing, settings).
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-16">
+              {[
+                {
+                  title: "Reconciliation core",
+                  body: "Runs, policies, schedules, and replay surfaces for deterministic execution truth.",
+                },
+                {
+                  title: "Exception ops",
+                  body: "Queues, severity, analytics, and bounded AI insights with explicit degraded states.",
+                },
+                {
+                  title: "Evidence + audit",
+                  body: "Proof explorer, audits, and audit trail for replayable, exportable artifacts.",
+                },
+                {
+                  title: "Control plane",
+                  body: "API keys, webhooks, workflows, billing, diagnostics, and tenant settings.",
+                },
+              ].map((pillar) => (
+                <div
+                  key={pillar.title}
+                  className="rounded-xl border border-border/60 bg-card/40 p-5 text-left"
+                >
+                  <h3 className="text-sm font-semibold text-foreground">{pillar.title}</h3>
+                  <p className="mt-2 text-xs text-muted-foreground leading-relaxed">{pillar.body}</p>
+                </div>
+              ))}
+            </div>
+          </Section>
+        </div>
+
         <Section className="py-20 lg:py-32">
           <div className="text-center space-y-4 max-w-3xl mx-auto mb-16">
             <h2 className="text-3xl font-bold tracking-tight">The Settlement Pipeline</h2>

--- a/packages/web/src/components/console/ConsoleLayout.tsx
+++ b/packages/web/src/components/console/ConsoleLayout.tsx
@@ -30,6 +30,7 @@ import {
   PlayCircle,
   AlertTriangle,
   Headphones,
+  CalendarClock,
   type LucideIcon,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -41,11 +42,10 @@ import { CONSOLE_ROUTE_REGISTRY, type ConsoleRouteEntry } from "@/lib/console/ro
 import { OperationalRouteNotice } from "@/components/shared/OperationalRouteNotice";
 
 const navSectionOrder = [
-  "Operations",
-  "Intelligence",
-  "Developer",
-  "Settings",
-  "Enterprise",
+  "Reconciliation core",
+  "Exception ops",
+  "Evidence + audit",
+  "Control plane",
   "Administration",
 ] as const;
 
@@ -72,6 +72,7 @@ const labelToIcon: Record<string, LucideIcon> = {
   "Audit Trail": ShieldCheck,
   "Operator Console": Bot,
   "Tenant Observability": Building2,
+  Schedules: CalendarClock,
 };
 
 function maturityBadge(entry: ConsoleRouteEntry) {

--- a/packages/web/src/components/console/SupportWidget.tsx
+++ b/packages/web/src/components/console/SupportWidget.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -43,6 +43,35 @@ export function SupportWidget({ defaultRoute, defaultRunId = "" }: SupportWidget
   const [submitted, setSubmitted] = useState(false);
   const [submissionId, setSubmissionId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+
+  const contextBundle = useMemo(() => {
+    const lines = [
+      "=== Settler support context bundle (paste into email or ticket) ===",
+      `Category: ${SUPPORT_ISSUE_CATEGORY_LABELS[category]} (${category})`,
+      subject.trim() ? `Title: ${subject.trim()}` : "Title: (none)",
+      runId.trim() ? `Run UUID: ${runId.trim()}` : "Run UUID: (not provided)",
+      moduleHint.trim() ? `Module hint: ${moduleHint.trim()}` : "Module hint: (none)",
+      defaultRoute?.trim() ? `Console route: ${defaultRoute.trim()}` : "Console route: (none)",
+      "",
+      "Details:",
+      description.trim() || "(draft — add at least 20 characters before submit)",
+      "",
+      "Note: Submitting the form also records tenant-scoped intake with audit attribution.",
+    ];
+    return lines.join("\n");
+  }, [category, subject, runId, moduleHint, description, defaultRoute]);
+
+  const copyBundle = async () => {
+    setCopyFeedback(null);
+    try {
+      await navigator.clipboard.writeText(contextBundle);
+      setCopyFeedback("Copied to clipboard");
+      setTimeout(() => setCopyFeedback(null), 2500);
+    } catch {
+      setCopyFeedback("Copy failed — select the text manually");
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -227,6 +256,27 @@ export function SupportWidget({ defaultRoute, defaultRunId = "" }: SupportWidget
                 required
                 minLength={20}
                 maxLength={5000}
+              />
+            </div>
+
+            <div className="rounded-lg border border-border/60 bg-muted/20 p-4 space-y-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <Label htmlFor="support-context-bundle" className="text-sm">
+                  Copy-paste context bundle
+                </Label>
+                <Button type="button" variant="outline" size="sm" onClick={() => void copyBundle()}>
+                  Copy bundle
+                </Button>
+              </div>
+              {copyFeedback ? (
+                <p className="text-xs text-muted-foreground">{copyFeedback}</p>
+              ) : null}
+              <Textarea
+                id="support-context-bundle"
+                readOnly
+                value={contextBundle}
+                rows={10}
+                className="font-mono text-xs"
               />
             </div>
 

--- a/packages/web/src/domain/billing/planConfig.ts
+++ b/packages/web/src/domain/billing/planConfig.ts
@@ -133,15 +133,20 @@ export function getDefaultPlan(): PlanConfig {
  * Map legacy planId to new planCode
  */
 export function mapLegacyPlanId(planId: string): PlanCode {
+  const normalized = planId?.trim().toLowerCase() ?? "";
+  if (normalized === "starter" || normalized === "growth" || normalized === "scale") {
+    return normalized;
+  }
   const mapping: Record<string, PlanCode> = {
-    base: 'starter',
-    free: 'starter',
-    pro: 'growth',
-    commercial: 'growth',
-    enterprise: 'scale',
-    scale: 'scale',
+    base: "starter",
+    free: "starter",
+    trial: "starter",
+    pro: "growth",
+    commercial: "growth",
+    enterprise: "enterprise",
+    scale: "scale",
   };
-  return mapping[planId] || 'starter';
+  return mapping[normalized] || "starter";
 }
 
 /**

--- a/packages/web/src/domain/billing/premiumPacks.ts
+++ b/packages/web/src/domain/billing/premiumPacks.ts
@@ -1,0 +1,69 @@
+import type { PlanCode } from "@/domain/billing/planConfig";
+
+/**
+ * Premium capability packs — additive overlays on top of base plans (`planConfig`).
+ * Each pack maps to real console surfaces; do not claim features without a route or API contract.
+ */
+export type PremiumPackCode =
+  | "exception_intelligence"
+  | "evidence_audit"
+  | "api_automation"
+  | "ai_augmentation"
+  | "managed_reliability";
+
+export interface PremiumPack {
+  code: PremiumPackCode;
+  name: string;
+  summary: string;
+  /** Console routes that materially deliver this pack today */
+  consoleRoutes: readonly string[];
+  /** Typical base plan this pack stacks on (not a hard entitlement gate here) */
+  suggestedBasePlan: PlanCode;
+}
+
+export const PREMIUM_PACKS: readonly PremiumPack[] = [
+  {
+    code: "exception_intelligence",
+    name: "Exception Intelligence",
+    summary:
+      "Exception queues, severity triage, analytics rollups, and bounded AI insights with explicit degraded states when providers are absent.",
+    consoleRoutes: ["/console/exceptions", "/console/analytics", "/console/insights"],
+    suggestedBasePlan: "growth",
+  },
+  {
+    code: "evidence_audit",
+    name: "Evidence & audit",
+    summary:
+      "Proof explorer, audit trail, and export-oriented surfaces for replayable, reviewable artifacts.",
+    consoleRoutes: ["/console/proof-explorer", "/console/audit-trail", "/console/audits"],
+    suggestedBasePlan: "growth",
+  },
+  {
+    code: "api_automation",
+    name: "API & automation",
+    summary:
+      "Programmatic execution, keys, webhooks, and workflow scaffolding (where marked thin/restricted in route maturity).",
+    consoleRoutes: ["/console/api-keys", "/console/webhooks", "/console/workflows"],
+    suggestedBasePlan: "growth",
+  },
+  {
+    code: "ai_augmentation",
+    name: "AI augmentation",
+    summary:
+      "Advisory summarization and insight surfaces only; never a substitute for deterministic run truth.",
+    consoleRoutes: ["/console/insights"],
+    suggestedBasePlan: "growth",
+  },
+  {
+    code: "managed_reliability",
+    name: "Managed reliability",
+    summary:
+      "Human-in-the-loop operations and named-operator coverage — sold as Managed / Enterprise offers, not a console toggle.",
+    consoleRoutes: [],
+    suggestedBasePlan: "scale",
+  },
+] as const;
+
+export function getPremiumPack(code: PremiumPackCode): PremiumPack | undefined {
+  return PREMIUM_PACKS.find((p) => p.code === code);
+}

--- a/packages/web/src/lib/console/route-maturity.ts
+++ b/packages/web/src/lib/console/route-maturity.ts
@@ -23,12 +23,12 @@ export type ConsoleMaturityClass =
 
 export type RuntimeDependencyClass = "none" | "supabase" | "stripe" | "providers" | "hybrid";
 
+/** Product IA pillars (canonical console grouping). Keep in sync with marketing `COMMERCIAL_OFFERS`. */
 export type ConsoleNavSection =
-  | "Operations"
-  | "Intelligence"
-  | "Developer"
-  | "Settings"
-  | "Enterprise"
+  | "Reconciliation core"
+  | "Exception ops"
+  | "Evidence + audit"
+  | "Control plane"
   | "Administration";
 
 export interface ConsoleRouteEntry {
@@ -57,7 +57,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console",
     label: "Workbench",
-    section: "Operations",
+    section: "Reconciliation core",
     domain: "overview",
     maturity: "runtime-degraded-without-env",
     runtimeDependency: "hybrid",
@@ -78,7 +78,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/reconciliations",
     label: "Reconciliations",
-    section: "Operations",
+    section: "Reconciliation core",
     domain: "reconciliations",
     maturity: "runtime-operational",
     runtimeDependency: "hybrid",
@@ -99,7 +99,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/runs",
     label: "Runs",
-    section: "Operations",
+    section: "Reconciliation core",
     domain: "reconciliations",
     maturity: "runtime-operational",
     runtimeDependency: "hybrid",
@@ -120,7 +120,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/exceptions",
     label: "Exceptions",
-    section: "Operations",
+    section: "Exception ops",
     domain: "reconciliations",
     maturity: "runtime-operational",
     runtimeDependency: "supabase",
@@ -141,7 +141,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/audits",
     label: "Audits",
-    section: "Operations",
+    section: "Evidence + audit",
     domain: "audits",
     maturity: "runtime-degraded-without-tenant",
     runtimeDependency: "supabase",
@@ -162,7 +162,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/proof-explorer",
     label: "Proof Explorer",
-    section: "Operations",
+    section: "Evidence + audit",
     domain: "audits",
     maturity: "runtime-degraded-without-tenant",
     runtimeDependency: "supabase",
@@ -184,7 +184,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/policies",
     label: "Policies",
-    section: "Operations",
+    section: "Reconciliation core",
     domain: "policies",
     maturity: "runtime-operational",
     runtimeDependency: "supabase",
@@ -205,7 +205,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/control-plane",
     label: "Control Plane",
-    section: "Operations",
+    section: "Control plane",
     domain: "control-plane",
     maturity: "runtime-operational",
     runtimeDependency: "hybrid",
@@ -226,7 +226,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/analytics",
     label: "Analytics",
-    section: "Intelligence",
+    section: "Exception ops",
     domain: "analytics",
     maturity: "runtime-degraded-without-env",
     runtimeDependency: "hybrid",
@@ -247,7 +247,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/insights",
     label: "AI Insights",
-    section: "Intelligence",
+    section: "Exception ops",
     domain: "analytics",
     maturity: "runtime-degraded-without-provider",
     runtimeDependency: "providers",
@@ -268,7 +268,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/diagnostics",
     label: "Diagnostics",
-    section: "Intelligence",
+    section: "Control plane",
     domain: "diagnostics",
     maturity: "runtime-degraded-without-env",
     runtimeDependency: "hybrid",
@@ -289,7 +289,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/api-keys",
     label: "API Keys",
-    section: "Developer",
+    section: "Control plane",
     domain: "developer",
     maturity: "runtime-operational",
     runtimeDependency: "supabase",
@@ -310,7 +310,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/webhooks",
     label: "Webhooks",
-    section: "Developer",
+    section: "Control plane",
     domain: "developer",
     maturity: "runtime-degraded-without-provider",
     runtimeDependency: "providers",
@@ -332,7 +332,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/workflows",
     label: "Workflows",
-    section: "Developer",
+    section: "Control plane",
     domain: "developer",
     maturity: "thin",
     runtimeDependency: "hybrid",
@@ -351,9 +351,30 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
     dataMode: "restricted",
   },
   {
+    href: "/console/schedules",
+    label: "Schedules",
+    section: "Control plane",
+    domain: "developer",
+    maturity: "runtime-operational",
+    runtimeDependency: "hybrid",
+    authRequired: true,
+    tenantScopeRequired: true,
+    roleRestriction: "none",
+    envRequired: true,
+    databaseRequired: true,
+    stripeRequired: false,
+    supabaseRequired: true,
+    externalProviderRequired: false,
+    explicitDisclosureRequired: false,
+    degradedBehavior: "Shows schedule list or empty state when none exist.",
+    navTreatment: "secondary",
+    ctaRestrictions: "none",
+    dataMode: "operational",
+  },
+  {
     href: "/console/billing",
     label: "Billing & Plan",
-    section: "Settings",
+    section: "Control plane",
     domain: "billing",
     maturity: "runtime-degraded-without-provider",
     runtimeDependency: "stripe",
@@ -375,7 +396,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/settings",
     label: "Settings",
-    section: "Settings",
+    section: "Control plane",
     domain: "settings",
     maturity: "runtime-operational",
     runtimeDependency: "supabase",
@@ -396,7 +417,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/report-issue",
     label: "Report issue",
-    section: "Settings",
+    section: "Control plane",
     domain: "settings",
     maturity: "runtime-operational",
     runtimeDependency: "supabase",
@@ -418,7 +439,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/site",
     label: "Site Designer",
-    section: "Settings",
+    section: "Control plane",
     domain: "site",
     maturity: "runtime-degraded-without-tenant",
     runtimeDependency: "supabase",
@@ -439,7 +460,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/replay",
     label: "Replay Lab",
-    section: "Enterprise",
+    section: "Reconciliation core",
     domain: "reconciliations",
     maturity: "thin",
     runtimeDependency: "none",
@@ -460,7 +481,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/audit-trail",
     label: "Audit Trail",
-    section: "Enterprise",
+    section: "Evidence + audit",
     domain: "audits",
     maturity: "runtime-degraded-without-tenant",
     runtimeDependency: "supabase",
@@ -482,7 +503,7 @@ export const CONSOLE_ROUTE_REGISTRY: readonly ConsoleRouteEntry[] = [
   {
     href: "/console/operator",
     label: "Operator Console",
-    section: "Enterprise",
+    section: "Control plane",
     domain: "control-plane",
     maturity: "runtime-degraded-without-env",
     runtimeDependency: "hybrid",

--- a/packages/web/src/middleware/usage-tracking.ts
+++ b/packages/web/src/middleware/usage-tracking.ts
@@ -156,28 +156,32 @@ export async function checkUsageLimit(
   limit: number;
   wouldExceed: boolean;
 }> {
-  const { getPlan } = await import("@/config/pricing-simple");
-  const plan = getPlan(planId);
+  const { mapLegacyPlanId, getReconciliationVolumeLimit, planConfigs } = await import(
+    "@/domain/billing/planConfig"
+  );
+  const planCode = mapLegacyPlanId(planId);
+  const includedVolume = getReconciliationVolumeLimit(planCode);
+  /** Only starter-equivalent plans hard-cap included reconciliation volume; paid tiers bill overage. */
+  const hasHardMonthlyCap =
+    planCode === "starter" && includedVolume > 0 && planConfigs[planCode].monthlyPrice === 0;
 
   const currentUsage = await getCurrentUsage(billingAccountId, "monthly");
   const totalUsage = currentUsage.totalTransactions + additionalTransactions;
 
-  // Free tier has hard limit
-  if (planId === "free") {
-    const allowed = totalUsage <= plan.includedTransactions;
+  if (hasHardMonthlyCap) {
+    const allowed = totalUsage <= includedVolume;
     return {
       allowed,
       currentUsage: currentUsage.totalTransactions,
-      limit: plan.includedTransactions,
-      wouldExceed: totalUsage > plan.includedTransactions,
+      limit: includedVolume,
+      wouldExceed: totalUsage > includedVolume,
     };
   }
 
-  // Paid tiers have no hard limit (just billing)
   return {
     allowed: true,
     currentUsage: currentUsage.totalTransactions,
-    limit: Infinity,
+    limit: includedVolume > 0 ? includedVolume : Infinity,
     wouldExceed: false,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This pass tightens information architecture around four product pillars, adds a route-backed premium pack model aligned to `planConfig` / `COMMERCIAL_OFFERS`, removes synthetic “fleet health” theatre from `/console/operator`, aligns optional usage-limit checks with canonical plan volumes, improves onboarding CTAs on the home page, documents pillars on the product page, and adds copy-paste support context bundles.

## Key changes

- **Console nav**: Sections renamed to Reconciliation core, Exception ops, Evidence + audit, Control plane (+ Administration). `/console/schedules` added to `CONSOLE_ROUTE_REGISTRY` for discoverability.
- **Pricing**: New `PREMIUM_PACKS` (`premiumPacks.ts`) rendered on the pricing page; each non-empty pack lists real console routes only.
- **Operator honesty**: `/console/operator` is now an index to workbench, diagnostics, ops (super-admin), and support inbox — no fabricated regional RTT / S3 metrics.
- **Billing alignment**: `mapLegacyPlanId` maps `enterprise` → `enterprise` (not `scale`). `checkUsageLimit` in `usage-tracking.ts` uses `planConfig` included reconciliation volume for starter-equivalent hard caps.
- **Support**: `SupportWidget` includes a read-only “context bundle” + copy button for paste-ready artifacts.
- **Marketing**: Home hero CTA → `/console`, secondary → `/docs/quickstart`; exception blurb emphasizes deterministic + bounded AI; product page adds anchorable pillar section (`#product-pillars`).

## Tests

- `console-route-pillars.test.ts` — pillar coverage, schedules in registry, offers ↔ planConfig, premium pack hrefs.
- `plan-config-legacy-map.test.ts` — enterprise + passthrough plan codes.

## Verification

- `pnpm lint` — pass (workspace).
- `pnpm typecheck` — **fails** on `@settler/web` due to pre-existing errors (reconciliation-core resolution, schedules components, workbench typings, etc.); not introduced by this PR’s touched paths.
- Scoped Jest: `pnpm exec jest --runInBand src/__tests__/productization/console-route-pillars.test.ts src/__tests__/billing/plan-config-legacy-map.test.ts` — pass.

## Residual / follow-ups

- Unify or deprecate `config/pricing-simple.ts` vs `planConfig` across any remaining consumers (only `usage-tracking` was aligned here).
- Solo-operator digest: wire `/console/operator` to real aggregated APIs when contracts exist (Workbench + MeaningfulChangesFeed already partial).
- Full `pnpm typecheck` / `pnpm test` green requires fixing upstream web package TS and workspace package resolution.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47d08832-8dd7-4ad7-87d3-cd60cc7ee0b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47d08832-8dd7-4ad7-87d3-cd60cc7ee0b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

