### PR TITLE
Tighten enterprise capability truth, add UI truth table, and enforce bootstrap setup verification

### DIFF
--- a/docs/reality/adoption-closure-matrix-2026-04-06.md
+++ b/docs/reality/adoption-closure-matrix-2026-04-06.md
@@ -18,8 +18,8 @@ This matrix maps each material recommendation theme from the report to current S
 | Local-first quickstart | Partial | `docs/getting-started/quickstart.md`, `SETUP.md`, `scripts/doctor.ts`, `scripts/bootstrap.mjs`, `pnpm dev:stack` | Canonical path exists; now tightened with explicit degraded states and teardown path in this pass. |
 | Reversible teardown / cleanup | Partial → tightened | `scripts/dev-teardown.mjs` (new), `pnpm dev:teardown`, `pnpm tb:stop`, `pnpm demo:reset` | New deterministic teardown entrypoint added; destructive DB reset remains explicit/manual. |
 | Deterministic first-value walkthrough | Partial | `pnpm demo:settler`, `scripts/settler-demo.ts`, `scripts/verify-replay.mjs`, `scripts/verify-determinism.mjs` | Present but depends on local infra availability and environment quality. |
-| OIDC / SAML enterprise SSO | Partial | UI/docs claims in web content and security docs; route and config surfaces present in repo | Requires full runtime integration evidence matrix per IdP before claiming general availability. |
-| SCIM provisioning | Partial / staged | Enterprise and security docs mention lifecycle posture | Need route-level SCIM contract verification and fixture-based provisioning tests for verified status. |
+| OIDC / SAML enterprise SSO | Partial (truth-gated) | `packages/web/src/lib/enterprise/capabilityTruth.ts`, enterprise/pricing/security surfaces now render explicit state boundaries | Requires full runtime integration evidence matrix per IdP before claiming general availability. |
+| SCIM provisioning | Partial / staged | `docs/reality/enterprise-capability-truth.md` and web capability truth table mark SCIM as staged, not GA | Need route-level SCIM contract verification and fixture-based provisioning tests for verified status. |
 | Tenant lifecycle + deprovisioning | Partial | `scripts/tenant-create.ts`, tenant/security verification commands in `package.json` | Need documented end-to-end deprovision + data export/delete runbook with runtime checks. |
 | Audit logs / who-did-what-when | Partial | `packages/api/src/routes/v1/audit-trail.ts`, audit viewers in web UI, audit-related tests/scripts | Need clearer SIEM export contract and evidence for enterprise integrations. |
 | SIEM exportability | Partial | export surfaces and operational tabs/docs exist | Need explicit vendor-neutral export format + validation fixtures. |
@@ -29,16 +29,17 @@ This matrix maps each material recommendation theme from the report to current S
 | Privacy / DPA / SCC / retention posture | Partial | privacy/compliance docs exist across `docs/compliance` + package docs | Needs one canonical buyer path with explicit “implemented vs planned” markers. |
 | Pilot runbook + rollback | Partial | pilot docs/scripts (`docs/PILOT_*`, `scripts/pilot/*`) | Some pilot helper references still indicate pending assets; requires closure before “verified.” |
 | SDK truth across languages | Partial | `packages/sdk*`, `examples/starter-kits/*`, SDK packages and docs | Need per-SDK smoke parity matrix and auth/error/retry examples normalized. |
-| Managed service / support boundaries | Partial | go-to-market, SLA/SLO, support docs present | Need canonical tier boundary matrix aligned to actual support operations. |
+| Managed service / support boundaries | Partial (narrowed) | pricing FAQ and enterprise metadata narrowed to engagement-scoped deployment commitments | Need canonical tier boundary matrix aligned to actual support operations. |
 | OSS/plugin/adapter leverage | Partial | `marketplace/adapters/*`, `docs/integrations/*`, open-source pages | Need stable extension contract + compatibility promises per adapter. |
 | Docs-as-product truth discipline | Partial | `docs/reality/*`, route/claim verifiers, docs governance metadata | Ongoing drift risk remains due to broad docs surface and duplicate historical docs. |
 | Adoption funnel instrumentation | Partial | operational scripts and validation tools exist | Need standardized adoption KPI schema + privacy-safe collection policy doc. |
 
 ## 2) Work classification for this pass
 
