### PR TITLE
Improve adoption closure mapping and add explicit local teardown path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory is the canonical documentation surface for Settler.
 - Security + compliance: `docs/security/`, `docs/compliance/`
 - API/reference: `docs/api/`, `docs/reference/`
 - Product + positioning context: `docs/product/README.md`, `docs/positioning/`
+- Reality/truth mapping: `docs/reality/`
 - Contribution guide: `CONTRIBUTING.md`
 - Repo operating system (canonical): `docs/repo-os/README.md`
 - Repo verification matrix: `docs/repo-os/verification-matrix.md`

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Canonical Path (Recommended)
 
-For the most reliable local development setup, follow the canonical install/run order defined in [SETUP.md](../SETUP.md). This ensures all services are properly configured and validated.
+For the most reliable local development setup, follow the canonical install/run order defined in [SETUP.md](../../SETUP.md). This ensures all services are properly configured and validated.
 
 ### Fastest Path to Working Screen
 
@@ -32,6 +32,33 @@ The `demo:settler` script provides a guided deterministic demonstration:
 - Demo artifacts are generated in `examples/demo-output/`
 - Web console is reachable at `http://localhost:3000`
 - API is reachable at `http://localhost:4000`
+
+## Explicit Degraded States (Local Dev)
+
+Settler supports explicit degraded states for optional dependencies in local development:
+
+- Redis unavailable: in-memory fallback is used for queue/cache paths.
+- TigerBeetle unavailable: ledger-dependent workflows are limited; core app routes can still run.
+- Missing non-critical API keys (for example, Sentry): local `pnpm dev` works, while production-grade `pnpm build` may fail until secrets are provided.
+
+Use `pnpm run doctor -- --first-run` to confirm which degraded states are active before evaluating behavior claims.
+
+## Teardown / Cleanup (Reversible)
+
+When you finish a local evaluation and want to stop services plus clean demo artifacts:
+
+```bash
+pnpm run dev:teardown
+```
+
+What this does:
+
+1. Stops TigerBeetle/Postgres local service stack (`pnpm tb:stop`) on a best-effort basis.
+2. Resets seeded demo records (`pnpm demo:reset`) on a best-effort basis.
+3. Removes local teardown artifacts under `examples/demo-output/local/` when present.
+4. Prints a machine-readable summary indicating any degraded cleanup steps that need manual follow-up.
+
+For destructive database reset workflows, use explicit DB commands separately (`pnpm db:reset`) so data-loss intent remains operator-visible.
 
 ## Environment Variables
 

