### PR TITLE
Operator Customization Studio: versioned layouts, proposals, suggestions

### DIFF
--- a/docs/launch/operator-customization-studio.md
+++ b/docs/launch/operator-customization-studio.md
@@ -1,0 +1,71 @@
+# Operator Customization Studio
+
+**Status:** implementation-backed operator documentation  
+**Last updated:** 2026-04-05
+
+## What this is
+
+The Operator Customization Studio is a **tenant- and user-scoped** layer for **admin console presentation**: which dashboard modules appear, in what order, optional title/help overrides, and numeric **attention** thresholds for presentation-only warnings (for example, usage volume highlighted against a configured limit).
+
+It does **not**:
+
+- change reconciliation outcomes, match results, or exception canonical status;
+- alter evidence contracts, proofpack semantics, or export truth;
+- inject uptime, SLA, or durability claims;
+- apply prompt-generated changes without an explicit **review → apply to draft → publish** path.
+
+Canonical metrics on the admin dashboard still come from **`GET /api/admin/metrics`** and stream posture from the existing admin stream. Customization only controls **composition and copy** of registered modules.
+
+## Data model and persistence
+
+- **Schema version:** `1` (`CUSTOMIZATION_SCHEMA_VERSION` in `packages/web/src/lib/operator-customization/schema.ts`).
+- **Tables:** `operator_customization_states`, `operator_customization_proposals`, `operator_customization_audits`, `operator_interaction_signals` (see `prisma/schema.prisma` and migration `20260405120000_operator_customization_studio`).
+- **Scope:** `tenantId` + **super-admin `userId`** + `surface` (`admin_dashboard` today). Super-admins may pass `?tenantId=` on APIs; otherwise the **`default`** slug tenant is used.
+
+## Registry and locked modules
+
+Module definitions live in `packages/web/src/lib/operator-customization/registry.ts`. Each module declares:
+
+- **truthClass** — e.g. `canonical_metric`, `connectivity_posture`, `operator_workflow`, `presentation_summary`;
+- **sourceOfTruthHint** — which API or subsystem backs the block;
+- **locked** — connectivity and time-range controls cannot be removed or reordered.
+
+## Draft vs published
+
+- **Draft** is edited in the studio and saved via **`PUT /api/admin/operator-customization`**.
+- **Publish** copies validated draft to **published** config: **`POST /api/admin/operator-customization/publish`**.
+- **Revert draft** resets the draft from published: **`POST /api/admin/operator-customization/revert-draft`**.
+- The admin dashboard (`/admin`) renders the **published** layout.
+
+## Prompt-assisted proposals
+
+- **POST `/api/admin/operator-customization/proposals`** accepts natural language and returns a **structured patch** when a **rules-based** intent matches (`packages/web/src/lib/operator-customization/proposal-rules.ts`).
+- **This build does not call an LLM.** `inferenceMode` is `rules` or recorded as `degraded_unavailable` only if extended later; the API response and studio copy state clearly that proposals are deterministic rules.
+- Applying a proposal: **POST `/api/admin/operator-customization/proposals/[id]/apply`** merges the patch into **draft only** (not live until publish).
+
+## Operator “learning” / suggestions
+
+- **POST `/api/admin/operator-customization/signals`** records `module_view` and `layout_reorder` events (module id must exist in the registry).
+- **GET `/api/admin/operator-customization/suggestions`** returns **pin module** style suggestions with **explicit visit counts** over seven days (`packages/web/src/lib/operator-customization/suggestion-engine.ts`).
+- Dismiss in the UI is **session-local** unless extended to server-side preference storage.
+
+## Audit trail
+
+`operator_customization_audits` records actions such as `draft_saved`, `published`, `draft_reverted_to_published`, and `proposal_applied_to_draft` with JSON **details** (before/after snapshots where applicable).
+
+## Presets
+
+System presets are defined in `packages/web/src/lib/operator-customization/presets.ts`, including **Solo operator**, **Buyer demo**, and **Exception ops**. Applying a preset updates the **draft**; operators still **publish** to change the live dashboard.
+
+## Intentional limits (this pass)
+
+- Single surface: **`admin_dashboard`** only.
+- No drag-and-drop canvas beyond **up/down reorder** and enable/disable where allowed.
+- No org-level entitlement gates in code yet (future packaging hook).
+- LLM-based intent or diff explanations are **out of scope** until a reviewed provider path exists.
+
+## Related files
+
+- UI: `packages/web/src/app/admin/operator-customization/page.tsx`, `packages/web/src/app/admin/page.tsx`
+- APIs: `packages/web/src/app/api/admin/operator-customization/**`
+- Services: `packages/web/src/lib/server/operator-customization/**`

--- a/packages/web/src/__tests__/operator-customization/schema-and-proposals.test.ts
+++ b/packages/web/src/__tests__/operator-customization/schema-and-proposals.test.ts
@@ -1,0 +1,56 @@
+import { applyCustomizationPatch, normalizeOperatorCustomization } from "@/lib/operator-customization/normalize";
+import { defaultAdminDashboardCustomization, validatePlacementsAgainstRegistry } from "@/lib/operator-customization/registry";
+import { buildProposalFromNaturalLanguage } from "@/lib/operator-customization/proposal-rules";
+import { getPresetById } from "@/lib/operator-customization/presets";
+
+describe("operator customization", () => {
+  it("normalizes default admin dashboard config", () => {
+    const d = defaultAdminDashboardCustomization();
+    const n = normalizeOperatorCustomization(d);
+    expect(n.ok).toBe(true);
+    if (n.ok) expect(n.value.modules.length).toBeGreaterThan(0);
+  });
+
+  it("rejects disabling locked modules", () => {
+    const d = defaultAdminDashboardCustomization();
+    const bad = {
+      ...d,
+      modules: d.modules.map((m) =>
+        m.moduleId === "trust_connection" ? { ...m, enabled: false } : m
+      ),
+    };
+    const n = normalizeOperatorCustomization(bad);
+    expect(n.ok).toBe(false);
+  });
+
+  it("registry validation surfaces unknown modules", () => {
+    const d = defaultAdminDashboardCustomization();
+    const r = validatePlacementsAgainstRegistry([
+      ...d.modules,
+      { moduleId: "fake_module", enabled: true, order: 99 },
+    ]);
+    expect(r.ok).toBe(false);
+  });
+
+  it("applyCustomizationPatch merges operating mode", () => {
+    const base = defaultAdminDashboardCustomization();
+    const merged = applyCustomizationPatch(base, { operatingMode: "solo_operator" });
+    expect(merged.ok).toBe(true);
+    if (merged.ok) expect(merged.value.operatingMode).toBe("solo_operator");
+  });
+
+  it("proposal rules map solo operator to preset", () => {
+    const p = buildProposalFromNaturalLanguage("I run this alone — solo operator view");
+    expect(p.ok).toBe(true);
+    if (p.ok) {
+      expect(p.patch.lastAppliedPresetId).toBe("solo_operator");
+      const preset = getPresetById("solo_operator");
+      expect(preset).toBeDefined();
+    }
+  });
+
+  it("proposal rules reject unsupported phrasing", () => {
+    const p = buildProposalFromNaturalLanguage("make the database faster");
+    expect(p.ok).toBe(false);
+  });
+});