-- **Leverage:** tightened developer adoption path with explicit teardown and degraded-state guidance.
-- **Maintenance:** fixed quickstart canonical link drift (`../SETUP.md` → `../../SETUP.md`).
-- **Moat impact:** explicit teardown and truthful degraded-state semantics reduce false-negative evaluations and preserve operator trust during first-value loops.
+- **Leverage:** tightened enterprise/public claim truth with implemented-vs-staged capability table integrated into product surfaces.
+- **Leverage:** strengthened local-first bootstrap by adding setup verification and explicit teardown/reset next steps.
+- **Maintenance:** narrowed overstated metadata/security wording to match currently verifiable state.
+- **Moat impact:** trust-preserving truth gating prevents false enterprise commitments while preserving evidence integrity over time.
 
 ## 3) Explicit deferrals in this pass
 

--- a/docs/reality/enterprise-capability-truth.md
+++ b/docs/reality/enterprise-capability-truth.md
@@ -1,0 +1,25 @@
+# Enterprise Capability Truth Table
+
+_Date: 2026-04-06_
+
+This document is the public-facing truth map for enterprise identity and export posture.
+
+## Status legend
+
+- **Verified**: implemented and covered by repeatable verification commands/tests.
+- **Implemented / unverified**: implementation exists but runtime interoperability is not yet proven across expected environments.
+- **Staged**: roadmap/partial scaffolding; not saleable as generally available.
+
+## Capability table
+
+| Capability | Status | Boundary | Verification path |
+| --- | --- | --- | --- |
+| Tenant-scoped RBAC | Verified | API/Web permissions are tenant-scoped and enforced at request boundaries. | `pnpm run verify:tenant`; `pnpm run test:cross-tenant` |
+| SSO (SAML/OIDC) | Implemented / unverified | Environment and provider configuration surfaces exist, but broad IdP interoperability evidence is incomplete. | Validate `SUPABASE_ENTERPRISE_SSO_*` env + run per-IdP smoke tests before GA claims. |
+| SCIM lifecycle provisioning | Staged | Lifecycle language exists; route-level provisioning/deprovisioning verification is incomplete. | Add route fixture tests and deprovision evidence bundle checks. |
+| Audit export / SIEM handoff | Implemented / unverified | Export surfaces exist; mapping and ingestion behavior are deployment-specific. | `pnpm run verify:security:evidence` + tenant-scoped export contract tests. |
+
+## Claim gating policy
+
+Marketing, pricing, onboarding, and enterprise docs must not promote any capability above this table state.
+If a capability status is changed to **Verified**, the corresponding verification command(s) and test coverage must be updated in the same PR.