--- a/docs/reality/adoption-closure-matrix-2026-04-06.md
+++ b/docs/reality/adoption-closure-matrix-2026-04-06.md
@@ -1,0 +1,52 @@
+# Adoption Closure Matrix (Research Report → Repo Truth)
+
+_Date: 2026-04-06_
+_Scope: external report themes provided in implementation prompt_
+
+This matrix maps each material recommendation theme from the report to current Settler evidence and closure status. Status values:
+
+- **Verified**: implemented + validated by route/tests/scripts.
+- **Partial**: implemented but materially incomplete or not fully validated.
+- **Docs-only**: described, but implementation evidence is weak.
+- **Missing**: no credible implementation evidence in repo.
+- **N/A**: intentionally out of scope (with reason).
+
+## 1) Report-to-repo closure matrix
+
+| Report theme | Status | Evidence in repo | Gap / action |
+| --- | --- | --- | --- |
+| Local-first quickstart | Partial | `docs/getting-started/quickstart.md`, `SETUP.md`, `scripts/doctor.ts`, `scripts/bootstrap.mjs`, `pnpm dev:stack` | Canonical path exists; now tightened with explicit degraded states and teardown path in this pass. |
+| Reversible teardown / cleanup | Partial → tightened | `scripts/dev-teardown.mjs` (new), `pnpm dev:teardown`, `pnpm tb:stop`, `pnpm demo:reset` | New deterministic teardown entrypoint added; destructive DB reset remains explicit/manual. |
+| Deterministic first-value walkthrough | Partial | `pnpm demo:settler`, `scripts/settler-demo.ts`, `scripts/verify-replay.mjs`, `scripts/verify-determinism.mjs` | Present but depends on local infra availability and environment quality. |
+| OIDC / SAML enterprise SSO | Partial | UI/docs claims in web content and security docs; route and config surfaces present in repo | Requires full runtime integration evidence matrix per IdP before claiming general availability. |
+| SCIM provisioning | Partial / staged | Enterprise and security docs mention lifecycle posture | Need route-level SCIM contract verification and fixture-based provisioning tests for verified status. |
+| Tenant lifecycle + deprovisioning | Partial | `scripts/tenant-create.ts`, tenant/security verification commands in `package.json` | Need documented end-to-end deprovision + data export/delete runbook with runtime checks. |
+| Audit logs / who-did-what-when | Partial | `packages/api/src/routes/v1/audit-trail.ts`, audit viewers in web UI, audit-related tests/scripts | Need clearer SIEM export contract and evidence for enterprise integrations. |
+| SIEM exportability | Partial | export surfaces and operational tabs/docs exist | Need explicit vendor-neutral export format + validation fixtures. |
+| OpenTelemetry / observability | Partial | strong OTel surface in `packages/workhorse/*`; API/web observability mixed | Need cross-surface telemetry parity doc + runtime check to mark verified. |
+| SBOM / supply chain / provenance | Verified (scripted) | `scripts/security/supply-chain.mjs`, `pnpm verify:security:supply-chain`, release/provenance scripts | Continue attaching artifacts to release evidence pack. |
+| Security evidence/trust pack | Partial | `docs/security/*`, `docs/compliance/*`, `scripts/security/*`, `security:evidence` scripts | Needs single procurement-facing index with freshness SLA and owner map. |
+| Privacy / DPA / SCC / retention posture | Partial | privacy/compliance docs exist across `docs/compliance` + package docs | Needs one canonical buyer path with explicit “implemented vs planned” markers. |
+| Pilot runbook + rollback | Partial | pilot docs/scripts (`docs/PILOT_*`, `scripts/pilot/*`) | Some pilot helper references still indicate pending assets; requires closure before “verified.” |
+| SDK truth across languages | Partial | `packages/sdk*`, `examples/starter-kits/*`, SDK packages and docs | Need per-SDK smoke parity matrix and auth/error/retry examples normalized. |
+| Managed service / support boundaries | Partial | go-to-market, SLA/SLO, support docs present | Need canonical tier boundary matrix aligned to actual support operations. |
+| OSS/plugin/adapter leverage | Partial | `marketplace/adapters/*`, `docs/integrations/*`, open-source pages | Need stable extension contract + compatibility promises per adapter. |
+| Docs-as-product truth discipline | Partial | `docs/reality/*`, route/claim verifiers, docs governance metadata | Ongoing drift risk remains due to broad docs surface and duplicate historical docs. |
+| Adoption funnel instrumentation | Partial | operational scripts and validation tools exist | Need standardized adoption KPI schema + privacy-safe collection policy doc. |
+
+## 2) Work classification for this pass
+
+- **Leverage:** tightened developer adoption path with explicit teardown and degraded-state guidance.
+- **Maintenance:** fixed quickstart canonical link drift (`../SETUP.md` → `../../SETUP.md`).
+- **Moat impact:** explicit teardown and truthful degraded-state semantics reduce false-negative evaluations and preserve operator trust during first-value loops.
+
+## 3) Explicit deferrals in this pass
+
+The following are intentionally deferred because they require deeper runtime integration passes beyond safe single-pass scope:
+
+1. Full SCIM route + provisioning lifecycle verification.
+2. IdP-by-IdP SSO validation matrix (Okta, Entra ID, Google Workspace, etc.).
+3. SIEM export schema/versioned contract tests.
+4. Cross-SDK parity smoke suite across all language SDKs.
+
+These remain high-leverage and should be the next implementation tranche after this pass.

--- a/package.json
+++ b/package.json
@@ -267,6 +267,7 @@
     "verify:security:enterprise": "SECURITY_DEPENDENCY_EVIDENCE_MODE=strict SECURITY_RLS_EVIDENCE_MODE=runtime-rls-required pnpm run security:evidence && node scripts/security/verdict.mjs",
     "bootstrap": "node scripts/bootstrap.mjs",
     "dev:stack": "pnpm run check:node && set -a; [ -f .env.local ] && . ./.env.local; set +a; (cd packages/api && PORT=${API_PORT:-4000} pnpm run dev) & (cd packages/web && PORT=${WEB_PORT:-3000} pnpm run dev) & wait",
