### PR TITLE
fix: remove fake diagnostics, hardcoded 99.9% trust stat, and duplicate import — sellability hardening

### DIFF
--- a/packages/web/src/app/console/diagnostics/page.tsx
+++ b/packages/web/src/app/console/diagnostics/page.tsx
@@ -1,271 +1,384 @@
+/**
+ * System Diagnostics Page
+ *
+ * Shows real runtime connectivity health sourced from /api/health.
+ * No synthetic fleet metrics, no hardcoded infrastructure values.
+ *
+ * What this page shows:
+ * - Database connectivity (live check)
+ * - Supabase connectivity (live check)
+ * - Runtime environment validity (live check)
+ * - Links to operator surfaces and support tooling
+ *
+ * What this page does NOT show:
+ * - CPU / memory (not available in Next.js App Router server components)
+ * - Worker fleet metrics (not applicable to this deployment model)
+ * - Redis or object storage ping (not exposed in health endpoint)
+ */
+
+import { headers } from "next/headers";
+import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Activity,
-  Terminal as TerminalIcon,
-  RefreshCw,
-  ShieldCheck,
-  Server,
-  Cloud,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
   Database,
-  SearchCode,
-  Globe,
+  Shield,
+  ExternalLink,
+  Info,
 } from "lucide-react";
+import { ConsolePageHeader } from "@/components/console/ConsolePageHeader";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
 export const metadata = {
-  title: "System Diagnostics | Settler",
-  description: "Deep-level infrastructure health and cryptographic integrity monitoring.",
+  title: "Diagnostics | Settler Console",
+  description: "Runtime connectivity and environment health for your Settler workspace.",
 };
 
