### PR TITLE
fix(vercel): include root scripts in deployment context to prevent preinstall failure

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -37,11 +37,9 @@ tests/
 # CI/CD (not needed in deployment)
 .github/
 
-# Root scripts directory (not needed in deployment)
-# IMPORTANT: Use /scripts/ (anchored) not scripts/ (unanchored)
-# Unanchored scripts/ matches ALL directories named "scripts" at any depth,
-# including packages/web/scripts/ which contains build-time assert-build-env.mjs
-/scripts/
+# Keep root scripts included.
+# Vercel install/build invokes root scripts via package lifecycle hooks (preinstall/postinstall/prebuild).
+# Excluding /scripts causes install-time MODULE_NOT_FOUND failures.
 
 # Other
 .DS_Store


### PR DESCRIPTION
### Motivation
- Vercel builds were failing during install because `.vercelignore` excluded the root `/scripts/` directory while `preinstall` runs `node scripts/assert-node-version.mjs`, causing a `MODULE_NOT_FOUND` error; the change restores required lifecycle scripts to the deployment context.

### Description
- Removed the `/scripts/` exclusion from `.vercelignore` and added a comment explaining that root lifecycle hooks (`preinstall`/`postinstall`/`prebuild`) require root `scripts/` to be present so install/build steps do not crash.

### Testing
- `git check-ignore -v scripts/assert-node-version.mjs` — ✅ confirmed the script is no longer ignored (included in upload context).
- `npx pnpm@10.13.1 install --frozen-lockfile` — ⚠️ attempted but blocked by host Node mismatch (v22.x in environment vs repo engines `>=24 <25`), not by missing script.
- `pnpm exec turbo run lint --filter @settler/web...` — ⚠️ could not run because workspace dependencies were not installed in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3547675608328a077c9c8a5efcf56)