### PR TITLE
Operator customization: explicit tenants, durable dismissals, entitlements, migration

### DIFF
--- a/packages/web/src/__tests__/api/operator-customization.routes.test.ts
+++ b/packages/web/src/__tests__/api/operator-customization.routes.test.ts
@@ -1,0 +1,145 @@
+/** @jest-environment node */
+
+import { GET as getCustomization, PUT as putCustomization } from "@/app/api/admin/operator-customization/route";
+import { GET as getProposals } from "@/app/api/admin/operator-customization/proposals/route";
+import { POST as postApplyProposal } from "@/app/api/admin/operator-customization/proposals/[id]/apply/route";
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/auth/super-admin", () => ({
+  isSuperAdmin: jest.fn(async () => true),
+  getSuperAdminStatus: jest.fn(async () => ({ userId: "00000000-0000-0000-0000-000000000099" })),
+}));
+
+/** Zod v4 uuid() requires RFC variant/version nibble constraints on segments 3–4. */
+const T1 = "11111111-1111-4111-8111-111111111111";
+const T2 = "22222222-2222-4222-8222-222222222222";
+
+jest.mock("@/shared/db/prismaClient", () => ({
+  prisma: {
+    tenant: {
+      count: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    operatorCustomizationState: {
+      findUnique: jest.fn(),
+      upsert: jest.fn(),
+      update: jest.fn(),
+    },
+    operatorCustomizationProposal: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    operatorCustomizationAudit: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/domain/billing/entitlements", () => ({
+  getAccountPlanCode: jest.fn(async () => "starter"),
+}));
+
+import { getAccountPlanCode } from "@/domain/billing/entitlements";
+import { prisma } from "@/shared/db/prismaClient";
+
+const prismaMock = prisma as jest.Mocked<typeof prisma>;
+
+function req(url: string, init?: { method?: string; body?: unknown }) {
+  return {
+    url,
+    method: init?.method ?? "GET",
+    headers: new Headers(),
+    nextUrl: new URL(url),
+    json: async () => {
+      if (init?.body instanceof Error) throw init.body;
+      return init?.body ?? {};
+    },
+  } as any;
+}
+
+describe("operator customization API", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.operatorCustomizationState.findUnique.mockResolvedValue(null as never);
+    prismaMock.operatorCustomizationState.upsert.mockResolvedValue({} as never);
+    prismaMock.operatorCustomizationAudit.create.mockResolvedValue({} as never);
+    (getAccountPlanCode as jest.Mock).mockResolvedValue("starter");
+    prismaMock.tenant.findUnique.mockResolvedValue({ billingAccountId: null });
+  });
+
+  it("GET returns 400 when multiple tenants and tenantId omitted", async () => {
+    prismaMock.tenant.count.mockResolvedValue(2);
+    const response = await getCustomization(req("http://localhost/api/admin/operator-customization"));
+    expect(response.status).toBe(400);
+    const j = await response.json();
+    expect(j.code).toBe("ambiguous_tenant");
+  });
+
+  it("GET succeeds for single-tenant implicit resolve", async () => {
+    prismaMock.tenant.count.mockResolvedValue(1);
+    prismaMock.tenant.findFirst.mockResolvedValue({ id: T1, slug: "only" });
+    const response = await getCustomization(req("http://localhost/api/admin/operator-customization"));
+    expect(response.status).toBe(200);
+    const j = await response.json();
+    expect(j.tenant.slug).toBe("only");
+    expect(j.entitlements.capabilities.baseline_studio).toBe(true);
+  });
+
+  it("GET returns 404 for unknown tenantId", async () => {
+    prismaMock.tenant.findFirst.mockResolvedValue(null);
+    const response = await getCustomization(
+      req(`http://localhost/api/admin/operator-customization?tenantId=${T2}`)
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("PUT rejects advanced preset when plan is starter", async () => {
+    prismaMock.tenant.count.mockResolvedValue(1);
+    prismaMock.tenant.findFirst.mockResolvedValue({ id: T1, slug: "solo" });
+    const { defaultAdminDashboardCustomization } = await import("@/lib/operator-customization/registry");
+    const draft = defaultAdminDashboardCustomization();
+    draft.lastAppliedPresetId = "buyer_demo";
+    const response = await putCustomization(
+      req("http://localhost/api/admin/operator-customization", {
+        method: "PUT",
+        body: { draft },
+      })
+    );
+    expect(response.status).toBe(403);
+    const j = await response.json();
+    expect(j.code).toBe("advanced_presets_require_plan");
+  });
+
+  it("proposals GET lists only current user rows for tenant", async () => {
+    prismaMock.tenant.findFirst.mockResolvedValue({ id: T1, slug: "solo" });
+    prismaMock.tenant.count.mockResolvedValue(2);
+    prismaMock.operatorCustomizationProposal.findMany.mockResolvedValue([]);
+    await getProposals(req(`http://localhost/api/admin/operator-customization/proposals?tenantId=${T1}`));
+    expect(prismaMock.operatorCustomizationProposal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tenantId: T1, userId: "00000000-0000-0000-0000-000000000099" },
+      })
+    );
+  });
+
+  it("apply proposal returns 404 when no proposal for resolved tenant (cross-tenant safe)", async () => {
+    prismaMock.tenant.findFirst.mockResolvedValue({ id: T1, slug: "a" });
+    prismaMock.tenant.count.mockResolvedValue(2);
+    // Proposal lives on another tenant; scoped find returns nothing.
+    prismaMock.operatorCustomizationProposal.findFirst.mockResolvedValue(null);
+    const response = await postApplyProposal(
+      req("http://localhost/api/admin/operator-customization/proposals/prop-1/apply", {
+        method: "POST",
+        body: { tenantId: T1 },
+      }),
+      { params: Promise.resolve({ id: "prop-1" }) }
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/web/src/__tests__/e2e/operator-customization-studio.spec.ts
+++ b/packages/web/src/__tests__/e2e/operator-customization-studio.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Operator Customization — API auth boundaries + optional authenticated smoke (storage state).
+ *
+ * Set PLAYWRIGHT_ADMIN_STORAGE_STATE to a path of a Playwright storageState JSON export
+ * for a super-admin session to run the persisted round-trip check in CI/staging.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
+const adminStorage = process.env.PLAYWRIGHT_ADMIN_STORAGE_STATE;
+
+test.describe("operator customization API (unauthenticated)", () => {
+  test("GET /api/admin/operator-customization returns 401 or 403 without session", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/operator-customization`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test("PUT /api/admin/operator-customization returns 401 or 403 without session", async ({ request }) => {
+    const res = await request.put(`${BASE}/api/admin/operator-customization`, {
+      data: { draft: { schemaVersion: "1", operatingMode: "standard", modules: [] } },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect([401, 403]).toContain(res.status());
+  });
+});
+
+const describeAdmin = adminStorage ? test.describe : test.describe.skip;
+
+describeAdmin("operator customization (super-admin storage state)", () => {
+  test.use({ storageState: adminStorage! });
+
+  test("GET customization returns 200 and JSON shape", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/admin/operator-customization`);
+    if (res.status() === 400) {
+      const body = await res.json().catch(() => ({}));
+      test.skip(
+        body.code === "ambiguous_tenant",
+        "Multiple tenants require explicit tenantId; set PLAYWRIGHT_CUSTOMIZATION_TENANT_ID or use single-tenant DB"
+      );
+    }
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    expect(json.draft).toBeDefined();
+    expect(json.published).toBeDefined();
+    expect(json.tenant).toBeDefined();
+  });
+
+  test("studio page loads shell when authenticated", async ({ page }) => {
+    await page.goto(`${BASE}/admin/operator-customization`, { waitUntil: "domcontentloaded" });
+    const studio = page.getByTestId("operator-customization-studio");
+    const loading = page.getByTestId("operator-customization-loading");
+    await expect(studio.or(loading)).toBeVisible({ timeout: 20000 });
+  });
+});

--- a/packages/web/src/__tests__/operator-customization/schema-and-proposals.test.ts
+++ b/packages/web/src/__tests__/operator-customization/schema-and-proposals.test.ts
@@ -44,6 +44,7 @@ describe("operator customization", () => {
     expect(p.ok).toBe(true);
     if (p.ok) {
       expect(p.patch.lastAppliedPresetId).toBe("solo_operator");
+      expect(p.explanationEvidence).toMatchObject({ engine: "rules", ruleId: "intent_solo_operator" });
       const preset = getPresetById("solo_operator");
       expect(preset).toBeDefined();
     }
@@ -52,5 +53,8 @@ describe("operator customization", () => {
   it("proposal rules reject unsupported phrasing", () => {
     const p = buildProposalFromNaturalLanguage("make the database faster");
     expect(p.ok).toBe(false);
+    if (!p.ok) {
+      expect(p.explanationEvidence.ruleId).toBe("no_match");
+    }
   });
 });

--- a/packages/web/src/app/admin/operator-customization/page.tsx
+++ b/packages/web/src/app/admin/operator-customization/page.tsx
@@ -16,13 +16,20 @@ import { ADMIN_DASHBOARD_MODULE_REGISTRY } from "@/lib/operator-customization/re
 import { OPERATOR_CUSTOMIZATION_PRESETS } from "@/lib/operator-customization/presets";
 import type { CustomizationPatch, ModulePlacement, OperatorSurfaceCustomization } from "@/lib/operator-customization/schema";
 
+const PREMIUM_PRESET_IDS = new Set(["buyer_demo", "exception_ops"]);
+
 type StudioPayload = {
   draft: OperatorSurfaceCustomization;
   published: OperatorSurfaceCustomization;
   publishedAt: string | null;
   draftUpdatedAt: string;
   registry: Array<(typeof ADMIN_DASHBOARD_MODULE_REGISTRY)[string]>;
-  degraded?: { inference: string; message: string };
+  tenant?: { id: string; slug: string; multiTenantEnvironment: boolean };
+  entitlements?: {
+    planCode: string;
+    capabilities: Record<string, boolean>;
+  };
+  degraded?: { inference: string; message: string; code?: string };
 };
 
 export default function OperatorCustomizationStudioPage() {
@@ -35,46 +42,105 @@ export default function OperatorCustomizationStudioPage() {
     patch: CustomizationPatch;
     rationale: string;
     inferenceMode: string;
+    explanationEvidence?: Record<string, unknown>;
   } | null>(null);
   const [proposalError, setProposalError] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<
-    Array<{ kind: string; moduleId: string; evidence: { visitsInWindow: number }; message: string }>
+    Array<{
+      kind: string;
+      moduleId: string;
+      evidence: { visitsInWindow: number; windowHours?: number };
+      message: string;
+    }>
   >([]);
-  const [dismissed, setDismissed] = useState<Set<string>>(() => new Set());
+  const [tenantOptions, setTenantOptions] = useState<Array<{ id: string; slug: string; name: string }>>([]);
+  const [selectedTenantId, setSelectedTenantId] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+
+  const tenantQuery = useMemo(
+    () => (selectedTenantId ? `?tenantId=${encodeURIComponent(selectedTenantId)}` : ""),
+    [selectedTenantId]
+  );
+
+  const persistBody = useCallback(
+    (extra: Record<string, unknown> = {}) =>
+      selectedTenantId ? { tenantId: selectedTenantId, ...extra } : { ...extra },
+    [selectedTenantId]
+  );
+
+  const loadTenants = useCallback(async () => {
+    const res = await fetch("/api/admin/operator-customization/tenants", { credentials: "include" });
+    if (!res.ok) return;
+    const json = (await res.json()) as { items: Array<{ id: string; slug: string; name: string }> };
+    const items = json.items ?? [];
+    setTenantOptions(items);
+    if (items.length === 1) {
+      setSelectedTenantId(items[0]!.id);
+    }
+  }, []);
 
   const load = useCallback(async () => {
     setLoadError(null);
-    const res = await fetch("/api/admin/operator-customization", { credentials: "include" });
+    if (tenantOptions.length > 1 && !selectedTenantId) {
+      setPayload(null);
+      return;
+    }
+    const res = await fetch(`/api/admin/operator-customization${tenantQuery}`, { credentials: "include" });
     if (!res.ok) {
-      setLoadError(`Failed to load (${res.status})`);
+      const b = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        code?: string;
+        message?: string;
+        activeTenantCount?: number;
+      };
+      const msg =
+        b.message ||
+        (b.code === "ambiguous_tenant"
+          ? "Select a workspace below — multiple active tenants require an explicit target."
+          : typeof b.error === "string"
+            ? b.error
+            : `Failed to load (${res.status})`);
+      setLoadError(msg);
       setPayload(null);
       return;
     }
     const json = (await res.json()) as StudioPayload;
     setPayload(json);
-  }, []);
+    if (json.tenant?.id) {
+      setSelectedTenantId(json.tenant.id);
+    }
+  }, [tenantQuery, tenantOptions.length, selectedTenantId]);
 
   const loadSuggestions = useCallback(async () => {
-    const res = await fetch("/api/admin/operator-customization/suggestions", { credentials: "include" });
+    if (tenantOptions.length > 1 && !selectedTenantId) return;
+    const res = await fetch(`/api/admin/operator-customization/suggestions${tenantQuery}`, {
+      credentials: "include",
+    });
     if (!res.ok) return;
     const json = (await res.json()) as {
       suggestions: Array<{
         kind: string;
         moduleId: string;
-        evidence: { visitsInWindow: number };
+        evidence: { visitsInWindow: number; windowHours?: number };
         message: string;
       }>;
     };
     setSuggestions(json.suggestions ?? []);
-  }, []);
+  }, [tenantQuery, tenantOptions.length, selectedTenantId]);
 
   useEffect(() => {
+    void loadTenants();
+  }, [loadTenants]);
+
+  useEffect(() => {
+    if (tenantOptions.length > 1 && !selectedTenantId) return;
     void load();
     void loadSuggestions();
-  }, [load, loadSuggestions]);
+  }, [load, loadSuggestions, tenantOptions.length, selectedTenantId]);
 
   const draft = payload?.draft;
   const published = payload?.published;