--- a/packages/web/src/app/admin/layout.tsx
+++ b/packages/web/src/app/admin/layout.tsx
@@ -14,6 +14,7 @@ import {
   Settings,
   Flag,
   Palette,
+  Paintbrush,
   FlaskConical,
   BarChart3,
   Activity,
@@ -57,6 +58,7 @@ const adminNavSections: { label: string; items: NavItem[] }[] = [
     label: "Configuration",
     items: [
       { href: "/admin/settings", label: "Settings", icon: Settings },
+      { href: "/admin/operator-customization", label: "Customization", icon: Paintbrush },
       { href: "/admin/branding", label: "Branding", icon: Palette },
       { href: "/admin/flags", label: "Feature Flags", icon: Flag },
       { href: "/admin/pages", label: "Pages", icon: FileText },

--- a/packages/web/src/app/admin/operator-customization/page.tsx
+++ b/packages/web/src/app/admin/operator-customization/page.tsx
@@ -1,0 +1,548 @@
+/**
+ * Operator Customization Studio — admin console presentation layout (tenant + user scoped).
+ */
+
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { ADMIN_DASHBOARD_MODULE_REGISTRY } from "@/lib/operator-customization/registry";
+import { OPERATOR_CUSTOMIZATION_PRESETS } from "@/lib/operator-customization/presets";
+import type { CustomizationPatch, ModulePlacement, OperatorSurfaceCustomization } from "@/lib/operator-customization/schema";
+
+type StudioPayload = {
+  draft: OperatorSurfaceCustomization;
+  published: OperatorSurfaceCustomization;
+  publishedAt: string | null;
+  draftUpdatedAt: string;
+  registry: Array<(typeof ADMIN_DASHBOARD_MODULE_REGISTRY)[string]>;
+  degraded?: { inference: string; message: string };
+};
+
+export default function OperatorCustomizationStudioPage() {
+  const [payload, setPayload] = useState<StudioPayload | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [promptText, setPromptText] = useState("");
+  const [proposal, setProposal] = useState<{
+    id: string;
+    patch: CustomizationPatch;
+    rationale: string;
+    inferenceMode: string;
+  } | null>(null);
+  const [proposalError, setProposalError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<
+    Array<{ kind: string; moduleId: string; evidence: { visitsInWindow: number }; message: string }>
+  >([]);
+  const [dismissed, setDismissed] = useState<Set<string>>(() => new Set());
+
+  const load = useCallback(async () => {
+    setLoadError(null);
+    const res = await fetch("/api/admin/operator-customization", { credentials: "include" });
+    if (!res.ok) {
+      setLoadError(`Failed to load (${res.status})`);
+      setPayload(null);
+      return;
+    }
+    const json = (await res.json()) as StudioPayload;
+    setPayload(json);
+  }, []);
+
+  const loadSuggestions = useCallback(async () => {
+    const res = await fetch("/api/admin/operator-customization/suggestions", { credentials: "include" });
+    if (!res.ok) return;
+    const json = (await res.json()) as {
+      suggestions: Array<{
+        kind: string;
+        moduleId: string;
+        evidence: { visitsInWindow: number };
+        message: string;
+      }>;
+    };
+    setSuggestions(json.suggestions ?? []);
+  }, []);
+
+  useEffect(() => {
+    void load();
+    void loadSuggestions();
+  }, [load, loadSuggestions]);
+
+  const draft = payload?.draft;
+  const published = payload?.published;
+
+  const sortedDraft = useMemo(() => {
+    if (!draft) return [];
+    return [...draft.modules].sort((a, b) => a.order - b.order || a.moduleId.localeCompare(b.moduleId));
+  }, [draft]);
+
+  const diffSummary = useMemo(() => {
+    if (!draft || !published) return [];
+    const lines: string[] = [];
+    const pubMap = new Map(published.modules.map((m) => [m.moduleId, m]));
+    for (const m of draft.modules) {
+      const p = pubMap.get(m.moduleId);
+      if (!p) continue;
+      if (p.enabled !== m.enabled) lines.push(`${m.moduleId}: enabled ${p.enabled} → ${m.enabled}`);
+      if (p.order !== m.order) lines.push(`${m.moduleId}: order ${p.order} → ${m.order}`);
+      if (p.titleOverride !== m.titleOverride) lines.push(`${m.moduleId}: title override changed`);
+      if (p.helpOverride !== m.helpOverride) lines.push(`${m.moduleId}: help override changed`);
+      if (JSON.stringify(p.thresholdOverrides) !== JSON.stringify(m.thresholdOverrides)) {
+        lines.push(`${m.moduleId}: thresholds changed`);
+      }
+    }
+    if (draft.operatingMode !== published.operatingMode) {
+      lines.push(`operatingMode: ${published.operatingMode} → ${draft.operatingMode}`);
+    }
+    return lines;
+  }, [draft, published]);
+
+  async function saveDraft(next: OperatorSurfaceCustomization) {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/admin/operator-customization", {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ draft: next }),
+      });
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        setLoadError(typeof b.error === "string" ? b.error : "save_failed");
+        return;
+      }
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function updatePlacement(moduleId: string, fn: (m: ModulePlacement) => ModulePlacement) {
+    if (!draft) return;
+    const next: OperatorSurfaceCustomization = {
+      ...draft,
+      modules: draft.modules.map((m) => (m.moduleId === moduleId ? fn(m) : m)),
+    };
+    setPayload((prev) => (prev ? { ...prev, draft: next } : prev));
+    void saveDraft(next);
+  }
+
+  function moveModule(moduleId: string, dir: -1 | 1) {
+    if (!draft) return;
+    const orderSorted = [...draft.modules].sort((a, b) => a.order - b.order);
+    const idx = orderSorted.findIndex((m) => m.moduleId === moduleId);
+    const swap = idx + dir;
+    if (idx < 0 || swap < 0 || swap >= orderSorted.length) return;
+    const a = orderSorted[idx]!;
+    const b = orderSorted[swap]!;
+    const nextModules = draft.modules.map((m) => {
+      if (m.moduleId === a.moduleId) return { ...m, order: b.order };
+      if (m.moduleId === b.moduleId) return { ...m, order: a.order };
+      return m;
+    });
+    void fetch("/api/admin/operator-customization/signals", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ signalType: "layout_reorder", moduleId }),
+    }).catch(() => {});
+    void saveDraft({ ...draft, modules: nextModules });
+  }
+
+  async function applyPreset(presetId: string) {
+    const preset = OPERATOR_CUSTOMIZATION_PRESETS.find((p) => p.id === presetId);
+    if (!preset || !draft) return;
+    const c = preset.customization();
+    await saveDraft({ ...c, schemaVersion: "1" });
+  }
+
+  async function publish() {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/admin/operator-customization/publish", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        setLoadError("publish_failed");
+        return;
+      }
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revertDraft() {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/admin/operator-customization/revert-draft", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        setLoadError("revert_failed");
+        return;
+      }
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function submitProposal() {
+    setProposal(null);
+    setProposalError(null);
+    const res = await fetch("/api/admin/operator-customization/proposals", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ request: promptText }),
+    });
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setProposalError(typeof json.proposal?.rationale === "string" ? json.proposal.rationale : "rejected");
+      return;
+    }
+    setProposal({
+      id: json.proposal.id,
+      patch: json.proposal.patch,
+      rationale: json.proposal.rationale,
+      inferenceMode: json.proposal.inferenceMode,
+    });
+  }
+
+  async function applyProposal() {
+    if (!proposal) return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/admin/operator-customization/proposals/${proposal.id}/apply`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        setLoadError("apply_proposal_failed");
+        return;
+      }
+      setProposal(null);
+      setPromptText("");
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!payload && !loadError) {
+    return (
+      <div className="p-8">
+        <p className="text-muted-foreground">Loading studio…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 sm:p-8 max-w-5xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Operator Customization Studio</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Presentation-only layout for the admin dashboard. Does not change reconciliation results, evidence, or run
+          health semantics.
+        </p>
+        <p className="text-sm mt-2">
+          <Link href="/admin" className="underline underline-offset-2">
+            ← Back to dashboard
+          </Link>
+        </p>
+      </div>
+
+      {loadError ? (
+        <p className="text-sm text-destructive" role="alert">
+          {loadError}
+        </p>
+      ) : null}
+
+      {payload?.degraded ? (
+        <Card className="border-amber-500/40">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Inference posture</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">{payload.degraded.message}</CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Draft vs published</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p>
+            <span className="text-muted-foreground">Published at:</span>{" "}
+            {payload?.publishedAt ? new Date(payload.publishedAt).toLocaleString() : "never"}
+          </p>
+          <p>
+            <span className="text-muted-foreground">Draft updated:</span>{" "}
+            {payload?.draftUpdatedAt ? new Date(payload.draftUpdatedAt).toLocaleString() : "—"}
+          </p>
+          <div>
+            <p className="font-medium mb-1">Change summary (draft vs published)</p>
+            {diffSummary.length === 0 ? (
+              <p className="text-muted-foreground">No differences.</p>
+            ) : (
+              <ul className="list-disc pl-5 space-y-0.5 font-mono text-xs">
+                {diffSummary.map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-2 pt-2">
+            <Button size="sm" onClick={() => void publish()} disabled={busy || !draft}>
+              Publish draft
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => void revertDraft()} disabled={busy}>
+              Revert draft to published
+            </Button>
+            <Button size="sm" variant="secondary" onClick={() => void load()} disabled={busy}>
+              Refresh
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Presets</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          {OPERATOR_CUSTOMIZATION_PRESETS.map((p) => (
+            <Button key={p.id} size="sm" variant="outline" onClick={() => void applyPreset(p.id)} disabled={busy}>
+              {p.label}
+            </Button>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Active layout (draft)</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {sortedDraft.map((m) => {
+            const def = ADMIN_DASHBOARD_MODULE_REGISTRY[m.moduleId];
+            return (
+              <div
+                key={m.moduleId}
+                className="border border-border rounded-lg p-3 space-y-2"
+                tabIndex={0}
+                aria-label={`Module ${m.moduleId}`}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{def?.defaultTitle ?? m.moduleId}</span>
+                    {def?.locked ? (
+                      <Badge variant="secondary" className="text-[10px]">
+                        Locked layout
+                      </Badge>
+                    ) : null}
+                    <Badge variant="outline" className="text-[10px]">
+                      {def?.truthClass?.replace(/_/g, " ")}
+                    </Badge>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground">Order {m.order}</span>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-8 w-8"
+                      aria-label={`Move ${m.moduleId} up`}
+                      onClick={() => moveModule(m.moduleId, -1)}
+                      disabled={busy || def?.allowReorder === false}
+                    >
+                      ↑
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-8 w-8"
+                      aria-label={`Move ${m.moduleId} down`}
+                      onClick={() => moveModule(m.moduleId, 1)}
+                      disabled={busy || def?.allowReorder === false}
+                    >
+                      ↓
+                    </Button>
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground">{def?.sourceOfTruthHint}</p>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={m.enabled}
+                    disabled={busy || def?.allowDisable === false}
+                    onCheckedChange={(v) => updatePlacement(m.moduleId, (x) => ({ ...x, enabled: v }))}
+                    aria-label={`Enable ${m.moduleId}`}
+                  />
+                  <span className="text-sm">Visible</span>
+                </div>
+                {def?.allowTitleOverride ? (
+                  <div className="space-y-1">
+                    <label className="text-xs text-muted-foreground" htmlFor={`title-${m.moduleId}`}>
+                      Title override
+                    </label>
+                    <Input
+                      id={`title-${m.moduleId}`}
+                      defaultValue={m.titleOverride ?? ""}
+                      key={`${m.moduleId}-title-${m.titleOverride ?? ""}`}
+                      placeholder={def.defaultTitle}
+                      onBlur={(e) =>
+                        updatePlacement(m.moduleId, (x) => ({
+                          ...x,
+                          titleOverride: e.target.value.trim() || undefined,
+                        }))
+                      }
+                      disabled={busy}
+                    />
+                  </div>
+                ) : null}
+                {def?.allowHelpOverride ? (
+                  <div className="space-y-1">
+                    <label className="text-xs text-muted-foreground" htmlFor={`help-${m.moduleId}`}>
+                      Help override
+                    </label>
+                    <Textarea
+                      id={`help-${m.moduleId}`}
+                      defaultValue={m.helpOverride ?? ""}
+                      key={`${m.moduleId}-help-${m.helpOverride ?? ""}`}
+                      placeholder={def.defaultHelp}
+                      rows={2}
+                      onBlur={(e) =>
+                        updatePlacement(m.moduleId, (x) => ({
+                          ...x,
+                          helpOverride: e.target.value.trim() || undefined,
+                        }))
+                      }
+                      disabled={busy}
+                    />
+                  </div>
+                ) : null}
+                {m.moduleId === "usage_warning" ? (
+                  <div className="space-y-1">
+                    <label className="text-xs text-muted-foreground" htmlFor={`thr-${m.moduleId}`}>
+                      Usage warning threshold (volume)
+                    </label>
+                    <Input
+                      id={`thr-${m.moduleId}`}
+                      type="number"
+                      defaultValue={m.thresholdOverrides?.usageWarningVolume ?? ""}
+                      key={`${m.moduleId}-thr-${m.thresholdOverrides?.usageWarningVolume ?? ""}`}
+                      placeholder="1000000"
+                      onBlur={(e) => {
+                        const n = e.target.value === "" ? undefined : Number(e.target.value);
+                        updatePlacement(m.moduleId, (x) => ({
+                          ...x,
+                          thresholdOverrides:
+                            n === undefined || Number.isNaN(n)
+                              ? undefined
+                              : { ...x.thresholdOverrides, usageWarningVolume: n },
+                        }));
+                      }}
+                      disabled={busy}
+                    />
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Prompt → proposal (review before apply)</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Textarea
+            value={promptText}
+            onChange={(e) => setPromptText(e.target.value)}
+            rows={3}
+            placeholder='Try: "solo operator layout" or "hide activity feed"'
+            aria-label="Customization request"
+          />
+          <Button size="sm" onClick={() => void submitProposal()} disabled={busy || !promptText.trim()}>
+            Generate proposal
+          </Button>
+          {proposalError ? <p className="text-sm text-destructive">{proposalError}</p> : null}
+          {proposal ? (
+            <div className="border rounded-md p-3 space-y-2 text-sm">
+              <p className="font-medium">Rationale</p>
+              <p className="text-muted-foreground">{proposal.rationale}</p>
+              <p className="text-xs text-muted-foreground">Mode: {proposal.inferenceMode}</p>
+              <pre className="text-xs bg-muted p-2 rounded-md overflow-x-auto">
+                {JSON.stringify(proposal.patch, null, 2)}
+              </pre>
+              <Button size="sm" onClick={() => void applyProposal()} disabled={busy}>
+                Apply to draft (not published)
+              </Button>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Suggestions (usage-based)</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p className="text-muted-foreground text-xs">
+            Based on recorded module views (tenant-scoped). Dismiss is local to this browser session only.
+          </p>
+          {suggestions.filter((s) => !dismissed.has(s.moduleId)).length === 0 ? (
+            <p className="text-muted-foreground">No suggestions right now.</p>
+          ) : (
+            suggestions
+              .filter((s) => !dismissed.has(s.moduleId))
+              .map((s) => (
+                <div key={s.moduleId} className="border rounded-md p-3 flex flex-col sm:flex-row sm:justify-between gap-2">
+                  <div>
+                    <p>{s.message}</p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Evidence: {s.evidence.visitsInWindow} views (7d window)
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setDismissed((prev) => new Set(prev).add(s.moduleId))}
+                  >
+                    Dismiss
+                  </Button>
+                </div>
+              ))
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Module registry reference</CardTitle>
+        </CardHeader>
+        <CardContent className="text-xs space-y-2 font-mono">
+          {(payload?.registry ?? []).map((r) => (
+            <div key={r.id} className="border-b border-border/40 pb-2">
+              <span className="font-semibold">{r.id}</span> · {r.truthClass} · {r.sourceOfTruthHint}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/app/admin/page.tsx
+++ b/packages/web/src/app/admin/page.tsx
@@ -1,15 +1,21 @@
 /**
  * Admin Dashboard Overview
  *
- * Main overview page with KPI tiles, trend charts, exception heatmap, and activity feed.
- * FinTech-native feel with high-signal, dense but readable information.
+ * Layout modules respect published Operator Customization (GET /api/admin/operator-customization).
+ * Canonical metrics still come from /api/admin/metrics; customization is presentation-only.
  */
 
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAdminMetrics, useAdminStream } from "@/lib/admin/hooks/use-admin-metrics";
 import { useTickScheduler } from "@/lib/admin/hooks/use-tick-scheduler";
+import {
+  recordModuleViewSignal,
+  useOperatorDashboardCustomization,
+} from "@/lib/admin/hooks/use-operator-dashboard-customization";
+import { ADMIN_DASHBOARD_MODULE_REGISTRY } from "@/lib/operator-customization/registry";
+import type { ModulePlacement } from "@/lib/operator-customization/schema";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -34,239 +40,303 @@ import Link from "next/link";
 
 export default function AdminDashboard() {
   const [timeRange, setTimeRange] = useState<"24h" | "7d" | "30d">("24h");
-
-  // Fetch metrics
   const { data: metrics, isLoading } = useAdminMetrics(timeRange);
-
-  // Connect to SSE stream
   const { connectionState, latency } = useAdminStream(["metrics"], undefined, true);
+  const { data: customization, loading: customizationLoading, error: customizationError, fallbackLayout } =
+    useOperatorDashboardCustomization();
 
-  // Throttle chart updates (4fps max)
-  useTickScheduler(() => {
-    // Chart updates would happen here
-  }, true);
+  useTickScheduler(() => {}, true);
 
   const kpis = metrics?.kpis;
   const lastUpdated = metrics?.timestamp ? new Date(metrics.timestamp) : new Date();
+
+  const layout = customization?.published ?? fallbackLayout;
+  const sortedModules = useMemo(
+    () => [...layout.modules].sort((a, b) => a.order - b.order || a.moduleId.localeCompare(b.moduleId)),
+    [layout.modules]
+  );
+
+  const placementById = useMemo(() => {
+    const m = new Map<string, ModulePlacement>();
+    for (const p of layout.modules) m.set(p.moduleId, p);
+    return m;
+  }, [layout.modules]);
+
+  const operatingModeLabel =
+    layout.operatingMode === "solo_operator"
+      ? "Solo operator"
+      : layout.operatingMode === "buyer_demo"
+        ? "Buyer demo"
+        : "Standard";
 
   return (
     <div
       className="p-4 sm:p-6 lg:p-8 space-y-4 sm:space-y-6 bg-background min-h-screen"
       id="main-content"
     >
-      {/* Header */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div>
-          <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
-            Admin Dashboard
-          </h1>
+          <h1 className="text-2xl sm:text-3xl font-bold text-foreground">Admin Dashboard</h1>
           <p className="text-muted-foreground mt-1 text-sm sm:text-base">
             Real-time oversight and reconciliation operations
           </p>
+          <p className="text-xs text-muted-foreground/80 mt-1">
+            Operating mode: <span className="font-medium text-foreground">{operatingModeLabel}</span>
+            {layout.lastAppliedPresetId ? (
+              <>
+                {" "}
+                · Preset: <span className="font-mono">{layout.lastAppliedPresetId}</span>
+              </>
+            ) : null}
+            {" · "}
+            <Link href="/admin/operator-customization" className="underline underline-offset-2">
+              Customize layout
+            </Link>
+          </p>
         </div>
         <div className="flex flex-wrap items-center gap-3 sm:gap-4">
-          {/* Trust Signals */}
-          <div className="flex items-center gap-2">
-            <SecurityBadge />
-            <SystemStatusCard
-              status={connectionState === "connected" ? "operational" : "degraded"}
-            />
-          </div>
+          {isModuleEnabled(placementById, "trust_connection") && (
+            <ModuleViewTracker moduleId="trust_connection">
+              <div className="flex items-center gap-2">
+                <SecurityBadge />
+                <SystemStatusCard
+                  status={connectionState === "connected" ? "operational" : "degraded"}
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <PulseIndicator active={connectionState === "connected"} color="green" />
+                <span className="text-xs sm:text-sm text-muted-foreground">
+                  {connectionState === "connected" ? "Live" : connectionState}
+                </span>
+                {latency ? (
+                  <span className="text-xs text-muted-foreground">({latency}ms)</span>
+                ) : null}
+              </div>
+              <LastUpdatedBadge timestamp={lastUpdated} />
+            </ModuleViewTracker>
+          )}
 
-          {/* Connection Status */}
-          <div className="flex items-center gap-2">
-            <PulseIndicator active={connectionState === "connected"} color="green" />
-            <span className="text-xs sm:text-sm text-muted-foreground">
-              {connectionState === "connected" ? "Live" : connectionState}
-            </span>
-            {latency && (
-              <span className="text-xs text-muted-foreground">({latency}ms)</span>
-            )}
-          </div>
-
-          {/* Last Updated */}
-          <LastUpdatedBadge timestamp={lastUpdated} />
-
-          {/* Time Range Selector */}
-          <div className="flex gap-2">
-            {(["24h", "7d", "30d"] as const).map((range) => (
-              <Button
-                key={range}
-                variant={timeRange === range ? "default" : "outline"}
-                size="sm"
-                onClick={() => setTimeRange(range)}
-                aria-pressed={timeRange === range}
-                aria-label={`Select ${range} time range`}
-              >
-                {range}
-              </Button>
-            ))}
-          </div>
+          {isModuleEnabled(placementById, "time_range") && (
+            <ModuleViewTracker moduleId="time_range">
+              <div className="flex gap-2">
+                {(["24h", "7d", "30d"] as const).map((range) => (
+                  <Button
+                    key={range}
+                    variant={timeRange === range ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => setTimeRange(range)}
+                    aria-pressed={timeRange === range}
+                    aria-label={`Select ${range} time range`}
+                  >
+                    {range}
+                  </Button>
+                ))}
+              </div>
+            </ModuleViewTracker>
+          )}
         </div>
       </div>
 
-      {/* Usage Warning (if applicable) */}
-      {kpis && kpis.totalVolume > 0 && (
-        <UsageWarning current={kpis.totalVolume} limit={1000000} type="usage" />
-      )}
+      {customizationLoading ? (
+        <p className="text-xs text-muted-foreground">Loading published layout…</p>
+      ) : null}
+      {customizationError ? (
+        <p className="text-xs text-amber-700 dark:text-amber-400">
+          Layout API unavailable ({customizationError}). Showing default module order.
+        </p>
+      ) : null}
+      {customization?.degraded ? (
+        <p className="text-xs text-muted-foreground border border-border/60 rounded-md px-3 py-2">
+          {customization.degraded.message}
+        </p>
+      ) : null}
 
-      {/* KPI Tiles */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {isLoading ? (
-          Array.from({ length: 6 }).map((_, i) => (
-            <Card key={i}>
-              <CardHeader className="pb-2">
-                <Skeleton className="h-4 w-24" />
-              </CardHeader>
-              <CardContent>
-                <Skeleton className="h-8 w-32" />
-              </CardContent>
-            </Card>
-          ))
-        ) : (
-          <>
-            <KPITile
-              title="Matched %"
-              value={kpis?.matchedPercent.toFixed(1) || "0.0"}
-              unit="%"
-              {...(kpis?.matchedPercent ? { trend: kpis.matchedPercent > 95 ? "up" : "down" } : {})}
-              icon={<CheckCircle2 className="w-5 h-5" />}
-              isLoading={isLoading}
-            />
-            <KPITile
-              title="Exceptions"
-              value={kpis?.exceptionsCount.toLocaleString() || "0"}
-              {...(kpis?.exceptionsCount !== undefined
-                ? { trend: kpis.exceptionsCount < 10 ? "up" : "down" }
-                : {})}
-              icon={<AlertTriangle className="w-5 h-5" />}
-              isLoading={isLoading}
-              href="/admin/exceptions"
-            />
-            <KPITile
-              title="Avg Time to Resolve"
-              value={kpis?.avgTimeToResolve ? formatDuration(kpis.avgTimeToResolve) : "0ms"}
-              {...(kpis?.avgTimeToResolve !== undefined
-                ? { trend: kpis.avgTimeToResolve < 3600000 ? "up" : "down" }
-                : {})}
-              icon={<Clock className="w-5 h-5" />}
-              isLoading={isLoading}
-            />
-            <KPITile
-              title="Total Volume"
-              value={kpis?.totalVolume.toLocaleString() || "0"}
-              icon={<Activity className="w-5 h-5" />}
-              isLoading={isLoading}
-            />
-            <KPITile
-              title="Refunds"
-              value={kpis?.refundsCount.toLocaleString() || "0"}
-              icon={<DollarSign className="w-5 h-5" />}
-              isLoading={isLoading}
-            />
-            <KPITile
-              title="Payout Gaps"
-              value={kpis?.payoutGaps.toLocaleString() || "0"}
-              icon={<AlertTriangle className="w-5 h-5" />}
-              isLoading={isLoading}
-            />
-          </>
-        )}
-      </div>
-
-      {/* Exception Heatmap */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Exception Heatmap</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="text-center py-8 text-muted-foreground">
-              <Skeleton className="h-4 w-32 mx-auto mb-2" />
-              <Skeleton className="h-4 w-24 mx-auto" />
-            </div>
-          ) : metrics?.exceptionHeatmap && metrics.exceptionHeatmap.length > 0 ? (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-              {metrics.exceptionHeatmap.map((item, idx) => (
-                <HoverCard key={idx}>
-                  <div
-                    className="p-4 border border-border rounded-lg transition-all"
-                    role="button"
-                    tabIndex={0}
-                    aria-label={`${item.source} exceptions: ${item.count} ${item.severity}`}
-                  >
-                    <div className="text-sm text-muted-foreground mb-1">
-                      {item.source}
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <Badge
-                        className={
-                          item.severity === "critical"
-                            ? "bg-red-100 text-red-800"
-                            : item.severity === "warn"
-                              ? "bg-yellow-100 text-yellow-800"
-                              : "bg-blue-100 text-blue-800"
-                        }
-                      >
-                        {item.severity}
-                      </Badge>
-                      <span className="text-lg font-semibold text-foreground">
-                        <AnimatedNumber value={item.count} />
-                      </span>
-                    </div>
+      {sortedModules.map((placement) => {
+        if (!placement.enabled) return null;
+        switch (placement.moduleId) {
+          case "usage_warning":
+            return (
+              <ModuleViewTracker key={placement.moduleId} moduleId="usage_warning">
+                {kpis && kpis.totalVolume > 0 ? (
+                  <UsageWarning
+                    current={kpis.totalVolume}
+                    limit={placement.thresholdOverrides?.usageWarningVolume ?? 1_000_000}
+                    type="usage"
+                  />
+                ) : null}
+              </ModuleViewTracker>
+            );
+          case "kpi_tiles":
+            return (
+              <ModuleViewTracker key={placement.moduleId} moduleId="kpi_tiles">
+                <ModuleChrome placement={placement} moduleId="kpi_tiles">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {isLoading ? (
+                      Array.from({ length: 6 }).map((_, i) => (
+                        <Card key={i}>
+                          <CardHeader className="pb-2">
+                            <Skeleton className="h-4 w-24" />
+                          </CardHeader>
+                          <CardContent>
+                            <Skeleton className="h-8 w-32" />
+                          </CardContent>
+                        </Card>
+                      ))
+                    ) : (
+                      <>
+                        <KPITile
+                          title="Matched %"
+                          value={kpis?.matchedPercent.toFixed(1) || "0.0"}
+                          unit="%"
+                          {...(kpis?.matchedPercent
+                            ? { trend: kpis.matchedPercent > 95 ? "up" : "down" }
+                            : {})}
+                          icon={<CheckCircle2 className="w-5 h-5" />}
+                          isLoading={isLoading}
+                        />
+                        <KPITile
+                          title="Exceptions"
+                          value={kpis?.exceptionsCount.toLocaleString() || "0"}
+                          {...(kpis?.exceptionsCount !== undefined
+                            ? { trend: kpis.exceptionsCount < 10 ? "up" : "down" }
+                            : {})}
+                          icon={<AlertTriangle className="w-5 h-5" />}
+                          isLoading={isLoading}
+                          href="/admin/exceptions"
+                        />
+                        <KPITile
+                          title="Avg Time to Resolve"
+                          value={kpis?.avgTimeToResolve ? formatDuration(kpis.avgTimeToResolve) : "0ms"}
+                          {...(kpis?.avgTimeToResolve !== undefined
+                            ? { trend: kpis.avgTimeToResolve < 3600000 ? "up" : "down" }
+                            : {})}
+                          icon={<Clock className="w-5 h-5" />}
+                          isLoading={isLoading}
+                        />
+                        <KPITile
+                          title="Total Volume"
+                          value={kpis?.totalVolume.toLocaleString() || "0"}
+                          icon={<Activity className="w-5 h-5" />}
+                          isLoading={isLoading}
+                        />
+                        <KPITile
+                          title="Refunds"
+                          value={kpis?.refundsCount.toLocaleString() || "0"}
+                          icon={<DollarSign className="w-5 h-5" />}
+                          isLoading={isLoading}
+                        />
+                        <KPITile
+                          title="Payout Gaps"
+                          value={kpis?.payoutGaps.toLocaleString() || "0"}
+                          icon={<AlertTriangle className="w-5 h-5" />}
+                          isLoading={isLoading}
+                        />
+                      </>
+                    )}
                   </div>
-                </HoverCard>
-              ))}
-            </div>
-          ) : (
-            <div className="text-center py-8 text-muted-foreground">
-              No exceptions in this period
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                </ModuleChrome>
+              </ModuleViewTracker>
+            );
+          case "exception_heatmap":
+            return (
+              <ModuleViewTracker key={placement.moduleId} moduleId="exception_heatmap">
+                <ModuleChrome placement={placement} moduleId="exception_heatmap">
+                  <Card>
+                    <CardContent className="pt-6">
+                      {isLoading ? (
+                        <div className="text-center py-8 text-muted-foreground">
+                          <Skeleton className="h-4 w-32 mx-auto mb-2" />
+                          <Skeleton className="h-4 w-24 mx-auto" />
+                        </div>
+                      ) : metrics?.exceptionHeatmap && metrics.exceptionHeatmap.length > 0 ? (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                          {metrics.exceptionHeatmap.map((item, idx) => (
+                            <HoverCard key={idx}>
+                              <div
+                                className="p-4 border border-border rounded-lg transition-all"
+                                role="button"
+                                tabIndex={0}
+                                aria-label={`${item.source} exceptions: ${item.count} ${item.severity}`}
+                              >
+                                <div className="text-sm text-muted-foreground mb-1">{item.source}</div>
+                                <div className="flex items-center gap-2">
+                                  <Badge
+                                    className={
+                                      item.severity === "critical"
+                                        ? "bg-red-100 text-red-800"
+                                        : item.severity === "warn"
+                                          ? "bg-yellow-100 text-yellow-800"
+                                          : "bg-blue-100 text-blue-800"
+                                    }
+                                  >
+                                    {item.severity}
+                                  </Badge>
+                                  <span className="text-lg font-semibold text-foreground">
+                                    <AnimatedNumber value={item.count} />
+                                  </span>
+                                </div>
+                              </div>
+                            </HoverCard>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="text-center py-8 text-muted-foreground">
+                          No exceptions in this period
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                </ModuleChrome>
+              </ModuleViewTracker>
+            );
+          case "activity_feed":
+            return (
+              <ModuleViewTracker key={placement.moduleId} moduleId="activity_feed">
+                <ModuleChrome placement={placement} moduleId="activity_feed">
+                  <Card>
+                    <CardContent className="pt-6">
+                      {isLoading ? (
+                        <div className="space-y-3">
+                          {Array.from({ length: 3 }).map((_, i) => (
+                            <Skeleton key={i} className="h-16 w-full" />
+                          ))}
+                        </div>
+                      ) : metrics?.recentActivity && metrics.recentActivity.length > 0 ? (
+                        <div className="space-y-3" role="list" aria-label="Recent activity">
+                          {metrics.recentActivity.map((activity) => (
+                            <div
+                              key={activity.id}
+                              className="flex items-start gap-3 p-3 border border-border rounded-lg hover:bg-muted/50 transition-colors"
+                              role="listitem"
+                            >
+                              <div className="w-2 h-2 rounded-full bg-blue-500 mt-2" aria-hidden="true" />
+                              <div className="flex-1">
+                                <div className="text-sm text-foreground">{activity.message}</div>
+                                <div className="text-xs text-muted-foreground mt-1">
+                                  <time dateTime={activity.timestamp}>
+                                    {new Date(activity.timestamp).toLocaleString()}
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="text-center py-8 text-muted-foreground">No recent activity</div>
+                      )}
+                    </CardContent>
+                  </Card>
+                </ModuleChrome>
+              </ModuleViewTracker>
+            );
+          case "trust_connection":
+          case "time_range":
+            return null;
+          default:
+            return null;
+        }
+      })}
 
-      {/* Recent Activity Feed */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Recent Activity</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="space-y-3">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <Skeleton key={i} className="h-16 w-full" />
-              ))}
-            </div>
-          ) : metrics?.recentActivity && metrics.recentActivity.length > 0 ? (
-            <div className="space-y-3" role="list" aria-label="Recent activity">
-              {metrics.recentActivity.map((activity) => (
-                <div
-                  key={activity.id}
-                  className="flex items-start gap-3 p-3 border border-border rounded-lg hover:bg-muted/50 transition-colors"
-                  role="listitem"
-                >
-                  <div className="w-2 h-2 rounded-full bg-blue-500 mt-2" aria-hidden="true" />
-                  <div className="flex-1">
-                    <div className="text-sm text-foreground">{activity.message}</div>
-                    <div className="text-xs text-muted-foreground mt-1">
-                      <time dateTime={activity.timestamp}>
-                        {new Date(activity.timestamp).toLocaleString()}
-                      </time>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="text-center py-8 text-muted-foreground">
-              No recent activity
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Quick Actions */}
       <div className="flex flex-wrap gap-3 sm:gap-4">
         <Link href="/admin/ops">
           <Button aria-label="View operations console">View Ops Console</Button>
@@ -284,6 +354,51 @@ export default function AdminDashboard() {
       </div>
     </div>
   );
+}
+
+function isModuleEnabled(map: Map<string, ModulePlacement>, id: string): boolean {
+  return map.get(id)?.enabled !== false;
+}
+
+function ModuleChrome({
+  moduleId,
+  placement,
+  children,
+}: {
+  moduleId: keyof typeof ADMIN_DASHBOARD_MODULE_REGISTRY;
+  placement: ModulePlacement;
+  children: React.ReactNode;
+}) {
+  const def = ADMIN_DASHBOARD_MODULE_REGISTRY[moduleId];
+  const title = placement.titleOverride ?? def?.defaultTitle ?? moduleId;
+  const help = placement.helpOverride ?? def?.defaultHelp ?? "";
+  const truth = def?.truthClass ?? "presentation_summary";
+  const source = def?.sourceOfTruthHint ?? "unknown";
+
+  return (
+    <section aria-labelledby={`mod-${moduleId}-title`} className="space-y-2">
+      <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1">
+        <h2 id={`mod-${moduleId}-title`} className="text-sm font-semibold text-foreground">
+          {title}
+        </h2>
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground/80">
+          {truth.replace(/_/g, " ")} · {source}
+        </span>
+      </div>
+      {help ? <p className="text-xs text-muted-foreground max-w-3xl">{help}</p> : null}
+      {children}
+    </section>
+  );
+}
+
+function ModuleViewTracker({ moduleId, children }: { moduleId: string; children: React.ReactNode }) {
+  const sent = useRef(false);
+  useEffect(() => {
+    if (sent.current) return;
+    sent.current = true;
+    recordModuleViewSignal(moduleId);
+  }, [moduleId]);
+  return <>{children}</>;
 }
 
 function KPITile({
@@ -308,9 +423,7 @@ function KPITile({
       <Card className={href ? "cursor-pointer" : ""} role={href ? "link" : undefined}>
         <CardHeader className="pb-2">
           <div className="flex items-center justify-between">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              {title}
-            </CardTitle>
+            <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
             <div aria-hidden="true">{icon}</div>
           </div>
         </CardHeader>

--- a/packages/web/src/app/api/admin/operator-customization/proposals/[id]/apply/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/proposals/[id]/apply/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { CustomizationPatchSchema } from "@/lib/operator-customization/schema";
+import {
+  applyPatchToDraft,
+  getCustomizationState,
+  recordCustomizationAudit,
+} from "@/lib/server/operator-customization/customization-service";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const BodySchema = z.object({ tenantId: z.string().uuid().optional() });
+
+export const POST = withSecurity(
+  async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    const admin = await isSuperAdmin();
+    if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    const { userId } = await getSuperAdminStatus();
+    if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { id } = await params;
+    const body = BodySchema.safeParse(await request.json().catch(() => ({})));
+    if (!body.success) return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+
+    const proposal = await prisma.operatorCustomizationProposal.findFirst({
+      where: { id, userId },
+    });
+    if (!proposal) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+    if (proposal.status !== "pending") {
+      return NextResponse.json({ error: "not_pending" }, { status: 409 });
+    }
+
+    const patchParse = CustomizationPatchSchema.safeParse(proposal.structuredPatch);
+    if (!patchParse.success) {
+      return NextResponse.json({ error: "invalid_stored_patch" }, { status: 500 });
+    }
+
+    const before = await getCustomizationState(prisma, proposal.tenantId, userId);
+    const applied = await applyPatchToDraft(prisma, proposal.tenantId, userId, patchParse.data);
+    if (!applied.ok) {
+      return NextResponse.json({ error: "validation_failed", errors: applied.errors }, { status: 400 });
+    }
+
+    await prisma.operatorCustomizationProposal.update({
+      where: { id },
+      data: { status: "applied", appliedAt: new Date() },
+    });
+
+    await recordCustomizationAudit(prisma, proposal.tenantId, userId, "proposal_applied_to_draft", "admin_dashboard", {
+      proposalId: id,
+      patch: patchParse.data,
+      draftBefore: before.draft,
+      draftAfter: applied.draft,
+    });
+
+    return NextResponse.json({ draft: applied.draft });
+  },
+  { requirePrivilegedApproval: false }
+);

--- a/packages/web/src/app/api/admin/operator-customization/proposals/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/proposals/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { CustomizationPatchSchema } from "@/lib/operator-customization/schema";
+import { buildProposalFromNaturalLanguage } from "@/lib/operator-customization/proposal-rules";
+import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const PostBodySchema = z.object({
+  tenantId: z.string().uuid().optional(),
+  request: z.string().min(1).max(4000),
+});
+
+export const POST = withSecurity(
+  async function POST(request: NextRequest) {
+  const admin = await isSuperAdmin();
+  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { userId } = await getSuperAdminStatus();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = PostBodySchema.safeParse(await request.json().catch(() => null));
+  if (!body.success) {
+    return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
+  }
+
+  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+  if (!tenant.ok) return tenant.response;
+
+  const built = buildProposalFromNaturalLanguage(body.data.request);
+  if (!built.ok) {
+    const row = await prisma.operatorCustomizationProposal.create({
+      data: {
+        tenantId: tenant.tenantId,
+        userId,
+        surface: "admin_dashboard",
+        status: "rejected",
+        naturalLanguageRequest: body.data.request,
+        structuredPatch: {},
+        rationale: built.reason,
+        inferenceMode: built.inferenceMode,
+        rejectedAt: new Date(),
+      },
+    });
+    return NextResponse.json(
+      {
+        proposal: {
+          id: row.id,
+          status: "rejected",
+          rationale: built.reason,
+          inferenceMode: built.inferenceMode,
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  const parsedPatch = CustomizationPatchSchema.safeParse(built.patch);
+  if (!parsedPatch.success) {
+    return NextResponse.json({ error: "patch_invalid", issues: parsedPatch.error.issues }, { status: 500 });
+  }
+
+  const row = await prisma.operatorCustomizationProposal.create({
+    data: {
+      tenantId: tenant.tenantId,
+      userId,
+      surface: "admin_dashboard",
+      status: "pending",
+      naturalLanguageRequest: body.data.request,
+      structuredPatch: parsedPatch.data as object,
+      rationale: built.rationale,
+      inferenceMode: built.inferenceMode,
+    },
+  });
+
+  return NextResponse.json({
+    proposal: {
+      id: row.id,
+      status: row.status,
+      patch: parsedPatch.data,
+      rationale: built.rationale,
+      inferenceMode: built.inferenceMode,
+    },
+  });
+  },
+  { requirePrivilegedApproval: false }
+);
+
+export const GET = withSecurity(async function GET(request: NextRequest) {
+  const admin = await isSuperAdmin();
+  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(request.url);
+  const tenant = await resolveCustomizationTenantId(searchParams.get("tenantId"));
+  if (!tenant.ok) return tenant.response;
+
+  const limit = Math.min(Number(searchParams.get("limit") ?? "20") || 20, 50);
+
+  const rows = await prisma.operatorCustomizationProposal.findMany({
+    where: { tenantId: tenant.tenantId },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: {
+      id: true,
+      status: true,
+      naturalLanguageRequest: true,
+      structuredPatch: true,
+      rationale: true,
+      inferenceMode: true,
+      createdAt: true,
+      appliedAt: true,
+      rejectedAt: true,
+    },
+  });
+
+  return NextResponse.json({ items: rows });
+});

--- a/packages/web/src/app/api/admin/operator-customization/publish/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/publish/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
+import { withSecurity } from "@/lib/middleware/api-security";
+import {
+  getCustomizationState,
+  publishDraft,
+  recordCustomizationAudit,
+} from "@/lib/server/operator-customization/customization-service";
+import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const BodySchema = z.object({ tenantId: z.string().uuid().optional() });
+
+export const POST = withSecurity(
+  async function POST(request: NextRequest) {
+  const admin = await isSuperAdmin();
+  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { userId } = await getSuperAdminStatus();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = BodySchema.safeParse(await request.json().catch(() => ({})));
+  if (!body.success) {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+
+  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+  if (!tenant.ok) return tenant.response;
+
+  const before = await getCustomizationState(prisma, tenant.tenantId, userId);
+  const pub = await publishDraft(prisma, tenant.tenantId, userId);
+  if (!pub.ok) {
+    return NextResponse.json({ error: "validation_failed", errors: pub.errors }, { status: 400 });
+  }
+
+  await recordCustomizationAudit(prisma, tenant.tenantId, userId, "published", "admin_dashboard", {
+    beforePublished: before.published,
+    afterPublished: pub.published,
+  });
+
+  return NextResponse.json({ published: pub.published, publishedAt: new Date().toISOString() });
+  },
+  { requirePrivilegedApproval: false }
+);

--- a/packages/web/src/app/api/admin/operator-customization/revert-draft/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/revert-draft/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
+import { withSecurity } from "@/lib/middleware/api-security";
+import {
+  recordCustomizationAudit,
+  revertPublishedToDraft,
+} from "@/lib/server/operator-customization/customization-service";
+import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const BodySchema = z.object({ tenantId: z.string().uuid().optional() });
+
+export const POST = withSecurity(
+  async function POST(request: NextRequest) {
+  const admin = await isSuperAdmin();
+  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { userId } = await getSuperAdminStatus();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = BodySchema.safeParse(await request.json().catch(() => ({})));
+  if (!body.success) return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+
+  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+  if (!tenant.ok) return tenant.response;
+
+  const rev = await revertPublishedToDraft(prisma, tenant.tenantId, userId);
+  if (!rev.ok) {
+    return NextResponse.json({ error: "validation_failed", errors: rev.errors }, { status: 400 });
+  }
+
+  await recordCustomizationAudit(prisma, tenant.tenantId, userId, "draft_reverted_to_published", "admin_dashboard", {});
+
+  return NextResponse.json({ draft: rev.draft });
+  },
+  { requirePrivilegedApproval: false }
+);

--- a/packages/web/src/app/api/admin/operator-customization/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/route.ts
@@ -1,0 +1,105 @@
+/**
+ * Operator Customization Studio — current draft/published state for admin dashboard surface.
+ * Super-admin only. Tenant scoped via ?tenantId= or default slug tenant.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { ADMIN_DASHBOARD_MODULE_REGISTRY } from "@/lib/operator-customization/registry";
+import { OperatorSurfaceCustomizationSchema } from "@/lib/operator-customization/schema";
+import { getCustomizationState, saveDraft } from "@/lib/server/operator-customization/customization-service";
+import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const GET = withSecurity(async function GET(request: NextRequest) {
+  const admin = await isSuperAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { searchParams } = new URL(request.url);
+  const tenant = await resolveCustomizationTenantId(searchParams.get("tenantId"));
+  if (!tenant.ok) return tenant.response;
+
+  const { userId } = await getSuperAdminStatus();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const state = await getCustomizationState(prisma, tenant.tenantId, userId);
+
+  return NextResponse.json({
+    ...state,
+    registry: Object.values(ADMIN_DASHBOARD_MODULE_REGISTRY),
+    degraded: {
+      inference: "rules_only",
+      message:
+        "Prompt-assisted proposals use deterministic rules only in this build. No LLM writes to config.",
+    },
+  });
+});
+
+const PutBodySchema = z.object({
+  tenantId: z.string().uuid().optional(),
+  draft: z.unknown(),
+});
+
+export const PUT = withSecurity(
+  async function PUT(request: NextRequest) {
+  const admin = await isSuperAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { userId } = await getSuperAdminStatus();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = PutBodySchema.safeParse(await request.json().catch(() => null));
+  if (!body.success) {
+    return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
+  }
+
+  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+  if (!tenant.ok) return tenant.response;
+
+  const parsedConfig = OperatorSurfaceCustomizationSchema.safeParse(body.data.draft);
+  if (!parsedConfig.success) {
+    return NextResponse.json(
+      { error: "invalid_config", issues: parsedConfig.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const saved = await saveDraft(prisma, tenant.tenantId, userId, parsedConfig.data);
+  if (!saved.ok) {
+    return NextResponse.json({ error: "validation_failed", errors: saved.errors }, { status: 400 });
+  }
+
+  await prisma.operatorCustomizationAudit.create({
+    data: {
+      tenantId: tenant.tenantId,
+      userId,
+      action: "draft_saved",
+      surface: "admin_dashboard",
+      details: { source: "studio_manual" },
+    },
+  });
+
+  const state = await getCustomizationState(prisma, tenant.tenantId, userId);
+  return NextResponse.json({
+    ...state,
+    registry: Object.values(ADMIN_DASHBOARD_MODULE_REGISTRY),
+    degraded: {
+      inference: "rules_only",
+      message:
+        "Prompt-assisted proposals use deterministic rules only in this build. No LLM writes to config.",
+    },
+  });
+  },
+  { requirePrivilegedApproval: false }
+);

--- a/packages/web/src/app/api/admin/operator-customization/signals/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/signals/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { listRegistryModuleIds } from "@/lib/operator-customization/registry";
+import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const BodySchema = z.object({
+  tenantId: z.string().uuid().optional(),
+  signalType: z.enum(["module_view", "layout_reorder"]),
+  moduleId: z.string().min(1).max(128),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const POST = withSecurity(
+  async function POST(request: NextRequest) {
+  const admin = await isSuperAdmin();
+  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { userId } = await getSuperAdminStatus();
+
+  const body = BodySchema.safeParse(await request.json().catch(() => null));
+  if (!body.success) {
+    return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
+  }
+
+  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+  if (!tenant.ok) return tenant.response;
+
+  const allowed = new Set(listRegistryModuleIds());
+  if (!allowed.has(body.data.moduleId)) {
+    return NextResponse.json({ error: "unknown_module" }, { status: 400 });
+  }
+
+  await prisma.operatorInteractionSignal.create({
+    data: {
+      tenantId: tenant.tenantId,
+      userId,
+      signalType: body.data.signalType,
+      moduleId: body.data.moduleId,
+      metadata: (body.data.metadata ?? {}) as object,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+  },
+  { requirePrivilegedApproval: false }
+);

--- a/packages/web/src/app/api/admin/operator-customization/suggestions/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/suggestions/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isSuperAdmin } from "@/lib/auth/super-admin";
+import { getSuperAdminStatus } from "@/lib/auth/super-admin";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { computeModuleVisitSuggestions } from "@/lib/operator-customization/suggestion-engine";
+import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const GET = withSecurity(async function GET(request: NextRequest) {
+  const admin = await isSuperAdmin();
+  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { userId } = await getSuperAdminStatus();
+
+  const { searchParams } = new URL(request.url);
+  const tenant = await resolveCustomizationTenantId(searchParams.get("tenantId"));
+  if (!tenant.ok) return tenant.response;
+
+  const suggestions = await computeModuleVisitSuggestions(prisma, tenant.tenantId, userId ?? null);
+
+  return NextResponse.json({
+    suggestions,
+    evidenceNote:
+      "Counts are from operator_interaction_signals (module_view) in the last 7 days, tenant-scoped.",
+  });
+});

--- a/packages/web/src/app/api/console/schedules/route.ts
+++ b/packages/web/src/app/api/console/schedules/route.ts
@@ -38,7 +38,7 @@ export const GET = withSecurity(
           orderBy: { createdAt: "desc" },
         });
 
-        const items = jobs.map((job) => {
+        const items = jobs.map((job: (typeof jobs)[number]) => {
           const latestResult = job.results[0] ?? null;
           return {
             id: job.id,

--- a/packages/web/src/app/console/schedules/components.tsx
+++ b/packages/web/src/app/console/schedules/components.tsx
@@ -89,7 +89,10 @@ function computeNextRuns(cron: string, timezone: string, count: number): Date[] 
   const parts = cron.trim().split(/\s+/);
   if (parts.length < 5) return runs;
 
-  const [minuteField, hourField, dayOfMonthField, , dayOfWeekField] = parts;
+  const minuteField = parts[0] ?? "*";
+  const hourField = parts[1] ?? "*";
+  const dayOfMonthField = parts[2] ?? "*";
+  const dayOfWeekField = parts[4] ?? "*";
 
   // Parse simple numeric or wildcard values
   const parseField = (field: string): number | null => {
@@ -106,7 +109,10 @@ function computeNextRuns(cron: string, timezone: string, count: number): Date[] 
   const targetDayOfWeek = parseField(dayOfWeekField);
 
   // Step values
-  const hourStep = hourField.startsWith("*/") ? parseInt(hourField.slice(2), 10) : null;
+  const hourStep =
+    hourField.startsWith("*/") && hourField.length > 2
+      ? parseInt(hourField.slice(2), 10)
+      : null;
 
   // Start from now, advance until we find `count` matching times
   const now = new Date();

--- a/packages/web/src/lib/admin/hooks/use-operator-dashboard-customization.ts
+++ b/packages/web/src/lib/admin/hooks/use-operator-dashboard-customization.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { OperatorSurfaceCustomization } from "@/lib/operator-customization/schema";
+import { defaultAdminDashboardCustomization } from "@/lib/operator-customization/registry";
+
+export type CustomizationApiResponse = {
+  surface: string;
+  draft: OperatorSurfaceCustomization;
+  published: OperatorSurfaceCustomization;
+  publishedAt: string | null;
+  draftUpdatedAt: string;
+  degraded?: { inference: string; message: string };
+};
+
+export function useOperatorDashboardCustomization() {
+  const [data, setData] = useState<CustomizationApiResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/operator-customization", { credentials: "include" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(typeof body.message === "string" ? body.message : `HTTP ${res.status}`);
+        setData(null);
+        return;
+      }
+      const json = (await res.json()) as CustomizationApiResponse;
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "load_failed");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return {
+    data,
+    error,
+    loading,
+    refetch,
+    fallbackLayout: defaultAdminDashboardCustomization(),
+  };
+}
+
+export function recordModuleViewSignal(moduleId: string): void {
+  try {
+    void fetch("/api/admin/operator-customization/signals", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ signalType: "module_view", moduleId }),
+    });
+  } catch {
+    /* non-blocking */
+  }
+}

--- a/packages/web/src/lib/operator-customization/normalize.ts
+++ b/packages/web/src/lib/operator-customization/normalize.ts
@@ -1,0 +1,58 @@
+import {
+  CUSTOMIZATION_SCHEMA_VERSION,
+  OperatorSurfaceCustomizationSchema,
+  type CustomizationPatch,
+  type OperatorSurfaceCustomization,
+} from "./schema";
+import {
+  defaultAdminDashboardCustomization,
+  validatePlacementsAgainstRegistry,
+} from "./registry";
+
+export type NormalizeResult =
+  | { ok: true; value: OperatorSurfaceCustomization }
+  | { ok: false; errors: string[] };
+
+function sortModules(m: OperatorSurfaceCustomization): OperatorSurfaceCustomization {
+  const modules = [...m.modules].sort((a, b) => a.order - b.order || a.moduleId.localeCompare(b.moduleId));
+  return { ...m, modules };
+}
+
+/** Merge patch onto base; then validate and normalize. */
+export function applyCustomizationPatch(
+  base: OperatorSurfaceCustomization,
+  patch: CustomizationPatch
+): NormalizeResult {
+  const merged: OperatorSurfaceCustomization = {
+    ...base,
+    ...(patch.operatingMode !== undefined ? { operatingMode: patch.operatingMode } : {}),
+    ...(patch.modules !== undefined ? { modules: patch.modules } : {}),
+    ...(patch.lastAppliedPresetId !== undefined ? { lastAppliedPresetId: patch.lastAppliedPresetId } : {}),
+    schemaVersion: CUSTOMIZATION_SCHEMA_VERSION,
+  };
+  return normalizeOperatorCustomization(merged);
+}
+
+export function normalizeOperatorCustomization(raw: unknown): NormalizeResult {
+  const parsed = OperatorSurfaceCustomizationSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`),
+    };
+  }
+  const sorted = sortModules(parsed.data);
+  const reg = validatePlacementsAgainstRegistry(sorted.modules);
+  if (!reg.ok) {
+    return { ok: false, errors: reg.errors };
+  }
+  return { ok: true, value: sorted };
+}
+
+export function ensureCustomizationShape(raw: unknown | null | undefined): OperatorSurfaceCustomization {
+  const base = defaultAdminDashboardCustomization();
+  if (raw == null) return base;
+  const n = normalizeOperatorCustomization(raw);
+  if (n.ok) return n.value;
+  return base;
+}

