### PR TITLE
feat: close highest-leverage adoption blockers across developer, pilot, and enterprise paths

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,97 @@
+name: SBOM Generation
+
+# Generates a Software Bill of Materials (SBOM) in CycloneDX format.
+# Runs on every release tag and weekly, producing a machine-readable
+# inventory of all dependencies for enterprise procurement and supply
+# chain security review.
+
+on:
+  push:
+    tags:
+      - "v*"
+  schedule:
+    - cron: "0 6 * * 1" # Weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install CycloneDX generator
+        run: npm install -g @cyclonedx/cyclonedx-npm
+
+      - name: Generate SBOM (CycloneDX JSON)
+        run: |
+          cyclonedx-npm --output-file sbom.cdx.json --output-format json --package-lock-only
+          echo "SBOM generated: sbom.cdx.json"
+          echo "Components: $(node -e "const s=require('./sbom.cdx.json');console.log(s.components?.length??0)")"
+
+      - name: Generate SBOM metadata summary
+        run: |
+          node -e "
+            const sbom = require('./sbom.cdx.json');
+            const summary = {
+              generated: new Date().toISOString(),
+              commit: process.env.GITHUB_SHA,
+              ref: process.env.GITHUB_REF_NAME,
+              format: 'CycloneDX',
+              specVersion: sbom.specVersion,
+              totalComponents: sbom.components?.length ?? 0,
+              componentTypes: {},
+            };
+            for (const c of sbom.components ?? []) {
+              summary.componentTypes[c.type] = (summary.componentTypes[c.type] ?? 0) + 1;
+            }
+            require('fs').writeFileSync('sbom-summary.json', JSON.stringify(summary, null, 2));
+            console.log(JSON.stringify(summary, null, 2));
+          "
+
+      - name: Attest SBOM provenance
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ github.sha }}
+          path: |
+            sbom.cdx.json
+            sbom-summary.json
+          retention-days: 365
+          if-no-files-found: error
+
+      - name: Report
+        run: |
+          echo ""
+          echo "========================================"
+          echo "  SBOM GENERATION COMPLETE"
+          echo "========================================"
+          echo "  Commit:     ${GITHUB_SHA}"
+          echo "  Ref:        ${GITHUB_REF_NAME}"
+          echo "  Format:     CycloneDX JSON"
+          echo "  Components: $(node -e "console.log(require('./sbom.cdx.json').components?.length??0)")"
+          echo "========================================"

--- a/README.md
+++ b/README.md
@@ -68,14 +68,24 @@ Global helper scripts are available for managing the local TigerBeetle container
 
 ## Documentation Hub
 
-- [What Works Today](docs/getting-started/WHAT_WORKS.md) — Core functional workflows
+**Getting started:**
 - [Quickstart](docs/getting-started/quickstart.md) — Fastest path to running locally
+- [Canonical Local Setup](SETUP.md) — Full local development setup
 - [Demo Walkthrough](docs/getting-started/DEMO_WALKTHROUGH.md) — Step-by-step demo guide
-- [Verification Commands](docs/VERIFICATION_COMMANDS.md) — All verification commands
-- [Common Setup Traps](docs/troubleshooting/SETUP_TRAPS.md) — Avoid setup issues
+- [Starter Kits](examples/starter-kits/) — Runnable example projects
+- [What Works Today](docs/getting-started/WHAT_WORKS.md) — Core functional workflows
 - [Intentional Boundaries](docs/getting-started/INTENTIONAL_BOUNDARIES.md) — What's not production-ready
+- [Common Setup Traps](docs/troubleshooting/SETUP_TRAPS.md) — Avoid setup issues
+
+**Evaluation and pilot:**
+- [Pilot Runbook](docs/pilot-runbook.md) — Run a pilot with go/no-go scorecard
+- [Trust Packet](docs/trust-packet.md) — Security, privacy, and procurement info
+- [Teardown Guide](docs/getting-started/teardown.md) — Clean removal and offboarding
+
+**Reference:**
 - [Architecture (Canonical)](docs/architecture/platform-architecture.md)
-- [Canonical Local Setup](SETUP.md)
+- [API Reference](docs/API_REFERENCE.md)
+- [Verification Commands](docs/VERIFICATION_COMMANDS.md) — All verification commands
 - [Security Policy](SECURITY.md)
 
 ## Contributing

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -92,3 +92,6 @@ pnpm check
 - **Architecture Overview:** [`docs/architecture/platform-architecture.md`](../architecture/platform-architecture.md)
 - **Using the CLI:** [`packages/cli/README.md`](../../packages/cli/README.md)
 - **API Reference:** [`docs/api/README.md`](../api/README.md)
+- **Starter Kits:** [`examples/starter-kits/`](../../examples/starter-kits/) - Runnable example projects
+- **Pilot Runbook:** [`docs/pilot-runbook.md`](../pilot-runbook.md) - Run a pilot with go/no-go scorecard
+- **Teardown Guide:** [`teardown.md`](./teardown.md) - Clean removal and offboarding

