### PR TITLE
Harden run proof summary contract across list and export surfaces

### DIFF
--- a/packages/api/src/__tests__/services/export-contract.test.ts
+++ b/packages/api/src/__tests__/services/export-contract.test.ts
@@ -16,6 +16,8 @@ jest.mock("../../infrastructure/db/prisma", () => ({
 }));
 
 jest.mock("@settler/reconciliation-core", () => ({
+  canonicalMissingProofpackReasonForRunKind: (runKind: string) =>
+    runKind === "ingestion_run" ? "ingestion_run_history_not_comparable" : "run_proofpack_missing",
   resolveOperatorRunDetailForTenants: (...args: unknown[]) =>
     resolveOperatorRunDetailForTenantsMock(...args),
   toRunCompactProofSummary: (index: any) => ({

--- a/packages/api/src/routes/__tests__/runs.test.ts
+++ b/packages/api/src/routes/__tests__/runs.test.ts
@@ -40,7 +40,7 @@ const {
   resolveOperatorRunDetailForTenants: mockResolveOperatorRunDetail,
   fetchMergedReconciliationRunsPage: mockFetchMergedReconciliationRunsPage,
   buildRunProofpackIndexByRunId: mockBuildRunProofpackIndexByRunId,
-  toRunCompactProofSummary: mockToRunCompactProofSummary,
+  resolveRunCompactProofSummary: mockResolveRunCompactProofSummary,
 } = require("@settler/reconciliation-core");
 
 // Mock governance middleware
@@ -153,7 +153,14 @@ describe("Runs Routes", () => {
     mockFetchMergedReconciliationRunsPage.mockReset();
     mockBuildRunProofpackIndexByRunId.mockReset();
     mockBuildRunProofpackIndexByRunId.mockImplementation(() => Promise.resolve(new Map()));
-    mockToRunCompactProofSummary.mockClear();
+    mockResolveRunCompactProofSummary.mockReset();
+    mockResolveRunCompactProofSummary.mockImplementation(({ proofpackIndex }: any) => ({
+      compactProofSummary: proofpackIndex
+        ? { delta: { state: proofpackIndex.comparison?.state ?? "unavailable" } }
+        : { delta: { state: "unavailable" } },
+      source: proofpackIndex ? "proofpack_index" : "fallback_unavailable",
+      fallbackReasonCode: proofpackIndex ? null : "run_proofpack_missing",
+    }));
   });
 
   describe("GET /api/runs", () => {
@@ -273,6 +280,10 @@ describe("Runs Routes", () => {
         summary: { total: 100, matched: 95, unmatched: 5, conflicts: 0 },
       });
       expect(res.body.data[0].compactProofSummary).toBeDefined();
+      expect(res.body.data[0].compactProofSummaryContext).toEqual({
+        source: "proofpack_index",
+        fallbackReasonCode: null,
+      });
 
       expect(mockScanMergedRunsForLegacyPage).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/api/src/routes/runs.ts
+++ b/packages/api/src/routes/runs.ts
@@ -21,10 +21,11 @@ import { Permission } from "../infrastructure/security/Permissions";
 import { enforceFreezeState } from "../middleware/governance";
 
 import {
+  type ApiRunsListLegacyItem,
   scanMergedRunsForLegacyPage,
   resolveOperatorRunDetailForTenants,
   buildRunProofpackIndexByRunId,
-  toRunCompactProofSummary,
+  resolveRunCompactProofSummary,
 } from "@settler/reconciliation-core";
 import { handleRouteError } from "../utils/error-handler";
 import {
@@ -85,14 +86,24 @@ router.get(
       const indexByRun = await buildRunProofpackIndexByRunId({
         prisma,
         tenantId,
-        runs: result.data.map((row) => ({ id: row.id, runKind: row.runKind })),
+        runs: result.data.map((row: ApiRunsListLegacyItem) => ({
+          id: row.id,
+          runKind: row.runKind,
+        })),
       });
 
-      const rowsWithSignals = result.data.map((row) => {
-        const index = indexByRun.get(row.id);
+      const rowsWithSignals = result.data.map((row: ApiRunsListLegacyItem) => {
+        const summaryResolution = resolveRunCompactProofSummary({
+          runKind: row.runKind,
+          proofpackIndex: indexByRun.get(row.id),
+        });
         return {
           ...row,
-          compactProofSummary: index ? toRunCompactProofSummary(index) : undefined,
+          compactProofSummary: summaryResolution.compactProofSummary,
+          compactProofSummaryContext: {
+            source: summaryResolution.source,
+            fallbackReasonCode: summaryResolution.fallbackReasonCode,
+          },
         };
       });
 

--- a/packages/api/src/services/reconciliation/export-contract.ts
+++ b/packages/api/src/services/reconciliation/export-contract.ts
@@ -4,6 +4,7 @@ import {
   validateTenantId,
 } from "../../infrastructure/tenancy/TenantEnforcement";
 import {
+  canonicalMissingProofpackReasonForRunKind,
   resolveRunCompactProofSummary,
   resolveOperatorRunDetailForTenants,
   type RunCompactProofSummary,
@@ -194,7 +195,10 @@ export async function buildReconciliationExport(
   };
 }
 
-async function buildHistoricalIntelligence(tenantId: string, runId: string): Promise<{
+async function buildHistoricalIntelligence(
+  tenantId: string,
+  runId: string
+): Promise<{
   summary: RunCompactProofSummary;
   context: ReconciliationExportDocument["historicalIntelligenceContext"];
 }> {
@@ -219,8 +223,7 @@ async function buildHistoricalIntelligence(tenantId: string, runId: string): Pro
       runKind: resolved.detail.runKind,
       compactProofSummary: resolved.detail.compactProofSummary,
       proofpackIndex: resolved.detail.proofpackIndex,
-      fallbackReasonCode:
-        resolved.detail.runKind === "ingestion_run" ? "ingestion_run_history_not_comparable" : "run_proofpack_missing",
+      fallbackReasonCode: canonicalMissingProofpackReasonForRunKind(resolved.detail.runKind),
     });
     return {
       summary: summaryResolution.compactProofSummary,

--- a/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
+++ b/packages/web/src/__tests__/api/api-runs-list-route.contract.test.ts
@@ -37,7 +37,8 @@ jest.mock("@settler/reconciliation-core", () => {
     decodeMergedRunsCursor: (...args: unknown[]) => decodeMergedRunsCursorMock(...args),
     mapCanonicalListItemToApiRunsLegacyRow: (...args: unknown[]) =>
       mapCanonicalListItemToApiRunsLegacyRowMock(...args),
-    buildRunProofpackIndexByRunId: (...args: unknown[]) => buildRunProofpackIndexByRunIdMock(...args),
+    buildRunProofpackIndexByRunId: (...args: unknown[]) =>
+      buildRunProofpackIndexByRunIdMock(...args),
   };
 });
 
@@ -291,6 +292,10 @@ describe("GET /api/runs", () => {
     expect(body.items[0].sourceModel).toBe("recon_jobs");
     expect(body.items[0].compactProofSummary.proofPackages.state).toBe("setup_required");
     expect(body.items[0].compactProofSummary.delta.state).toBe("unavailable");
+    expect(body.items[0].compactProofSummaryContext).toEqual({
+      source: "proofpack_index",
+      fallbackReasonCode: null,
+    });
     expect(body.items[0].detailHref).toBe("/console/runs/job-1");
     expect(body.next_cursor).toBe("next");
     expect(body.response_meta.pagination_mode).toBe("merged_cursor");

--- a/packages/web/src/app/api/runs/route.ts
+++ b/packages/web/src/app/api/runs/route.ts
@@ -26,7 +26,7 @@ import {
   mapCanonicalListItemToApiRunsLegacyRow,
   MergedRunsCursorError,
   buildRunProofpackIndexByRunId,
-  toRunCompactProofSummary,
+  resolveRunCompactProofSummary,
   type MergedRunsCursorV1,
 } from "@settler/reconciliation-core";
 import {
@@ -38,7 +38,11 @@ import {
 export const runtime = "nodejs";
 
 type RunListItemWithSignals = ReturnType<typeof mapCanonicalListItemToApiRunsLegacyRow> & {
-  compactProofSummary?: ReturnType<typeof toRunCompactProofSummary>;
+  compactProofSummary: ReturnType<typeof resolveRunCompactProofSummary>["compactProofSummary"];
+  compactProofSummaryContext: {
+    source: ReturnType<typeof resolveRunCompactProofSummary>["source"];
+    fallbackReasonCode: ReturnType<typeof resolveRunCompactProofSummary>["fallbackReasonCode"];
+  };
 };
 
 function resolveTenantIdForRuns(
@@ -77,10 +81,17 @@ async function withRunCompactProofSignals(
   const indexByRun = await buildRunProofpackIndexByRunId({ prisma, tenantId, runs: rows });
   return rows.map((row) => {
     const legacy = mapCanonicalListItemToApiRunsLegacyRow(row);
-    const index = indexByRun.get(row.id);
+    const summaryResolution = resolveRunCompactProofSummary({
+      runKind: row.runKind,
+      proofpackIndex: indexByRun.get(row.id),
+    });
     return {
       ...legacy,
-      compactProofSummary: index ? toRunCompactProofSummary(index) : undefined,
+      compactProofSummary: summaryResolution.compactProofSummary,
+      compactProofSummaryContext: {
+        source: summaryResolution.source,
+        fallbackReasonCode: summaryResolution.fallbackReasonCode,
+      },
     };
   });
 }


### PR DESCRIPTION
### Motivation
- Prevent silent omission of compact proof summary on run-list surfaces by making fallback semantics explicit and machine-visible. 
- Unify proofpack fallback reasoning so export artifacts and list/detail surfaces use the same canonical helper, avoiding silent drift. 
- Improve operator/auditor confidence by shipping provenance metadata (`source` / `fallbackReasonCode`) with compact summaries.

### Description
- Switched list-summary derivation to the canonical resolver `resolveRunCompactProofSummary` in both Next.js web API and Express API list routes (`packages/web/src/app/api/runs/route.ts`, `packages/api/src/routes/runs.ts`).
- Added `compactProofSummaryContext` to run list items containing `source` and `fallbackReasonCode`, and ensured `compactProofSummary` is always produced from the canonical resolution. 
- Replaced local run-kind ternary in export intelligence with the canonical helper `canonicalMissingProofpackReasonForRunKind` in `packages/api/src/services/reconciliation/export-contract.ts`. 
- Updated and adapted existing tests/mocks to assert the new explicit context and to mock `resolveRunCompactProofSummary`/`canonicalMissingProofpackReasonForRunKind` where required (`packages/web` and `packages/api` tests).

### Testing
- ✅ `pnpm --filter @settler/web test -- api-runs-list-route.contract.test.ts` — contract test passed locally. 
- ⚠️ `pnpm --filter @settler/api test -- src/routes/__tests__/runs.test.ts src/__tests__/services/export-contract.test.ts` — blocked by repository Node runtime gate (repo requires Node >=24.0.0 <25.0.0; environment is Node v22.21.1). 
- ⚠️ `pnpm --filter @settler/api exec jest --runInBand src/routes/__tests__/runs.test.ts src/__tests__/services/export-contract.test.ts` — attempted but failed in current environment due to workspace build/type prerequisites and unresolved module/type generation for `@settler/reconciliation-core`. 
- ⚠️ `pnpm --filter @settler/web typecheck` — executed and surfaced pre-existing workspace-wide type errors unrelated to this change, so full workspace typecheck must be re-run in the repository toolchain (Node 24) to get a green signal. 

If CI executes in the repository Node 24 toolchain, re-running the API tests and full typecheck should validate the changes end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5c64a5ce8832887cabb03dec8e3c9)