--- a/packages/web/src/lib/operator-customization/presets.ts
+++ b/packages/web/src/lib/operator-customization/presets.ts
@@ -1,0 +1,97 @@
+import type { OperatorSurfaceCustomization } from "./schema";
+import { defaultAdminDashboardCustomization } from "./registry";
+
+export type PresetDefinition = {
+  id: string;
+  label: string;
+  description: string;
+  scope: "system";
+  /** Human-readable; applied into config.lastAppliedPresetId */
+  customization: () => OperatorSurfaceCustomization;
+};
+
+function cloneDefault(): OperatorSurfaceCustomization {
+  return JSON.parse(JSON.stringify(defaultAdminDashboardCustomization())) as OperatorSurfaceCustomization;
+}
+
+/** Compact solo layout: highest-signal blocks first; optional modules off by default where safe. */
+function soloOperatorDashboard(): OperatorSurfaceCustomization {
+  const c = cloneDefault();
+  c.operatingMode = "solo_operator";
+  c.lastAppliedPresetId = "solo_operator";
+  c.modules = [
+    { moduleId: "trust_connection", enabled: true, order: 0 },
+    { moduleId: "time_range", enabled: true, order: 1 },
+    { moduleId: "usage_warning", enabled: true, order: 2, thresholdOverrides: { usageWarningVolume: 500_000 } },
+    { moduleId: "kpi_tiles", enabled: true, order: 3 },
+    { moduleId: "exception_heatmap", enabled: true, order: 4 },
+    { moduleId: "activity_feed", enabled: false, order: 5 },
+  ];
+  return c;
+}
+
+function buyerDemoDashboard(): OperatorSurfaceCustomization {
+  const c = cloneDefault();
+  c.operatingMode = "buyer_demo";
+  c.lastAppliedPresetId = "buyer_demo";
+  c.modules = c.modules.map((m) =>
+    m.moduleId === "usage_warning"
+      ? { ...m, enabled: false }
+      : { ...m, titleOverride: m.moduleId === "kpi_tiles" ? "Operational snapshot" : undefined }
+  );
+  return c;
+}
+
+function exceptionOpsDashboard(): OperatorSurfaceCustomization {
+  const c = cloneDefault();
+  c.operatingMode = "standard";
+  c.lastAppliedPresetId = "exception_ops";
+  c.modules = [
+    { moduleId: "trust_connection", enabled: true, order: 0 },
+    { moduleId: "time_range", enabled: true, order: 1 },
+    { moduleId: "exception_heatmap", enabled: true, order: 2 },
+    { moduleId: "kpi_tiles", enabled: true, order: 3 },
+    { moduleId: "usage_warning", enabled: true, order: 4 },
+    { moduleId: "activity_feed", enabled: true, order: 5 },
+  ];
+  return c;
+}
+
+export const OPERATOR_CUSTOMIZATION_PRESETS: PresetDefinition[] = [
+  {
+    id: "default",
+    label: "Default",
+    description: "Balanced modules with standard ordering.",
+    scope: "system",
+    customization: () => {
+      const c = cloneDefault();
+      c.lastAppliedPresetId = "default";
+      return c;
+    },
+  },
+  {
+    id: "solo_operator",
+    label: "Solo operator",
+    description: "Compact signal path: connectivity, range, usage attention, KPIs, heatmap; activity feed off.",
+    scope: "system",
+    customization: soloOperatorDashboard,
+  },
+  {
+    id: "buyer_demo",
+    label: "Buyer demo",
+    description: "Buyer-safe framing; suppresses usage warning strip by default.",
+    scope: "system",
+    customization: buyerDemoDashboard,
+  },
+  {
+    id: "exception_ops",
+    label: "Exception ops",
+    description: "Elevates heatmap ahead of KPI tiles for queue-first review.",
+    scope: "system",
+    customization: exceptionOpsDashboard,
+  },
+];
+
+export function getPresetById(id: string): PresetDefinition | undefined {
+  return OPERATOR_CUSTOMIZATION_PRESETS.find((p) => p.id === id);
+}