--- a/docs/getting-started/teardown.md
+++ b/docs/getting-started/teardown.md
@@ -1,0 +1,205 @@
+# Teardown, Cleanup & Offboarding
+
+How to cleanly remove Settler from your environment. This covers local development, pilot, and production teardown.
+
+## Local Development Teardown
+
+### Stop services
+
+```bash
+# Stop development servers
+# (Ctrl+C if running pnpm dev)
+
+# Stop infrastructure containers (TigerBeetle, PostgreSQL, Redis)
+docker compose -f packages/api/docker-compose.yml down
+
+# Or, if you only started TigerBeetle:
+pnpm tb:stop
+```
+
+### Remove local data
+
+```bash
+# Remove Docker volumes (deletes all local database data)
+docker compose -f packages/api/docker-compose.yml down -v
+
+# Remove demo data files
+rm -rf demo/data/
+
+# Remove generated artifacts
+rm -rf examples/demo-output/
+```
+
+### Remove local environment
+
+```bash
+# Remove node_modules and build artifacts
+pnpm run clean
+rm -rf node_modules/
+
+# Remove local environment files (contains secrets)
+rm .env.local
+
+# Optionally remove the entire repository
+cd .. && rm -rf settler/
+```
+
+## Pilot / Sandbox Teardown
+
+### 1. Export your data first
+
+Before deleting anything, export all reconciliation data for your records:
+
+```bash
+# Via CLI
+settler export --tenant <tenant-id> --format csv --output ./settler-export/
+
+# Via API
+curl -X POST https://api.settler.dev/api/v1/exports \
+  -H "X-API-Key: $SETTLER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"format": "csv", "includeEvidence": true}'
+```
+
+### 2. Revoke API keys
+
+Revoke all API keys associated with the pilot to prevent further API calls:
+
+```bash
+# Via the console: Settings → API Keys → Revoke
+# Via API:
+curl -X DELETE https://api.settler.dev/api/v1/console/api-keys/<key-id> \
+  -H "X-API-Key: $SETTLER_API_KEY"
+```
+
+### 3. Remove webhooks
+
+Deregister all webhook endpoints to stop event delivery:
+
+```bash
+# List webhooks
+curl https://api.settler.dev/api/v1/webhooks \
+  -H "X-API-Key: $SETTLER_API_KEY"
+
+# Delete each webhook
+curl -X DELETE https://api.settler.dev/api/v1/webhooks/<webhook-id> \
+  -H "X-API-Key: $SETTLER_API_KEY"
+```
+
+### 4. Remove scheduled jobs
+
+Cancel any scheduled reconciliation jobs:
+
+```bash
+# List jobs
+settler jobs list --tenant <tenant-id>
+
+# Delete each scheduled job
+settler jobs delete <job-id>
+```
+
+### 5. Request data deletion
+
+For hosted/managed accounts, request full data deletion:
+
+- Email: support@settler.io
+- Subject: "Data deletion request — [Tenant Name]"
+- Include your tenant ID and confirm you have exported any data you need
+
+Settler will confirm deletion within 5 business days per the [Data Portability](../../DATA_PORTABILITY.md) policy.
+
+## Production Teardown
+
+### Pre-teardown checklist
+
+- [ ] All reconciliation data has been exported
+- [ ] Downstream systems no longer depend on Settler webhooks
+- [ ] API keys have been removed from CI/CD secrets and environment variables
+- [ ] Scheduled jobs have been cancelled
+- [ ] Team members have been notified
+
+### 1. Drain active work
+
+```bash
+# Pause all scheduled jobs (prevents new runs)
+settler jobs pause --all --tenant <tenant-id>
+
+# Wait for in-flight reconciliation runs to complete
+settler jobs list --status running --tenant <tenant-id>
+```
+
+### 2. Export everything
+
+```bash
+# Full tenant data export (reconciliation runs, exceptions, audit logs, evidence)
+settler export --tenant <tenant-id> \
+  --format csv \
+  --include-audit-logs \
+  --include-evidence \
+  --output ./settler-full-export/
+```
+
+### 3. Revoke all credentials
+
+- Revoke all API keys in the console
+- Remove `SETTLER_API_KEY` from all environment variables, secret managers, and CI/CD pipelines
+- Remove webhook endpoints
+- If using SSO/OIDC: remove the Settler application from your identity provider
+
+### 4. Remove infrastructure (self-hosted only)
+
+```bash
+# Stop and remove containers
+docker compose -f enterprise/docker-compose.yml down -v
+
+# Remove Settler-specific database
+# WARNING: This is irreversible
+psql -h <host> -U <user> -c "DROP DATABASE settler;"
+
+# Remove TigerBeetle data directory
+rm -rf /var/lib/tigerbeetle/
+```
+
+### 5. Request account closure
+
+For managed accounts, email support@settler.io with:
+
+- Tenant ID
+- Confirmation that all data has been exported
+- Preferred deletion timeline
+
+## What gets deleted
+
+| Data                      | Local teardown       | Managed account closure |
+| ------------------------- | -------------------- | ----------------------- |
+| Reconciliation runs       | Docker volume removal | Deleted within 5 days   |
+| Exception records         | Docker volume removal | Deleted within 5 days   |
+| Audit logs                | Docker volume removal | Retained 90 days (regulatory), then deleted |
+| Evidence / proofpacks     | Docker volume removal | Deleted within 5 days   |
+| API keys                  | Immediate             | Immediate               |
+| Webhook registrations     | Immediate             | Immediate               |
+| Billing data              | N/A                   | Retained per legal requirements |
+
+## Verify cleanup
+
+After teardown, verify that Settler is fully removed:
+
+```bash
+# Confirm API keys no longer work
+curl -I https://api.settler.dev/api/v1/health \
+  -H "X-API-Key: $SETTLER_API_KEY"
+# Expected: 401 Unauthorized
+
+# Confirm no Docker containers running
+docker ps --filter "name=settler" --filter "name=tigerbeetle"
+# Expected: empty
+
+# Confirm no environment references remain
+grep -r "SETTLER_API_KEY" ~/.bashrc ~/.zshrc .env* || echo "Clean"
+```
+
+## Related
+
+- [Data Portability](../../DATA_PORTABILITY.md)
+- [Privacy Policy](../../PRIVACY.md)
+- [Support](../../SUPPORT.md)