-export default function DiagnosticsPage() {
+type CheckStatus = "ok" | "error" | "unknown";
+
+interface HealthCheck {
+  status: CheckStatus;
+  message?: string;
+}
+
+interface HealthPayload {
+  overallStatus?: "healthy" | "degraded" | "unhealthy";
+  checks?: Record<string, HealthCheck>;
+  connectivity?: {
+    checks?: Record<string, { ok?: boolean; status?: string; reason?: string }>;
+    degraded_reasons?: string[];
+    timestamp?: string;
+  };
+  traceId?: string;
+  error?: string;
+}
+
+async function fetchHealth(): Promise<HealthPayload | null> {
+  try {
+    const h = await headers();
+    const host = h.get("host") || "localhost:3000";
+    const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
+    const res = await fetch(`${protocol}://${host}/api/health`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as HealthPayload;
+  } catch {
+    return null;
+  }
+}
+
+function statusIcon(status: CheckStatus | boolean | undefined) {
+  if (status === true || status === "ok") {
+    return <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />;
+  }
+  if (status === false || status === "error") {
+    return <XCircle className="h-4 w-4 text-destructive" />;
+  }
+  return <AlertTriangle className="h-4 w-4 text-yellow-500" />;
+}
+
+function statusBadge(status: CheckStatus | boolean | undefined) {
+  if (status === true || status === "ok") {
+    return (
+      <Badge variant="outline" className="text-green-700 border-green-300 bg-green-50 dark:bg-green-950/30 dark:text-green-400 dark:border-green-800">
+        OK
+      </Badge>
+    );
+  }
+  if (status === false || status === "error") {
+    return <Badge variant="destructive">Error</Badge>;
+  }
+  return <Badge variant="outline">Unknown</Badge>;
+}
+
+interface CheckRowProps {
+  label: string;
+  description: string;
+  status: CheckStatus | boolean | undefined;
+  message?: string;
+}
+
+function CheckRow({ label, description, status, message }: CheckRowProps) {
   return (
-    <div className="space-y-8 pb-12">
-      <div className="flex items-end justify-between">
-        <div className="max-w-4xl">
-          <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary/70 mb-2">
-            System Observability
-          </p>
-          <h1 className="text-4xl font-bold tracking-tight text-foreground">Diagnostics</h1>
-          <p className="mt-4 text-base text-muted-foreground leading-relaxed">
-            Real-time health telemetry across the reconciliation fleet. Monitor resource usage,
-            worker health, and the cryptographic consistency of distributed trust nodes.
-          </p>
-        </div>
-        <div className="flex gap-3">
-          <Button variant="outline" size="lg" className="h-12 font-bold gap-2">
-            <RefreshCw className="h-4 w-4" />
-            Full System Re-Scan
-          </Button>
+    <div className="flex items-start justify-between gap-4 py-4 border-b border-border/40 last:border-0">
+      <div className="flex items-start gap-3 min-w-0">
+        <div className="mt-0.5">{statusIcon(status)}</div>
+        <div className="min-w-0">
+          <div className="text-sm font-medium">{label}</div>
+          <div className="text-xs text-muted-foreground mt-0.5">{description}</div>
+          {message && (
+            <div className="text-xs text-muted-foreground/70 mt-1 font-mono break-all">{message}</div>
+          )}
         </div>
       </div>
+      <div className="shrink-0">{statusBadge(status)}</div>
+    </div>
+  );
+}
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Resource Telemetry */}
-        <div className="lg:col-span-2 space-y-8">
-          <Card className="border-border/40 overflow-hidden glass border-l-4 border-l-primary/60">
-            <CardHeader className="bg-muted/10 pb-6 border-b border-border/40">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <Activity className="h-5 w-5 text-primary" />
-                  <div>
-                    <CardTitle className="text-lg font-bold italic underline">
-                      Resource Real-time Telemetry
-                    </CardTitle>
-                    <CardDescription className="text-xs font-medium">
-                      Performance metrics for active reconciliation workers
-                    </CardDescription>
-                  </div>
-                </div>
-                <Badge className="bg-success text-white font-black tracking-widest text-[9px] h-6 px-3">
-                  ALL SYSTEMS NOMINAL
-                </Badge>
+export default async function DiagnosticsPage() {
+  const health = await fetchHealth();
+
+  const fetchFailed = !health;
+  const overallStatus = health?.overallStatus ?? "unknown";
+  const checks = health?.checks ?? {};
+  const connChecks = health?.connectivity?.checks ?? {};
+  const degradedReasons = health?.connectivity?.degraded_reasons ?? [];
+  const ts = health?.connectivity?.timestamp ?? null;
+
+  const envOk = checks.env?.status === "ok";
+  const dbOk = connChecks.database?.ok === true || checks.database?.status === "ok";
+  const supabaseOk = connChecks.supabase?.ok === true || checks.supabase?.status === "ok";
+
+  return (
+    <div className="space-y-6 pb-12">
+      <ConsolePageHeader
+        title="Diagnostics"
+        description="Runtime connectivity health for your Settler workspace. All checks source from live API calls — no synthetic values."
+      />
+
+      {fetchFailed && (
+        <Card className="border-destructive/40 bg-destructive/5">
+          <CardContent className="pt-6 flex items-start gap-3">
+            <XCircle className="h-5 w-5 text-destructive mt-0.5 shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-destructive">Health endpoint unreachable</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                The diagnostics page could not fetch{" "}
+                <code className="text-[11px]">/api/health</code>. The app itself is running if you
+                see this page, but the health check circuit failed. Check your environment
+                variables and Supabase configuration.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Overall status banner */}
+      {!fetchFailed && (
+        <Card
+          className={
+            overallStatus === "healthy"
+              ? "border-green-300 bg-green-50/50 dark:bg-green-950/20 dark:border-green-800/40"
+              : overallStatus === "degraded"
+                ? "border-yellow-300 bg-yellow-50/50 dark:bg-yellow-950/20 dark:border-yellow-700/40"
+                : "border-destructive/40 bg-destructive/5"
+          }
+        >
+          <CardContent className="pt-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <Activity
+                className={`h-5 w-5 ${overallStatus === "healthy" ? "text-green-600 dark:text-green-400" : overallStatus === "degraded" ? "text-yellow-600 dark:text-yellow-400" : "text-destructive"}`}
+              />
+              <div>
+                <p className="text-sm font-semibold">
+                  {overallStatus === "healthy"
+                    ? "All connectivity checks passed"
+                    : overallStatus === "degraded"
+                      ? "Some connectivity checks degraded"
+                      : "Connectivity checks failed"}
+                </p>
+                {ts && (
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Checked at {new Date(ts).toLocaleString()}
+                  </p>
+                )}
               </div>
+            </div>
+            <Badge
+              variant={
+                overallStatus === "healthy"
+                  ? "outline"
+                  : overallStatus === "degraded"
+                    ? "warning"
+                    : "destructive"
+              }
+              className={
+                overallStatus === "healthy"
+                  ? "text-green-700 border-green-300 dark:text-green-400 dark:border-green-800"
+                  : ""
+              }
+            >
+              {overallStatus.toUpperCase()}
+            </Badge>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Degraded reasons */}
+      {degradedReasons.length > 0 && (
+        <Card className="border-yellow-300/60 bg-yellow-50/30 dark:bg-yellow-950/10">
+          <CardContent className="pt-6">
+            <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
+              Degraded signals
+            </p>
+            <ul className="space-y-1">
+              {degradedReasons.map((r, i) => (
+                <li key={i} className="text-sm text-muted-foreground flex items-start gap-2">
+                  <AlertTriangle className="h-3.5 w-3.5 text-yellow-500 mt-0.5 shrink-0" />
+                  {r}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Runtime checks */}
+        <div className="lg:col-span-2 space-y-6">
+          <Card>
+            <CardHeader className="pb-2 border-b border-border/40">
+              <div className="flex items-center gap-2">
+                <Database className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-sm font-semibold">Connectivity checks</CardTitle>
+              </div>
+              <CardDescription className="text-xs">
+                Live checks run on each page load against your configured environment.
+              </CardDescription>
             </CardHeader>
-            <CardContent className="p-8 space-y-12">
-              <div className="grid grid-cols-2 gap-12">
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-black uppercase tracking-wider text-muted-foreground">
-                      Fleet Heap Memory
-                    </span>
-                    <span className="text-sm font-bold font-mono">4.12 GB / 64 GB</span>
-                  </div>
-                  <div className="h-2 w-full bg-muted rounded-full overflow-hidden">
-                    <div className="h-full bg-primary w-[6.4%]" />
-                  </div>
-                  <p className="text-[10px] text-muted-foreground font-medium italic">
-                    Peak utilization during batch match: 12.8 GB
-                  </p>
-                </div>
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-black uppercase tracking-wider text-muted-foreground">
-                      Orchestration CPU
-                    </span>
-                    <span className="text-sm font-bold font-mono">1.2% / 100%</span>
-                  </div>
-                  <div className="h-2 w-full bg-muted rounded-full overflow-hidden">
-                    <div className="h-full bg-primary w-[1.2%]" />
-                  </div>
-                  <p className="text-[10px] text-muted-foreground font-medium italic underline">
-                    Worker auto-scaling active (Min: 4, Max: 64)
-                  </p>
-                </div>
-              </div>
-
-              <div className="pt-8 border-t border-border/20 space-y-6">
-                <h3 className="text-sm font-bold flex items-center gap-2">
-                  <Cloud className="h-4 w-4 text-primary" />
-                  Infrastructure Layer Status
-                </h3>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {[
-                    { label: "Redis Mesh Connection", status: "Healthy", ping: "0.2ms" },
-                    { label: "Postgres Connection Pool", status: "Available", ping: "1.4ms" },
-                    { label: "Object Store Persistence", status: "Verified", ping: "—" },
-                    { label: "Global Auth Node (Edge)", status: "Active", ping: "18ms" },
-                  ].map((item) => (
-                    <div
-                      key={item.label}
-                      className="p-4 rounded-xl border border-border/40 bg-muted/20 flex items-center justify-between"
-                    >
-                      <div className="flex flex-col gap-1">
-                        <span className="text-[10px] font-black uppercase tracking-widest text-muted-foreground/80">
-                          {item.label}
-                        </span>
-                        <span className="text-xs font-bold font-mono text-primary uppercase italic underline">
-                          {item.status}
-                        </span>
-                      </div>
-                      <span className="text-[10px] font-bold text-muted-foreground/60">
-                        {item.ping}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </div>
+            <CardContent className="pt-2">
+              {fetchFailed ? (
+                <p className="text-sm text-muted-foreground py-4">
+                  Health endpoint unreachable — checks unavailable.
+                </p>
+              ) : (
+                <>
+                  <CheckRow
+                    label="Environment variables"
+                    description="Required Supabase and app environment variables are present."
+                    status={envOk ? "ok" : "error"}
+                    message={checks.env?.message}
+                  />
+                  <CheckRow
+                    label="Database (Prisma/PostgreSQL)"
+                    description="Prisma can reach the configured database endpoint."
+                    status={
+                      connChecks.database
+                        ? connChecks.database.ok
+                        : checks.database?.status
+                    }
+                    message={
+                      connChecks.database?.reason ||
+                      checks.database?.message
+                    }
+                  />
+                  <CheckRow
+                    label="Supabase connectivity"
+                    description="Supabase client can reach the configured project."
+                    status={
+                      connChecks.supabase
+                        ? connChecks.supabase.ok
+                        : checks.supabase?.status
+                    }
+                    message={
+                      connChecks.supabase?.reason ||
+                      checks.supabase?.message
+                    }
+                  />
+                  <CheckRow
+                    label="Runtime environment"
+                    description="App runtime can read its required configuration."
+                    status={
+                      connChecks.runtime_env
+                        ? connChecks.runtime_env.ok
+                        : envOk
+                          ? "ok"
+                          : "error"
+                    }
+                    message={connChecks.runtime_env?.reason}
+                  />
+                </>
+              )}
             </CardContent>
           </Card>
 
-          <Card className="border-border/40 bg-card/50 overflow-hidden">
-            <CardHeader className="pb-4 border-b border-border/40">
-              <CardTitle className="text-sm font-bold flex items-center gap-2 uppercase tracking-[0.2em] text-muted-foreground">
-                <SearchCode className="h-4 w-4" />
-                Recent Anomaly Traces
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="p-0">
-              <div className="divide-y divide-border/20 italic">
-                {[
-                  {
-                    id: "TR-921",
-                    time: "14:21:05",
-                    detail: "Signature mismatch on ingestion packet retry [REF: sk_921]",
-                    lvl: "Warn",
-                  },
-                  {
-                    id: "TR-884",
-                    time: "12:05:12",
-                    detail: "Worker NODE-14 garbage collection took > 200ms",
-                    lvl: "Info",
-                  },
-                ].map((trace) => (
-                  <div
-                    key={trace.id}
-                    className="p-4 flex items-center justify-between group hover:bg-primary/5 cursor-pointer transition-colors"
-                  >
-                    <div className="flex items-center gap-4">
-                      <span className="text-[10px] font-bold text-muted-foreground/60 font-mono">
-                        {trace.time}
-                      </span>
-                      <span className="text-xs font-medium text-foreground">{trace.detail}</span>
-                    </div>
-                    <Badge
-                      variant="outline"
-                      className={`text-[10px] font-black tracking-widest h-5 ${trace.lvl === "Warn" ? "text-warning border-warning/30 bg-warning/5" : "text-primary border-primary/30 bg-primary/5"}`}
-                    >
-                      TRACE_{trace.lvl.toUpperCase()}
-                    </Badge>
-                  </div>
-                ))}
-              </div>
-              <div className="p-4 bg-muted/10 text-center border-t border-border/20">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-[10px] font-black uppercase tracking-widest text-muted-foreground hover:text-primary"
-                >
-                  Clear Diagnostics Buffer
-                </Button>
+          {/* Scope note */}
+          <Card className="border-border/30 bg-muted/20">
+            <CardContent className="pt-6 flex items-start gap-3">
+              <Info className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+              <div className="text-xs text-muted-foreground leading-relaxed space-y-2">
+                <p>
+                  <strong className="font-medium text-foreground">Scope of these checks:</strong>{" "}
+                  connectivity checks validate that the app can reach its core dependencies.
+                  They do not surface application-layer metrics (CPU, memory, queue depth) — those
+                  are available in your infrastructure provider console.
+                </p>
+                <p>
+                  Worker-level metrics, cache state, and fleet telemetry are not exposed here
+                  because this deployment model does not provide application-layer resource
+                  visibility via the web runtime. If you need infrastructure observability, consult
+                  your Vercel / host dashboard.
+                </p>
               </div>
             </CardContent>
           </Card>
         </div>
 
-        {/* Sidebar Controls */}
-        <div className="space-y-8">
-          <Card className="border-border/40 bg-slate-950 shadow-2xl relative overflow-hidden group h-fit">
-            <div className="absolute inset-0 bg-primary/5 opacity-0 group-hover:opacity-100 transition-opacity" />
-            <CardHeader className="pb-4">
-              <div className="p-2 rounded-lg bg-primary/20 text-primary w-fit mb-4">
-                <ShieldCheck className="h-6 w-6" />
+        {/* Sidebar: operator surfaces */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="pb-3 border-b border-border/40">
+              <div className="flex items-center gap-2">
+                <Shield className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-sm font-semibold">Operator surfaces</CardTitle>
               </div>
-              <CardTitle className="text-white text-lg font-bold italic underline">
-                Integrity Health Check
-              </CardTitle>
-              <CardDescription className="text-slate-400 font-medium">
-                Verify the cryptographic consistency of the platform
+              <CardDescription className="text-xs">
+                Evidence-backed observability surfaces with query-backed truth.
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="space-y-4 pt-2">
-                <div className="flex items-center justify-between text-xs font-bold text-slate-300">
-                  <span className="flex items-center gap-2">
-                    <Globe size={14} className="opacity-40" />
-                    Trust Graph Sync
-                  </span>
-                  <span className="text-primary font-mono italic underline">100% OK</span>
-                </div>
-                <div className="flex items-center justify-between text-xs font-bold text-slate-300">
-                  <span className="flex items-center gap-2">
-                    <Database size={14} className="opacity-40" />
-                    Archive Retention
-                  </span>
-                  <span className="text-primary font-mono italic underline">VERIFIED</span>
-                </div>
-              </div>
-              <div className="pt-6 border-t border-white/5 space-y-4">
-                <p className="text-[10px] text-slate-500 font-bold leading-relaxed uppercase tracking-widest italic underline pb-4">
-                  Manual verification triggers a full scan of all Merkle roots for the current
-                  tenant. This process may take several minutes.
-                </p>
-                <Button className="w-full h-11 font-bold shadow-2xl gap-2 shadow-primary/40 group-hover:ring-2 ring-primary/40 transition-all">
-                  Exert System Pressure Test
-                </Button>
-              </div>
+            <CardContent className="pt-4 space-y-2">
+              <Button variant="outline" size="sm" className="w-full justify-between" asChild>
+                <Link href="/console/operator-digest">
+                  <span>Operator digest</span>
+                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+                </Link>
+              </Button>
+              <Button variant="outline" size="sm" className="w-full justify-between" asChild>
+                <Link href="/console/admin/tenants">
+                  <span>Tenant observability</span>
+                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+                </Link>
+              </Button>
+              <Button variant="outline" size="sm" className="w-full justify-between" asChild>
+                <Link href="/status">
+                  <span>Public status page</span>
+                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+                </Link>
+              </Button>
+              <Button variant="outline" size="sm" className="w-full justify-between" asChild>
+                <Link href="/console/audit-trail">
+                  <span>Audit trail</span>
+                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+                </Link>
+              </Button>
             </CardContent>
           </Card>
 
-          <Card className="border-border/40 bg-card/50">
-            <CardHeader className="pb-4 border-b border-border/20">
-              <div className="flex items-center gap-3">
-                <TerminalIcon className="h-4 w-4 text-primary" />
-                <CardTitle className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
-                  Operator Toolbox
-                </CardTitle>
-              </div>
+          <Card>
+            <CardHeader className="pb-3 border-b border-border/40">
+              <CardTitle className="text-sm font-semibold">Support & reporting</CardTitle>
             </CardHeader>
-            <CardContent className="p-4 space-y-3 pt-6">
-              <Button
-                variant="outline"
-                className="w-full h-10 text-xs font-bold justify-between group hover:border-primary/40 transition-all"
-              >
-                <span>Export Health Report</span>
-                <RefreshCw
-                  size={12}
-                  className="text-muted-foreground group-hover:text-primary transition-colors"
-                />
+            <CardContent className="pt-4 space-y-2">
+              <Button variant="outline" size="sm" className="w-full justify-between" asChild>
+                <Link href="/console/report-issue">
+                  <span>Report an issue</span>
+                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+                </Link>
               </Button>
-              <Button
-                variant="outline"
-                className="w-full h-10 text-xs font-bold justify-between group hover:border-primary/40 transition-all"
-              >
-                <span>Flush Engine Cache</span>
-                <RefreshCw
-                  size={12}
-                  className="text-muted-foreground group-hover:text-primary transition-colors"
-                />
-              </Button>
-              <Button
-                variant="outline"
-                className="w-full h-10 text-xs font-bold justify-between group hover:border-primary/40 transition-all"
-              >
-                <span>Provision New Worker</span>
-                <Server
-                  size={12}
-                  className="text-muted-foreground group-hover:text-primary transition-colors"
-                />
+              <Button variant="outline" size="sm" className="w-full justify-between" asChild>
+                <Link href="/console/support">
+                  <span>Support inbox (admin)</span>
+                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+                </Link>
               </Button>
             </CardContent>
           </Card>

--- a/packages/web/src/app/console/runs/[runId]/page.tsx
+++ b/packages/web/src/app/console/runs/[runId]/page.tsx
@@ -5,7 +5,6 @@ import { useParams, useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import {
   ArrowLeft,
-  CheckCircle2,
   AlertCircle,
   Settings,
   Shield,
@@ -101,11 +100,11 @@ export default function RunPage() {
         <div className="p-4 rounded-full bg-red-500/10 text-red-500">
           <AlertCircle className="w-12 h-12" />
         </div>
-        <CardTitle className="text-2xl">Reconciliation Intelligence Unavailable</CardTitle>
+        <CardTitle className="text-2xl">Run detail unavailable</CardTitle>
         <CardDescription className="max-w-md mx-auto">
           {error instanceof Error
             ? error.message
-            : "The requested run detail could not be resolved. This may be due to a transient network issue or invalid scope."}
+            : "The requested run detail could not be loaded. This may be due to a transient network issue or an invalid run ID."}
         </CardDescription>
         <div className="flex gap-3 pt-4">
           <Button variant="outline" onClick={() => router.back()}>
@@ -163,7 +162,7 @@ export default function RunPage() {
             onClick={handleRetry}
           >
             <RotateCcw className="w-4 h-4 mr-2" />
-            Re-run Intelligence
+            Retry run
           </Button>
         </div>
       </div>
@@ -172,7 +171,7 @@ export default function RunPage() {
         <DetailCard
           label="Operational State"
           value={run.status.toUpperCase()}
-          subtext={run.isTerminal ? "Execution Finalized" : "Running Intelligence Engine"}
+          subtext={run.isTerminal ? "Terminal" : "In progress"}
           status={run.status}
         />
         <DetailCard
@@ -188,10 +187,14 @@ export default function RunPage() {
           icon={BarChart3}
         />
         <DetailCard
-          label="Compliance Confidence"
-          value="99.9%"
-          subtext="Cryptographic Trust"
-          icon={CheckCircle2}
+          label="Proof signal"
+          value={run.compactProofSummary.operatorSummary.signal.replace(/_/g, " ").toUpperCase()}
+          subtext={
+            run.compactProofSummary.operatorSummary.proofPosture !== "unavailable"
+              ? `Posture ${run.compactProofSummary.operatorSummary.proofPosture}`
+              : "Posture unavailable"
+          }
+          icon={Shield}
         />
       </div>
 
@@ -222,9 +225,9 @@ export default function RunPage() {
       <Tabs defaultValue="statistics" className="w-full">
         <div className="flex items-center justify-between border-b border-border/40 pb-px mb-8 sticky top-0 bg-background/80 backdrop-blur-xl z-20">
           <TabsList className="bg-transparent h-12 p-0 gap-8">
-            <TabTrigger value="statistics" label="Performance & Variance" icon={BarChart3} />
-            <TabTrigger value="stages" label="Worker Lifecycle" icon={History} />
-            <TabTrigger value="config" label="Intelligence Config" icon={Settings} />
+            <TabTrigger value="statistics" label="Statistics" icon={BarChart3} />
+            <TabTrigger value="stages" label="Stages" icon={History} />
+            <TabTrigger value="config" label="Configuration" icon={Settings} />
             <TabTrigger value="provenance" label="Proof & Provenance" icon={Shield} />
           </TabsList>
           {isRefetching && (

--- a/packages/web/src/app/console/schedules/page.tsx
+++ b/packages/web/src/app/console/schedules/page.tsx
@@ -11,7 +11,6 @@ import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusBadge, type StatusType } from "@/components/ui/status-badge";
 import { ConsolePageHeader } from "@/components/console/ConsolePageHeader";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { safeFetch } from "@/lib/safe-fetch";
 import { ScheduleConfigPanel, type ScheduleJob } from "./components";
 

--- a/packages/web/src/app/docs/getting-started/page.tsx
+++ b/packages/web/src/app/docs/getting-started/page.tsx
@@ -1,57 +1,267 @@
-import { Metadata } from 'next';
-import Link from 'next/link';
+import { Metadata } from "next";
+import Link from "next/link";
+import { Navigation } from "@/components/Navigation";
+import { Footer } from "@/components/Footer";
+import {
+  ArrowRight,
+  Terminal,
+  Database,
+  CheckCircle2,
+  FileText,
+  Shield,
+  AlertTriangle,
+  Play,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 
 export const metadata: Metadata = {
-  title: 'Getting Started - Docs',
-  description: 'Get started with Settler in minutes',
+  title: "Getting Started — Settler Docs",
+  description:
+    "Set up your first reconciliation in Settler. This guide covers account creation, workspace setup, connecting data sources, and running your first reconciliation.",
 };
+
+const paths = [
+  {
+    title: "Cloud API (managed)",
+    description:
+      "Sign up, connect your data sources, and run reconciliation without infrastructure to manage.",
+    badge: "Recommended",
+    steps: [
+      {
+        icon: CheckCircle2,
+        step: "1",
+        title: "Create account and workspace",
+        description:
+          "Sign up at settler.dev. After signup you will be prompted to create a workspace — this is your tenant scope for all runs, exceptions, and proof artifacts.",
+        link: { href: "/signup", label: "Create account" },
+      },
+      {
+        icon: Database,
+        step: "2",
+        title: "Connect a data source",
+        description:
+          "Go to Console → Integrations and add your first adapter (Stripe, a database, or a CSV upload). Settler will ingest and normalize records for matching.",
+        link: { href: "/console/onboarding", label: "Open onboarding" },
+      },
+      {
+        icon: Play,
+        step: "3",
+        title: "Trigger a reconciliation run",
+        description:
+          "Once your data source is connected, trigger a run from the Console → Runs page or via the API. Settler will match records and surface every exception.",
+        link: { href: "/console/runs", label: "View runs" },
+      },
+      {
+        icon: AlertTriangle,
+        step: "4",
+        title: "Review exceptions",
+        description:
+          "Open Console → Exceptions to see every unmatched or conflicting record. Each exception shows provenance, evidence, and suggested actions.",
+        link: { href: "/console/exceptions", label: "View exceptions" },
+      },
+      {
+        icon: Shield,
+        step: "5",
+        title: "Export proof artifacts",
+        description:
+          "Each completed run produces a proofpack — a hash-linked evidence artifact you can export for audit, close packs, or compliance review.",
+        link: { href: "/console/proof-explorer", label: "Open proof explorer" },
+      },
+    ],
+  },
+  {
+    title: "Self-hosted (open source)",
+    description:
+      "Run the Settler engine on your own infrastructure. Full Apache 2.0 OSS — no vendor dependency.",
+    badge: "OSS",
+    steps: [
+      {
+        icon: Terminal,
+        step: "1",
+        title: "Clone and install",
+        description:
+          "Clone the repository and install dependencies. Settler requires Node.js 20+, pnpm, and a PostgreSQL database.",
+        code: "git clone https://github.com/Hardonian/Settler && pnpm install",
+      },
+      {
+        icon: Database,
+        step: "2",
+        title: "Configure environment",
+        description:
+          "Copy .env.example to .env and fill in your database URL and Supabase credentials. See SETUP.md for a full variable reference.",
+        code: "cp .env.example .env",
+      },
+      {
+        icon: Play,
+        step: "3",
+        title: "Run database migrations",
+        description: "Apply the Prisma schema to your database and start the development server.",
+        code: "pnpm prisma migrate deploy && pnpm dev",
+      },
+      {
+        icon: FileText,
+        step: "4",
+        title: "Read the architecture docs",
+        description:
+          "Before connecting production data, read the architecture overview to understand tenant isolation, authz, and data flow.",
+        link: { href: "/docs/architecture/platform-architecture", label: "Architecture overview" },
+      },
+    ],
+  },
+];
+
+const callouts = [
+  {
+    title: "What Settler is",
+    body: "Settler is a reconciliation engine and exception-management system. It matches records across two or more data sources (payment processors, banks, ERPs, CSVs), surfaces every mismatch as a structured exception, and produces hash-linked proof artifacts for each run.",
+  },
+  {
+    title: "What a run produces",
+    body: "Each reconciliation run produces: matched records (with tolerance metadata), exceptions (unmatched or conflicting records), a run summary with counts, and a proofpack — a replayable evidence artifact you can export, share, or use for audit review.",
+  },
+  {
+    title: "Tenant isolation",
+    body: "Every workspace in Settler is tenant-scoped. Runs, exceptions, evidence, API keys, and exports are isolated to your workspace. Super-admin access is separate and explicitly declared in the role system.",
+  },
+];
 
 export default function GettingStartedPage() {
   return (
-    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-      <h1 className="text-4xl font-bold mb-6">Getting Started</h1>
-      <div className="prose prose-slate dark:prose-invert max-w-none">
-        <p className="text-lg text-muted-foreground mb-8">
-          Welcome to Settler! This guide will help you get up and running in minutes.
-        </p>
-        
-        <div className="space-y-8">
-          <section>
-            <h2 className="text-2xl font-bold mb-4">Quick Start</h2>
-            <ol className="list-decimal list-inside space-y-4">
-              <li>
-                <Link href="/signup" className="text-blue-600 dark:text-blue-400 hover:underline">
-                  Create an account
-                </Link> or sign in to your existing account
-              </li>
-              <li>
-                <Link href="/console/playground" className="text-blue-600 dark:text-blue-400 hover:underline">
-                  Try the Playground
-                </Link> to test the API without setup
-              </li>
-              <li>
-                <Link href="/docs/quickstart" className="text-blue-600 dark:text-blue-400 hover:underline">
-                  Follow the Quickstart guide
-                </Link> to create your first reconciliation
-              </li>
-              <li>
-                <Link href="/console/api-keys" className="text-blue-600 dark:text-blue-400 hover:underline">
-                  Generate an API key
-                </Link> to start integrating
-              </li>
-            </ol>
-          </section>
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main className="pt-20">
+        {/* Header */}
+        <section className="border-b border-border/40 bg-muted/10 py-16 px-4">
+          <div className="max-w-4xl mx-auto">
+            <Badge variant="outline" className="mb-4 text-xs font-semibold tracking-widest uppercase">
+              Documentation
+            </Badge>
+            <h1 className="text-4xl font-bold tracking-tight mb-4">Getting started</h1>
+            <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
+              Settler matches financial records across systems, surfaces every mismatch as a
+              structured exception, and produces auditable proof for each run. This guide covers
+              two paths: managed cloud and self-hosted open source.
+            </p>
+            <div className="flex flex-wrap gap-3 mt-8">
+              <Button asChild>
+                <Link href="/signup">
+                  Create account <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+              <Button variant="outline" asChild>
+                <Link href="/docs/quickstart">5-minute quickstart</Link>
+              </Button>
+            </div>
+          </div>
+        </section>
 
-          <section>
-            <h2 className="text-2xl font-bold mb-4">Next Steps</h2>
-            <ul className="list-disc list-inside space-y-2">
-              <li><Link href="/docs/api" className="text-blue-600 dark:text-blue-400 hover:underline">Explore the API Reference</Link></li>
-              <li><Link href="/docs/integrations" className="text-blue-600 dark:text-blue-400 hover:underline">Browse Integrations</Link></li>
-              <li><Link href="/docs/sdk" className="text-blue-600 dark:text-blue-400 hover:underline">Install an SDK</Link></li>
-            </ul>
-          </section>
-        </div>
-      </div>
+        {/* Before you start callouts */}
+        <section className="py-12 px-4 border-b border-border/40">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-sm font-bold uppercase tracking-widest text-muted-foreground mb-6">
+              Before you start
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {callouts.map((c) => (
+                <Card key={c.title} className="border-border/50">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-sm font-semibold">{c.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground leading-relaxed">{c.body}</p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Setup paths */}
+        <section className="py-12 px-4">
+          <div className="max-w-4xl mx-auto space-y-16">
+            {paths.map((path) => (
+              <div key={path.title}>
+                <div className="flex items-center gap-3 mb-8">
+                  <h2 className="text-2xl font-semibold">{path.title}</h2>
+                  <Badge variant={path.badge === "Recommended" ? "default" : "secondary"}>
+                    {path.badge}
+                  </Badge>
+                </div>
+                <p className="text-muted-foreground mb-8">{path.description}</p>
+
+                <div className="space-y-6">
+                  {path.steps.map((s) => (
+                    <div
+                      key={s.step}
+                      className="flex gap-5 p-5 rounded-xl border border-border/50 bg-card/40"
+                    >
+                      <div className="shrink-0 w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center text-sm font-bold">
+                        {s.step}
+                      </div>
+                      <div className="min-w-0 space-y-2">
+                        <div className="flex items-center gap-2">
+                          <s.icon className="h-4 w-4 text-muted-foreground" />
+                          <h3 className="font-semibold text-sm">{s.title}</h3>
+                        </div>
+                        <p className="text-sm text-muted-foreground leading-relaxed">
+                          {s.description}
+                        </p>
+                        {"code" in s && s.code && (
+                          <code className="block text-xs bg-muted px-3 py-2 rounded font-mono mt-2">
+                            {s.code}
+                          </code>
+                        )}
+                        {"link" in s && s.link && (
+                          <Link
+                            href={s.link.href}
+                            className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline mt-1"
+                          >
+                            {s.link.label} <ArrowRight className="h-3 w-3" />
+                          </Link>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Next steps */}
+        <section className="py-12 px-4 border-t border-border/40 bg-muted/10">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-sm font-bold uppercase tracking-widest text-muted-foreground mb-6">
+              Next steps
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+              {[
+                { href: "/docs/api", label: "API reference", desc: "Full REST API documentation." },
+                { href: "/docs/sdk", label: "SDK guide", desc: "TypeScript/Node.js SDK." },
+                { href: "/docs/integrations", label: "Integrations", desc: "Available data source adapters." },
+                { href: "/docs/auth", label: "Auth & RBAC", desc: "Roles, scopes, and API keys." },
+                { href: "/docs/webhooks", label: "Webhooks", desc: "Real-time event notifications." },
+                { href: "/pricing", label: "Pricing", desc: "Cloud, managed ops, and enterprise tiers." },
+              ].map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="block p-4 rounded-lg border border-border/50 hover:border-primary/40 hover:bg-muted/20 transition-colors group"
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-sm font-medium">{item.label}</span>
+                    <ArrowRight className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" />
+                  </div>
+                  <p className="text-xs text-muted-foreground">{item.desc}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
TRUST BLOCKERS CLOSED:
- diagnostics/page.tsx: replaced entirely fake static page (hardcoded 4.12GB memory,
  1.2% CPU, fake trace IDs TR-921/TR-884, non-functional buttons "Exert System Pressure
  Test" / "Flush Engine Cache" / "Provision New Worker") with honest runtime-backed
  connectivity checks sourced from /api/health. Clear scope note explains what is and
  is not measured.

- runs/[runId]/page.tsx: removed hardcoded "99.9% Compliance Confidence / Cryptographic
  Trust" stat card. Replaced with real compactProofSummary.operatorSummary.signal and
  proofPosture — values sourced from the canonical reconciliation-core proof index, so
  the card reflects actual run proof state (strong/weak/degraded/unavailable). Also
  cleaned up theatrical UI copy: "Re-run Intelligence" → "Retry run", "Running
  Intelligence Engine" → "In progress", "Execution Finalized" → "Terminal",
  "Reconciliation Intelligence Unavailable" → "Run detail unavailable".

BUILD BLOCKER CLOSED:
- schedules/page.tsx: removed duplicate import of Alert/AlertDescription/AlertTitle
  that would cause linting and TypeScript errors.

BUYER TRUST IMPROVEMENT:
- docs/getting-started/page.tsx: replaced thin stub (4 bullet links) with a
  substantive getting-started page covering both cloud and self-hosted paths,
  step-by-step with descriptions, code snippets, and navigation to follow-on docs.
  This is what buyers land on after clicking any "Get Started" CTA.

https://claude.ai/code/session_0173Kyt4P69evr7TmNrePLgT