--- a/packages/web/src/lib/operator-customization/proposal-rules.ts
+++ b/packages/web/src/lib/operator-customization/proposal-rules.ts
@@ -1,0 +1,106 @@
+/**
+ * Rules-based intent → structured customization patch.
+ * No LLM: deterministic, auditable, safe when inference is disabled.
+ */
+
+import type { CustomizationPatch, InferenceMode, OperatingMode } from "./schema";
+import { getPresetById } from "./presets";
+
+export type ProposalBuildResult =
+  | {
+      ok: true;
+      patch: CustomizationPatch;
+      rationale: string;
+      inferenceMode: InferenceMode;
+    }
+  | { ok: false; reason: string; inferenceMode: InferenceMode };
+
+function applyPreset(presetId: string, rationale: string): ProposalBuildResult {
+  const preset = getPresetById(presetId);
+  if (!preset) {
+    return { ok: false, reason: `Unknown preset: ${presetId}`, inferenceMode: "rules" };
+  }
+  const full = preset.customization();
+  return {
+    ok: true,
+    patch: {
+      modules: full.modules,
+      operatingMode: full.operatingMode,
+      lastAppliedPresetId: full.lastAppliedPresetId,
+    },
+    rationale,
+    inferenceMode: "rules",
+  };
+}
+
+export function buildProposalFromNaturalLanguage(request: string): ProposalBuildResult {
+  const trimmed = request.trim();
+  if (!trimmed) {
+    return { ok: false, reason: "Empty request.", inferenceMode: "rules" };
+  }
+
+  if (/solo|single\s*operator|one\s*person|compact/i.test(trimmed)) {
+    return applyPreset(
+      "solo_operator",
+      "Matched solo-operator intent: Solo operator preset (compact path; activity feed off)."
+    );
+  }
+  if (/buyer|demo|enterprise\s*pitch|sales/i.test(trimmed)) {
+    return applyPreset("buyer_demo", "Matched buyer-demo intent: Buyer demo preset.");
+  }
+  if (/exception|queue|heatmap|ops\s*first/i.test(trimmed)) {
+    return applyPreset(
+      "exception_ops",
+      "Matched exception-ops intent: heatmap ordered before KPI tiles."
+    );
+  }
+  if (/default|reset|baseline/i.test(trimmed)) {
+    return applyPreset("default", "Reset to default layout and standard operating mode.");
+  }
+
+  if (/hide\s*activity|no\s*activity\s*feed|disable\s*activity/i.test(trimmed)) {
+    return applyPreset(
+      "solo_operator",
+      "Activity feed hidden via Solo operator preset (other modules unchanged vs that preset)."
+    );
+  }
+
+  if (/finance|executive|summary|kpi/i.test(trimmed)) {
+    const preset = getPresetById("default");
+    if (!preset) return { ok: false, reason: "Default preset missing.", inferenceMode: "rules" };
+    const full = preset.customization();
+    return {
+      ok: true,
+      patch: {
+        modules: full.modules.map((m) =>
+          m.moduleId === "kpi_tiles"
+            ? {
+                ...m,
+                titleOverride: "Finance summary",
+                helpOverride:
+                  "Volume and match-rate snapshot from admin metrics (operational, not statutory reporting).",
+              }
+            : m
+        ),
+        operatingMode: full.operatingMode,
+      },
+      rationale:
+        "Finance/leadership wording: KPI title/help only; data still from GET /api/admin/metrics.",
+      inferenceMode: "rules",
+    };
+  }
+
+  return {
+    ok: false,
+    reason:
+      "No rules match. Try: solo operator, buyer demo, exception ops, hide activity feed, finance summary, or reset to default.",
+    inferenceMode: "rules",
+  };
+}
+
+export function coerceOperatingMode(text: string): OperatingMode | undefined {
+  if (/solo/i.test(text)) return "solo_operator";
+  if (/buyer|demo/i.test(text)) return "buyer_demo";
+  if (/standard|normal/i.test(text)) return "standard";
+  return undefined;
+}