--- a/packages/web/src/__tests__/enterprise/capability-truth.test.ts
+++ b/packages/web/src/__tests__/enterprise/capability-truth.test.ts
@@ -1,0 +1,29 @@
+import {
+  ENTERPRISE_CAPABILITY_TRUTH,
+  getCapabilityStateLabel,
+} from "@/lib/enterprise/capabilityTruth";
+
+describe("enterprise capability truth contract", () => {
+  it("contains explicit SSO and SCIM boundaries", () => {
+    const sso = ENTERPRISE_CAPABILITY_TRUTH.find((item) => item.capability === "SSO (SAML/OIDC)");
+    const scim = ENTERPRISE_CAPABILITY_TRUTH.find(
+      (item) => item.capability === "SCIM lifecycle provisioning"
+    );
+
+    expect(sso?.state).toBe("implemented_unverified");
+    expect(scim?.state).toBe("staged");
+  });
+
+  it("keeps verification paths non-empty for all listed capabilities", () => {
+    for (const capability of ENTERPRISE_CAPABILITY_TRUTH) {
+      expect(capability.verificationPath.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("maps state to a stable label", () => {
+    expect(getCapabilityStateLabel("verified")).toBe("Verified");
+    expect(getCapabilityStateLabel("implemented_unverified")).toBe("Implemented / unverified");
+    expect(getCapabilityStateLabel("staged")).toBe("Staged");
+    expect(getCapabilityStateLabel("missing")).toBe("Missing");
+  });
+});

--- a/packages/web/src/app/enterprise/layout.tsx
+++ b/packages/web/src/app/enterprise/layout.tsx
@@ -5,7 +5,7 @@ import { generateMetadata } from "@/lib/metadata";
 export const metadata: Metadata = generateMetadata({
   title: "Enterprise Solutions - Custom Reconciliation Platform",
   description:
-    "Enterprise-grade reconciliation with SOC 2 Type II, SSO, SAML, RBAC, unlimited scale, dedicated support, and on-premise deployment options. Custom solutions for large organizations.",
+    "Enterprise reconciliation for tenant isolation, deterministic evidence, and governed operations. Identity and lifecycle capabilities are explicitly status-scoped (implemented vs staged).",
   keywords: [
     "enterprise reconciliation",
     "enterprise API",

--- a/packages/web/src/app/enterprise/page.tsx
+++ b/packages/web/src/app/enterprise/page.tsx
@@ -12,6 +12,7 @@ import {
   IsolationVaultVisual,
   VisualGrid,
 } from "@/components/site/infographics";
+import { CapabilityTruthTable } from "@/components/enterprise/CapabilityTruthTable";
 import {
   Shield,
   Lock,
@@ -235,6 +236,10 @@ export default function EnterprisePage() {
 
       <Section className="bg-muted/10">
         <VisualGrid />
+      </Section>
+
+      <Section className="py-20" containerClassName="max-w-6xl">
+        <CapabilityTruthTable />
       </Section>
 
       <Section className="py-24" containerClassName="max-w-4xl text-center">

--- a/packages/web/src/app/pricing/page.tsx
+++ b/packages/web/src/app/pricing/page.tsx
@@ -179,8 +179,9 @@ export default function PricingPage() {
                 Is the Enterprise plan available on-prem?
               </h3>
               <p className="text-sm leading-relaxed text-muted-foreground">
-                Yes. For highly regulated industries, we provide a containerized version of the
-                Settler stack for air-gapped or VPC deployments.
+                Enterprise deployment options are engagement-scoped. VPC and on-prem availability
+                depend on architecture review, support model, and verified identity/export controls
+                in your environment.
               </p>
             </div>
           </div>

--- a/packages/web/src/app/security-and-audit/page.tsx
+++ b/packages/web/src/app/security-and-audit/page.tsx
@@ -73,7 +73,7 @@ const securityPillars = [
     items: [
       "Owner / Admin / Reviewer / Viewer roles",
       "Workspace-scoped API keys",
-      "SSO / OAuth via standard providers",
+      "SSO/OIDC capability is configuration-gated and verified per deployment",
     ],
   },
   {

--- a/packages/web/src/components/FeatureComparison.tsx
+++ b/packages/web/src/components/FeatureComparison.tsx
@@ -46,8 +46,8 @@ const features: Feature[] = [
     name: "SSO / policy controls",
     oss: false,
     cloud: false,
-    managed: "Optional",
-    enterprise: true,
+    managed: "Config-gated",
+    enterprise: "Implemented / staged by capability",
   },
   { name: "Audit export support", oss: false, cloud: true, managed: true, enterprise: true },
   {

--- a/packages/web/src/components/enterprise/CapabilityTruthTable.tsx
+++ b/packages/web/src/components/enterprise/CapabilityTruthTable.tsx
@@ -1,0 +1,51 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  ENTERPRISE_CAPABILITY_TRUTH,
+  getCapabilityStateBadgeClass,
+  getCapabilityStateLabel,
+} from "@/lib/enterprise/capabilityTruth";
+
+export function CapabilityTruthTable() {
+  return (
+    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+      <h3 className="text-xl font-semibold text-foreground">Implemented vs staged enterprise truth</h3>
+      <p className="mt-2 text-sm text-muted-foreground">
+        This table is contract-first: claims stay narrow until verification evidence exists.
+      </p>
+      <div className="mt-6 overflow-x-auto" role="region" aria-label="Enterprise capability truth">
+        <table className="w-full min-w-[760px] text-sm">
+          <thead>
+            <tr className="border-b border-border text-left">
+              <th className="py-3 pr-4 font-semibold">Capability</th>
+              <th className="py-3 pr-4 font-semibold">State</th>
+              <th className="py-3 pr-4 font-semibold">Boundary</th>
+              <th className="py-3 font-semibold">Verification path</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ENTERPRISE_CAPABILITY_TRUTH.map((row) => (
+              <tr key={row.capability} className="border-b border-border/70 align-top last:border-0">
+                <td className="py-4 pr-4 font-medium text-foreground">{row.capability}</td>
+                <td className="py-4 pr-4">
+                  <Badge variant="outline" className={getCapabilityStateBadgeClass(row.state)}>
+                    {getCapabilityStateLabel(row.state)}
+                  </Badge>
+                </td>
+                <td className="py-4 pr-4 text-muted-foreground">{row.operatorBoundary}</td>
+                <td className="py-4 text-muted-foreground">
+                  <ul className="list-disc pl-5 space-y-1">
+                    {row.verificationPath.map((item) => (
+                      <li key={item} className="font-mono text-xs sm:text-sm">
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/stitch-import/SecurityOverview.tsx
+++ b/packages/web/src/components/stitch-import/SecurityOverview.tsx
@@ -35,7 +35,7 @@ const pillars = [
   },
 ];
 
-const certifications = ["SOC 2 Type II", "GDPR", "HIPAA", "ISO 27001"];
+const certifications = ["SOC 2 alignment (audit pending)", "GDPR support", "HIPAA-mapped controls"];
 
 const technicalDetails = [
   {
@@ -46,7 +46,7 @@ const technicalDetails = [
   {
     icon: BadgeCheck,
     title: "Access Control & SSO",
-    body: "Role-based access control (RBAC) with granular permissions. SAML 2.0 and OIDC supported for Single Sign-On.",
+    body: "Role-based access control (RBAC) is implemented. SSO/SAML/OIDC is environment and IdP dependent and must be validated before production rollout.",
   },
   {
     icon: AlertTriangle,

--- a/packages/web/src/lib/enterprise/capabilityTruth.ts
+++ b/packages/web/src/lib/enterprise/capabilityTruth.ts
@@ -1,0 +1,78 @@
+export type CapabilityState = "verified" | "implemented_unverified" | "staged" | "missing";
+
+export interface EnterpriseCapabilityTruth {
+  capability: string;
+  state: CapabilityState;
+  customerLabel: string;
+  operatorBoundary: string;
+  verificationPath: readonly string[];
+}
+
+/**
+ * Canonical enterprise capability truth map.
+ *
+ * Purpose: keep pricing/enterprise/security pages aligned with runtime evidence.
+ */
+export const ENTERPRISE_CAPABILITY_TRUTH: readonly EnterpriseCapabilityTruth[] = [
+  {
+    capability: "Tenant-scoped RBAC",
+    state: "verified",
+    customerLabel: "Available",
+    operatorBoundary: "Role + tenant-scoped authorization is active in API/web paths.",
+    verificationPath: ["pnpm run verify:tenant", "pnpm run test:cross-tenant"],
+  },
+  {
+    capability: "SSO (SAML/OIDC)",
+    state: "implemented_unverified",
+    customerLabel: "Config-gated",
+    operatorBoundary:
+      "Configuration flags exist, but general IdP interoperability is not marked GA without per-IdP evidence.",
+    verificationPath: ["SUPABASE_ENTERPRISE_SSO_* env contract", "IdP-specific smoke tests (required before GA claim)"],
+  },
+  {
+    capability: "SCIM lifecycle provisioning",
+    state: "staged",
+    customerLabel: "Staged",
+    operatorBoundary:
+      "Enterprise lifecycle is documented, but route-level provisioning verification is not yet complete.",
+    verificationPath: ["Route + fixture lifecycle tests (pending)", "Deprovisioning evidence bundle (pending)"],
+  },
+  {
+    capability: "Audit export / SIEM handoff",
+    state: "implemented_unverified",
+    customerLabel: "Available with validation scope",
+    operatorBoundary:
+      "Export routes exist; downstream SIEM mappings vary by deployment and require buyer validation.",
+    verificationPath: ["pnpm run verify:security:evidence", "tenant-scoped export contract tests"],
+  },
+];
+
+export function getCapabilityStateBadgeClass(state: CapabilityState): string {
+  switch (state) {
+    case "verified":
+      return "bg-emerald-500/10 text-emerald-700 border-emerald-600/30";
+    case "implemented_unverified":
+      return "bg-amber-500/10 text-amber-700 border-amber-600/30";
+    case "staged":
+      return "bg-slate-500/10 text-slate-700 border-slate-500/30";
+    case "missing":
+      return "bg-rose-500/10 text-rose-700 border-rose-500/30";
+    default:
+      return "bg-muted text-muted-foreground border-border";
+  }
+}
+
+export function getCapabilityStateLabel(state: CapabilityState): string {
+  switch (state) {
+    case "verified":
+      return "Verified";
+    case "implemented_unverified":
+      return "Implemented / unverified";
+    case "staged":
+      return "Staged";
+    case "missing":
+      return "Missing";
+    default:
+      return "Unknown";
+  }
+}

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -30,8 +30,11 @@ copyIfMissing(".env.local.example", ".env.local");
 
 run("pnpm", ["install"], "Install dependencies");
 run("pnpm", ["run", "repo-integrity"], "Validate monorepo contract");
+run("pnpm", ["run", "verify:setup"], "Check local prerequisites and degraded-state blockers");
 run("pnpm", ["run", "doctor", "--", "--skip-pipeline", "--first-run"], "Run first-run doctor");
 
 console.log("\n✅ Bootstrap completed. Next commands:");
 console.log("   pnpm run demo     # guided deterministic demo");
 console.log("   pnpm run dev:stack # web + api local stack");
+console.log("   pnpm run dev:teardown # stop local processes started by dev:stack");
+console.log("   pnpm run demo:reset # clear demo fixtures before next eval pass");


### PR DESCRIPTION
### Motivation
- Reduce adoption friction and procurement risk by narrowing enterprise identity/export claims to explicit, verifiable states (avoid overstated GA claims). 
- Make public product surfaces (marketing/pricing/security) reflect runtime evidence so buyers and evaluators see implemented vs staged features. 
- Improve local-first evaluation determinism by surfacing setup/preflight verification and teardown guidance in the bootstrap flow.

### Description
- Add a canonical enterprise capability truth model and helpers in `packages/web/src/lib/enterprise/capabilityTruth.ts` that expose `verified | implemented_unverified | staged | missing` states. 
- Add a UI component `CapabilityTruthTable` in `packages/web/src/components/enterprise/CapabilityTruthTable.tsx` and mount it on the enterprise page so claim state is rendered to customers. 
- Narrowed marketing/security/pricing copy to reflect status-scoped claims in `packages/web/src/app/enterprise/layout.tsx`, `packages/web/src/app/enterprise/page.tsx`, `packages/web/src/app/pricing/page.tsx`, `packages/web/src/app/security-and-audit/page.tsx`, and `packages/web/src/components/FeatureComparison.tsx`. 
- Strengthen local bootstrap by adding a `verify:setup` step and extra teardown/reset hints in `scripts/bootstrap.mjs`. 
- Add a public-facing reality document `docs/reality/enterprise-capability-truth.md` and update the adoption closure matrix `docs/reality/adoption-closure-matrix-2026-04-06.md` to reflect the truth-gated state. 
- Add a focused web unit test `packages/web/src/__tests__/enterprise/capability-truth.test.ts` that asserts the SSO/SCIM state boundaries and non-empty verification paths.

### Testing
- Added unit test `packages/web/src/__tests__/enterprise/capability-truth.test.ts` (present in the PR) that verifies capability states and verification-path non-emptiness. 
- Attempted to run package and repo verification commands including `pnpm --filter @settler/web test src/__tests__/enterprise/capability-truth.test.ts`, `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, and security/tenant verification scripts, but all were blocked by the environment Node version mismatch (repo requires `node >=24 <25`, current environment is `v22.21.1`), so test execution is environment-blocked (⚠️). 
- Commit created with the changes; CI should run full verification in a Node 24.x environment where the new test and verification commands will execute.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d310902b808328b4d8a985389f63b5)