--- a/docs/pilot-runbook.md
+++ b/docs/pilot-runbook.md
@@ -1,0 +1,204 @@
+# Pilot Runbook
+
+Operational guide for running a Settler pilot. Covers setup, success criteria, weekly checkpoints, go/no-go decision, and rollback.
+
+## Pilot overview
+
+A typical Settler pilot runs 2–4 weeks with a single reconciliation use case (e.g., Stripe payments vs. bank deposits). The goal is to validate three things:
+
+1. **Technical fit** — Can Settler match your real transaction data accurately?
+2. **Operational fit** — Does the exception workflow integrate with your team's process?
+3. **Trust fit** — Are audit trails, evidence, and tenant isolation sufficient for your compliance requirements?
+
+## Pre-pilot checklist
+
+| Step | Owner | Status |
+|------|-------|--------|
+| Settler account or local instance provisioned | Engineering | [ ] |
+| API key generated and stored in secret manager | Engineering | [ ] |
+| Source adapter configured (e.g., Stripe) | Engineering | [ ] |
+| Target adapter configured (e.g., bank/ledger) | Engineering | [ ] |
+| First reconciliation job created and tested | Engineering | [ ] |
+| Webhook endpoint registered (if using events) | Engineering | [ ] |
+| Pilot success criteria agreed with stakeholders | Eng Lead / Finance | [ ] |
+| Pilot timeline communicated to team | Eng Lead | [ ] |
+
+## Week-by-week guide
+
+### Week 1: Setup and first run
+
+**Goals:** Working integration, first successful reconciliation, team access.
+
+```bash
+# Quick setup path
+git clone https://github.com/settler/settler.git
+cd settler
+pnpm run bootstrap
+pnpm tb:start
+pnpm dev
+pnpm demo:seed   # Load demo data for evaluation
+```
+
+**Or use the hosted API:**
+
+```bash
+# Install the starter kit
+cd examples/starter-kits/settler-recon-starter
+npm install
+cp .env.example .env
+# Set SETTLER_API_KEY
+npm start
+```
+
+**Week 1 checkpoint:**
+- [ ] First reconciliation run completed
+- [ ] Match/unmatch results reviewed
+- [ ] At least one exception reviewed in the console
+- [ ] Team members have console access
+
+### Week 2: Real data integration
+
+**Goals:** Connect real data sources, run against production-like volume.
+
+- Replace demo adapters with your real Stripe/bank credentials
+- Run reconciliation against a representative data window (e.g., last 30 days)
+- Set up scheduled runs if applicable
+- Configure webhook notifications for your team's Slack/PagerDuty
+
+**Week 2 checkpoint:**
+- [ ] Real data sources connected
+- [ ] Reconciliation accuracy measured on real data
+- [ ] Exception volume is manageable (< 5% of transactions ideally)
+- [ ] No data quality issues blocking progress
+
+### Week 3: Operational validation
+
+**Goals:** Test the full operational loop — exceptions, evidence, audit.
+
+- Assign exception review to a finance team member
+- Generate a proofpack for one completed reconciliation
+- Review audit logs for compliance
+- Test the export pipeline (CSV/JSON)
+
+**Week 3 checkpoint:**
+- [ ] Exception workflow tested by a non-engineer
+- [ ] Proofpack generated and reviewed
+- [ ] Audit log export completed
+- [ ] No blocking operational issues
+
+### Week 4: Evaluation and decision
+
+**Goals:** Collect metrics, evaluate against success criteria, make go/no-go call.
+
+## Success criteria scorecard
+
+Score each criterion. **Go = all critical met + majority of important met.**
+
+### Critical (must pass)
+
+| Criterion | Target | Actual | Pass? |
+|-----------|--------|--------|-------|
+| Reconciliation accuracy | ≥ 95% | | [ ] |
+| No data leakage across tenants | 0 incidents | | [ ] |
+| API available during pilot | ≥ 99% | | [ ] |
+| First reconciliation in < 1 day | Yes/No | | [ ] |
+| Data export works | Yes/No | | [ ] |
+
+### Important (should pass)
+
+| Criterion | Target | Actual | Pass? |
+|-----------|--------|--------|-------|
+| Exception resolution time | < 4 hours avg | | [ ] |
+| Team can use console without training | Yes/No | | [ ] |
+| Audit log meets compliance needs | Yes/No | | [ ] |
+| Webhook delivery reliable | ≥ 99% | | [ ] |
+| Time saved vs. manual process | ≥ 50% | | [ ] |
+
+### Nice to have
+
+| Criterion | Target | Actual | Pass? |
+|-----------|--------|--------|-------|
+| Scheduled runs working | Yes/No | | [ ] |
+| Multi-currency support | If needed | | [ ] |
+| Custom adapter built | If needed | | [ ] |
+
+## Go/No-Go decision
+
+### Go
+
+All critical criteria met. Proceed to:
+1. Production deployment plan
+2. Contract/pricing discussion
+3. SSO/identity integration (if enterprise)
+4. Full team rollout
+
+### Conditional Go
+
+Critical criteria met, but important gaps remain. Proceed with:
+1. Documented workarounds for gaps
+2. Timeline for gap resolution
+3. Limited rollout scope
+
+### No-Go
+
+Critical criteria not met. Actions:
+1. Document specific failures and root causes
+2. Determine if failures are addressable (config issues vs. fundamental limitations)
+3. Schedule follow-up evaluation in 4–8 weeks if addressable
+4. Execute rollback plan (below)
+
+## Rollback plan
+
+If the pilot is unsuccessful or needs to be unwound:
+
+### 1. Revert to previous process
+
+- Re-enable manual reconciliation workflow
+- Restore any processes that were paused during the pilot
+
+### 2. Export pilot data
+
+```bash
+# Export all reconciliation data from the pilot
+settler export --tenant <tenant-id> --format csv --output ./pilot-export/
+```
+
+### 3. Clean up Settler resources
+
+Follow the [Teardown Guide](getting-started/teardown.md):
+
+- Revoke API keys
+- Remove webhooks
+- Cancel scheduled jobs
+- Remove environment variables from CI/CD
+
+### 4. Document lessons learned
+
+Even for a no-go, document:
+- What worked well
+- What didn't work
+- Specific blockers and whether they're addressable
+- Recommendation for re-evaluation timeline
+
+## Pilot-to-production checklist
+
+When the pilot succeeds, before going to production:
+
+- [ ] Production environment provisioned (or managed account upgraded)
+- [ ] SSO/OIDC configured (if enterprise)
+- [ ] RBAC roles assigned for team members
+- [ ] Production API keys generated and stored in secret manager
+- [ ] Webhook endpoints updated to production URLs
+- [ ] Scheduled reconciliation jobs configured
+- [ ] Alerting configured (webhook → PagerDuty/Slack)
+- [ ] Data retention policy confirmed
+- [ ] Security review completed (see [Trust Packet](trust-packet.md))
+- [ ] Billing/subscription confirmed
+
+## Related
+
+- [Quickstart](getting-started/quickstart.md)
+- [Teardown Guide](getting-started/teardown.md)
+- [Trust Packet](trust-packet.md)
+- [What Works Today](getting-started/WHAT_WORKS.md)
+- [Intentional Boundaries](getting-started/INTENTIONAL_BOUNDARIES.md)

