### PR TITLE
feat(web): operator run truth panel and canonical run delta depth

### DIFF
--- a/packages/web/src/__tests__/reconciliation/operator-run-truth.test.ts
+++ b/packages/web/src/__tests__/reconciliation/operator-run-truth.test.ts
@@ -1,0 +1,233 @@
+import type { OperatorRunDetail } from "@/types/operator-run-detail";
+import { deriveOperatorRunAttention, deriveOperatorRunNextActions } from "@/lib/runs/operator-run-truth";
+
+function baseRun(overrides: Partial<OperatorRunDetail> = {}): OperatorRunDetail {
+  const compactProofSummary: OperatorRunDetail["compactProofSummary"] = {
+    proofPackages: {
+      total: 1,
+      finalized: 1,
+      bestCompletenessScore: 1,
+      missingEvidenceCount: 0,
+      latestCreatedAt: null,
+      state: "ready",
+      degradedEvidenceReasons: [],
+    },
+    recurrence: {
+      exceptionsWithMemories: 0,
+      repeatedResolutionReasons: [],
+      state: "ready",
+      topRecurringFamilies: [],
+    },
+    delta: {
+      changedSincePreviousRun: "unchanged",
+      summary: "ok",
+      state: "available",
+      certainty: "high",
+      reasonCodes: [],
+      baseline: { priorResultId: null, priorResultStartedAt: null },
+      history: {
+        lookbackWindow: 2,
+        comparableWindowCount: 2,
+        certainty: "high",
+        trend: "stable",
+        pattern: "stable_pattern",
+        reasonCodes: [],
+        summary: "Stable.",
+      },
+      deltas: {
+        matched: 0,
+        unmatched: 0,
+        conflicts: 0,
+        proofCompleteness: "unchanged",
+        recurringFamilyConcentration: "stable",
+      },
+    },
+    operatorSummary: {
+      signal: "strong",
+      pattern: "stable_pattern",
+      changedSincePreviousRun: "unchanged",
+      proofPosture: "stronger",
+      primaryReasonCodes: [],
+      recurringFamilies: [],
+      summary: "Strong signal.",
+      explainerCodes: [],
+    },
+  };
+
+  return {
+    runKind: "recon_job",
+    sourceModel: "recon_jobs",
+    id: "r1",
+    detailHref: "/console/runs/r1",
+    name: "Test",
+    status: "completed",
+    statusLabel: "Completed",
+    isTerminal: true,
+    progress: 100,
+    progressState: "done",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:01:00.000Z",
+    summary: {
+      total: 100,
+      sourceCount: 50,
+      targetCount: 50,
+      matched: 95,
+      unmatched: 5,
+      unmatchedSourceCount: 2,
+      unmatchedTargetCount: 3,
+      conflicts: 0,
+    },
+    summarySemantics: {
+      processed: 100,
+      matchedWithTolerance: 0,
+      exceptioned: 5,
+      unresolved: 5,
+      ignored: 0,
+      resolved: 0,
+    },
+    summaryState: "success",
+    summaryMath: {
+      sourceCount: 50,
+      targetCount: 50,
+      matchedCount: 95,
+      unmatchedSourceCount: 2,
+      unmatchedTargetCount: 3,
+      conflictCount: 0,
+      note: "",
+    },
+    provenance: {
+      sourceModel: "recon_jobs",
+      runKind: "recon_job",
+      ingestionId: null,
+      reconJobId: "r1",
+      executedAt: "2026-01-01T00:00:00.000Z",
+      completedAt: "2026-01-01T00:01:00.000Z",
+      sourceAdapter: "a",
+      targetAdapter: "b",
+    },
+    resultContext: {
+      latestResultId: null,
+      latestResultStatus: null,
+      latestResultStartedAt: null,
+      latestResultCompletedAt: null,
+      persistedResultCount: 0,
+      comparison: null,
+    },
+    config: {
+      sourceAdapter: "a",
+      targetAdapter: "b",
+      reconStrategy: null,
+      templateId: null,
+      validationRuleCount: 0,
+      validationRuleLabels: [],
+      ruleVersionCount: 0,
+      ruleVersionLabels: [],
+      snapshotId: null,
+      inputHash: null,
+      configSource: "snapshot",
+      configCapturedAt: null,
+      definitionDriftDetected: false,
+      definitionDriftNotes: [],
+      summaryBasis: "",
+    },
+    configDrift: { status: "none", adapter: "none" },
+    exceptions: {
+      total: 0,
+      pending: 0,
+      investigating: 0,
+      resolved: 0,
+      ignored: 0,
+      reviewRequired: 0,
+    },
+    rowRationale: { available: false, rowCount: 0, codes: [] },
+    rowResultsPreview: [],
+    stages: [],
+    compactProofSummary,
+    kindDetail: {
+      kind: "recon_job",
+      reconJob: { rowRationale: { available: false, rowCount: 0, codes: [] } },
+    },
+    ...overrides,
+  };
+}
+
+describe("deriveOperatorRunAttention", () => {
+  it("returns empty when run is clean and proof is strong", () => {
+    expect(deriveOperatorRunAttention(baseRun())).toEqual([]);
+  });
+
+  it("surfaces run error as critical", () => {
+    const items = deriveOperatorRunAttention(baseRun({ error: "Upstream timeout" }));
+    expect(items.some((i) => i.code === "run_error" && i.severity === "critical")).toBe(true);
+  });
+
+  it("surfaces review-required exceptions", () => {
+    const items = deriveOperatorRunAttention(
+      baseRun({
+        exceptions: {
+          total: 2,
+          pending: 1,
+          investigating: 0,
+          resolved: 0,
+          ignored: 0,
+          reviewRequired: 2,
+        },
+      })
+    );
+    expect(items.some((i) => i.code === "exceptions_review")).toBe(true);
+  });
+
+  it("does not duplicate ingestion exception note on recon_job", () => {
+    const items = deriveOperatorRunAttention(
+      baseRun({ exceptionWorkflowNote: "Should not show for recon_job" })
+    );
+    expect(items.some((i) => i.code === "ingestion_exception_scope")).toBe(false);
+  });
+
+  it("shows ingestion exception note only for ingestion_run", () => {
+    const items = deriveOperatorRunAttention(
+      baseRun({
+        runKind: "ingestion_run",
+        sourceModel: "reconciliation_runs",
+        exceptionWorkflowNote: "Keyed differently",
+      })
+    );
+    expect(items.some((i) => i.code === "ingestion_exception_scope")).toBe(true);
+  });
+});
+
+describe("deriveOperatorRunNextActions", () => {
+  it("suggests exceptions when queue has work", () => {
+    const actions = deriveOperatorRunNextActions(
+      baseRun({
+        exceptions: {
+          total: 1,
+          pending: 1,
+          investigating: 0,
+          resolved: 0,
+          ignored: 0,
+          reviewRequired: 0,
+        },
+      })
+    );
+    expect(actions.some((a) => a.href === "/console/exceptions")).toBe(true);
+  });
+
+  it("suggests close evidence when terminal and clean", () => {
+    const actions = deriveOperatorRunNextActions(
+      baseRun({
+        summary: {
+          total: 10,
+          sourceCount: 5,
+          targetCount: 5,
+          matched: 10,
+          unmatched: 0,
+          unmatchedSourceCount: 0,
+          unmatchedTargetCount: 0,
+          conflicts: 0,
+        },
+      })
+    );
+    expect(actions.some((a) => a.label.includes("Archive evidence"))).toBe(true);
+  });
+});

