### PR TITLE
fix: resolve two webpack build blockers preventing Vercel deploy

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -71,6 +71,8 @@ const nextConfig = {
     "bcrypt", // Password hashing (server-only)
     "jsonwebtoken", // JWT signing (server-only)
     "nodemailer", // Email (server-only)
+    "@jobforge/sdk-ts", // Server-only JobForge SDK
+    "@jobforge/shared", // Server-only JobForge shared types
   ],
   typescript: {
     // Scale-Readiness: Type safety enforced during development, not deployment

--- a/packages/web/src/app/console/schedules/page.tsx
+++ b/packages/web/src/app/console/schedules/page.tsx
@@ -66,10 +66,6 @@ export default function SchedulesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [editingJobId, setEditingJobId] = useState<string | null>(null);
-  const [scheduleCapability, setScheduleCapability] = useState<{
-    state: string;
-    reason?: string;
-  } | null>(null);
 
   const loadJobs = useCallback(async () => {
     setLoading(true);


### PR DESCRIPTION
1. Remove duplicate scheduleCapability useState in schedules/page.tsx
   (identical variable declared twice — JS parse error at line 52)

2. Add @jobforge/sdk-ts and @jobforge/shared to serverExternalPackages
   in next.config.js so webpack skips bundling the server-only JobForge
   SDK and lets Node resolve it at runtime (fixes Module not found error)

https://claude.ai/code/session_01AV9X2w72wxG5AN2suhComf