--- a/packages/web/src/lib/operator-customization/registry.ts
+++ b/packages/web/src/lib/operator-customization/registry.ts
@@ -1,0 +1,186 @@
+/**
+ * Declarative registry of configurable admin dashboard modules.
+ * `locked` modules cannot be removed or reordered; only copy/help/thresholds may be constrained per module.
+ */
+
+import type { ModulePlacement } from "./schema";
+
+export type ModuleTruthClass =
+  | "canonical_metric"
+  | "connectivity_posture"
+  | "operator_workflow"
+  | "presentation_summary";
+
+export type DashboardModuleDefinition = {
+  id: string;
+  /** Stable category for UI grouping */
+  category: "signal" | "operations" | "trust" | "workflow";
+  defaultTitle: string;
+  defaultHelp: string;
+  locked: boolean;
+  /** What kind of truth this block reflects — operators must not treat presentation as canonical run truth. */
+  truthClass: ModuleTruthClass;
+  /** When degraded, which API or subsystem backs the block */
+  sourceOfTruthHint: string;
+  allowTitleOverride: boolean;
+  allowHelpOverride: boolean;
+  allowDisable: boolean;
+  allowReorder: boolean;
+  supportedThresholdKeys?: string[];
+};
+
+export const ADMIN_DASHBOARD_MODULE_REGISTRY: Record<string, DashboardModuleDefinition> = {
+  kpi_tiles: {
+    id: "kpi_tiles",
+    category: "signal",
+    defaultTitle: "KPI tiles",
+    defaultHelp: "Aggregated volume, match rate, and exception counts from admin metrics snapshot.",
+    locked: false,
+    truthClass: "canonical_metric",
+    sourceOfTruthHint: "GET /api/admin/metrics",
+    allowTitleOverride: true,
+    allowHelpOverride: true,
+    allowDisable: true,
+    allowReorder: true,
+    supportedThresholdKeys: ["usageWarningVolume"],
+  },
+  exception_heatmap: {
+    id: "exception_heatmap",
+    category: "operations",
+    defaultTitle: "Exception heatmap",
+    defaultHelp: "Distribution of exceptions by type from the same metrics snapshot.",
+    locked: false,
+    truthClass: "canonical_metric",
+    sourceOfTruthHint: "GET /api/admin/metrics (heatmap)",
+    allowTitleOverride: true,
+    allowHelpOverride: true,
+    allowDisable: true,
+    allowReorder: true,
+  },
+  activity_feed: {
+    id: "activity_feed",
+    category: "operations",
+    defaultTitle: "Activity feed",
+    defaultHelp: "Recent operational events derived from admin metrics aggregation.",
+    locked: false,
+    truthClass: "operator_workflow",
+    sourceOfTruthHint: "GET /api/admin/metrics (activity)",
+    allowTitleOverride: true,
+    allowHelpOverride: true,
+    allowDisable: true,
+    allowReorder: true,
+  },
+  trust_connection: {
+    id: "trust_connection",
+    category: "trust",
+    defaultTitle: "Live connection",
+    defaultHelp: "SSE / stream connectivity to admin metrics; degraded when disconnected.",
+    locked: true,
+    truthClass: "connectivity_posture",
+    sourceOfTruthHint: "GET /api/admin/stream",
+    allowTitleOverride: true,
+    allowHelpOverride: true,
+    allowDisable: false,
+    allowReorder: false,
+  },
+  time_range: {
+    id: "time_range",
+    category: "workflow",
+    defaultTitle: "Time range",
+    defaultHelp: "Selects the window passed to the metrics API.",
+    locked: true,
+    truthClass: "operator_workflow",
+    sourceOfTruthHint: "Client query param → /api/admin/metrics",
+    allowTitleOverride: true,
+    allowHelpOverride: true,
+    allowDisable: false,
+    allowReorder: false,
+  },
+  usage_warning: {
+    id: "usage_warning",
+    category: "signal",
+    defaultTitle: "Usage warning",
+    defaultHelp: "Highlights when volume approaches a configured attention threshold (presentation only).",
+    locked: false,
+    truthClass: "presentation_summary",
+    sourceOfTruthHint: "Derived from KPI totalVolume + local threshold",
+    allowTitleOverride: true,
+    allowHelpOverride: true,
+    allowDisable: true,
+    allowReorder: true,
+    supportedThresholdKeys: ["usageWarningVolume"],
+  },
+};
+
+const DEFAULT_ORDER: string[] = [
+  "trust_connection",
+  "time_range",
+  "usage_warning",
+  "kpi_tiles",
+  "exception_heatmap",
+  "activity_feed",
+];
+
+export function defaultAdminDashboardCustomization(): import("./schema").OperatorSurfaceCustomization {
+  return {
+    schemaVersion: "1",
+    operatingMode: "standard",
+    modules: DEFAULT_ORDER.map((moduleId, index) => ({
+      moduleId,
+      enabled: true,
+      order: index,
+    })),
+  };
+}
+
+export function listRegistryModuleIds(): string[] {
+  return Object.keys(ADMIN_DASHBOARD_MODULE_REGISTRY);
+}
+
+export function validatePlacementsAgainstRegistry(
+  modules: ModulePlacement[]
+): { ok: true } | { ok: false; errors: string[] } {
+  const errors: string[] = [];
+  const seen = new Set<string>();
+
+  for (const m of modules) {
+    const def = ADMIN_DASHBOARD_MODULE_REGISTRY[m.moduleId];
+    if (!def) {
+      errors.push(`Unknown moduleId: ${m.moduleId}`);
+      continue;
+    }
+    seen.add(m.moduleId);
+    if (!def.allowDisable && !m.enabled) {
+      errors.push(`Module ${m.moduleId} is locked on and cannot be disabled.`);
+    }
+    if (!def.allowReorder && m.order !== DEFAULT_ORDER.indexOf(m.moduleId)) {
+      /* reorder of locked modules: allow if order matches default position */
+      const expected = DEFAULT_ORDER.indexOf(m.moduleId);
+      if (expected >= 0 && m.order !== expected) {
+        errors.push(`Module ${m.moduleId} order is fixed; reset to default layout.`);
+      }
+    }
+    if (m.titleOverride && !def.allowTitleOverride) {
+      errors.push(`Module ${m.moduleId} does not allow title override.`);
+    }
+    if (m.helpOverride && !def.allowHelpOverride) {
+      errors.push(`Module ${m.moduleId} does not allow help override.`);
+    }
+    if (m.thresholdOverrides) {
+      const allowed = new Set(def.supportedThresholdKeys ?? []);
+      for (const key of Object.keys(m.thresholdOverrides)) {
+        if (!allowed.has(key)) {
+          errors.push(`Module ${m.moduleId} does not support threshold key: ${key}`);
+        }
+      }
+    }
+  }
+
+  for (const id of DEFAULT_ORDER) {
+    if (!seen.has(id)) {
+      errors.push(`Missing required module: ${id}`);
+    }
+  }
+
+  return errors.length ? { ok: false, errors } : { ok: true };
+}