--- a/docs/trust-packet.md
+++ b/docs/trust-packet.md
@@ -1,0 +1,175 @@
+# Trust Packet
+
+This document provides the information typically required for enterprise security review and procurement. It describes what Settler does and does not do, with references to verifiable evidence in this repository.
+
+## Product summary
+
+Settler is a deterministic reconciliation platform. It matches financial transactions across data sources (e.g., payment processor vs. bank ledger) and produces audit-grade evidence for every decision.
+
+**Settler processes:** Transaction metadata, amounts, dates, identifiers, reconciliation results, exception records, audit logs.
+
+**Settler does not process:** Raw payment credentials, PII beyond what exists in transaction metadata, or any data outside the reconciliation domain.
+
+## Architecture overview
+
+| Component | Technology | Purpose |
+|-----------|-----------|---------|
+| Control Plane API | Node.js / Express / TypeScript | Orchestration, routing, tenant management |
+| Console | Next.js | Operator dashboard |
+| Primary Database | PostgreSQL (Supabase) | Projections, metadata, audit logs, tenant config |
+| Ledger | TigerBeetle | Immutable financial-grade transaction ledger |
+| Cache / Queue | Redis | Job queue, caching (optional for basic operation) |
+| CLI | TypeScript | Operator tooling, verification, test data generation |
+
+See: [`docs/architecture/platform-architecture.md`](architecture/platform-architecture.md)
+
+## Tenant isolation
+
+Settler is multi-tenant by design. Tenant isolation is enforced at multiple layers:
+
+1. **Database (Row-Level Security):** All PostgreSQL tables with tenant data have RLS policies. Every query is scoped by `tenant_id`.
+2. **API middleware:** Every authenticated request is bound to a tenant. Cross-tenant access is mechanically prevented.
+3. **Ledger isolation:** TigerBeetle accounts are partitioned by tenant.
+
+**Verification evidence:**
+- RLS policies: [`supabase/migrations/`](../supabase/migrations/) (search for `CREATE POLICY`)
+- Tenant middleware: [`packages/api/src/middleware/`](../packages/api/src/middleware/)
+- Security invariants: [`SECURITY_INVARIANTS.md`](../SECURITY_INVARIANTS.md)
+- Cross-tenant test suite: `pnpm test:cross-tenant`
+
+## Authentication and authorization
+
+| Method | Use case | Implementation |
+|--------|----------|----------------|
+| API Key (`X-API-Key` header) | Server-to-server, SDK, CI/CD | Scoped to tenant, revocable |
+| JWT Bearer token | Console sessions, user auth | Supabase Auth, short-lived tokens |
+| Webhook signatures | Event verification | HMAC-SHA256, timestamp validation |
+
+SSO (SAML/OIDC) support is available for enterprise deployments.
+
+## Audit logging
+
+Every significant operation produces an audit log entry:
+
+- Reconciliation runs (start, complete, fail)
+- Exception state transitions (created, investigating, resolved, ignored)
+- API key lifecycle (created, revoked)
+- Data exports
+- Configuration changes
+
+Audit logs include: timestamp, actor ID, tenant ID, action, resource, and metadata.
+
+**Verification evidence:**
+- Audit log schema: [`prisma/schema.prisma`](../prisma/schema.prisma) (search for `AuditLog`)
+- Audit log service: [`packages/api/src/services/`](../packages/api/src/services/)
+
+## Data handling
+
+### Data at rest
+
+- PostgreSQL: Encrypted at rest (Supabase managed infrastructure or self-hosted with disk encryption)
+- TigerBeetle: Data file integrity verified by the engine; encryption at rest via volume-level encryption
+- Application-level encryption for sensitive fields using `ENCRYPTION_KEY`
+
+### Data in transit
+
+- All API traffic over TLS 1.2+
+- Webhook payloads signed with HMAC-SHA256
+- Internal service communication within private network
+
+### Data retention
+
+- Reconciliation data: Retained for the lifetime of the tenant account (configurable)
+- Audit logs: Minimum 90-day retention (configurable, cannot be reduced below 90 days)
+- Deleted data: Purged within 30 days of deletion request
+
+### Data portability
+
+Full data export is available at any time:
+- Via API: `POST /api/v1/exports`
+- Via CLI: `settler export --tenant <id>`
+- Formats: CSV, JSON
+- Includes: Runs, exceptions, evidence, audit logs
+
+See: [`DATA_PORTABILITY.md`](../DATA_PORTABILITY.md)
+
+## Privacy
+
+- Settler is a data processor (not controller) for customer transaction data
+- No transaction data is used for model training or shared across tenants
+- Data Processing Agreement (DPA) available on request
+- GDPR deletion requests handled within 30 days
+- No data sub-processors beyond stated infrastructure providers
+
+See: [`PRIVACY.md`](../PRIVACY.md), [`legal/DPA_TEMPLATE.md`](../legal/DPA_TEMPLATE.md)
+
+## Infrastructure and deployment
+
+### Managed (hosted)
+
+- Hosted on Vercel (application) and Supabase (database)
+- Infrastructure in US and EU regions
+- Automated deployments from `main` branch with CI/CD gates
+
+### Self-hosted
+
+- Docker Compose deployment: [`packages/api/docker-compose.yml`](../packages/api/docker-compose.yml)
+- Enterprise deployment: [`enterprise/docker-compose.yml`](../enterprise/docker-compose.yml)
+- No phone-home telemetry in self-hosted mode
+
+## CI/CD and release integrity
+
+- 70+ CI/CD workflows enforcing quality gates
+- All PRs require: lint, typecheck, build, test suite pass
+- Release provenance workflow: [`.github/workflows/release-provenance.yml`](../.github/workflows/release-provenance.yml)
+- Dependency management via Dependabot: [`.github/dependabot.yml`](../.github/dependabot.yml)
+
+## Vulnerability management
+
+- Security policy: [`SECURITY.md`](../SECURITY.md)
+- Responsible disclosure via security@settler.io
+- Dependency scanning via Dependabot and automated security workflows
+- Security-focused CI workflows: [`.github/workflows/security.yml`](../.github/workflows/security.yml)
+
+## Open source components
+
+Settler uses a dual licensing model:
+
+- **Core protocol** (`@settler/protocol`): MIT licensed — [LICENSE](../packages/protocol/LICENSE)
+- **Platform** (API, Console, CLI): Proprietary — [LICENSE](../LICENSE)
+- **React components** (`@settler/react-settler`): Dual licensed
+
+Full dependency tree available via `pnpm ls --depth=0` or the SBOM generation workflow.
+
+## Compliance readiness
+
+| Framework | Status | Evidence |
+|-----------|--------|----------|
+| SOC 2 Type II | In preparation | [`docs/compliance/SOC2_PREPARATION.md`](compliance/SOC2_PREPARATION.md) |
+| GDPR | Operational controls in place | [`PRIVACY.md`](../PRIVACY.md), DPA template |
+| Audit trail | Implemented | Audit log system, evidence generation |
+| Data portability | Implemented | Export API, CLI, [`DATA_PORTABILITY.md`](../DATA_PORTABILITY.md) |
+
+## Procurement FAQ
+
+**Q: Can we get a security questionnaire response?**
+A: Yes. Contact sales@settler.io or your account manager. We maintain a pre-filled SIG Lite / CAIQ response pack.
+
+**Q: Do you have a DPA?**
+A: Yes. A template is available at [`legal/DPA_TEMPLATE.md`](../legal/DPA_TEMPLATE.md). Custom DPAs are available for enterprise agreements.
+
+**Q: Can we run Settler in our own infrastructure?**
+A: Yes. Self-hosted deployment is supported via Docker Compose. Enterprise deployment support is available.
+
+**Q: What happens to our data if we stop using Settler?**
+A: You can export all data at any time. After account closure, data is deleted within 30 days. See the [Teardown Guide](getting-started/teardown.md).
+
+**Q: Do you have SOC 2?**
+A: SOC 2 Type II certification is in preparation. Current security controls are documented in [`SECURITY.md`](../SECURITY.md) and [`SECURITY_INVARIANTS.md`](../SECURITY_INVARIANTS.md). The security architecture is described in [`docs/SECURITY_ARCHITECTURE.md`](SECURITY_ARCHITECTURE.md).
+
+## Contact
+
+- Security issues: security@settler.io
+- Procurement questions: sales@settler.io
+- Technical support: support@settler.io
+- General: [SUPPORT.md](../SUPPORT.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -507,10 +507,19 @@ function verifyWebhook(payload: string, signature: string, secret: string): bool
 
 ---
 
-## Contributing
+## Starter Kits
 
-Have a use case that's not covered? Submit a PR with your example!
+Runnable, self-contained projects you can clone and use immediately:
+
+| Kit | Description | Command |
+|-----|-------------|---------|
+| [settler-recon-starter](starter-kits/settler-recon-starter/) | End-to-end reconciliation (Stripe → ledger) | `cd starter-kits/settler-recon-starter && npm install && npm start` |
+| [settler-workflow-starter](starter-kits/settler-workflow-starter/) | Webhook-driven pipeline (reconcile → export) | `cd starter-kits/settler-workflow-starter && npm install && npm start` |
+
+Each kit includes `package.json`, TypeScript source, `.env.example`, and a README with instructions.
 
 ---
 
-**Last Updated:** 2026-01-15
+## Contributing
+
+Have a use case that's not covered? Submit a PR with your example!

--- a/examples/starter-kits/settler-recon-starter/.env.example
+++ b/examples/starter-kits/settler-recon-starter/.env.example
@@ -1,0 +1,5 @@
+# Get your API key from the Settler console: Settings → API Keys
+SETTLER_API_KEY=sk_test_your_api_key_here
+
+# Optional: point to a self-hosted instance instead of https://api.settler.dev
+# SETTLER_BASE_URL=http://localhost:4000

--- a/examples/starter-kits/settler-recon-starter/README.md
+++ b/examples/starter-kits/settler-recon-starter/README.md
@@ -1,81 +1,65 @@
 # Settler Recon Starter
 
-Quickstart template for building reconciliation workflows with Settler.dev.
+Runnable quickstart for reconciling payment transactions with Settler.
 
-## Getting Started
+## What this does
 
-1. **Install dependencies:**
-   ```bash
-   npm install
-   ```
+1. Creates a reconciliation job (Stripe payments → internal ledger)
+2. Executes the job and waits for results
+3. Prints a match/unmatch summary
+4. Lists any exceptions that need manual review
 
-2. **Set up your API key:**
-   ```bash
-   export SETTLER_API_KEY=sk_your_api_key
-   ```
+## Prerequisites
 
-3. **Run the example:**
-   ```bash
-   npm start
-   ```
+- Node.js 20+
+- A Settler API key (get one at **Settings → API Keys** in the console, or use a local dev instance)
 
-## Example: Basic Reconciliation
+## Quick start
 
-```javascript
-const { SettlerClient } = require('@settler/sdk');
+```bash
+# 1. Install
+npm install
 
-const client = new SettlerClient({
-  apiKey: process.env.SETTLER_API_KEY,
-});
+# 2. Configure
+cp .env.example .env
+# Edit .env and set SETTLER_API_KEY
 
-async function reconcile() {
-  // Create reconciliation job
-  const job = await client.recon.jobs.create({
-    name: 'Monthly Reconciliation',
-    sourceAdapter: 'stripe',
-    targetAdapter: 'internal_ledger',
-    reconStrategy: 'deterministic',
-  });
-
-  // Execute reconciliation
-  const result = await client.recon.jobs.execute(job.id);
-
-  // View results
-  console.log('Matched:', result.matchedCount);
-  console.log('Unmatched:', result.unmatchedSourceCount);
-}
+# 3. Run
+npm start
 ```
 
-## Example: With Drift Detection
+### Point to a local Settler instance
 
-```javascript
-async function reconcileWithDrift() {
-  const job = await client.recon.jobs.create({
-    name: 'Reconciliation with Drift Detection',
-    sourceAdapter: 'stripe',
-    targetAdapter: 'internal_ledger',
-    reconStrategy: 'deterministic',
-  });
+If you're running Settler locally (`pnpm dev` from the monorepo root):
 
-  const result = await client.recon.jobs.execute(job.id);
-
-  // Check for drift
-  const drifts = await client.drift.list({
-    reconJobId: job.id,
-  });
-
-  if (drifts.length > 0) {
-    console.log('Drift detected:', drifts);
-    // Auto-repair if enabled
-    for (const drift of drifts) {
-      await client.drift.autoRepair(drift.id);
-    }
-  }
-}
+```bash
+SETTLER_BASE_URL=http://localhost:4000 npm start
 ```
 
-## Next Steps
+## Scripts
 
-- [Documentation](https://docs.settler.io)
-- [API Reference](https://docs.settler.io/api-reference)
-- [Examples](https://github.com/settler/examples)
+| Command              | Description                                |
+| -------------------- | ------------------------------------------ |
+| `npm start`          | Run the reconciliation example             |
+| `npm run check-results` | Fetch results for a previous job (set `JOB_ID`) |
+
+## Project structure
+
+```
+settler-recon-starter/
+├── src/
+│   ├── index.ts           # Main reconciliation flow
+│   └── check-results.ts   # Fetch results for a previous job
+├── .env.example           # Environment template
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## Next steps
+
+- Swap `stripe` / `internal_ledger` adapters for your real data sources
+- Add a webhook listener instead of polling for results
+- Set up scheduled reconciliation with `schedule: "0 2 * * *"`
+- Explore the [SDK reference](../../packages/sdk/README.md) for the full API surface
+- See [examples/](../../) for more use cases (multi-currency, exception handling, etc.)

--- a/examples/starter-kits/settler-recon-starter/package.json
+++ b/examples/starter-kits/settler-recon-starter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "settler-recon-starter",
+  "version": "1.0.0",
+  "description": "Quickstart: reconcile Stripe payments against your bank statement with Settler",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "reconcile": "tsx src/index.ts",
+    "check-results": "tsx src/check-results.ts"
+  },
+  "dependencies": {
+    "@settler/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/examples/starter-kits/settler-recon-starter/src/check-results.ts
+++ b/examples/starter-kits/settler-recon-starter/src/check-results.ts
@@ -1,0 +1,35 @@
+/**
+ * Check the results of a previous reconciliation run.
+ *
+ * Usage:
+ *   JOB_ID=job_abc123 npm run check-results
+ */
+
+import SettlerClient from "@settler/sdk";
+
+const apiKey = process.env.SETTLER_API_KEY;
+if (!apiKey) {
+  console.error("Missing SETTLER_API_KEY");
+  process.exit(1);
+}
+
+const jobId = process.env.JOB_ID;
+if (!jobId) {
+  console.error("Missing JOB_ID – set the JOB_ID env var to a reconciliation job ID.");
+  process.exit(1);
+}
+
+const settler = new SettlerClient({
+  apiKey,
+  baseUrl: process.env.SETTLER_BASE_URL || "https://api.settler.dev",
+});
+
+async function main() {
+  const report = await settler.reports.get(jobId!);
+  console.log(JSON.stringify(report.data, null, 2));
+}
+
+main().catch((err) => {
+  console.error("Failed to fetch results:", err.message ?? err);
+  process.exit(1);
+});

--- a/examples/starter-kits/settler-recon-starter/src/index.ts
+++ b/examples/starter-kits/settler-recon-starter/src/index.ts
@@ -1,0 +1,100 @@
+/**
+ * Settler Recon Starter — end-to-end reconciliation example
+ *
+ * This script:
+ *   1. Creates a reconciliation job (Stripe → bank ledger)
+ *   2. Executes the job
+ *   3. Prints match/unmatch summary
+ *   4. Lists any exceptions that need manual review
+ *
+ * Run:
+ *   cp .env.example .env   # fill in your API key
+ *   npm install
+ *   npm start
+ */
+
+import SettlerClient from "@settler/sdk";
+
+const apiKey = process.env.SETTLER_API_KEY;
+if (!apiKey) {
+  console.error("Missing SETTLER_API_KEY – copy .env.example to .env and set your key.");
+  process.exit(1);
+}
+
+const settler = new SettlerClient({
+  apiKey,
+  baseUrl: process.env.SETTLER_BASE_URL || "https://api.settler.dev",
+  enableLogging: true,
+});
+
+async function main() {
+  // ── 1. Create a reconciliation job ────────────────────────────────
+  console.log("\n▸ Creating reconciliation job…");
+  const job = await settler.jobs.create({
+    name: `Starter Kit Recon – ${new Date().toISOString().slice(0, 10)}`,
+    source: {
+      adapter: "stripe",
+      config: {
+        // In production, these come from your Stripe dashboard
+        apiKey: process.env.STRIPE_SECRET_KEY ?? "sk_test_placeholder",
+      },
+    },
+    target: {
+      adapter: "internal_ledger",
+      config: {},
+    },
+    rules: {
+      matching: [
+        { field: "transaction_id", type: "exact" },
+        { field: "amount", type: "exact", tolerance: 0.01 },
+        { field: "date", type: "range", days: 2 },
+      ],
+    },
+  });
+  console.log(`  Job created: ${job.data.id}`);
+
+  // ── 2. Execute the job ────────────────────────────────────────────
+  console.log("\n▸ Executing reconciliation…");
+  const execution = await settler.jobs.run(job.data.id);
+  console.log(`  Execution started: ${execution.data.id}`);
+
+  // Wait for completion (in production, use webhooks instead of polling)
+  console.log("  Waiting for results…");
+  await sleep(3000);
+
+  // ── 3. Fetch the report ───────────────────────────────────────────
+  console.log("\n▸ Fetching report…");
+  const report = await settler.reports.get(job.data.id);
+  const { summary } = report.data;
+
+  console.log("\n┌─────────────────────────────────────┐");
+  console.log("│  Reconciliation Summary              │");
+  console.log("├─────────────────────────────────────┤");
+  console.log(`│  Matched:    ${String(summary.matched).padStart(8)}             │`);
+  console.log(`│  Unmatched:  ${String(summary.unmatched).padStart(8)}             │`);
+  console.log(`│  Accuracy:   ${String(summary.accuracy + "%").padStart(8)}             │`);
+  console.log("└─────────────────────────────────────┘");
+
+  // ── 4. List open exceptions ───────────────────────────────────────
+  if (summary.unmatched > 0) {
+    console.log("\n▸ Open exceptions:");
+    const exceptions = await settler.reports.list({
+      jobId: job.data.id,
+      status: "open",
+    });
+    for (const ex of exceptions.data) {
+      console.log(`  • ${ex.id}  ${ex.type}  ${ex.status}`);
+    }
+  }
+
+  console.log("\n✓ Done. View full results in the Settler console.");
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+main().catch((err) => {
+  console.error("Reconciliation failed:", err.message ?? err);
+  process.exit(1);
+});

--- a/examples/starter-kits/settler-recon-starter/tsconfig.json
+++ b/examples/starter-kits/settler-recon-starter/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/examples/starter-kits/settler-workflow-starter/.env.example
+++ b/examples/starter-kits/settler-workflow-starter/.env.example
@@ -1,0 +1,11 @@
+# Get your API key from the Settler console: Settings → API Keys
+SETTLER_API_KEY=sk_test_your_api_key_here
+
+# Optional: point to a self-hosted instance
+# SETTLER_BASE_URL=http://localhost:4000
+
+# Webhook secret for signature verification (shown when you register a webhook)
+SETTLER_WEBHOOK_SECRET=whsec_your_webhook_secret_here
+
+# Port for the local webhook receiver
+WEBHOOK_PORT=8080

--- a/examples/starter-kits/settler-workflow-starter/README.md
+++ b/examples/starter-kits/settler-workflow-starter/README.md
@@ -1,95 +1,66 @@
 # Settler Workflow Starter
 
-Quickstart template for building workflow orchestration with Settler.dev.
+Runnable quickstart for a webhook-driven reconciliation pipeline with Settler.
 
-## Getting Started
+## What this does
 
-1. **Install dependencies:**
-   ```bash
-   npm install
-   ```
+1. Registers a webhook for reconciliation events
+2. Creates and executes a reconciliation job
+3. Exports results as CSV
+4. Receives real-time events via a local webhook server
 
-2. **Set up your API key:**
-   ```bash
-   export SETTLER_API_KEY=sk_your_api_key
-   ```
+## Prerequisites
 
-3. **Run the example:**
-   ```bash
-   npm start
-   ```
+- Node.js 20+
+- A Settler API key (get one at **Settings → API Keys** in the console, or use a local dev instance)
 
-## Example: Simple Workflow
+## Quick start
 
-```javascript
-const { SettlerClient } = require('@settler/sdk');
+```bash
+# 1. Install
+npm install
 
-const client = new SettlerClient({
-  apiKey: process.env.SETTLER_API_KEY,
-});
+# 2. Configure
+cp .env.example .env
+# Edit .env and set SETTLER_API_KEY
 
-async function runWorkflow() {
-  // Create workflow
-  const workflow = await client.workflows.create({
-    name: 'Monthly Reconciliation Workflow',
-    steps: [
-      {
-        id: 'ingest',
-        type: 'ingestion',
-        config: { adapter: 'stripe' },
-        onSuccess: 'transform',
-      },
-      {
-        id: 'transform',
-        type: 'transform',
-        config: { recipeId: 'recipe_123' },
-        onSuccess: 'recon',
-      },
-      {
-        id: 'recon',
-        type: 'recon',
-        config: { jobId: 'job_123' },
-        onSuccess: 'audit',
-      },
-      {
-        id: 'audit',
-        type: 'audit',
-        config: { format: 'pdf' },
-      },
-    ],
-  });
+# 3. Start the webhook receiver (terminal 1)
+npm run webhook-server
 
-  // Execute workflow
-  const run = await client.workflows.execute(workflow.id);
-  console.log('Workflow completed:', run.status);
-}
+# 4. Run the pipeline (terminal 2)
+npm start
 ```
 
-## Example: Scheduled Workflow
+### Point to a local Settler instance
 
-```javascript
-async function scheduledWorkflow() {
-  const workflow = await client.workflows.create({
-    name: 'Daily Reconciliation',
-    steps: [
-      // ... workflow steps
-    ],
-    triggers: [
-      {
-        type: 'schedule',
-        config: {
-          cron: '0 0 * * *', // Daily at midnight
-        },
-      },
-    ],
-  });
-
-  console.log('Workflow scheduled:', workflow.id);
-}
+```bash
+SETTLER_BASE_URL=http://localhost:4000 npm start
 ```
 
-## Next Steps
+## Scripts
 
-- [Workflow Documentation](https://docs.settler.io/workflows)
-- [API Reference](https://docs.settler.io/api-reference)
-- [Examples](https://github.com/settler/examples)
+| Command                | Description                              |
+| ---------------------- | ---------------------------------------- |
+| `npm start`            | Create job, run reconciliation, export   |
+| `npm run webhook-server` | Start the local webhook event receiver |
+
+## Project structure
+
+```
+settler-workflow-starter/
+├── src/
+│   ├── index.ts           # Pipeline: register webhook → reconcile → export
+│   └── webhook-server.ts  # Local HTTP server that receives Settler events
+├── .env.example           # Environment template
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## Next steps
+
+- Deploy the webhook server behind a public URL (ngrok, Cloudflare Tunnel, etc.)
+- Add `schedule` to the job config for automated daily runs
+- Handle `exception.created` events to route exceptions to Slack or PagerDuty
+- Explore the [SDK reference](../../packages/sdk/README.md) for the full API surface
+- See [examples/](../../) for more use cases (multi-provider, multi-currency, etc.)

--- a/examples/starter-kits/settler-workflow-starter/package.json
+++ b/examples/starter-kits/settler-workflow-starter/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "settler-workflow-starter",
+  "version": "1.0.0",
+  "description": "Quickstart: ingest, reconcile, and export with Settler webhooks",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "webhook-server": "tsx src/webhook-server.ts"
+  },
+  "dependencies": {
+    "@settler/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/examples/starter-kits/settler-workflow-starter/src/index.ts
+++ b/examples/starter-kits/settler-workflow-starter/src/index.ts
@@ -1,0 +1,88 @@
+/**
+ * Settler Workflow Starter — webhook-driven reconciliation pipeline
+ *
+ * This script:
+ *   1. Registers a webhook endpoint for reconciliation events
+ *   2. Creates and executes a reconciliation job
+ *   3. Exports the results as CSV
+ *
+ * The companion webhook-server.ts receives events in real time.
+ *
+ * Run:
+ *   cp .env.example .env   # fill in your API key
+ *   npm install
+ *   npm start
+ */
+
+import SettlerClient from "@settler/sdk";
+
+const apiKey = process.env.SETTLER_API_KEY;
+if (!apiKey) {
+  console.error("Missing SETTLER_API_KEY – copy .env.example to .env and set your key.");
+  process.exit(1);
+}
+
+const settler = new SettlerClient({
+  apiKey,
+  baseUrl: process.env.SETTLER_BASE_URL || "https://api.settler.dev",
+  enableLogging: true,
+});
+
+async function main() {
+  // ── 1. Register webhook (idempotent) ──────────────────────────────
+  console.log("\n▸ Registering webhook…");
+  const webhook = await settler.webhooks.create({
+    url: `http://localhost:${process.env.WEBHOOK_PORT || 8080}/settler/webhook`,
+    events: [
+      "reconciliation.completed",
+      "reconciliation.failed",
+      "exception.created",
+    ],
+  });
+  console.log(`  Webhook registered: ${webhook.data.id}`);
+  console.log(`  Secret: ${webhook.data.secret}`);
+  console.log("  (Start the webhook server in a second terminal: npm run webhook-server)\n");
+
+  // ── 2. Create and run a reconciliation job ────────────────────────
+  console.log("▸ Creating reconciliation job…");
+  const job = await settler.jobs.create({
+    name: `Workflow Starter – ${new Date().toISOString().slice(0, 10)}`,
+    source: {
+      adapter: "stripe",
+      config: { apiKey: process.env.STRIPE_SECRET_KEY ?? "sk_test_placeholder" },
+    },
+    target: {
+      adapter: "internal_ledger",
+      config: {},
+    },
+    rules: {
+      matching: [
+        { field: "transaction_id", type: "exact" },
+        { field: "amount", type: "exact", tolerance: 0.01 },
+      ],
+    },
+  });
+  console.log(`  Job created: ${job.data.id}`);
+
+  console.log("\n▸ Executing reconciliation…");
+  const execution = await settler.jobs.run(job.data.id);
+  console.log(`  Execution: ${execution.data.id}`);
+  console.log("  The webhook server will receive events as the run progresses.\n");
+
+  // ── 3. Export results ─────────────────────────────────────────────
+  console.log("▸ Requesting CSV export…");
+  const exportResult = await settler.exports.create({
+    jobId: job.data.id,
+    format: "csv",
+    includeEvidence: true,
+  });
+  console.log(`  Export queued: ${exportResult.data.id}`);
+  console.log(`  Download will be available at: ${exportResult.data.downloadUrl ?? "(pending)"}`);
+
+  console.log("\n✓ Pipeline complete. Check the webhook server terminal for real-time events.");
+}
+
+main().catch((err) => {
+  console.error("Pipeline failed:", err.message ?? err);
+  process.exit(1);
+});

--- a/examples/starter-kits/settler-workflow-starter/src/webhook-server.ts
+++ b/examples/starter-kits/settler-workflow-starter/src/webhook-server.ts
@@ -1,0 +1,88 @@
+/**
+ * Minimal webhook receiver for Settler events.
+ *
+ * Run in a separate terminal:
+ *   npm run webhook-server
+ *
+ * This server:
+ *   - Verifies webhook signatures using the SDK
+ *   - Logs events to the console
+ *   - Shows how to handle reconciliation lifecycle events
+ */
+
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { verifyWebhookSignature } from "@settler/sdk";
+
+const PORT = Number(process.env.WEBHOOK_PORT) || 8080;
+const WEBHOOK_SECRET = process.env.SETTLER_WEBHOOK_SECRET || "";
+
+if (!WEBHOOK_SECRET) {
+  console.warn("WARNING: SETTLER_WEBHOOK_SECRET not set – signature verification will be skipped.");
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    req.on("error", reject);
+  });
+}
+
+const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  // Health check
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok" }));
+    return;
+  }
+
+  // Webhook endpoint
+  if (req.method === "POST" && req.url === "/settler/webhook") {
+    const body = await readBody(req);
+
+    // Verify signature
+    if (WEBHOOK_SECRET) {
+      const signature = req.headers["x-settler-signature"] as string | undefined;
+      if (!signature || !verifyWebhookSignature(body, signature, WEBHOOK_SECRET)) {
+        console.error("  ✗ Invalid webhook signature – rejecting");
+        res.writeHead(401);
+        res.end("Invalid signature");
+        return;
+      }
+    }
+
+    const event = JSON.parse(body);
+    const ts = new Date().toISOString().slice(11, 19);
+
+    switch (event.type) {
+      case "reconciliation.completed":
+        console.log(`[${ts}] ✓ Reconciliation completed – job=${event.data.jobId} matched=${event.data.matched} unmatched=${event.data.unmatched}`);
+        break;
+
+      case "reconciliation.failed":
+        console.log(`[${ts}] ✗ Reconciliation failed – job=${event.data.jobId} error=${event.data.error}`);
+        break;
+
+      case "exception.created":
+        console.log(`[${ts}] ! Exception created – id=${event.data.id} type=${event.data.type}`);
+        break;
+
+      default:
+        console.log(`[${ts}] ? Unknown event: ${event.type}`);
+    }
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ received: true }));
+    return;
+  }
+
+  res.writeHead(404);
+  res.end("Not found");
+});
+
+server.listen(PORT, () => {
+  console.log(`\nSettler webhook server listening on http://localhost:${PORT}`);
+  console.log(`Webhook endpoint: POST http://localhost:${PORT}/settler/webhook`);
+  console.log(`Health check:     GET  http://localhost:${PORT}/health\n`);
+});

--- a/examples/starter-kits/settler-workflow-starter/tsconfig.json
+++ b/examples/starter-kits/settler-workflow-starter/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
- Convert starter kits from README stubs to runnable TypeScript projects
  with package.json, tsconfig, src/, and .env.example (recon-starter and
  workflow-starter)
- Add teardown/cleanup/offboarding guide (docs/getting-started/teardown.md)
- Add pilot runbook with go/no-go scorecard and rollback plan
  (docs/pilot-runbook.md)
- Add public-facing trust packet for enterprise procurement
  (docs/trust-packet.md) — references actual repo evidence, no overclaiming
- Add SBOM generation workflow (CycloneDX, weekly + on release tags)
- Update README documentation hub with evaluation/pilot/teardown links
- Cross-link new docs from examples/README.md and getting-started/README.md

https://claude.ai/code/session_01UCNCm3tzXDGpVKLbY8DhN6