+  const advancedOk = payload?.entitlements?.capabilities?.advanced_presets === true;
 
   const sortedDraft = useMemo(() => {
     if (!draft) return [];
@@ -104,18 +170,31 @@ export default function OperatorCustomizationStudioPage() {
 
   async function saveDraft(next: OperatorSurfaceCustomization) {
     setBusy(true);
+    setSaveStatus("saving");
     try {
       const res = await fetch("/api/admin/operator-customization", {
         method: "PUT",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ draft: next }),
+        body: JSON.stringify(persistBody({ draft: next })),
       });
       if (!res.ok) {
-        const b = await res.json().catch(() => ({}));
-        setLoadError(typeof b.error === "string" ? b.error : "save_failed");
+        const b = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          code?: string;
+          message?: string;
+          planCode?: string;
+        };
+        setSaveStatus("error");
+        setLoadError(
+          b.code === "advanced_presets_require_plan"
+            ? `This preset requires a Growth (or higher) plan for this workspace (current: ${b.planCode ?? "unknown"}).`
+            : b.message || (typeof b.error === "string" ? b.error : "save_failed")
+        );
         return;
       }
+      setSaveStatus("saved");
+      setLoadError(null);
       await load();
     } finally {
       setBusy(false);
@@ -149,12 +228,18 @@ export default function OperatorCustomizationStudioPage() {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ signalType: "layout_reorder", moduleId }),
+      body: JSON.stringify(persistBody({ signalType: "layout_reorder", moduleId })),
     }).catch(() => {});
     void saveDraft({ ...draft, modules: nextModules });
   }
 
   async function applyPreset(presetId: string) {
+    if (!advancedOk && PREMIUM_PRESET_IDS.has(presetId)) {
+      setLoadError(
+        "That preset is gated to Growth+ on the workspace billing plan. Default and Solo operator remain available on Starter."
+      );
+      return;
+    }
     const preset = OPERATOR_CUSTOMIZATION_PRESETS.find((p) => p.id === presetId);
     if (!preset || !draft) return;
     const c = preset.customization();
@@ -168,12 +253,18 @@ export default function OperatorCustomizationStudioPage() {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        body: JSON.stringify(persistBody()),
       });
       if (!res.ok) {
-        setLoadError("publish_failed");
+        const b = (await res.json().catch(() => ({}))) as { code?: string; planCode?: string };
+        setLoadError(
+          b.code === "advanced_presets_require_plan"
+            ? `Cannot publish: draft references a preset that requires Growth+ (plan: ${b.planCode ?? "unknown"}).`
+            : "publish_failed"
+        );
         return;
       }
+      setLoadError(null);
       await load();
     } finally {
       setBusy(false);
@@ -187,12 +278,13 @@ export default function OperatorCustomizationStudioPage() {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        body: JSON.stringify(persistBody()),
       });
       if (!res.ok) {
         setLoadError("revert_failed");
         return;
       }
+      setLoadError(null);
       await load();
     } finally {
       setBusy(false);
@@ -206,7 +298,7 @@ export default function OperatorCustomizationStudioPage() {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ request: promptText }),
+      body: JSON.stringify(persistBody({ request: promptText })),
     });
     const json = await res.json().catch(() => ({}));
     if (!res.ok) {
@@ -218,6 +310,7 @@ export default function OperatorCustomizationStudioPage() {
       patch: json.proposal.patch,
       rationale: json.proposal.rationale,
       inferenceMode: json.proposal.inferenceMode,
+      explanationEvidence: json.proposal.explanationEvidence,
     });
   }
 
@@ -229,35 +322,63 @@ export default function OperatorCustomizationStudioPage() {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        body: JSON.stringify(persistBody()),
       });
       if (!res.ok) {
-        setLoadError("apply_proposal_failed");
+        const b = (await res.json().catch(() => ({}))) as { code?: string };
+        setLoadError(
+          b.code === "advanced_presets_require_plan"
+            ? "Proposal would apply a Growth+ preset — upgrade the workspace plan or edit the draft."
+            : "apply_proposal_failed"
+        );
         return;
       }
       setProposal(null);
       setPromptText("");
+      setLoadError(null);
       await load();
     } finally {
       setBusy(false);
     }
   }
 
-  if (!payload && !loadError) {
+  async function dismissSuggestion(moduleId: string) {
+    const res = await fetch("/api/admin/operator-customization/suggestions/dismiss", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        persistBody({
+          surface: "admin_dashboard",
+          suggestionKind: "pin_module",
+          suggestionKey: moduleId,
+          reasonCategory: "operator_dismissed",
+        })
+      ),
+    });
+    if (res.ok) {
+      await loadSuggestions();
+    }
+  }
+
+  const awaitingTenantPick = tenantOptions.length > 1 && !selectedTenantId;
+
+  if (!payload && !loadError && !awaitingTenantPick) {
     return (
-      <div className="p-8">
+      <div className="p-8" data-testid="operator-customization-loading">
         <p className="text-muted-foreground">Loading studio…</p>
       </div>
     );
   }
 
   return (
-    <div className="p-4 sm:p-8 max-w-5xl space-y-6">
+    <div className="p-4 sm:p-8 max-w-5xl space-y-6" data-testid="operator-customization-studio">
       <div>
         <h1 className="text-2xl font-bold">Operator Customization Studio</h1>
         <p className="text-sm text-muted-foreground mt-1">
           Presentation-only layout for the admin dashboard. Does not change reconciliation results, evidence, or run
-          health semantics.
+          health semantics. Draft saves are persisted; publish makes the layout live for your operator session on this
+          workspace.
         </p>
         <p className="text-sm mt-2">
           <Link href="/admin" className="underline underline-offset-2">
@@ -266,18 +387,80 @@ export default function OperatorCustomizationStudioPage() {
         </p>
       </div>
 
+      {tenantOptions.length > 1 ? (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Workspace target</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p className="text-muted-foreground text-xs">
+              Multiple active tenants exist. Customization writes are scoped to the workspace you select.
+            </p>
+            <label className="sr-only" htmlFor="tenant-select">
+              Workspace
+            </label>
+            <select
+              id="tenant-select"
+              data-testid="operator-customization-tenant-select"
+              className="border rounded-md px-3 py-2 text-sm bg-background"
+              value={selectedTenantId ?? ""}
+              onChange={(e) => {
+                const v = e.target.value || null;
+                setSelectedTenantId(v);
+                setPayload(null);
+                setLoadError(null);
+              }}
+            >
+              <option value="">Select workspace…</option>
+              {tenantOptions.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name} ({t.slug})
+                </option>
+              ))}
+            </select>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {payload?.tenant ? (
+        <p className="text-xs text-muted-foreground" data-testid="operator-customization-tenant-context">
+          Workspace: <span className="font-mono">{payload.tenant.slug}</span>
+          {payload.entitlements ? (
+            <>
+              {" "}
+              · Plan: <span className="font-mono">{payload.entitlements.planCode}</span>
+            </>
+          ) : null}
+        </p>
+      ) : null}
+
       {loadError ? (
-        <p className="text-sm text-destructive" role="alert">
+        <p className="text-sm text-destructive" role="alert" data-testid="operator-customization-error">
           {loadError}
         </p>
+      ) : null}
+
+      {saveStatus !== "idle" ? (
+        <p className="text-xs text-muted-foreground" data-testid="operator-customization-save-status">
+          {saveStatus === "saving" ? "Saving draft…" : saveStatus === "saved" ? "Draft saved (server)" : "Save failed"}
+        </p>
+      ) : null}
+
+      {awaitingTenantPick ? (
+        <p className="text-sm text-muted-foreground">Choose a workspace to load customization.</p>
       ) : null}
 
       {payload?.degraded ? (
         <Card className="border-amber-500/40">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm">Inference posture</CardTitle>
+            <CardTitle className="text-sm">Advisory proposals</CardTitle>
           </CardHeader>
-          <CardContent className="text-sm text-muted-foreground">{payload.degraded.message}</CardContent>
+          <CardContent className="text-sm text-muted-foreground space-y-1">
+            <p>{payload.degraded.message}</p>
+            {payload.degraded.code ? (
+              <p className="text-xs font-mono">Code: {payload.degraded.code}</p>
+            ) : null}
+          </CardContent>
         </Card>
       ) : null}
 
@@ -307,13 +490,18 @@ export default function OperatorCustomizationStudioPage() {
             )}
           </div>
           <div className="flex flex-wrap gap-2 pt-2">
-            <Button size="sm" onClick={() => void publish()} disabled={busy || !draft}>
+            <Button
+              size="sm"
+              onClick={() => void publish()}
+              disabled={busy || !draft || awaitingTenantPick}
+              data-testid="operator-customization-publish"
+            >
               Publish draft
             </Button>
-            <Button size="sm" variant="outline" onClick={() => void revertDraft()} disabled={busy}>
+            <Button size="sm" variant="outline" onClick={() => void revertDraft()} disabled={busy || awaitingTenantPick}>
               Revert draft to published
             </Button>