--- a/packages/web/src/lib/operator-customization/schema.ts
+++ b/packages/web/src/lib/operator-customization/schema.ts
@@ -1,0 +1,50 @@
+/**
+ * Versioned operator customization config (presentation + workflow layout only).
+ * Does not describe reconciliation outcomes, evidence contracts, or run health semantics.
+ */
+
+import { z } from "zod";
+
+export const CUSTOMIZATION_SCHEMA_VERSION = "1" as const;
+
+export const OperatorSurfaceIdSchema = z.enum(["admin_dashboard"]);
+export type OperatorSurfaceId = z.infer<typeof OperatorSurfaceIdSchema>;
+
+export const OperatingModeSchema = z.enum(["standard", "solo_operator", "buyer_demo"]);
+export type OperatingMode = z.infer<typeof OperatingModeSchema>;
+
+export const ModulePlacementSchema = z.object({
+  moduleId: z.string().min(1),
+  enabled: z.boolean(),
+  order: z.number().int().min(0).max(999),
+  titleOverride: z.string().max(120).optional(),
+  helpOverride: z.string().max(500).optional(),
+  /** Numeric attention rules for modules that support them (e.g. usage warning). */
+  thresholdOverrides: z.record(z.string(), z.number().finite()).optional(),
+});
+
+export type ModulePlacement = z.infer<typeof ModulePlacementSchema>;
+
+export const OperatorSurfaceCustomizationSchema = z.object({
+  schemaVersion: z.literal(CUSTOMIZATION_SCHEMA_VERSION),
+  operatingMode: OperatingModeSchema.default("standard"),
+  modules: z.array(ModulePlacementSchema).max(64),
+  /** Last applied preset id for operator visibility (not authoritative for validation). */
+  lastAppliedPresetId: z.string().max(64).optional(),
+});
+
+export type OperatorSurfaceCustomization = z.infer<typeof OperatorSurfaceCustomizationSchema>;
+
+export const CustomizationPatchSchema = z.object({
+  operatingMode: OperatingModeSchema.optional(),
+  modules: z.array(ModulePlacementSchema).optional(),
+  lastAppliedPresetId: z.string().max(64).optional(),
+});
+
+export type CustomizationPatch = z.infer<typeof CustomizationPatchSchema>;
+
+export const ProposalStatusSchema = z.enum(["pending", "applied", "rejected"]);
+export type ProposalStatus = z.infer<typeof ProposalStatusSchema>;
+
+export const InferenceModeSchema = z.enum(["rules", "degraded_unavailable"]);
+export type InferenceMode = z.infer<typeof InferenceModeSchema>;

