### PR TITLE
fix: resolve three TypeScript build errors blocking Vercel deploy

### DIFF
--- a/packages/api/src/routes/v2/compliance.ts
+++ b/packages/api/src/routes/v2/compliance.ts
@@ -113,7 +113,7 @@ router.get(
     );
     if (!capability) return;
 
-    const exports = complianceExportSystem.listExports(tenantId);
+    const exports = await complianceExportSystem.listExportsFromDb(tenantId);
 
     res.json({
       data: exports,
@@ -162,7 +162,7 @@ router.get(
     if (!id) {
       return res.status(400).json({ error: "Export ID is required" });
     }
-    const export_ = complianceExportSystem.getExport(id);
+    const export_ = await complianceExportSystem.getExportFromDb(id, tenantId);
 
     if (!export_) {
       return res.status(404).json({

--- a/packages/support-intake/src/service.ts
+++ b/packages/support-intake/src/service.ts
@@ -3,6 +3,8 @@ import { supportIntakeSubmissionSchema, type SupportIntakeSubmission } from "./c
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | { [key: string]: JsonValue } | JsonValue[];
+// InputJsonValue excludes top-level null to match Prisma's InputJsonValue constraint.
+type InputJsonObject = { [key: string]: JsonValue | undefined };
 
 interface SupportIntakePrismaClient {
   $executeRaw(query: TemplateStringsArray, ...values: unknown[]): Promise<unknown>;
@@ -14,8 +16,8 @@ interface SupportIntakePrismaClient {
         action: string;
         resourceType: string;
         resourceId: string;
-        changes: JsonValue;
-        metadata: JsonValue;
+        changes: InputJsonObject;
+        metadata: InputJsonObject;
       };
     }): Promise<unknown>;
   };
@@ -122,7 +124,7 @@ async function persistSupportIntakeToAuditLog(params: {
   payload: SupportIntakeSubmission;
   runContext: Record<string, unknown> | null;
 }): Promise<void> {
-  const changes: JsonValue = {
+  const changes: InputJsonObject = {
     submission_id: params.submissionId,
     category: params.payload.category,
     run_id: params.payload.run_id ?? null,
@@ -135,6 +137,11 @@ async function persistSupportIntakeToAuditLog(params: {
     run_context: params.runContext ? (params.runContext as unknown as JsonValue) : null,
   };
 
+  const metadata: InputJsonObject = {
+    intake_version: 1,
+    path: params.path,
+  };
+
   await params.prisma.auditLog.create({
     data: {
       userId: params.userId,
@@ -143,10 +150,7 @@ async function persistSupportIntakeToAuditLog(params: {
       resourceType: SUPPORT_INTAKE_RESOURCE_TYPE,
       resourceId: params.submissionId,
       changes,
-      metadata: {
-        intake_version: 1,
-        path: params.path,
-      },
+      metadata,
     },
   });
 }


### PR DESCRIPTION
compliance.ts: call listExportsFromDb(tenantId) and getExportFromDb(id, tenantId)
instead of the non-existent listExports/getExport methods, and properly await
both async calls.

support-intake/service.ts: narrow SupportIntakePrismaClient.auditLog.create
data.changes and data.metadata from JsonValue (includes top-level null) to
InputJsonObject (Record<string, JsonValue | undefined>) to satisfy Prisma's
InputJsonValue constraint. Extract metadata into a typed variable to match.

https://claude.ai/code/session_01Qhh3y2REX9f5T4tMkuzFNb