--- a/packages/web/src/app/console/runs/[runId]/components/RunOperatorTruthPanel.tsx
+++ b/packages/web/src/app/console/runs/[runId]/components/RunOperatorTruthPanel.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, CircleAlert, Info, ListChecks } from "lucide-react";
+import type { OperatorRunDetail } from "@/types/operator-run-detail";
+import {
+  deriveOperatorRunAttention,
+  deriveOperatorRunNextActions,
+  type OperatorAttentionSeverity,
+} from "@/lib/runs/operator-run-truth";
+import { cn } from "@/lib/utils";
+
+const severityIcon: Record<OperatorAttentionSeverity, typeof CircleAlert> = {
+  critical: CircleAlert,
+  warning: AlertTriangle,
+  info: Info,
+};
+
+const severityStyles: Record<OperatorAttentionSeverity, string> = {
+  critical: "border-red-500/25 bg-red-500/5 text-foreground",
+  warning: "border-amber-500/25 bg-amber-500/5 text-foreground",
+  info: "border-border/80 bg-muted/30 text-foreground",
+};
+
+const severityLabel: Record<OperatorAttentionSeverity, string> = {
+  critical: "Requires action",
+  warning: "Review",
+  info: "Context",
+};
+
+interface RunOperatorTruthPanelProps {
+  run: OperatorRunDetail;
+}
+
+export function RunOperatorTruthPanel({ run }: RunOperatorTruthPanelProps) {
+  const attention = deriveOperatorRunAttention(run);
+  const nextActions = deriveOperatorRunNextActions(run);
+
+  if (attention.length === 0 && nextActions.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className="rounded-2xl border border-border/60 bg-card/40 backdrop-blur-sm overflow-hidden"
+      aria-label="Operator run truth"
+    >
+      <div className="border-b border-border/50 px-5 py-4 flex flex-wrap items-center gap-3 justify-between bg-muted/20">
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
+            Run intelligence
+          </p>
+          <h2 className="text-lg font-semibold tracking-tight text-foreground mt-0.5">
+            What needs attention on this run
+          </h2>
+          <p className="text-xs text-muted-foreground mt-1 max-w-2xl leading-relaxed">
+            Signals below come from the canonical run payload — exceptions, proof posture, drift, and
+            recorded deltas. Nothing here is inferred client-side.
+          </p>
+        </div>
+      </div>
+
+      <div className="p-5 grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="space-y-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-2">
+            <CircleAlert className="w-3.5 h-3.5" />
+            Attention
+          </h3>
+          {attention.length === 0 ? (
+            <p className="text-sm text-muted-foreground border border-dashed rounded-xl p-4">
+              No blocking signals from the server for this run. Still verify exceptions and proof
+              posture before close.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {attention.map((item) => {
+                const Icon = severityIcon[item.severity];
+                return (
+                  <li
+                    key={`${item.code}-${item.title}`}
+                    className={cn(
+                      "rounded-xl border p-4 text-sm",
+                      severityStyles[item.severity]
+                    )}
+                  >
+                    <div className="flex items-start gap-3">
+                      <Icon
+                        className={cn(
+                          "w-4 h-4 shrink-0 mt-0.5",
+                          item.severity === "critical" && "text-red-600 dark:text-red-400",
+                          item.severity === "warning" && "text-amber-600 dark:text-amber-400",
+                          item.severity === "info" && "text-muted-foreground"
+                        )}
+                        aria-hidden
+                      />
+                      <div className="min-w-0 space-y-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-semibold text-foreground">{item.title}</span>
+                          <span className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground">
+                            {severityLabel[item.severity]}
+                          </span>
+                        </div>
+                        <p className="text-xs leading-relaxed text-muted-foreground">{item.detail}</p>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-2">
+            <ListChecks className="w-3.5 h-3.5" />
+            Suggested next steps
+          </h3>
+          {nextActions.length === 0 ? (
+            <p className="text-sm text-muted-foreground border border-dashed rounded-xl p-4">
+              No automated suggestions for this state.
+            </p>
+          ) : (
+            <ol className="space-y-3 list-none m-0 p-0">
+              {nextActions.map((action, i) => (
+                <li
+                  key={`${action.label}-${i}`}
+                  className="rounded-xl border border-border/60 bg-background/50 p-4"
+                >
+                  <div className="flex items-start gap-3">
+                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[11px] font-bold text-primary">
+                      {i + 1}
+                    </span>
+                    <div className="min-w-0 space-y-1">
+                      {action.href ? (
+                        <Link
+                          href={action.href}
+                          className="text-sm font-semibold text-primary hover:underline"
+                        >
+                          {action.label}
+                        </Link>
+                      ) : (
+                        <span className="text-sm font-semibold text-foreground">{action.label}</span>
+                      )}
+                      <p className="text-xs text-muted-foreground leading-relaxed">{action.rationale}</p>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/app/console/runs/[runId]/components/RunStatistics.tsx
+++ b/packages/web/src/app/console/runs/[runId]/components/RunStatistics.tsx
@@ -14,12 +14,17 @@ import type { OperatorRunDetail } from "@/types/operator-run-detail";
 interface RunStatisticsProps {
   summary: OperatorRunDetail["summary"];
   runDelta: OperatorRunDetail["runDelta"];
+  configDrift: OperatorRunDetail["configDrift"];
+  compactProofSummary: OperatorRunDetail["compactProofSummary"];
 }
 
 export const RunStatistics = memo(function RunStatistics({
   summary,
   runDelta,
+  configDrift,
+  compactProofSummary,
 }: RunStatisticsProps) {
+  const proofOp = compactProofSummary.operatorSummary;
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -51,48 +56,117 @@ export const RunStatistics = memo(function RunStatistics({
       <div className="p-5 rounded-2xl border bg-gradient-to-br from-card/30 to-muted/20 backdrop-blur-sm">
         <div className="flex items-center gap-2 mb-4">
           <BarChart3 className="w-4 h-4 text-primary" />
-          <h3 className="text-sm font-bold uppercase tracking-wider">Comparative Drift Insights</h3>
+          <h3 className="text-sm font-bold uppercase tracking-wider">Run delta vs prior run</h3>
         </div>
+        {!runDelta ? (
+          <p className="text-xs text-muted-foreground mb-4 border border-dashed rounded-lg p-3">
+            No prior-run delta is recorded for this run yet. When available, input stability, pattern
+            changes, and config drift flags appear here.
+          </p>
+        ) : null}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
           <div className="space-y-4">
             <h4 className="text-xs font-semibold text-muted-foreground uppercase">
-              Input Patterns
+              Input & configuration
             </h4>
             <div className="flex items-center justify-between p-3 rounded-lg border bg-background/50">
-              <span className="text-sm">Input Hash Stability</span>
+              <span className="text-sm">Input hash (vs prior)</span>
               <span
                 className={`text-[10px] font-bold px-2 py-0.5 rounded border ${
                   runDelta?.inputChanged
                     ? "bg-red-500/10 text-red-500 border-red-500/20"
-                    : "bg-green-500/10 text-green-500 border-green-500/20"
+                    : runDelta
+                      ? "bg-green-500/10 text-green-500 border-green-500/20"
+                      : "bg-muted/40 text-muted-foreground border-border/60"
                 }`}
               >
-                {runDelta?.inputChanged ? "CHANGED" : "STABLE"}
+                {runDelta ? (runDelta.inputChanged ? "CHANGED" : "STABLE") : "NO DELTA"}
               </span>
             </div>
             <div className="flex items-center justify-between p-3 rounded-lg border bg-background/50">
-              <span className="text-sm">Reconciliation Coverage</span>
+              <span className="text-sm">Snapshot config drift</span>
+              <span
+                className={`text-[10px] font-bold px-2 py-0.5 rounded border ${
+                  configDrift.status === "detected"
+                    ? "bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/25"
+                    : configDrift.status === "indeterminate"
+                      ? "bg-muted/50 text-muted-foreground border-border/60"
+                      : "bg-green-500/10 text-green-600 border-green-500/20"
+                }`}
+              >
+                {configDrift.status === "detected"
+                  ? `DETECTED (${configDrift.adapter})`
+                  : configDrift.status === "indeterminate"
+                    ? "INDETERMINATE"
+                    : "NONE"}
+              </span>
+            </div>
+            <div className="flex items-center justify-between p-3 rounded-lg border bg-background/50">
+              <span className="text-sm">Delta config drift flag</span>
+              <span
+                className={`text-[10px] font-bold px-2 py-0.5 rounded border ${
+                  runDelta?.configDriftDetected
+                    ? "bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/25"
+                    : runDelta
+                      ? "bg-green-500/10 text-green-600 border-green-500/20"
+                      : "bg-muted/40 text-muted-foreground border-border/60"
+                }`}
+              >
+                {runDelta
+                  ? runDelta.configDriftDetected
+                    ? "YES"
+                    : "NO"
+                  : "N/A"}
+              </span>
+            </div>
+            <div className="flex items-center justify-between p-3 rounded-lg border bg-background/50">
+              <span className="text-sm">Reconciliation coverage</span>
               <span className="text-sm font-mono font-bold">
                 {Math.round((summary.matched / (summary.total || 1)) * 100)}%
               </span>
             </div>
+            <div className="rounded-lg border bg-background/50 p-3 space-y-1">
+              <span className="text-sm">Proof / history signal (run-level)</span>
+              <p className="text-xs text-muted-foreground leading-relaxed">{proofOp.summary}</p>
+            </div>
           </div>
           <div className="space-y-4">
             <h4 className="text-xs font-semibold text-muted-foreground uppercase">
-              New Exception Patterns
+              Exception pattern delta
             </h4>
-            <div className="min-h-[100px] flex flex-col justify-center items-center rounded-lg border border-dashed p-4 opacity-50 italic text-xs text-center">
+            <div className="min-h-[100px] flex flex-col justify-center rounded-lg border border-dashed p-4 text-xs">
               {runDelta?.newExceptionPatterns && runDelta.newExceptionPatterns.length > 0 ? (
-                <ul className="w-full space-y-2 text-left not-italic opacity-100">
+                <ul className="w-full space-y-2 text-left">
                   {runDelta.newExceptionPatterns.map((p, i) => (
-                    <li key={i} className="flex items-center gap-2 text-red-500">
-                      <AlertCircle className="w-3 h-3" />
+                    <li key={i} className="flex items-center gap-2 text-red-600 dark:text-red-400">
+                      <AlertCircle className="w-3 h-3 shrink-0" />
                       <span>{p}</span>
                     </li>
                   ))}
                 </ul>
               ) : (
-                "No new exception patterns detected in this run delta."
+                <p className="text-muted-foreground text-center italic">
+                  No new exception patterns in the recorded run delta.
+                </p>
+              )}
+            </div>
+            <h4 className="text-xs font-semibold text-muted-foreground uppercase pt-2">
+              Resolved patterns (prior run)
+            </h4>
+            <div className="min-h-[72px] flex flex-col justify-center rounded-lg border border-dashed p-4 text-xs">
+              {runDelta?.resolvedPatterns && runDelta.resolvedPatterns.length > 0 ? (
+                <ul className="w-full space-y-2 text-left">
+                  {runDelta.resolvedPatterns.map((p, i) => (
+                    <li key={i} className="flex items-center gap-2 text-green-600 dark:text-green-400">
+                      <CheckCircle2 className="w-3 h-3 shrink-0" />
+                      <span>{p}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-muted-foreground text-center italic">
+                  No resolved patterns recorded on this delta.
+                </p>
               )}
             </div>
           </div>

--- a/packages/web/src/app/console/runs/[runId]/page.tsx
+++ b/packages/web/src/app/console/runs/[runId]/page.tsx
@@ -39,6 +39,7 @@ import { RunStages } from "./components/RunStages";
 import { RunConfiguration } from "./components/RunConfiguration";
 import { RunStatistics } from "./components/RunStatistics";
 import { RunProvenance } from "./components/RunProvenance";
+import { RunOperatorTruthPanel } from "./components/RunOperatorTruthPanel";
 
 export default function RunPage() {
   const params = useParams();
@@ -238,8 +239,8 @@ export default function RunPage() {
           value={run.compactProofSummary.operatorSummary.signal.replace(/_/g, " ").toUpperCase()}
           subtext={
             run.compactProofSummary.operatorSummary.proofPosture !== "unavailable"
-              ? `Posture ${run.compactProofSummary.operatorSummary.proofPosture}`
-              : "Posture unavailable"
+              ? `Evidence posture: ${run.compactProofSummary.operatorSummary.proofPosture.replace(/_/g, " ")}`
+              : "Evidence posture unavailable for this run"
           }
           icon={Shield}
         />
@@ -248,26 +249,28 @@ export default function RunPage() {
       {run.proofpackIndex ? (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <DetailCard
-            label="History Trend"
-            value={run.proofpackIndex.comparison.history.trend.toUpperCase()}
-            subtext={`certainty ${run.proofpackIndex.comparison.history.certainty}`}
+            label="Comparable history"
+            value={run.proofpackIndex.comparison.history.trend.replace(/_/g, " ").toUpperCase()}
+            subtext={run.proofpackIndex.comparison.history.summary}
           />
           <DetailCard
-            label="Recurring Families"
-            value={run.proofpackIndex.recurrence.topRecurringFamilies.length.toString()}
+            label="Recurring exception families"
+            value={run.proofpackIndex.recurrence.topRecurringFamilies.length.toLocaleString()}
             subtext={
               run.proofpackIndex.recurrence.topRecurringFamilies[0]
-                ? `top ${run.proofpackIndex.recurrence.topRecurringFamilies[0].family}`
-                : "No ranked families yet"
+                ? `Largest cluster: ${run.proofpackIndex.recurrence.topRecurringFamilies[0].family}`
+                : "No ranked families in index window"
             }
           />
           <DetailCard
-            label="Proof Coverage"
+            label="Proof package coverage"
             value={`${run.proofpackIndex.proofPackages.finalized}/${run.proofpackIndex.proofPackages.total}`}
-            subtext={run.proofpackIndex.proofPackages.state}
+            subtext={`${run.proofpackIndex.proofPackages.state.replace(/_/g, " ")}${run.proofpackIndex.proofPackages.missingEvidenceCount > 0 ? ` · ${run.proofpackIndex.proofPackages.missingEvidenceCount} missing evidence` : ""}`}
           />
         </div>
       ) : null}
+
+      <RunOperatorTruthPanel run={run} />
 
       <Tabs defaultValue="statistics" className="w-full">
         <div className="flex items-center justify-between border-b border-border/40 pb-px mb-8 sticky top-0 bg-background/80 backdrop-blur-xl z-20">
@@ -286,7 +289,12 @@ export default function RunPage() {
         </div>
 
         <TabsContent value="statistics" className="mt-0 focus-visible:outline-none ring-0">
-          <RunStatistics summary={run.summary} runDelta={run.runDelta} />
+          <RunStatistics
+            summary={run.summary}
+            runDelta={run.runDelta}
+            configDrift={run.configDrift}
+            compactProofSummary={run.compactProofSummary}
+          />
         </TabsContent>
 
         <TabsContent value="stages" className="mt-0 focus-visible:outline-none ring-0">

--- a/packages/web/src/lib/runs/operator-run-truth.ts
+++ b/packages/web/src/lib/runs/operator-run-truth.ts
@@ -1,0 +1,249 @@
+import type { OperatorRunDetail } from "@/types/operator-run-detail";
+
+export type OperatorAttentionSeverity = "critical" | "warning" | "info";
+
+export interface OperatorAttentionItem {
+  severity: OperatorAttentionSeverity;
+  code: string;
+  title: string;
+  detail: string;
+}
+
+export interface OperatorNextAction {
+  label: string;
+  href?: string;
+  rationale: string;
+}
+
+function pushUnique(
+  items: OperatorAttentionItem[],
+  item: OperatorAttentionItem,
+  seen: Set<string>
+) {
+  const key = `${item.code}:${item.title}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  items.push(item);
+}
+
+/**
+ * Derives operator-facing attention items from canonical {@link OperatorRunDetail}.
+ * All semantics are backend-owned; this layer only prioritizes and presents them.
+ */
+export function deriveOperatorRunAttention(run: OperatorRunDetail): OperatorAttentionItem[] {
+  const items: OperatorAttentionItem[] = [];
+  const seen = new Set<string>();
+
+  if (run.error) {
+    pushUnique(
+      items,
+      {
+        severity: "critical",
+        code: "run_error",
+        title: "Run ended with an error",
+        detail: run.error,
+      },
+      seen
+    );
+  }
+
+  if (run.status === "failed" && run.isTerminal) {
+    pushUnique(
+      items,
+      {
+        severity: "critical",
+        code: "terminal_failed",
+        title: "Run status is failed",
+        detail:
+          "This run completed in a failed state. Inspect stages for the failing step and upstream data before retrying.",
+      },
+      seen
+    );
+  }
+
+  if (run.configDrift.status === "detected") {
+    pushUnique(
+      items,
+      {
+        severity: "warning",
+        code: "adapter_drift",
+        title: "Adapter or connector drift detected",
+        detail: `Source/target adapter inputs changed since capture (${run.configDrift.adapter}). Compare configuration against the prior snapshot before trusting like-for-like deltas.`,
+      },
+      seen
+    );
+  }
+
+  if (run.runDelta?.configDriftDetected) {
+    pushUnique(
+      items,
+      {
+        severity: "warning",
+        code: "run_delta_config_drift",
+        title: "Config drift flagged on this run delta",
+        detail:
+          "The recorded delta marks configuration drift versus the prior run. Treat period-over-period comparisons as provisional until configuration is reconciled.",
+      },
+      seen
+    );
+  }
+
+  const { exceptions } = run;
+  if (exceptions.reviewRequired > 0) {
+    pushUnique(
+      items,
+      {
+        severity: "warning",
+        code: "exceptions_review",
+        title: `${exceptions.reviewRequired} exception${exceptions.reviewRequired === 1 ? "" : "s"} require review`,
+        detail: `Pending: ${exceptions.pending}, investigating: ${exceptions.investigating}. Resolved: ${exceptions.resolved}, ignored: ${exceptions.ignored}.`,
+      },
+      seen
+    );
+  } else if (exceptions.pending > 0 || exceptions.investigating > 0) {
+    pushUnique(
+      items,
+      {
+        severity: "info",
+        code: "exceptions_in_flight",
+        title: "Exceptions still in workflow",
+        detail: `${exceptions.pending} pending, ${exceptions.investigating} investigating (total ${exceptions.total} on this run).`,
+      },
+      seen
+    );
+  }
+
+  const proof = run.compactProofSummary;
+  const op = proof.operatorSummary;
+  if (op.signal === "degraded" || op.signal === "unavailable" || op.signal === "not_comparable") {
+    pushUnique(
+      items,
+      {
+        severity: op.signal === "not_comparable" ? "warning" : "info",
+        code: `proof_signal_${op.signal}`,
+        title: `Proof / history signal: ${op.signal.replace(/_/g, " ")}`,
+        detail: op.summary,
+      },
+      seen
+    );
+  }
+
+  const pkg = proof.proofPackages;
+  if (pkg.state === "degraded" && pkg.degradedEvidenceReasons.length > 0) {
+    pushUnique(
+      items,
+      {
+        severity: "warning",
+        code: "proof_packages_degraded",
+        title: "Proof package completeness is degraded",
+        detail: pkg.degradedEvidenceReasons.join("; "),
+      },
+      seen
+    );
+  } else if (pkg.state === "setup_required") {
+    pushUnique(
+      items,
+      {
+        severity: "info",
+        code: "proof_packages_setup",
+        title: "Proof packages not fully established",
+        detail:
+          "Finalize or attach proof packages for this job so audit exports and support bundles carry complete evidence.",
+      },
+      seen
+    );
+  }
+
+  if (run.runDelta?.newExceptionPatterns && run.runDelta.newExceptionPatterns.length > 0) {
+    pushUnique(
+      items,
+      {
+        severity: "warning",
+        code: "new_exception_patterns",
+        title: "New exception patterns vs prior run",
+        detail: run.runDelta.newExceptionPatterns.join("; "),
+      },
+      seen
+    );
+  }
+
+  if (run.runKind === "ingestion_run" && run.exceptionWorkflowNote) {
+    pushUnique(
+      items,
+      {
+        severity: "info",
+        code: "ingestion_exception_scope",
+        title: "Exception workflow scope (ingestion run)",
+        detail: run.exceptionWorkflowNote,
+      },
+      seen
+    );
+  }
+
+  const order: Record<OperatorAttentionSeverity, number> = {
+    critical: 0,
+    warning: 1,
+    info: 2,
+  };
+  return [...items].sort((a, b) => order[a.severity] - order[b.severity]);
+}
+
+/**
+ * Suggested next steps grounded in the same canonical detail (no invented intelligence).
+ */
+export function deriveOperatorRunNextActions(run: OperatorRunDetail): OperatorNextAction[] {
+  const actions: OperatorNextAction[] = [];
+
+  if (run.status === "failed" && run.isTerminal) {
+    actions.push({
+      label: "Review stages for the failing step",
+      href: undefined,
+      rationale: "Failed runs need the upstream error cleared before retry is meaningful.",
+    });
+  }
+
+  if (run.exceptions.reviewRequired > 0 || run.exceptions.pending > 0) {
+    actions.push({
+      label: "Open exceptions for this workspace",
+      href: "/console/exceptions",
+      rationale: "Work the queue while run and proof context are still fresh.",
+    });
+  }
+
+  if (
+    run.compactProofSummary.proofPackages.state === "degraded" ||
+    run.compactProofSummary.proofPackages.state === "setup_required"
+  ) {
+    actions.push({
+      label: "Download proofpack from Proof & Provenance",
+      href: undefined,
+      rationale: "Proofpack is the portable, hash-linked record auditors and support expect.",
+    });
+  }
+
+  if (run.runDelta?.newExceptionPatterns && run.runDelta.newExceptionPatterns.length > 0) {
+    actions.push({
+      label: "Review run delta and new patterns",
+      href: undefined,
+      rationale: "New patterns often indicate data or rule changes worth capturing in playbooks.",
+    });
+  }
+
+  if (run.configDrift.status === "detected" || run.runDelta?.configDriftDetected) {
+    actions.push({
+      label: "Compare configuration to prior snapshot",
+      href: undefined,
+      rationale: "Drift explains variance that is not reconciliation logic.",
+    });
+  }
+
+  if (actions.length === 0 && run.isTerminal && run.summary.unmatched === 0 && run.summary.conflicts === 0) {
+    actions.push({
+      label: "Archive evidence for close or audit",
+      href: undefined,
+      rationale: "Clean runs are the right time to export CSV and proofpack for the record.",
+    });
+  }
+
+  return actions;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Elevates the console **run detail** from a metrics shell into an **operator-facing run intelligence** surface grounded in the existing `OperatorRunDetail` contract from `@settler/reconciliation-core`—no client-side inference or fake scoring.

## What changed

- **`RunOperatorTruthPanel`**: Prioritized attention items (errors, config drift, exception queue, proof posture, new exception patterns, ingestion-run scope notes) and **honest next steps** (links to `/console/exceptions`, proofpack reminder, drift review) derived only from canonical payload fields.
- **`operator-run-truth.ts`**: Pure helpers `deriveOperatorRunAttention` and `deriveOperatorRunNextActions` with Jest coverage.
- **`RunStatistics`**: Renamed/clarified the drift section as **run delta vs prior**; surfaces snapshot **config drift**, **delta config drift flag**, **resolved patterns**, and **`compactProofSummary.operatorSummary.summary`** (backend-owned narrative).
- **Run detail header cards**: Proofpack index row now uses **history summary** text, clearer labels, and **missing evidence count** when present; proof signal subtext uses **evidence posture** wording.

## Verification

- `pnpm --filter @settler/web exec jest ... operator-run-truth.test.ts` — pass
- `pnpm lint` — pass (existing warnings in unrelated files)
- `pnpm typecheck` — **fails** on pre-existing `@settler/web` issues (SupportIntake Prisma typing, `Workbench` ReadinessState compare); not introduced by this PR
- `pnpm --filter @settler/web test` — **2 failing suites** pre-existing (`operator-customization.routes`, `status-no-self-hop`); new tests pass
- `pnpm build` — pass

## Residual risk

Attention ordering/heuristics are presentation-only; if we want stricter product rules, they should move into reconciliation-core next to `compactProofSummary`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cf2150e-4fe8-4bf4-bc0d-8d548c10fad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cf2150e-4fe8-4bf4-bc0d-8d548c10fad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