--- a/packages/web/src/lib/operator-customization/suggestion-engine.ts
+++ b/packages/web/src/lib/operator-customization/suggestion-engine.ts
@@ -1,0 +1,52 @@
+/**
+ * Deterministic suggestions from recorded interaction signals (tenant-scoped).
+ * Evidence = counts and windows; no hidden mutation.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+export type ModuleVisitSuggestion = {
+  kind: "pin_module";
+  moduleId: string;
+  evidence: { visitsInWindow: number; windowHours: number };
+  message: string;
+};
+
+const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const MIN_VISITS = 8;
+const MAX_SUGGESTIONS = 3;
+
+export async function computeModuleVisitSuggestions(
+  prisma: PrismaClient,
+  tenantId: string,
+  userId: string | null
+): Promise<ModuleVisitSuggestion[]> {
+  const since = new Date(Date.now() - WINDOW_MS);
+
+  const where = {
+    tenantId,
+    signalType: "module_view",
+    createdAt: { gte: since },
+    ...(userId ? { userId } : {}),
+  };
+
+  const rows = await prisma.operatorInteractionSignal.groupBy({
+    by: ["moduleId"],
+    where,
+    _count: { moduleId: true },
+  });
+
+  type Row = (typeof rows)[number];
+
+  const sorted = rows
+    .filter((r: Row) => r._count.moduleId >= MIN_VISITS)
+    .sort((a: Row, b: Row) => b._count.moduleId - a._count.moduleId)
+    .slice(0, MAX_SUGGESTIONS);
+
+  return sorted.map((r: Row) => ({
+    kind: "pin_module" as const,
+    moduleId: r.moduleId,
+    evidence: { visitsInWindow: r._count.moduleId, windowHours: 168 },
+    message: `You opened “${r.moduleId}” ${r._count.moduleId} times in the last 7 days — consider keeping it high in your layout.`,
+  }));
+}

--- a/packages/web/src/lib/server/exceptions/reconciliation-workbench.ts
+++ b/packages/web/src/lib/server/exceptions/reconciliation-workbench.ts
@@ -1,5 +1,30 @@
 import type { PrismaClient } from "@prisma/client";
 import type { ReadinessState } from "@/lib/activation/readiness";
+
+/** Row from similar-resolved adjudication memory query (similarity scoring input). */
+type SimilarResolvedMemoryRow = {
+  exceptionId: string;
+  resolution: string;
+  resolutionReason: string | null;
+  archetypeId: string | null;
+  createdAt: Date;
+  confidence: unknown;
+  adjudicatorId: string;
+  archetype: { code: string; label: string } | null;
+};
+
+/** Scored similar case before stripping internal `_score`. */
+type SimilarScoredCaseRow = {
+  exceptionId: string;
+  resolution: string;
+  resolutionReason: string | null;
+  confidence: number | null;
+  adjudicatedAt: string;
+  adjudicatorId: string;
+  archetypeCode: string | null;
+  archetypeLabel: string | null;
+  _score: number;
+};
 import {
   EXCEPTION_MATCH_TYPES,
   operatorStatusToCanonical,
@@ -1366,7 +1391,7 @@ export async function getReconciliationWorkbenchExceptionDetail(
   const currentMatchType = row.matchType;
   const currentMatchReason = row.matchReason ?? "";
   const scoredSimilarCases = similarMemories
-    .map((mem) => {
+    .map((mem: SimilarResolvedMemoryRow): SimilarScoredCaseRow => {
       let score = 0;
       // Same archetype as current exception's top archetype
       if (topArchetype && mem.archetypeId === topArchetype.id) score += 0.4;
@@ -1385,7 +1410,8 @@ export async function getReconciliationWorkbenchExceptionDetail(
         exceptionId: mem.exceptionId,
         resolution: mem.resolution,
         resolutionReason: mem.resolutionReason,
-        confidence: mem.confidence != null ? Number(mem.confidence) : null,
+        confidence:
+          mem.confidence != null && mem.confidence !== "" ? Number(mem.confidence) : null,
         adjudicatedAt: mem.createdAt.toISOString(),
         adjudicatorId: mem.adjudicatorId,
         archetypeCode: mem.archetype?.code ?? null,
@@ -1393,10 +1419,14 @@ export async function getReconciliationWorkbenchExceptionDetail(
         _score: score,
       };
     })
-    .filter((c) => c._score > 0.1)
-    .sort((a, b) => b._score - a._score)
+    .filter((c: SimilarScoredCaseRow) => c._score > 0.1)
+    .sort((a: SimilarScoredCaseRow, b: SimilarScoredCaseRow) => b._score - a._score)
     .slice(0, 5)
-    .map(({ _score, ...rest }) => rest);
+    .map((item: SimilarScoredCaseRow) => {
+      const { _score, ...rest } = item;
+      void _score;
+      return rest;
+    });
 
   // Why-flagged: deterministic explanation of why this exception was created
   const primaryReasons: Array<{ reason: string; code: string; weight: number; evidence?: string }> = [];

--- a/packages/web/src/lib/server/operator-customization/customization-service.ts
+++ b/packages/web/src/lib/server/operator-customization/customization-service.ts
@@ -1,0 +1,163 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import type { CustomizationPatch, OperatorSurfaceId } from "@/lib/operator-customization/schema";
+import {
+  applyCustomizationPatch,
+  ensureCustomizationShape,
+  normalizeOperatorCustomization,
+} from "@/lib/operator-customization/normalize";
+import { defaultAdminDashboardCustomization } from "@/lib/operator-customization/registry";
+import type { OperatorSurfaceCustomization } from "@/lib/operator-customization/schema";
+
+const SURFACE: OperatorSurfaceId = "admin_dashboard";
+
+export async function getCustomizationState(
+  prisma: PrismaClient,
+  tenantId: string,
+  userId: string
+): Promise<{
+  surface: OperatorSurfaceId;
+  draft: OperatorSurfaceCustomization;
+  published: OperatorSurfaceCustomization;
+  publishedAt: string | null;
+  draftUpdatedAt: string;
+}> {
+  const row = await prisma.operatorCustomizationState.findUnique({
+    where: {
+      tenantId_userId_surface: { tenantId, userId, surface: SURFACE },
+    },
+  });
+
+  const published = ensureCustomizationShape(row?.publishedConfig);
+  const draft = ensureCustomizationShape(row?.draftConfig ?? row?.publishedConfig);
+
+  return {
+    surface: SURFACE,
+    draft,
+    published,
+    publishedAt: row?.publishedAt?.toISOString() ?? null,
+    draftUpdatedAt: row?.draftUpdatedAt.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function saveDraft(
+  prisma: PrismaClient,
+  tenantId: string,
+  userId: string,
+  config: OperatorSurfaceCustomization
+): Promise<{ ok: true } | { ok: false; errors: string[] }> {
+  const n = normalizeOperatorCustomization(config);
+  if (!n.ok) return n;
+
+  await prisma.operatorCustomizationState.upsert({
+    where: { tenantId_userId_surface: { tenantId, userId, surface: SURFACE } },
+    create: {
+      tenantId,
+      userId,
+      surface: SURFACE,
+      schemaVersion: n.value.schemaVersion,
+      draftConfig: n.value as unknown as Prisma.InputJsonValue,
+      publishedConfig: defaultAdminDashboardCustomization() as unknown as Prisma.InputJsonValue,
+      draftUpdatedAt: new Date(),
+    },
+    update: {
+      schemaVersion: n.value.schemaVersion,
+      draftConfig: n.value as unknown as Prisma.InputJsonValue,
+      draftUpdatedAt: new Date(),
+    },
+  });
+
+  return { ok: true };
+}
+
+export async function publishDraft(
+  prisma: PrismaClient,
+  tenantId: string,
+  userId: string
+): Promise<{ ok: true; published: OperatorSurfaceCustomization } | { ok: false; errors: string[] }> {
+  const row = await prisma.operatorCustomizationState.findUnique({
+    where: { tenantId_userId_surface: { tenantId, userId, surface: SURFACE } },
+  });
+  const draft = ensureCustomizationShape(row?.draftConfig);
+  const n = normalizeOperatorCustomization(draft);
+  if (!n.ok) return n;
+
+  await prisma.operatorCustomizationState.upsert({
+    where: { tenantId_userId_surface: { tenantId, userId, surface: SURFACE } },
+    create: {
+      tenantId,
+      userId,
+      surface: SURFACE,
+      schemaVersion: n.value.schemaVersion,
+      draftConfig: n.value as unknown as Prisma.InputJsonValue,
+      publishedConfig: n.value as unknown as Prisma.InputJsonValue,
+      publishedAt: new Date(),
+      draftUpdatedAt: new Date(),
+    },
+    update: {
+      publishedConfig: n.value as unknown as Prisma.InputJsonValue,
+      publishedAt: new Date(),
+      schemaVersion: n.value.schemaVersion,
+    },
+  });
+
+  return { ok: true, published: n.value };
+}
+
+export async function revertPublishedToDraft(
+  prisma: PrismaClient,
+  tenantId: string,
+  userId: string
+): Promise<{ ok: true; draft: OperatorSurfaceCustomization } | { ok: false; errors: string[] }> {
+  const row = await prisma.operatorCustomizationState.findUnique({
+    where: { tenantId_userId_surface: { tenantId, userId, surface: SURFACE } },
+  });
+  if (!row) {
+    return { ok: false, errors: ["No saved customization state."] };
+  }
+  const published = ensureCustomizationShape(row.publishedConfig);
+  const n = normalizeOperatorCustomization(published);
+  if (!n.ok) return n;
+
+  await prisma.operatorCustomizationState.update({
+    where: { tenantId_userId_surface: { tenantId, userId, surface: SURFACE } },
+    data: {
+      draftConfig: n.value as unknown as Prisma.InputJsonValue,
+      draftUpdatedAt: new Date(),
+    },
+  });
+
+  return { ok: true, draft: n.value };
+}
+
+export async function applyPatchToDraft(
+  prisma: PrismaClient,
+  tenantId: string,
+  userId: string,
+  patch: CustomizationPatch
+): Promise<{ ok: true; draft: OperatorSurfaceCustomization } | { ok: false; errors: string[] }> {
+  const current = await getCustomizationState(prisma, tenantId, userId);
+  const merged = applyCustomizationPatch(current.draft, patch);
+  if (!merged.ok) return merged;
+  const saved = await saveDraft(prisma, tenantId, userId, merged.value);
+  if (!saved.ok) return saved;
+  return { ok: true, draft: merged.value };
+}
+
+export async function recordCustomizationAudit(
+  prisma: PrismaClient,
+  tenantId: string,
+  userId: string | null,
+  action: string,
+  surface: string | null,
+  details: Record<string, unknown>
+): Promise<void> {
+  await prisma.operatorCustomizationAudit.create({
+    data: {
+      tenantId,
+      userId,
+      action,
+      surface,
+      details: details as Prisma.InputJsonValue,
+    },
+  });
+}

--- a/packages/web/src/lib/server/operator-customization/tenant-context.ts
+++ b/packages/web/src/lib/server/operator-customization/tenant-context.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/shared/db/prismaClient";
+
+/**
+ * Resolve tenant for admin customization APIs.
+ * Super-admins may pass ?tenantId=; otherwise default slug tenant is used.
+ */
+export async function resolveCustomizationTenantId(
+  requestedTenantId: string | null
+): Promise<{ ok: true; tenantId: string } | { ok: false; response: NextResponse }> {
+  if (requestedTenantId) {
+    const t = await prisma.tenant.findFirst({
+      where: { id: requestedTenantId },
+      select: { id: true },
+    });
+    if (!t) {
+      return {
+        ok: false,
+        response: NextResponse.json({ error: "tenant_not_found" }, { status: 404 }),
+      };
+    }
+    return { ok: true, tenantId: t.id };
+  }
+
+  const def = await prisma.tenant.findUnique({
+    where: { slug: "default" },
+    select: { id: true },
+  });
+  if (!def) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "default_tenant_missing", message: "No default tenant row (slug=default)." },
+        { status: 503 }
+      ),
+    };
+  }
+  return { ok: true, tenantId: def.id };
+}

--- a/packages/web/src/lib/server/settler/meaningful-changes.ts
+++ b/packages/web/src/lib/server/settler/meaningful-changes.ts
@@ -99,12 +99,16 @@ export async function listMeaningfulChanges(
           : undefined;
 
         const sourceReliability = getSourceReliabilityScore(result.recon_job_id ?? "unknown");
+        const summaryRecord =
+          result.summary != null && typeof result.summary === "object" && !Array.isArray(result.summary)
+            ? (result.summary as Record<string, unknown>)
+            : {};
         const explanation = generateExplanation(
           {
             type: "reconciliation",
             sourceId: result.recon_job_id ?? "unknown",
             timestamp: new Date(result.started_at),
-            rawData: result.summary ?? {},
+            rawData: summaryRecord,
           },
           delta
         );
@@ -122,7 +126,7 @@ export async function listMeaningfulChanges(
             type: "reconciliation",
             sourceId: result.recon_job_id ?? "unknown",
             timestamp: new Date(result.started_at),
-            rawData: result.summary ?? {},
+            rawData: summaryRecord,
           },
           explanation,
           impact,

--- a/packages/web/src/middleware/usage-tracking.ts
+++ b/packages/web/src/middleware/usage-tracking.ts
@@ -165,9 +165,11 @@ export async function checkUsageLimit(
   const currentUsage = await getCurrentUsage(billingAccountId, "monthly");
   const totalUsage = currentUsage.totalTransactions + additionalTransactions;
 
+  const includedVolume = plan.includedTransactions;
+
   // Only starter-equivalent has a hard included-volume cap in the commercial spine
   if (canonicalPlanId === "starter") {
-    const allowed = totalUsage <= plan.includedTransactions;
+    const allowed = totalUsage <= includedVolume;
     return {
       allowed,
       currentUsage: currentUsage.totalTransactions,
@@ -179,7 +181,7 @@ export async function checkUsageLimit(
   return {
     allowed: true,
     currentUsage: currentUsage.totalTransactions,
-    limit: includedVolume > 0 ? includedVolume : Infinity,
+    limit: Infinity,
     wouldExceed: false,
   };
 }

--- a/prisma/migrations/20260405120000_operator_customization_studio/migration.sql
+++ b/prisma/migrations/20260405120000_operator_customization_studio/migration.sql
@@ -1,0 +1,94 @@
+-- Operator Customization Studio: versioned presentation/workflow config, proposals, audit, usage signals.
+-- Tenant-scoped; user-scoped layouts via user_id (super-admin console).
+
+CREATE TABLE "operator_customization_states" (
+    "id" UUID NOT NULL,
+    "tenant_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "surface" TEXT NOT NULL,
+    "schema_version" TEXT NOT NULL DEFAULT '1',
+    "draft_config" JSONB NOT NULL DEFAULT '{}',
+    "published_config" JSONB NOT NULL DEFAULT '{}',
+    "published_at" TIMESTAMP(3),
+    "draft_updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "operator_customization_states_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "operator_customization_states_tenant_user_surface_key"
+  ON "operator_customization_states"("tenant_id", "user_id", "surface");
+
+CREATE INDEX "operator_customization_states_tenant_id_idx" ON "operator_customization_states"("tenant_id");
+CREATE INDEX "operator_customization_states_user_id_idx" ON "operator_customization_states"("user_id");
+
+CREATE TABLE "operator_customization_proposals" (
+    "id" UUID NOT NULL,
+    "tenant_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "surface" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "natural_language_request" TEXT NOT NULL,
+    "structured_patch" JSONB NOT NULL DEFAULT '{}',
+    "rationale" TEXT,
+    "inference_mode" TEXT NOT NULL DEFAULT 'rules',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "applied_at" TIMESTAMP(3),
+    "rejected_at" TIMESTAMP(3),
+
+    CONSTRAINT "operator_customization_proposals_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "operator_customization_proposals_tenant_id_created_at_idx"
+  ON "operator_customization_proposals"("tenant_id", "created_at" DESC);
+CREATE INDEX "operator_customization_proposals_user_id_idx" ON "operator_customization_proposals"("user_id");
+CREATE INDEX "operator_customization_proposals_status_idx" ON "operator_customization_proposals"("status");
+
+CREATE TABLE "operator_customization_audits" (
+    "id" UUID NOT NULL,
+    "tenant_id" UUID NOT NULL,
+    "user_id" UUID,
+    "action" TEXT NOT NULL,
+    "surface" TEXT,
+    "details" JSONB NOT NULL DEFAULT '{}',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "operator_customization_audits_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "operator_customization_audits_tenant_id_created_at_idx"
+  ON "operator_customization_audits"("tenant_id", "created_at" DESC);
+
+CREATE TABLE "operator_interaction_signals" (
+    "id" UUID NOT NULL,
+    "tenant_id" UUID NOT NULL,
+    "user_id" UUID,
+    "signal_type" TEXT NOT NULL,
+    "module_id" TEXT NOT NULL,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "operator_interaction_signals_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "operator_interaction_signals_tenant_module_created_idx"
+  ON "operator_interaction_signals"("tenant_id", "module_id", "created_at" DESC);
+CREATE INDEX "operator_interaction_signals_user_id_idx" ON "operator_interaction_signals"("user_id");
+
+ALTER TABLE "operator_customization_states"
+  ADD CONSTRAINT "operator_customization_states_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "operator_customization_proposals"
+  ADD CONSTRAINT "operator_customization_proposals_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "operator_customization_audits"
+  ADD CONSTRAINT "operator_customization_audits_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "operator_interaction_signals"
+  ADD CONSTRAINT "operator_interaction_signals_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1036,6 +1036,10 @@ model Tenant {
   navigation         TenantNavigation?
   pages              TenantPage[]
   experiments        Experiment[]
+  operatorCustomizationStates OperatorCustomizationState[]
+  operatorCustomizationProposals OperatorCustomizationProposal[]
+  operatorCustomizationAudits OperatorCustomizationAudit[]
+  operatorInteractionSignals OperatorInteractionSignal[]
 
   @@index([slug])
   @@index([primaryDomain])
@@ -2232,4 +2236,85 @@ model ApprovalDelegation {
   @@index([delegateId])
   @@index([isActive])
   @@map("approval_delegations")
+}
+
+// ============================================================================
+// OPERATOR CUSTOMIZATION STUDIO
+// Versioned presentation/workflow layout for admin console; tenant + user scoped.
+// Does not store reconciliation truth — only module visibility, order, labels, thresholds.
+// ============================================================================
+
+model OperatorCustomizationState {
+  id               String    @id @default(uuid())
+  tenantId         String    @db.Uuid
+  userId           String    @db.Uuid
+  surface          String // e.g. admin_dashboard
+  schemaVersion    String    @default("1")
+  draftConfig      Json      @default("{}")
+  publishedConfig  Json      @default("{}")
+  publishedAt      DateTime?
+  draftUpdatedAt   DateTime  @default(now())
+  metadata         Json      @default("{}")
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@unique([tenantId, userId, surface])
+  @@index([tenantId])
+  @@index([userId])
+  @@map("operator_customization_states")
+}
+
+model OperatorCustomizationProposal {
+  id                     String    @id @default(uuid())
+  tenantId               String    @db.Uuid
+  userId                 String    @db.Uuid
+  surface                String
+  status                 String    @default("pending") // pending, applied, rejected
+  naturalLanguageRequest String    @db.Text
+  structuredPatch        Json      @default("{}")
+  rationale              String?   @db.Text
+  inferenceMode          String    @default("rules") // rules | degraded_unavailable
+  createdAt              DateTime  @default(now())
+  appliedAt              DateTime?
+  rejectedAt             DateTime?
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, createdAt(sort: Desc)])
+  @@index([userId])
+  @@index([status])
+  @@map("operator_customization_proposals")
+}
+
+model OperatorCustomizationAudit {
+  id        String   @id @default(uuid())
+  tenantId  String   @db.Uuid
+  userId    String?  @db.Uuid
+  action    String
+  surface   String?
+  details   Json     @default("{}")
+  createdAt DateTime @default(now())
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, createdAt(sort: Desc)])
+  @@map("operator_customization_audits")
+}
+
+model OperatorInteractionSignal {
+  id         String   @id @default(uuid())
+  tenantId   String   @db.Uuid
+  userId     String?  @db.Uuid
+  signalType String // module_view, layout_reorder, etc.
+  moduleId   String
+  metadata   Json     @default("{}")
+  createdAt  DateTime @default(now())
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, moduleId, createdAt(sort: Desc)])
+  @@index([userId])
+  @@map("operator_interaction_signals")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ships the first production-oriented **Operator Customization Studio** for the super-admin console: versioned presentation config for the admin dashboard, draft/publish flow, rules-only prompt proposals (explicit review/apply), usage-based suggestions with evidence counts, Prisma persistence + audit rows, and documentation aligned to implementation.

Also fixes **pre-existing `@settler/web` typecheck** failures (schedules route/components, reconciliation workbench scoring, meaningful-changes JSON typing, `checkUsageLimit` undefined `includedVolume`).

## Key behavior

- **Canonical metrics unchanged** — still from `GET /api/admin/metrics`; customization only controls module composition, copy, and presentation thresholds.
- **Published vs draft** — `/admin` reads **published** config; studio edits **draft** until **Publish**.
- **Prompt flow** — `POST /api/admin/operator-customization/proposals` uses **deterministic rules** (no LLM); apply merges to **draft** via `POST .../proposals/[id]/apply`.
- **Learning** — `module_view` / `layout_reorder` signals; suggestions from grouped counts (7d), with explicit evidence in API + UI.
- **DB** — migration `20260405120000_operator_customization_studio` (run before relying on APIs in prod).

## Docs

- `docs/launch/operator-customization-studio.md`

## Verification

- `pnpm --filter @settler/web lint`
- `pnpm typecheck`
- `pnpm exec jest --runInBand src/__tests__/operator-customization/schema-and-proposals.test.ts` (from `packages/web`)

## Follow-ups (intentionally out of scope)

- Additional surfaces beyond `admin_dashboard`
- Org/plan entitlements for customization tiers
- Server-persisted dismiss/snooze for suggestions
- LLM-backed proposals behind explicit provider + policy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f6e962c-f9b6-422b-8748-196712d05cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f6e962c-f9b6-422b-8748-196712d05cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