+    "dev:teardown": "node scripts/dev-teardown.mjs",
     "generate:test-data": "pnpm exec tsx packages/cli/src/index.ts foundry reconciliation-generate --seed 42 --profile smoke --output test-data/exports/latest",
     "generate:test-data:smoke": "pnpm exec tsx packages/cli/src/index.ts foundry reconciliation-generate --seed 42 --profile smoke --output test-data/exports/smoke-seed42",
     "generate:test-data:chaos": "pnpm exec tsx packages/cli/src/index.ts foundry reconciliation-generate --seed 42 --profile chaos --output test-data/exports/chaos-seed42",

--- a/scripts/dev-teardown.mjs
+++ b/scripts/dev-teardown.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import { existsSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const demoOutputDir = resolve(repoRoot, "examples/demo-output");
+const localTeardownDir = resolve(demoOutputDir, "local");
+
+/**
+ * Run a command and capture status without throwing.
+ * This keeps degraded cleanup states explicit and machine-visible.
+ */
+function runStep(label, command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: false,
+    ...options,
+  });
+
+  const ok = result.status === 0;
+  return {
+    label,
+    ok,
+    exitCode: result.status ?? 1,
+    command: `${command} ${args.join(" ")}`.trim(),
+  };
+}
+
+const steps = [];
+
+steps.push(runStep("stop_services", "pnpm", ["tb:stop"]));
+steps.push(runStep("reset_demo_seed", "pnpm", ["demo:reset"]));
+
+let demoOutputRemoved = false;
+let demoOutputMessage = "not_found";
+if (existsSync(localTeardownDir)) {
+  rmSync(localTeardownDir, { recursive: true, force: true });
+  demoOutputRemoved = true;
+  demoOutputMessage = "removed_local_only";
+} else if (existsSync(demoOutputDir)) {
+  demoOutputMessage = "skipped_tracked_artifacts";
+}
+
+const summary = {
+  operation: "dev_teardown",
+  generatedAt: new Date().toISOString(),
+  steps,
+  artifacts: {
+    demoOutputDir: localTeardownDir,
+    status: demoOutputMessage,
+    removed: demoOutputRemoved,
+  },
+  degraded: steps.filter((s) => !s.ok).map((s) => ({
+    step: s.label,
+    command: s.command,
+    exitCode: s.exitCode,
+  })),
+};
+
+const hardFailures = summary.degraded.length;
+if (hardFailures > 0) {
+  console.warn("\n⚠️ dev:teardown completed with degraded steps.");
+} else {
+  console.log("\n✅ dev:teardown completed successfully.");
+}
+
+console.log(JSON.stringify(summary, null, 2));
+
+process.exit(0);


### PR DESCRIPTION
### Motivation

- Map the external adoption report into concrete repo truth so each recommendation is classified and evidence-backed. 
- Reduce time-to-first-value and avoid false-positive success signals by making local degraded states explicit and providing a reversible cleanup path. 
- Preserve operator-truth and deterministic evaluation for first-run/demo scenarios while narrowing claims that require deeper runtime proof. 

### Description

- Added a report-to-repo adoption closure matrix at `docs/reality/adoption-closure-matrix-2026-04-06.md` that maps report themes to repo evidence and deferrals. 
- Tightened quickstart: fixed canonical `SETUP.md` link and added an "Explicit Degraded States" section plus a reversible teardown doc fragment in `docs/getting-started/quickstart.md`. 
- Implemented a machine-visible local teardown script `scripts/dev-teardown.mjs` that runs cleanup steps (`pnpm tb:stop`, `pnpm demo:reset`) non-throwingly and emits a JSON summary of steps, artifacts, and degraded outcomes. 
- Exposed `dev:teardown` in root `package.json` and added discoverability for `docs/reality/` in `docs/README.md` to centralize reality/truth artifacts. 

### Testing

- ⚠️ `pnpm run check:node` — blocked by environment Node version (`v22.21.1`) while repository requires `>=24 <25`. 
- ⚠️ `pnpm run verify:docs` — blocked by the same Node engine mismatch in this environment. 
- ⚠️ `pnpm run dev:teardown` — invocation via `pnpm` was blocked by engine mismatch in this environment. 
- ✅ `node scripts/dev-teardown.mjs` — executed successfully in this environment and produced a machine-readable summary showing degraded steps where `pnpm` subcommands could not run, and removed local teardown artifacts as applicable. 

Work classification: **Leverage** (developer adoption path tightened) with a **Maintenance** fix (quickstart link) and positive **Moat** impact by improving first-value truth and operator-visible degraded-state semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d30d5e3b008328b6da6af90d4f72d3)