-            <Button size="sm" variant="secondary" onClick={() => void load()} disabled={busy}>
+            <Button size="sm" variant="secondary" onClick={() => void load()} disabled={busy || awaitingTenantPick}>
               Refresh
             </Button>
           </div>
@@ -325,11 +513,27 @@ export default function OperatorCustomizationStudioPage() {
           <CardTitle className="text-base">Presets</CardTitle>
         </CardHeader>
         <CardContent className="flex flex-wrap gap-2">
-          {OPERATOR_CUSTOMIZATION_PRESETS.map((p) => (
-            <Button key={p.id} size="sm" variant="outline" onClick={() => void applyPreset(p.id)} disabled={busy}>
-              {p.label}
-            </Button>
-          ))}
+          {OPERATOR_CUSTOMIZATION_PRESETS.map((p) => {
+            const gated = PREMIUM_PRESET_IDS.has(p.id) && !advancedOk;
+            return (
+              <Button
+                key={p.id}
+                size="sm"
+                variant="outline"
+                onClick={() => void applyPreset(p.id)}
+                disabled={busy || gated}
+                title={gated ? "Requires Growth+ plan for this workspace" : undefined}
+                data-testid={`operator-customization-preset-${p.id}`}
+              >
+                {p.label}
+                {gated ? (
+                  <Badge variant="secondary" className="ml-2 text-[9px]">
+                    Growth+
+                  </Badge>
+                ) : null}
+              </Button>
+            );
+          })}
         </CardContent>
       </Card>
 
@@ -467,29 +671,44 @@ export default function OperatorCustomizationStudioPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Prompt → proposal (review before apply)</CardTitle>
+          <CardTitle className="text-base">Rules-based proposal (review before apply)</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            Advisory only: deterministic pattern match to a patch. Does not auto-publish; does not change reconciliation
+            truth.
+          </p>
           <Textarea
             value={promptText}
             onChange={(e) => setPromptText(e.target.value)}
             rows={3}
             placeholder='Try: "solo operator layout" or "hide activity feed"'
             aria-label="Customization request"
+            data-testid="operator-customization-proposal-input"
           />
-          <Button size="sm" onClick={() => void submitProposal()} disabled={busy || !promptText.trim()}>
+          <Button
+            size="sm"
+            onClick={() => void submitProposal()}
+            disabled={busy || !promptText.trim() || awaitingTenantPick}
+            data-testid="operator-customization-proposal-generate"
+          >
             Generate proposal
           </Button>
           {proposalError ? <p className="text-sm text-destructive">{proposalError}</p> : null}
           {proposal ? (
-            <div className="border rounded-md p-3 space-y-2 text-sm">
+            <div className="border rounded-md p-3 space-y-2 text-sm" data-testid="operator-customization-proposal-panel">
               <p className="font-medium">Rationale</p>
               <p className="text-muted-foreground">{proposal.rationale}</p>
               <p className="text-xs text-muted-foreground">Mode: {proposal.inferenceMode}</p>
+              {proposal.explanationEvidence ? (
+                <pre className="text-xs bg-muted p-2 rounded-md overflow-x-auto">
+                  {JSON.stringify(proposal.explanationEvidence, null, 2)}
+                </pre>
+              ) : null}
               <pre className="text-xs bg-muted p-2 rounded-md overflow-x-auto">
                 {JSON.stringify(proposal.patch, null, 2)}
               </pre>
-              <Button size="sm" onClick={() => void applyProposal()} disabled={busy}>
+              <Button size="sm" onClick={() => void applyProposal()} disabled={busy} data-testid="operator-customization-proposal-apply">
                 Apply to draft (not published)
               </Button>
             </div>
@@ -503,30 +722,34 @@ export default function OperatorCustomizationStudioPage() {
         </CardHeader>
         <CardContent className="space-y-3 text-sm">
           <p className="text-muted-foreground text-xs">
-            Based on recorded module views (tenant-scoped). Dismiss is local to this browser session only.
+            Based on recorded module views (tenant-scoped). Dismiss is stored for this workspace and your operator
+            account (not session-only).
           </p>
-          {suggestions.filter((s) => !dismissed.has(s.moduleId)).length === 0 ? (
+          {suggestions.length === 0 ? (
             <p className="text-muted-foreground">No suggestions right now.</p>
           ) : (
-            suggestions
-              .filter((s) => !dismissed.has(s.moduleId))
-              .map((s) => (
-                <div key={s.moduleId} className="border rounded-md p-3 flex flex-col sm:flex-row sm:justify-between gap-2">
-                  <div>
-                    <p>{s.message}</p>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Evidence: {s.evidence.visitsInWindow} views (7d window)
-                    </p>
-                  </div>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => setDismissed((prev) => new Set(prev).add(s.moduleId))}
-                  >
-                    Dismiss
-                  </Button>
+            suggestions.map((s) => (
+              <div
+                key={s.moduleId}
+                className="border rounded-md p-3 flex flex-col sm:flex-row sm:justify-between gap-2"
+                data-testid={`operator-customization-suggestion-${s.moduleId}`}
+              >
+                <div>
+                  <p>{s.message}</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Evidence: {s.evidence.visitsInWindow} views (7d window)
+                  </p>
                 </div>
-              ))
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => void dismissSuggestion(s.moduleId)}
+                  data-testid={`operator-customization-suggestion-dismiss-${s.moduleId}`}
+                >
+                  Dismiss (saved)
+                </Button>
+              </div>
+            ))
           )}
         </CardContent>
       </Card>

--- a/packages/web/src/app/admin/page.tsx
+++ b/packages/web/src/app/admin/page.tsx
@@ -62,6 +62,13 @@ export default function AdminDashboard() {
     return m;
   }, [layout.modules]);
 
+  /** Only attach tenant to signals when workspace is unambiguous (single active tenant). */
+  const signalTenantId = useMemo(() => {
+    const t = customization?.tenant;
+    if (t && !t.multiTenantEnvironment) return t.id;
+    return null;
+  }, [customization?.tenant]);
+
   const operatingModeLabel =
     layout.operatingMode === "solo_operator"
       ? "Solo operator"
@@ -96,7 +103,7 @@ export default function AdminDashboard() {
         </div>
         <div className="flex flex-wrap items-center gap-3 sm:gap-4">
           {isModuleEnabled(placementById, "trust_connection") && (
-            <ModuleViewTracker moduleId="trust_connection">
+            <ModuleViewTracker moduleId="trust_connection" tenantId={signalTenantId}>
               <div className="flex items-center gap-2">
                 <SecurityBadge />
                 <SystemStatusCard
@@ -117,7 +124,7 @@ export default function AdminDashboard() {
           )}
 
           {isModuleEnabled(placementById, "time_range") && (
-            <ModuleViewTracker moduleId="time_range">
+            <ModuleViewTracker moduleId="time_range" tenantId={signalTenantId}>
               <div className="flex gap-2">
                 {(["24h", "7d", "30d"] as const).map((range) => (
                   <Button
@@ -156,7 +163,7 @@ export default function AdminDashboard() {
         switch (placement.moduleId) {
           case "usage_warning":
             return (
-              <ModuleViewTracker key={placement.moduleId} moduleId="usage_warning">
+              <ModuleViewTracker key={placement.moduleId} moduleId="usage_warning" tenantId={signalTenantId}>
                 {kpis && kpis.totalVolume > 0 ? (
                   <UsageWarning
                     current={kpis.totalVolume}
@@ -168,7 +175,7 @@ export default function AdminDashboard() {
             );
           case "kpi_tiles":
             return (
-              <ModuleViewTracker key={placement.moduleId} moduleId="kpi_tiles">
+              <ModuleViewTracker key={placement.moduleId} moduleId="kpi_tiles" tenantId={signalTenantId}>
                 <ModuleChrome placement={placement} moduleId="kpi_tiles">
                   <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                     {isLoading ? (
@@ -239,7 +246,7 @@ export default function AdminDashboard() {
             );
           case "exception_heatmap":
             return (
-              <ModuleViewTracker key={placement.moduleId} moduleId="exception_heatmap">
+              <ModuleViewTracker key={placement.moduleId} moduleId="exception_heatmap" tenantId={signalTenantId}>
                 <ModuleChrome placement={placement} moduleId="exception_heatmap">
                   <Card>
                     <CardContent className="pt-6">
@@ -291,7 +298,7 @@ export default function AdminDashboard() {
             );
           case "activity_feed":
             return (
-              <ModuleViewTracker key={placement.moduleId} moduleId="activity_feed">
+              <ModuleViewTracker key={placement.moduleId} moduleId="activity_feed" tenantId={signalTenantId}>
                 <ModuleChrome placement={placement} moduleId="activity_feed">
                   <Card>
                     <CardContent className="pt-6">
@@ -391,13 +398,21 @@ function ModuleChrome({
   );
 }
 
-function ModuleViewTracker({ moduleId, children }: { moduleId: string; children: React.ReactNode }) {
+function ModuleViewTracker({
+  moduleId,
+  tenantId,
+  children,
+}: {
+  moduleId: string;
+  tenantId?: string | null;
+  children: React.ReactNode;
+}) {
   const sent = useRef(false);
   useEffect(() => {
     if (sent.current) return;
     sent.current = true;
-    recordModuleViewSignal(moduleId);
-  }, [moduleId]);
+    recordModuleViewSignal(moduleId, tenantId);
+  }, [moduleId, tenantId]);
   return <>{children}</>;
 }
 

--- a/packages/web/src/app/api/admin/operator-customization/proposals/[id]/apply/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/proposals/[id]/apply/route.ts
@@ -3,11 +3,14 @@ import { z } from "zod";
 import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
 import { withSecurity } from "@/lib/middleware/api-security";
 import { CustomizationPatchSchema } from "@/lib/operator-customization/schema";
+import { getOperatorCustomizationEntitlementsForTenant } from "@/lib/server/operator-customization/operator-customization-entitlements";
+import { handleOperatorCustomizationRoute } from "@/lib/server/operator-customization/operator-customization-route-guard";
 import {
   applyPatchToDraft,
   getCustomizationState,
   recordCustomizationAudit,
 } from "@/lib/server/operator-customization/customization-service";
+import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
 import { prisma } from "@/shared/db/prismaClient";
 
 export const dynamic = "force-dynamic";
@@ -17,49 +20,76 @@ const BodySchema = z.object({ tenantId: z.string().uuid().optional() });
 
 export const POST = withSecurity(
   async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-    const admin = await isSuperAdmin();
-    if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    const { userId } = await getSuperAdminStatus();
-    if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return handleOperatorCustomizationRoute(async () => {
+      const admin = await isSuperAdmin();
+      if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      const { userId } = await getSuperAdminStatus();
+      if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    const { id } = await params;
-    const body = BodySchema.safeParse(await request.json().catch(() => ({})));
-    if (!body.success) return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+      const { id } = await params;
+      const body = BodySchema.safeParse(await request.json().catch(() => ({})));
+      if (!body.success) return NextResponse.json({ error: "invalid_body" }, { status: 400 });
 
-    const proposal = await prisma.operatorCustomizationProposal.findFirst({
-      where: { id, userId },
+      const resolved = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+      if (!resolved.ok) return resolved.response;
+
+      const proposal = await prisma.operatorCustomizationProposal.findFirst({
+        where: { id, userId, tenantId: resolved.tenant.tenantId },
+      });
+      if (!proposal) {
+        return NextResponse.json({ error: "not_found" }, { status: 404 });
+      }
+      if (proposal.status !== "pending") {
+        return NextResponse.json({ error: "not_pending" }, { status: 409 });
+      }
+
+      const patchParse = CustomizationPatchSchema.safeParse(proposal.structuredPatch);
+      if (!patchParse.success) {
+        return NextResponse.json({ error: "invalid_stored_patch" }, { status: 500 });
+      }
+
+      const entitlements = await getOperatorCustomizationEntitlementsForTenant(resolved.tenant.tenantId);
+
+      const before = await getCustomizationState(prisma, proposal.tenantId, userId);
+      const applied = await applyPatchToDraft(
+        prisma,
+        proposal.tenantId,
+        userId,
+        patchParse.data,
+        entitlements
+      );
+      if (!applied.ok) {
+        if ("code" in applied && applied.code === "preset_not_entitled") {
+          return NextResponse.json(
+            {
+              error: "preset_not_entitled",
+              code: "advanced_presets_require_plan",
+              presetId: applied.presetId,
+              planCode: entitlements.planCode,
+            },
+            { status: 403 }
+          );
+        }
+        if ("errors" in applied) {
+          return NextResponse.json({ error: "validation_failed", errors: applied.errors }, { status: 400 });
+        }
+        return NextResponse.json({ error: "apply_failed" }, { status: 500 });
+      }
+
+      await prisma.operatorCustomizationProposal.update({
+        where: { id },
+        data: { status: "applied", appliedAt: new Date() },
+      });
+
+      await recordCustomizationAudit(prisma, proposal.tenantId, userId, "proposal_applied_to_draft", "admin_dashboard", {
+        proposalId: id,
+        patch: patchParse.data,
+        draftBefore: before.draft,
+        draftAfter: applied.draft,
+      });
+
+      return NextResponse.json({ draft: applied.draft });
     });
-    if (!proposal) {
-      return NextResponse.json({ error: "not_found" }, { status: 404 });
-    }
-    if (proposal.status !== "pending") {
-      return NextResponse.json({ error: "not_pending" }, { status: 409 });
-    }
-
-    const patchParse = CustomizationPatchSchema.safeParse(proposal.structuredPatch);
-    if (!patchParse.success) {
-      return NextResponse.json({ error: "invalid_stored_patch" }, { status: 500 });
-    }
-
-    const before = await getCustomizationState(prisma, proposal.tenantId, userId);
-    const applied = await applyPatchToDraft(prisma, proposal.tenantId, userId, patchParse.data);
-    if (!applied.ok) {
-      return NextResponse.json({ error: "validation_failed", errors: applied.errors }, { status: 400 });
-    }
-
-    await prisma.operatorCustomizationProposal.update({
-      where: { id },
-      data: { status: "applied", appliedAt: new Date() },
-    });
-
-    await recordCustomizationAudit(prisma, proposal.tenantId, userId, "proposal_applied_to_draft", "admin_dashboard", {
-      proposalId: id,
-      patch: patchParse.data,
-      draftBefore: before.draft,
-      draftAfter: applied.draft,
-    });
-
-    return NextResponse.json({ draft: applied.draft });
   },
   { requirePrivilegedApproval: false }
 );

--- a/packages/web/src/app/api/admin/operator-customization/proposals/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/proposals/route.ts
@@ -4,6 +4,7 @@ import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
 import { withSecurity } from "@/lib/middleware/api-security";
 import { CustomizationPatchSchema } from "@/lib/operator-customization/schema";
 import { buildProposalFromNaturalLanguage } from "@/lib/operator-customization/proposal-rules";
+import { handleOperatorCustomizationRoute } from "@/lib/server/operator-customization/operator-customization-route-guard";
 import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
 import { prisma } from "@/shared/db/prismaClient";
 
@@ -17,104 +18,118 @@ const PostBodySchema = z.object({
 
 export const POST = withSecurity(
   async function POST(request: NextRequest) {
-  const admin = await isSuperAdmin();
-  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  const { userId } = await getSuperAdminStatus();
-  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return handleOperatorCustomizationRoute(async () => {
+      const admin = await isSuperAdmin();
+      if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      const { userId } = await getSuperAdminStatus();
+      if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = PostBodySchema.safeParse(await request.json().catch(() => null));
-  if (!body.success) {
-    return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
-  }
+      const body = PostBodySchema.safeParse(await request.json().catch(() => null));
+      if (!body.success) {
+        return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
+      }
 
-  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
-  if (!tenant.ok) return tenant.response;
+      const resolved = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+      if (!resolved.ok) return resolved.response;
 
-  const built = buildProposalFromNaturalLanguage(body.data.request);
-  if (!built.ok) {
-    const row = await prisma.operatorCustomizationProposal.create({
-      data: {
-        tenantId: tenant.tenantId,
-        userId,
-        surface: "admin_dashboard",
-        status: "rejected",
-        naturalLanguageRequest: body.data.request,
-        structuredPatch: {},
-        rationale: built.reason,
-        inferenceMode: built.inferenceMode,
-        rejectedAt: new Date(),
-      },
-    });
-    return NextResponse.json(
-      {
+      const built = buildProposalFromNaturalLanguage(body.data.request);
+      if (!built.ok) {
+        const row = await prisma.operatorCustomizationProposal.create({
+          data: {
+            tenantId: resolved.tenant.tenantId,
+            userId,
+            surface: "admin_dashboard",
+            status: "rejected",
+            naturalLanguageRequest: body.data.request,
+            structuredPatch: {},
+            rationale: built.reason,
+            inferenceMode: built.inferenceMode,
+            proposalLane: "rules",
+            explanationEvidence: built.explanationEvidence as object,
+            rejectedAt: new Date(),
+          },
+        });
+        return NextResponse.json(
+          {
+            proposal: {
+              id: row.id,
+              status: "rejected",
+              rationale: built.reason,
+              inferenceMode: built.inferenceMode,
+              explanationEvidence: built.explanationEvidence,
+            },
+          },
+          { status: 422 }
+        );
+      }
+
+      const parsedPatch = CustomizationPatchSchema.safeParse(built.patch);
+      if (!parsedPatch.success) {
+        return NextResponse.json({ error: "patch_invalid", issues: parsedPatch.error.issues }, { status: 500 });
+      }
+
+      const row = await prisma.operatorCustomizationProposal.create({
+        data: {
+          tenantId: resolved.tenant.tenantId,
+          userId,
+          surface: "admin_dashboard",
+          status: "pending",
+          naturalLanguageRequest: body.data.request,
+          structuredPatch: parsedPatch.data as object,
+          rationale: built.rationale,
+          inferenceMode: built.inferenceMode,
+          proposalLane: "rules",
+          explanationEvidence: built.explanationEvidence as object,
+        },
+      });
+
+      return NextResponse.json({
         proposal: {
           id: row.id,
-          status: "rejected",
-          rationale: built.reason,
+          status: row.status,
+          patch: parsedPatch.data,
+          rationale: built.rationale,
           inferenceMode: built.inferenceMode,
+          explanationEvidence: built.explanationEvidence,
         },
-      },
-      { status: 422 }
-    );
-  }
-
-  const parsedPatch = CustomizationPatchSchema.safeParse(built.patch);
-  if (!parsedPatch.success) {
-    return NextResponse.json({ error: "patch_invalid", issues: parsedPatch.error.issues }, { status: 500 });
-  }
-
-  const row = await prisma.operatorCustomizationProposal.create({
-    data: {
-      tenantId: tenant.tenantId,
-      userId,
-      surface: "admin_dashboard",
-      status: "pending",
-      naturalLanguageRequest: body.data.request,
-      structuredPatch: parsedPatch.data as object,
-      rationale: built.rationale,
-      inferenceMode: built.inferenceMode,
-    },
-  });
-
-  return NextResponse.json({
-    proposal: {
-      id: row.id,
-      status: row.status,
-      patch: parsedPatch.data,
-      rationale: built.rationale,
-      inferenceMode: built.inferenceMode,
-    },
-  });
+      });
+    });
   },
   { requirePrivilegedApproval: false }
 );
 
 export const GET = withSecurity(async function GET(request: NextRequest) {
-  const admin = await isSuperAdmin();
-  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  return handleOperatorCustomizationRoute(async () => {
+    const admin = await isSuperAdmin();
+    if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    const { userId } = await getSuperAdminStatus();
+    if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { searchParams } = new URL(request.url);
-  const tenant = await resolveCustomizationTenantId(searchParams.get("tenantId"));
-  if (!tenant.ok) return tenant.response;
+    const { searchParams } = new URL(request.url);
+    const resolved = await resolveCustomizationTenantId(searchParams.get("tenantId"));
+    if (!resolved.ok) return resolved.response;
 
-  const limit = Math.min(Number(searchParams.get("limit") ?? "20") || 20, 50);
+    const limit = Math.min(Number(searchParams.get("limit") ?? "20") || 20, 50);
 
-  const rows = await prisma.operatorCustomizationProposal.findMany({
-    where: { tenantId: tenant.tenantId },
-    orderBy: { createdAt: "desc" },
-    take: limit,
-    select: {
-      id: true,
-      status: true,
-      naturalLanguageRequest: true,
-      structuredPatch: true,
-      rationale: true,
-      inferenceMode: true,
-      createdAt: true,
-      appliedAt: true,
-      rejectedAt: true,
-    },
+    const rows = await prisma.operatorCustomizationProposal.findMany({
+      where: { tenantId: resolved.tenant.tenantId, userId },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      select: {
+        id: true,
+        status: true,
+        naturalLanguageRequest: true,
+        structuredPatch: true,
+        rationale: true,
+        inferenceMode: true,
+        proposalLane: true,
+        explanationEvidence: true,
+        createdAt: true,
+        appliedAt: true,
+        rejectedAt: true,
+      },
+    });
+
+    return NextResponse.json({ items: rows });
   });
-
-  return NextResponse.json({ items: rows });
 });

--- a/packages/web/src/app/api/admin/operator-customization/publish/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/publish/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
 import { withSecurity } from "@/lib/middleware/api-security";
+import { getOperatorCustomizationEntitlementsForTenant } from "@/lib/server/operator-customization/operator-customization-entitlements";
+import { handleOperatorCustomizationRoute } from "@/lib/server/operator-customization/operator-customization-route-guard";
 import {
   getCustomizationState,
   publishDraft,
@@ -17,31 +19,49 @@ const BodySchema = z.object({ tenantId: z.string().uuid().optional() });
 
 export const POST = withSecurity(
   async function POST(request: NextRequest) {
-  const admin = await isSuperAdmin();
-  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  const { userId } = await getSuperAdminStatus();
-  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return handleOperatorCustomizationRoute(async () => {
+      const admin = await isSuperAdmin();
+      if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      const { userId } = await getSuperAdminStatus();
+      if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = BodySchema.safeParse(await request.json().catch(() => ({})));
-  if (!body.success) {
-    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
-  }
+      const body = BodySchema.safeParse(await request.json().catch(() => ({})));
+      if (!body.success) {
+        return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+      }
 
-  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
-  if (!tenant.ok) return tenant.response;
+      const resolved = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+      if (!resolved.ok) return resolved.response;
 
-  const before = await getCustomizationState(prisma, tenant.tenantId, userId);
-  const pub = await publishDraft(prisma, tenant.tenantId, userId);
-  if (!pub.ok) {
-    return NextResponse.json({ error: "validation_failed", errors: pub.errors }, { status: 400 });
-  }
+      const entitlements = await getOperatorCustomizationEntitlementsForTenant(resolved.tenant.tenantId);
 
-  await recordCustomizationAudit(prisma, tenant.tenantId, userId, "published", "admin_dashboard", {
-    beforePublished: before.published,
-    afterPublished: pub.published,
-  });
+      const before = await getCustomizationState(prisma, resolved.tenant.tenantId, userId);
+      const pub = await publishDraft(prisma, resolved.tenant.tenantId, userId, entitlements);
+      if (!pub.ok) {
+        if ("code" in pub && pub.code === "preset_not_entitled") {
+          return NextResponse.json(
+            {
+              error: "preset_not_entitled",
+              code: "advanced_presets_require_plan",
+              presetId: pub.presetId,
+              planCode: entitlements.planCode,
+            },
+            { status: 403 }
+          );
+        }
+        if ("errors" in pub) {
+          return NextResponse.json({ error: "validation_failed", errors: pub.errors }, { status: 400 });
+        }
+        return NextResponse.json({ error: "publish_failed" }, { status: 500 });
+      }
 
-  return NextResponse.json({ published: pub.published, publishedAt: new Date().toISOString() });
+      await recordCustomizationAudit(prisma, resolved.tenant.tenantId, userId, "published", "admin_dashboard", {
+        beforePublished: before.published,
+        afterPublished: pub.published,
+      });
+
+      return NextResponse.json({ published: pub.published, publishedAt: new Date().toISOString() });
+    });
   },
   { requirePrivilegedApproval: false }
 );

--- a/packages/web/src/app/api/admin/operator-customization/revert-draft/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/revert-draft/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
 import { withSecurity } from "@/lib/middleware/api-security";
+import { handleOperatorCustomizationRoute } from "@/lib/server/operator-customization/operator-customization-route-guard";
 import {
   recordCustomizationAudit,
   revertPublishedToDraft,
@@ -16,25 +17,34 @@ const BodySchema = z.object({ tenantId: z.string().uuid().optional() });
 
 export const POST = withSecurity(
   async function POST(request: NextRequest) {
-  const admin = await isSuperAdmin();
-  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  const { userId } = await getSuperAdminStatus();
-  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return handleOperatorCustomizationRoute(async () => {
+      const admin = await isSuperAdmin();
+      if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      const { userId } = await getSuperAdminStatus();
+      if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = BodySchema.safeParse(await request.json().catch(() => ({})));
-  if (!body.success) return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+      const body = BodySchema.safeParse(await request.json().catch(() => ({})));
+      if (!body.success) return NextResponse.json({ error: "invalid_body" }, { status: 400 });
 
-  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
-  if (!tenant.ok) return tenant.response;
+      const resolved = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+      if (!resolved.ok) return resolved.response;
 
-  const rev = await revertPublishedToDraft(prisma, tenant.tenantId, userId);
-  if (!rev.ok) {
-    return NextResponse.json({ error: "validation_failed", errors: rev.errors }, { status: 400 });
-  }
+      const rev = await revertPublishedToDraft(prisma, resolved.tenant.tenantId, userId);
+      if (!rev.ok) {
+        return NextResponse.json({ error: "validation_failed", errors: rev.errors }, { status: 400 });
+      }
 
-  await recordCustomizationAudit(prisma, tenant.tenantId, userId, "draft_reverted_to_published", "admin_dashboard", {});
+      await recordCustomizationAudit(
+        prisma,
+        resolved.tenant.tenantId,
+        userId,
+        "draft_reverted_to_published",
+        "admin_dashboard",
+        {}
+      );
 
-  return NextResponse.json({ draft: rev.draft });
+      return NextResponse.json({ draft: rev.draft });
+    });
   },
   { requirePrivilegedApproval: false }
 );

--- a/packages/web/src/app/api/admin/operator-customization/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/route.ts
@@ -1,6 +1,6 @@
 /**
  * Operator Customization Studio — current draft/published state for admin dashboard surface.
- * Super-admin only. Tenant scoped via ?tenantId= or default slug tenant.
+ * Super-admin only. Tenant scoped via ?tenantId= or implicit single active tenant.
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -9,6 +9,8 @@ import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
 import { withSecurity } from "@/lib/middleware/api-security";
 import { ADMIN_DASHBOARD_MODULE_REGISTRY } from "@/lib/operator-customization/registry";
 import { OperatorSurfaceCustomizationSchema } from "@/lib/operator-customization/schema";
+import { getOperatorCustomizationEntitlementsForTenant } from "@/lib/server/operator-customization/operator-customization-entitlements";
+import { handleOperatorCustomizationRoute } from "@/lib/server/operator-customization/operator-customization-route-guard";
 import { getCustomizationState, saveDraft } from "@/lib/server/operator-customization/customization-service";
 import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
 import { prisma } from "@/shared/db/prismaClient";
@@ -17,29 +19,39 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export const GET = withSecurity(async function GET(request: NextRequest) {
-  const admin = await isSuperAdmin();
-  if (!admin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-  const { searchParams } = new URL(request.url);
-  const tenant = await resolveCustomizationTenantId(searchParams.get("tenantId"));
-  if (!tenant.ok) return tenant.response;
+  return handleOperatorCustomizationRoute(async () => {
+    const admin = await isSuperAdmin();
+    if (!admin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    const { searchParams } = new URL(request.url);
+    const resolved = await resolveCustomizationTenantId(searchParams.get("tenantId"));
+    if (!resolved.ok) return resolved.response;
 
-  const { userId } = await getSuperAdminStatus();
-  if (!userId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+    const { userId } = await getSuperAdminStatus();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
 
-  const state = await getCustomizationState(prisma, tenant.tenantId, userId);
+    const entitlements = await getOperatorCustomizationEntitlementsForTenant(resolved.tenant.tenantId);
+    const state = await getCustomizationState(prisma, resolved.tenant.tenantId, userId);
 
-  return NextResponse.json({
-    ...state,
-    registry: Object.values(ADMIN_DASHBOARD_MODULE_REGISTRY),
-    degraded: {
-      inference: "rules_only",
-      message:
-        "Prompt-assisted proposals use deterministic rules only in this build. No LLM writes to config.",
-    },
+    return NextResponse.json({
+      ...state,
+      tenant: {
+        id: resolved.tenant.tenantId,
+        slug: resolved.tenant.tenantSlug,
+        multiTenantEnvironment: resolved.tenant.multiTenantEnvironment,
+      },
+      entitlements,
+      registry: Object.values(ADMIN_DASHBOARD_MODULE_REGISTRY),
+      degraded: {
+        inference: "rules_only",
+        code: "rules_only_build",
+        message:
+          "Advisory proposals use deterministic rules only in this build. Nothing auto-publishes; review before apply.",
+      },
+    });
   });
 });
 
@@ -50,56 +62,87 @@ const PutBodySchema = z.object({
 
 export const PUT = withSecurity(
   async function PUT(request: NextRequest) {
-  const admin = await isSuperAdmin();
-  if (!admin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-  const { userId } = await getSuperAdminStatus();
-  if (!userId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+    return handleOperatorCustomizationRoute(async () => {
+      const admin = await isSuperAdmin();
+      if (!admin) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+      const { userId } = await getSuperAdminStatus();
+      if (!userId) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
 
-  const body = PutBodySchema.safeParse(await request.json().catch(() => null));
-  if (!body.success) {
-    return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
-  }
+      const body = PutBodySchema.safeParse(await request.json().catch(() => null));
+      if (!body.success) {
+        return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
+      }
 
-  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
-  if (!tenant.ok) return tenant.response;
+      const resolved = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+      if (!resolved.ok) return resolved.response;
 
-  const parsedConfig = OperatorSurfaceCustomizationSchema.safeParse(body.data.draft);
-  if (!parsedConfig.success) {
-    return NextResponse.json(
-      { error: "invalid_config", issues: parsedConfig.error.issues },
-      { status: 400 }
-    );
-  }
+      const entitlements = await getOperatorCustomizationEntitlementsForTenant(resolved.tenant.tenantId);
 
-  const saved = await saveDraft(prisma, tenant.tenantId, userId, parsedConfig.data);
-  if (!saved.ok) {
-    return NextResponse.json({ error: "validation_failed", errors: saved.errors }, { status: 400 });
-  }
+      const parsedConfig = OperatorSurfaceCustomizationSchema.safeParse(body.data.draft);
+      if (!parsedConfig.success) {
+        return NextResponse.json(
+          { error: "invalid_config", issues: parsedConfig.error.issues },
+          { status: 400 }
+        );
+      }
 
-  await prisma.operatorCustomizationAudit.create({
-    data: {
-      tenantId: tenant.tenantId,
-      userId,
-      action: "draft_saved",
-      surface: "admin_dashboard",
-      details: { source: "studio_manual" },
-    },
-  });
+      const saved = await saveDraft(
+        prisma,
+        resolved.tenant.tenantId,
+        userId,
+        parsedConfig.data,
+        entitlements
+      );
+      if (!saved.ok) {
+        if ("code" in saved && saved.code === "preset_not_entitled") {
+          return NextResponse.json(
+            {
+              error: "preset_not_entitled",
+              code: "advanced_presets_require_plan",
+              presetId: saved.presetId,
+              planCode: entitlements.planCode,
+            },
+            { status: 403 }
+          );
+        }
+        if ("errors" in saved) {
+          return NextResponse.json({ error: "validation_failed", errors: saved.errors }, { status: 400 });
+        }
+        return NextResponse.json({ error: "save_failed" }, { status: 500 });
+      }
 
-  const state = await getCustomizationState(prisma, tenant.tenantId, userId);
-  return NextResponse.json({
-    ...state,
-    registry: Object.values(ADMIN_DASHBOARD_MODULE_REGISTRY),
-    degraded: {
-      inference: "rules_only",
-      message:
-        "Prompt-assisted proposals use deterministic rules only in this build. No LLM writes to config.",
-    },
-  });
+      await prisma.operatorCustomizationAudit.create({
+        data: {
+          tenantId: resolved.tenant.tenantId,
+          userId,
+          action: "draft_saved",
+          surface: "admin_dashboard",
+          details: { source: "studio_manual" },
+        },
+      });
+
+      const state = await getCustomizationState(prisma, resolved.tenant.tenantId, userId);
+      return NextResponse.json({
+        ...state,
+        tenant: {
+          id: resolved.tenant.tenantId,
+          slug: resolved.tenant.tenantSlug,
+          multiTenantEnvironment: resolved.tenant.multiTenantEnvironment,
+        },
+        entitlements,
+        registry: Object.values(ADMIN_DASHBOARD_MODULE_REGISTRY),
+        degraded: {
+          inference: "rules_only",
+          code: "rules_only_build",
+          message:
+            "Advisory proposals use deterministic rules only in this build. Nothing auto-publishes; review before apply.",
+        },
+      });
+    });
   },
   { requirePrivilegedApproval: false }
 );

--- a/packages/web/src/app/api/admin/operator-customization/signals/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/signals/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
 import { withSecurity } from "@/lib/middleware/api-security";
 import { listRegistryModuleIds } from "@/lib/operator-customization/registry";
+import { handleOperatorCustomizationRoute } from "@/lib/server/operator-customization/operator-customization-route-guard";
 import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
 import { prisma } from "@/shared/db/prismaClient";
 
@@ -18,34 +19,36 @@ const BodySchema = z.object({
 
 export const POST = withSecurity(
   async function POST(request: NextRequest) {
-  const admin = await isSuperAdmin();
-  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  const { userId } = await getSuperAdminStatus();
+    return handleOperatorCustomizationRoute(async () => {
+      const admin = await isSuperAdmin();
+      if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      const { userId } = await getSuperAdminStatus();
 
-  const body = BodySchema.safeParse(await request.json().catch(() => null));
-  if (!body.success) {
-    return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
-  }
+      const body = BodySchema.safeParse(await request.json().catch(() => null));
+      if (!body.success) {
+        return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
+      }
 
-  const tenant = await resolveCustomizationTenantId(body.data.tenantId ?? null);
-  if (!tenant.ok) return tenant.response;
+      const resolved = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+      if (!resolved.ok) return resolved.response;
 
-  const allowed = new Set(listRegistryModuleIds());
-  if (!allowed.has(body.data.moduleId)) {
-    return NextResponse.json({ error: "unknown_module" }, { status: 400 });
-  }
+      const allowed = new Set(listRegistryModuleIds());
+      if (!allowed.has(body.data.moduleId)) {
+        return NextResponse.json({ error: "unknown_module" }, { status: 400 });
+      }
 
-  await prisma.operatorInteractionSignal.create({
-    data: {
-      tenantId: tenant.tenantId,
-      userId,
-      signalType: body.data.signalType,
-      moduleId: body.data.moduleId,
-      metadata: (body.data.metadata ?? {}) as object,
-    },
-  });
+      await prisma.operatorInteractionSignal.create({
+        data: {
+          tenantId: resolved.tenant.tenantId,
+          userId,
+          signalType: body.data.signalType,
+          moduleId: body.data.moduleId,
+          metadata: (body.data.metadata ?? {}) as object,
+        },
+      });
 
-  return NextResponse.json({ ok: true });
+      return NextResponse.json({ ok: true });
+    });
   },
   { requirePrivilegedApproval: false }
 );

--- a/packages/web/src/app/api/admin/operator-customization/suggestions/dismiss/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/suggestions/dismiss/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { isSuperAdmin, getSuperAdminStatus } from "@/lib/auth/super-admin";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
+import { handleOperatorCustomizationRoute } from "@/lib/server/operator-customization/operator-customization-route-guard";
+import { prisma } from "@/shared/db/prismaClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const BodySchema = z.object({
+  tenantId: z.string().uuid().optional(),
+  surface: z.literal("admin_dashboard").default("admin_dashboard"),
+  suggestionKind: z.literal("pin_module"),
+  suggestionKey: z.string().min(1).max(128),
+  reasonCategory: z.string().max(64).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const POST = withSecurity(
+  async function POST(request: NextRequest) {
+    return handleOperatorCustomizationRoute(async () => {
+      const admin = await isSuperAdmin();
+      if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      const { userId } = await getSuperAdminStatus();
+      if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+      const body = BodySchema.safeParse(await request.json().catch(() => null));
+      if (!body.success) {
+        return NextResponse.json({ error: "invalid_body", issues: body.error.issues }, { status: 400 });
+      }
+
+      const resolved = await resolveCustomizationTenantId(body.data.tenantId ?? null);
+      if (!resolved.ok) return resolved.response;
+      const { tenantId } = resolved.tenant;
+
+      await prisma.operatorSuggestionDismissal.upsert({
+        where: {
+          tenantId_userId_surface_suggestionKind_suggestionKey: {
+            tenantId,
+            userId,
+            surface: body.data.surface,
+            suggestionKind: body.data.suggestionKind,
+            suggestionKey: body.data.suggestionKey,
+          },
+        },
+        create: {
+          tenantId,
+          userId,
+          surface: body.data.surface,
+          suggestionKind: body.data.suggestionKind,
+          suggestionKey: body.data.suggestionKey,
+          reasonCategory: body.data.reasonCategory ?? null,
+          metadata: (body.data.metadata ?? {}) as object,
+        },
+        update: {
+          reasonCategory: body.data.reasonCategory ?? null,
+          metadata: (body.data.metadata ?? {}) as object,
+          dismissedAt: new Date(),
+        },
+      });
+
+      await prisma.operatorCustomizationAudit.create({
+        data: {
+          tenantId,
+          userId,
+          action: "suggestion_dismissed",
+          surface: body.data.surface,
+          details: {
+            suggestionKind: body.data.suggestionKind,
+            suggestionKey: body.data.suggestionKey,
+            reasonCategory: body.data.reasonCategory ?? null,
+          },
+        },
+      });
+
+      return NextResponse.json({ ok: true });
+    });
+  },
+  { requirePrivilegedApproval: false }
+);

--- a/packages/web/src/app/api/admin/operator-customization/suggestions/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/suggestions/route.ts
@@ -3,6 +3,7 @@ import { isSuperAdmin } from "@/lib/auth/super-admin";
 import { getSuperAdminStatus } from "@/lib/auth/super-admin";
 import { withSecurity } from "@/lib/middleware/api-security";
 import { computeModuleVisitSuggestions } from "@/lib/operator-customization/suggestion-engine";
+import { handleOperatorCustomizationRoute } from "@/lib/server/operator-customization/operator-customization-route-guard";
 import { resolveCustomizationTenantId } from "@/lib/server/operator-customization/tenant-context";
 import { prisma } from "@/shared/db/prismaClient";
 
@@ -10,19 +11,29 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export const GET = withSecurity(async function GET(request: NextRequest) {
-  const admin = await isSuperAdmin();
-  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  const { userId } = await getSuperAdminStatus();
+  return handleOperatorCustomizationRoute(async () => {
+    const admin = await isSuperAdmin();
+    if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    const { userId } = await getSuperAdminStatus();
 
-  const { searchParams } = new URL(request.url);
-  const tenant = await resolveCustomizationTenantId(searchParams.get("tenantId"));
-  if (!tenant.ok) return tenant.response;
+    const { searchParams } = new URL(request.url);
+    const resolved = await resolveCustomizationTenantId(searchParams.get("tenantId"));
+    if (!resolved.ok) return resolved.response;
 
-  const suggestions = await computeModuleVisitSuggestions(prisma, tenant.tenantId, userId ?? null);
+    const suggestions = await computeModuleVisitSuggestions(
+      prisma,
+      resolved.tenant.tenantId,
+      userId ?? null
+    );
 
-  return NextResponse.json({
-    suggestions,
-    evidenceNote:
-      "Counts are from operator_interaction_signals (module_view) in the last 7 days, tenant-scoped.",
+    return NextResponse.json({
+      suggestions,
+      tenant: {
+        id: resolved.tenant.tenantId,
+        slug: resolved.tenant.tenantSlug,
+      },
+      evidenceNote:
+        "Counts are from operator_interaction_signals (module_view) in the last 7 days, tenant-scoped. Dismissals persist per tenant and operator.",
+    });
   });
 });

--- a/packages/web/src/app/api/admin/operator-customization/tenants/route.ts
+++ b/packages/web/src/app/api/admin/operator-customization/tenants/route.ts
@@ -1,0 +1,22 @@
+/**
+ * Active tenants for super-admin customization targeting (explicit tenant selection in multi-tenant envs).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { isSuperAdmin } from "@/lib/auth/super-admin";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { listActiveTenantsForPicker } from "@/lib/server/operator-customization/tenant-context";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const GET = withSecurity(async function GET(_request: NextRequest) {
+  const admin = await isSuperAdmin();
+  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const items = await listActiveTenantsForPicker();
+  return NextResponse.json({
+    items,
+    activeTenantCount: items.length,
+  });
+});

--- a/packages/web/src/lib/admin/hooks/use-operator-dashboard-customization.ts
+++ b/packages/web/src/lib/admin/hooks/use-operator-dashboard-customization.ts
@@ -10,7 +10,9 @@ export type CustomizationApiResponse = {
   published: OperatorSurfaceCustomization;
   publishedAt: string | null;
   draftUpdatedAt: string;
-  degraded?: { inference: string; message: string };
+  tenant?: { id: string; slug: string; multiTenantEnvironment?: boolean };
+  entitlements?: { planCode: string; capabilities: Record<string, boolean> };
+  degraded?: { inference: string; message: string; code?: string };
 };
 
 export function useOperatorDashboardCustomization() {
@@ -52,13 +54,17 @@ export function useOperatorDashboardCustomization() {
   };
 }
 
-export function recordModuleViewSignal(moduleId: string): void {
+export function recordModuleViewSignal(moduleId: string, tenantId?: string | null): void {
   try {
     void fetch("/api/admin/operator-customization/signals", {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ signalType: "module_view", moduleId }),
+      body: JSON.stringify({
+        signalType: "module_view",
+        moduleId,
+        ...(tenantId ? { tenantId } : {}),
+      }),
     });
   } catch {
     /* non-blocking */

--- a/packages/web/src/lib/operator-customization/proposal-rules.ts
+++ b/packages/web/src/lib/operator-customization/proposal-rules.ts
@@ -12,13 +12,20 @@ export type ProposalBuildResult =
       patch: CustomizationPatch;
       rationale: string;
       inferenceMode: InferenceMode;
+      /** Bounded, machine-auditable metadata (no free-form claims). */
+      explanationEvidence: Record<string, unknown>;
     }
-  | { ok: false; reason: string; inferenceMode: InferenceMode };
+  | { ok: false; reason: string; inferenceMode: InferenceMode; explanationEvidence: Record<string, unknown> };
 
-function applyPreset(presetId: string, rationale: string): ProposalBuildResult {
+function applyPreset(presetId: string, rationale: string, ruleId: string): ProposalBuildResult {
   const preset = getPresetById(presetId);
   if (!preset) {
-    return { ok: false, reason: `Unknown preset: ${presetId}`, inferenceMode: "rules" };
+    return {
+      ok: false,
+      reason: `Unknown preset: ${presetId}`,
+      inferenceMode: "rules",
+      explanationEvidence: { engine: "rules", ruleId: "unknown_preset", presetId },
+    };
   }
   const full = preset.customization();
   return {
@@ -30,44 +37,65 @@ function applyPreset(presetId: string, rationale: string): ProposalBuildResult {
     },
     rationale,
     inferenceMode: "rules",
+    explanationEvidence: {
+      engine: "rules",
+      ruleId,
+      presetId,
+      proposalLane: "rules",
+    },
   };
 }
 
 export function buildProposalFromNaturalLanguage(request: string): ProposalBuildResult {
   const trimmed = request.trim();
   if (!trimmed) {
-    return { ok: false, reason: "Empty request.", inferenceMode: "rules" };
+    return {
+      ok: false,
+      reason: "Empty request.",
+      inferenceMode: "rules",
+      explanationEvidence: { engine: "rules", ruleId: "empty_request" },
+    };
   }
 
   if (/solo|single\s*operator|one\s*person|compact/i.test(trimmed)) {
     return applyPreset(
       "solo_operator",
-      "Matched solo-operator intent: Solo operator preset (compact path; activity feed off)."
+      "Matched solo-operator intent: Solo operator preset (compact path; activity feed off).",
+      "intent_solo_operator"
     );
   }
   if (/buyer|demo|enterprise\s*pitch|sales/i.test(trimmed)) {
-    return applyPreset("buyer_demo", "Matched buyer-demo intent: Buyer demo preset.");
+    return applyPreset("buyer_demo", "Matched buyer-demo intent: Buyer demo preset.", "intent_buyer_demo");
   }
   if (/exception|queue|heatmap|ops\s*first/i.test(trimmed)) {
     return applyPreset(
       "exception_ops",
-      "Matched exception-ops intent: heatmap ordered before KPI tiles."
+      "Matched exception-ops intent: heatmap ordered before KPI tiles.",
+      "intent_exception_ops"
     );
   }
   if (/default|reset|baseline/i.test(trimmed)) {
-    return applyPreset("default", "Reset to default layout and standard operating mode.");
+    return applyPreset("default", "Reset to default layout and standard operating mode.", "intent_reset_default");
   }
 
   if (/hide\s*activity|no\s*activity\s*feed|disable\s*activity/i.test(trimmed)) {
     return applyPreset(
       "solo_operator",
-      "Activity feed hidden via Solo operator preset (other modules unchanged vs that preset)."
+      "Activity feed hidden via Solo operator preset (other modules unchanged vs that preset).",
+      "intent_hide_activity"
     );
   }
 
   if (/finance|executive|summary|kpi/i.test(trimmed)) {
     const preset = getPresetById("default");
-    if (!preset) return { ok: false, reason: "Default preset missing.", inferenceMode: "rules" };
+    if (!preset) {
+      return {
+        ok: false,
+        reason: "Default preset missing.",
+        inferenceMode: "rules",
+        explanationEvidence: { engine: "rules", ruleId: "default_preset_missing" },
+      };
+    }
     const full = preset.customization();
     return {
       ok: true,
@@ -87,6 +115,12 @@ export function buildProposalFromNaturalLanguage(request: string): ProposalBuild
       rationale:
         "Finance/leadership wording: KPI title/help only; data still from GET /api/admin/metrics.",
       inferenceMode: "rules",
+      explanationEvidence: {
+        engine: "rules",
+        ruleId: "intent_finance_kpi_labels",
+        moduleId: "kpi_tiles",
+        proposalLane: "rules",
+      },
     };
   }
 
@@ -95,6 +129,7 @@ export function buildProposalFromNaturalLanguage(request: string): ProposalBuild
     reason:
       "No rules match. Try: solo operator, buyer demo, exception ops, hide activity feed, finance summary, or reset to default.",
     inferenceMode: "rules",
+    explanationEvidence: { engine: "rules", ruleId: "no_match" },
   };
 }
 

--- a/packages/web/src/lib/operator-customization/schema.ts
+++ b/packages/web/src/lib/operator-customization/schema.ts
@@ -46,5 +46,6 @@ export type CustomizationPatch = z.infer<typeof CustomizationPatchSchema>;
 export const ProposalStatusSchema = z.enum(["pending", "applied", "rejected"]);
 export type ProposalStatus = z.infer<typeof ProposalStatusSchema>;
 
-export const InferenceModeSchema = z.enum(["rules", "degraded_unavailable"]);
+/** `premium_llm` reserved for future advisory lane; never implies autonomous publish. */
+export const InferenceModeSchema = z.enum(["rules", "degraded_unavailable", "premium_llm"]);
 export type InferenceMode = z.infer<typeof InferenceModeSchema>;

--- a/packages/web/src/lib/operator-customization/suggestion-engine.ts
+++ b/packages/web/src/lib/operator-customization/suggestion-engine.ts
@@ -16,6 +16,9 @@ const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 const MIN_VISITS = 8;
 const MAX_SUGGESTIONS = 3;
 
+const SURFACE = "admin_dashboard";
+const KIND = "pin_module";
+
 export async function computeModuleVisitSuggestions(
   prisma: PrismaClient,
   tenantId: string,
@@ -38,8 +41,18 @@ export async function computeModuleVisitSuggestions(
 
   type Row = (typeof rows)[number];
 
+  let dismissedKeys = new Set<string>();
+  if (userId) {
+    const dismissals = await prisma.operatorSuggestionDismissal.findMany({
+      where: { tenantId, userId, surface: SURFACE, suggestionKind: KIND },
+      select: { suggestionKey: true },
+    });
+    dismissedKeys = new Set(dismissals.map((d: { suggestionKey: string }) => d.suggestionKey));
+  }
+
   const sorted = rows
     .filter((r: Row) => r._count.moduleId >= MIN_VISITS)
+    .filter((r: Row) => !dismissedKeys.has(r.moduleId))
     .sort((a: Row, b: Row) => b._count.moduleId - a._count.moduleId)
     .slice(0, MAX_SUGGESTIONS);
 

--- a/packages/web/src/lib/server/operator-customization/customization-service.ts
+++ b/packages/web/src/lib/server/operator-customization/customization-service.ts
@@ -7,6 +7,8 @@ import {
 } from "@/lib/operator-customization/normalize";
 import { defaultAdminDashboardCustomization } from "@/lib/operator-customization/registry";
 import type { OperatorSurfaceCustomization } from "@/lib/operator-customization/schema";
+import type { OperatorCustomizationEntitlements } from "./operator-customization-entitlements";
+import { validateCustomizationAgainstEntitlements } from "./operator-customization-validate";
 
 const SURFACE: OperatorSurfaceId = "admin_dashboard";
 
@@ -43,10 +45,16 @@ export async function saveDraft(
   prisma: PrismaClient,
   tenantId: string,
   userId: string,
-  config: OperatorSurfaceCustomization
-): Promise<{ ok: true } | { ok: false; errors: string[] }> {
+  config: OperatorSurfaceCustomization,
+  entitlements: OperatorCustomizationEntitlements
+): Promise<
+  { ok: true } | { ok: false; errors: string[] } | { ok: false; code: "preset_not_entitled"; presetId: string }
+> {
   const n = normalizeOperatorCustomization(config);
   if (!n.ok) return n;
+
+  const ent = validateCustomizationAgainstEntitlements(n.value, entitlements);
+  if (!ent.ok) return ent;
 
   await prisma.operatorCustomizationState.upsert({
     where: { tenantId_userId_surface: { tenantId, userId, surface: SURFACE } },
@@ -72,14 +80,22 @@ export async function saveDraft(
 export async function publishDraft(
   prisma: PrismaClient,
   tenantId: string,
-  userId: string
-): Promise<{ ok: true; published: OperatorSurfaceCustomization } | { ok: false; errors: string[] }> {
+  userId: string,
+  entitlements: OperatorCustomizationEntitlements
+): Promise<
+  | { ok: true; published: OperatorSurfaceCustomization }
+  | { ok: false; errors: string[] }
+  | { ok: false; code: "preset_not_entitled"; presetId: string }
+> {
   const row = await prisma.operatorCustomizationState.findUnique({
     where: { tenantId_userId_surface: { tenantId, userId, surface: SURFACE } },
   });
   const draft = ensureCustomizationShape(row?.draftConfig);
   const n = normalizeOperatorCustomization(draft);
   if (!n.ok) return n;
+
+  const ent = validateCustomizationAgainstEntitlements(n.value, entitlements);
+  if (!ent.ok) return ent;
 
   await prisma.operatorCustomizationState.upsert({
     where: { tenantId_userId_surface: { tenantId, userId, surface: SURFACE } },
@@ -133,12 +149,17 @@ export async function applyPatchToDraft(
   prisma: PrismaClient,
   tenantId: string,
   userId: string,
-  patch: CustomizationPatch
-): Promise<{ ok: true; draft: OperatorSurfaceCustomization } | { ok: false; errors: string[] }> {
+  patch: CustomizationPatch,
+  entitlements: OperatorCustomizationEntitlements
+): Promise<
+  | { ok: true; draft: OperatorSurfaceCustomization }
+  | { ok: false; errors: string[] }
+  | { ok: false; code: "preset_not_entitled"; presetId: string }
+> {
   const current = await getCustomizationState(prisma, tenantId, userId);
   const merged = applyCustomizationPatch(current.draft, patch);
   if (!merged.ok) return merged;
-  const saved = await saveDraft(prisma, tenantId, userId, merged.value);
+  const saved = await saveDraft(prisma, tenantId, userId, merged.value, entitlements);
   if (!saved.ok) return saved;
   return { ok: true, draft: merged.value };
 }

--- a/packages/web/src/lib/server/operator-customization/operator-customization-entitlements.ts
+++ b/packages/web/src/lib/server/operator-customization/operator-customization-entitlements.ts
@@ -1,0 +1,73 @@
+/**
+ * Server-truth capability boundaries for Operator Customization Studio.
+ * Additive to billing/reconciliation; does not gate reconciliation-core APIs.
+ */
+
+import { getAccountPlanCode } from "@/domain/billing/entitlements";
+import type { PlanCode } from "@/domain/billing/planConfig";
+import { prisma } from "@/shared/db/prismaClient";
+
+export type OperatorCustomizationCapability =
+  | "baseline_studio"
+  | "advanced_presets"
+  | "premium_proposal_lane"
+  | "llm_assisted_suggestions";
+
+const PREMIUM_PRESET_IDS = new Set(["buyer_demo", "exception_ops"]);
+
+/** Plans that unlock advanced preset packs (non-default layouts beyond baseline). */
+function planAllowsAdvancedPresets(plan: PlanCode): boolean {
+  return plan === "growth" || plan === "scale" || plan === "enterprise";
+}
+
+/** Future: enterprise + explicit flag; today always false until LLM lane ships. */
+function planAllowsPremiumProposalLane(_plan: PlanCode): boolean {
+  return false;
+}
+
+export type OperatorCustomizationEntitlements = {
+  planCode: PlanCode;
+  capabilities: Record<OperatorCustomizationCapability, boolean>;
+};
+
+export async function getOperatorCustomizationEntitlementsForTenant(
+  tenantId: string
+): Promise<OperatorCustomizationEntitlements> {
+  const tenant = await prisma.tenant.findUnique({
+    where: { id: tenantId },
+    select: { billingAccountId: true },
+  });
+
+  const planCode: PlanCode =
+    tenant?.billingAccountId != null
+      ? await getAccountPlanCode(tenant.billingAccountId)
+      : "starter";
+
+  const advancedPresets = planAllowsAdvancedPresets(planCode);
+  const premiumLane = planAllowsPremiumProposalLane(planCode);
+
+  return {
+    planCode,
+    capabilities: {
+      baseline_studio: true,
+      advanced_presets: advancedPresets,
+      premium_proposal_lane: premiumLane,
+      llm_assisted_suggestions: premiumLane,
+    },
+  };
+}
+
+export function isPresetIdEntitled(
+  presetId: string,
+  entitlements: OperatorCustomizationEntitlements
+): boolean {
+  if (!PREMIUM_PRESET_IDS.has(presetId)) return true;
+  return entitlements.capabilities.advanced_presets === true;
+}
+
+export function assertPremiumProposalLaneAllowed(entitlements: OperatorCustomizationEntitlements): {
+  ok: true;
+} | { ok: false; code: "premium_lane_not_entitled" } {
+  if (entitlements.capabilities.premium_proposal_lane) return { ok: true };
+  return { ok: false, code: "premium_lane_not_entitled" };
+}

--- a/packages/web/src/lib/server/operator-customization/operator-customization-errors.ts
+++ b/packages/web/src/lib/server/operator-customization/operator-customization-errors.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Detect Prisma errors that indicate customization tables/columns are missing (migration not applied).
+ * Uses structural check so we do not depend on Prisma error class export surface across versions.
+ */
+export function isOperatorCustomizationSchemaMissingError(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("code" in error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "P2021" || code === "P2022";
+}
+
+export function customizationSchemaNotReadyResponse(): NextResponse {
+  return NextResponse.json(
+    {
+      error: "schema_not_ready",
+      code: "operator_customization_migration_required",
+      message:
+        "Operator customization persistence is unavailable until the latest database migration is applied.",
+    },
+    { status: 503 }
+  );
+}

--- a/packages/web/src/lib/server/operator-customization/operator-customization-route-guard.ts
+++ b/packages/web/src/lib/server/operator-customization/operator-customization-route-guard.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import {
+  customizationSchemaNotReadyResponse,
+  isOperatorCustomizationSchemaMissingError,
+} from "./operator-customization-errors";
+
+/** Map Prisma P2021/P2022 to a truthful 503 for operator customization routes. */
+export async function handleOperatorCustomizationRoute(
+  fn: () => Promise<NextResponse>
+): Promise<NextResponse> {
+  try {
+    return await fn();
+  } catch (e) {
+    if (isOperatorCustomizationSchemaMissingError(e)) {
+      return customizationSchemaNotReadyResponse();
+    }
+    throw e;
+  }
+}

--- a/packages/web/src/lib/server/operator-customization/operator-customization-validate.ts
+++ b/packages/web/src/lib/server/operator-customization/operator-customization-validate.ts
@@ -1,0 +1,16 @@
+import type { OperatorSurfaceCustomization } from "@/lib/operator-customization/schema";
+import {
+  type OperatorCustomizationEntitlements,
+  isPresetIdEntitled,
+} from "./operator-customization-entitlements";
+
+export function validateCustomizationAgainstEntitlements(
+  config: OperatorSurfaceCustomization,
+  entitlements: OperatorCustomizationEntitlements
+): { ok: true } | { ok: false; code: "preset_not_entitled"; presetId: string } {
+  const pid = config.lastAppliedPresetId;
+  if (pid && !isPresetIdEntitled(pid, entitlements)) {
+    return { ok: false, code: "preset_not_entitled", presetId: pid };
+  }
+  return { ok: true };
+}

--- a/packages/web/src/lib/server/operator-customization/tenant-context.ts
+++ b/packages/web/src/lib/server/operator-customization/tenant-context.ts
@@ -1,39 +1,115 @@
 import { NextResponse } from "next/server";
+import {
+  customizationSchemaNotReadyResponse,
+  isOperatorCustomizationSchemaMissingError,
+} from "./operator-customization-errors";
 import { prisma } from "@/shared/db/prismaClient";
+
+export type ResolvedCustomizationTenant = {
+  tenantId: string;
+  tenantSlug: string;
+  /** True when more than one active tenant exists; UI should show explicit context. */
+  multiTenantEnvironment: boolean;
+};
 
 /**
  * Resolve tenant for admin customization APIs.
- * Super-admins may pass ?tenantId=; otherwise default slug tenant is used.
+ * - With `tenantId`: must exist (UUID).
+ * - Without `tenantId`: allowed only when exactly one active tenant exists (solo-operator ergonomics).
+ * - Multiple active tenants: require explicit `tenantId` (fail closed on ambiguity).
  */
 export async function resolveCustomizationTenantId(
   requestedTenantId: string | null
-): Promise<{ ok: true; tenantId: string } | { ok: false; response: NextResponse }> {
+): Promise<{ ok: true; tenant: ResolvedCustomizationTenant } | { ok: false; response: NextResponse }> {
   if (requestedTenantId) {
-    const t = await prisma.tenant.findFirst({
-      where: { id: requestedTenantId },
-      select: { id: true },
-    });
-    if (!t) {
+    try {
+      const t = await prisma.tenant.findFirst({
+        where: { id: requestedTenantId, isActive: true },
+        select: { id: true, slug: true },
+      });
+      if (!t) {
+        return {
+          ok: false,
+          response: NextResponse.json({ error: "tenant_not_found" }, { status: 404 }),
+        };
+      }
+      const count = await prisma.tenant.count({ where: { isActive: true } });
       return {
-        ok: false,
-        response: NextResponse.json({ error: "tenant_not_found" }, { status: 404 }),
+        ok: true,
+        tenant: {
+          tenantId: t.id,
+          tenantSlug: t.slug,
+          multiTenantEnvironment: count > 1,
+        },
       };
+    } catch (e) {
+      if (isOperatorCustomizationSchemaMissingError(e)) {
+        return { ok: false, response: customizationSchemaNotReadyResponse() };
+      }
+      throw e;
     }
-    return { ok: true, tenantId: t.id };
   }
 
-  const def = await prisma.tenant.findUnique({
-    where: { slug: "default" },
-    select: { id: true },
-  });
-  if (!def) {
+  try {
+    const activeCount = await prisma.tenant.count({ where: { isActive: true } });
+    if (activeCount === 0) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          { error: "no_active_tenant", message: "No active tenant rows in database." },
+          { status: 503 }
+        ),
+      };
+    }
+    if (activeCount > 1) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          {
+            error: "tenant_selection_required",
+            code: "ambiguous_tenant",
+            message:
+              "Multiple active tenants exist. Pass tenantId (query or body) to target exactly one workspace.",
+            activeTenantCount: activeCount,
+          },
+          { status: 400 }
+        ),
+      };
+    }
+
+    const only = await prisma.tenant.findFirst({
+      where: { isActive: true },
+      select: { id: true, slug: true },
+    });
+    if (!only) {
+      return {
+        ok: false,
+        response: NextResponse.json({ error: "tenant_resolve_failed" }, { status: 503 }),
+      };
+    }
+
     return {
-      ok: false,
-      response: NextResponse.json(
-        { error: "default_tenant_missing", message: "No default tenant row (slug=default)." },
-        { status: 503 }
-      ),
+      ok: true,
+      tenant: {
+        tenantId: only.id,
+        tenantSlug: only.slug,
+        multiTenantEnvironment: false,
+      },
     };
+  } catch (e) {
+    if (isOperatorCustomizationSchemaMissingError(e)) {
+      return { ok: false, response: customizationSchemaNotReadyResponse() };
+    }
+    throw e;
   }
-  return { ok: true, tenantId: def.id };
+}
+
+export async function listActiveTenantsForPicker(): Promise<
+  Array<{ id: string; slug: string; name: string }>
+> {
+  return prisma.tenant.findMany({
+    where: { isActive: true },
+    select: { id: true, slug: true, name: true },
+    orderBy: { slug: "asc" },
+  });
 }

--- a/prisma/migrations/20260406100000_operator_customization_dismissals_and_proposal_metadata/migration.sql
+++ b/prisma/migrations/20260406100000_operator_customization_dismissals_and_proposal_metadata/migration.sql
@@ -1,0 +1,29 @@
+-- Durable suggestion dismissals + proposal lane / evidence metadata (additive; no reconciliation contract change).
+
+ALTER TABLE "operator_customization_proposals"
+  ADD COLUMN "proposal_lane" TEXT NOT NULL DEFAULT 'rules',
+  ADD COLUMN "explanation_evidence" JSONB NOT NULL DEFAULT '{}';
+
+CREATE TABLE "operator_suggestion_dismissals" (
+    "id" UUID NOT NULL,
+    "tenant_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "surface" TEXT NOT NULL,
+    "suggestion_kind" TEXT NOT NULL,
+    "suggestion_key" TEXT NOT NULL,
+    "reason_category" TEXT,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "dismissed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "operator_suggestion_dismissals_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "operator_suggestion_dismissals_tenant_user_surface_kind_key_key"
+  ON "operator_suggestion_dismissals"("tenant_id", "user_id", "surface", "suggestion_kind", "suggestion_key");
+
+CREATE INDEX "operator_suggestion_dismissals_tenant_id_user_id_surface_idx"
+  ON "operator_suggestion_dismissals"("tenant_id", "user_id", "surface");
+
+ALTER TABLE "operator_suggestion_dismissals"
+  ADD CONSTRAINT "operator_suggestion_dismissals_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1040,6 +1040,7 @@ model Tenant {
   operatorCustomizationProposals OperatorCustomizationProposal[]
   operatorCustomizationAudits OperatorCustomizationAudit[]
   operatorInteractionSignals OperatorInteractionSignal[]
+  operatorSuggestionDismissals OperatorSuggestionDismissal[]
 
   @@index([slug])
   @@index([primaryDomain])
@@ -2275,7 +2276,9 @@ model OperatorCustomizationProposal {
   naturalLanguageRequest String    @db.Text
   structuredPatch        Json      @default("{}")
   rationale              String?   @db.Text
-  inferenceMode          String    @default("rules") // rules | degraded_unavailable
+  inferenceMode          String    @default("rules") // rules | degraded_unavailable | premium_llm (future lane)
+  proposalLane           String    @default("rules") // rules | premium_llm — packaging / audit only; never auto-publish
+  explanationEvidence    Json      @default("{}") // bounded metadata: matched rule ids, registry version, etc.
   createdAt              DateTime  @default(now())
   appliedAt              DateTime?
   rejectedAt             DateTime?
@@ -2317,4 +2320,23 @@ model OperatorInteractionSignal {
   @@index([tenantId, moduleId, createdAt(sort: Desc)])
   @@index([userId])
   @@map("operator_interaction_signals")
+}
+
+/** Durable dismissal of a suggestion (tenant + user); not reconciliation truth. */
+model OperatorSuggestionDismissal {
+  id              String   @id @default(uuid())
+  tenantId        String   @db.Uuid
+  userId          String   @db.Uuid // actor who dismissed (same scope as customization draft)
+  surface         String
+  suggestionKind  String // e.g. pin_module
+  suggestionKey   String // e.g. module_id for pin_module
+  reasonCategory  String?
+  metadata        Json     @default("{}")
+  dismissedAt     DateTime @default(now())
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@unique([tenantId, userId, surface, suggestionKind, suggestionKey])
+  @@index([tenantId, userId, surface])
+  @@map("operator_suggestion_dismissals")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes major seams for the admin Operator Customization Studio: **explicit tenant targeting** when multiple active tenants exist, **durable suggestion dismissals** (tenant + user) with audit, **server-enforced preset entitlements** tied to billing plan (Growth+ for advanced presets), **proposal metadata** (`proposal_lane`, `explanation_evidence`) for auditability, and **truthful degraded responses** when customization tables/columns are missing (migration not applied).

## Key changes

- **Tenant resolution**: Removed implicit `slug=default` fallback. Single active tenant → implicit resolve; multiple → `400` with `tenant_selection_required` unless `tenantId` is passed.
- **New migration** `20260406100000_operator_customization_dismissals_and_proposal_metadata`: `operator_suggestion_dismissals` table; `proposal_lane` + `explanation_evidence` on proposals.
- **API**: `GET /api/admin/operator-customization/tenants` for workspace picker; `POST .../suggestions/dismiss`; GET proposals scoped to **current user + tenant**; apply proposal requires **matching tenant**.
- **UX**: Studio workspace selector, Growth+ gating UI for buyer/exception presets, clearer draft/publish/save copy, rules-based proposal labeling (not “AI”).
- **Signals**: Admin dashboard passes `tenantId` on `module_view` / reorder only when customization API reports a **non–multi-tenant** workspace (avoids wrong-tenant attribution).

## Tests

- Jest: `operator-customization.routes.test.ts` (authz shape, ambiguous tenant, preset entitlement, proposal scoping).
- Playwright: unauthenticated API 401/403 gates; optional super-admin `storageState` path documented in spec.

## Rollout

Apply Prisma migrations before relying on dismissals or new proposal columns; pre-migration runtime returns **503** `schema_not_ready` for customization routes when Prisma reports missing table/column.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86dabc5e-5736-43be-b6ae-8847647fbda2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86dabc5e-5736-43be-b6ae-8847647fbda2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

