### PR TITLE
Demote synthetic telemetry, mark experimental CLI surfaces, and reconcile launch-truth docs

### DIFF
--- a/docs/HARDENING_ASSESSMENT.md
+++ b/docs/HARDENING_ASSESSMENT.md
@@ -1,3 +1,5 @@
+> **Status Update (2026-04-08):** This report is historical context and contains superseded claims (including references to stubbed enterprise routes). Treat `docs/repo-os/*`, `docs/launch/*`, and verification command outputs as canonical source of current maturity.
+
 # SETTLER PRODUCTION HARDENING - FINAL ASSESSMENT
 
 **Generated:** 2026-02-24  
@@ -9,24 +11,25 @@
 
 Settler has been audited and hardened to meet production-grade requirements for a Reconciliation Control Plane. The following phases have been completed:
 
-| Phase | Status | Key Deliverables |
-|-------|--------|-----------------|
-| Phase 1: Reality Audit | ✅ Complete | Weakness Map, Risk Classification |
-| Phase 2: Determinism Hardening | ✅ Complete | RunSnapshot, Input Hashing, Provenance |
-| Phase 3: Evidence & Traceability | ✅ Complete | ProvenanceService, Match Metadata |
-| Phase 4: Boundary Enforcement | ✅ Complete | validate-boundaries.ts |
-| Phase 5: Evaluation Engine | ✅ Complete | Weighted Scoring, Drift Detection |
-| Phase 6: OSS Polish | ⚠️ Partial | README updated in previous work |
-| Phase 7: Enterprise Surface | ✅ Complete | Enterprise routes (stubbed) |
+| Phase                            | Status      | Key Deliverables                       |
+| -------------------------------- | ----------- | -------------------------------------- |
+| Phase 1: Reality Audit           | ✅ Complete | Weakness Map, Risk Classification      |
+| Phase 2: Determinism Hardening   | ✅ Complete | RunSnapshot, Input Hashing, Provenance |
+| Phase 3: Evidence & Traceability | ✅ Complete | ProvenanceService, Match Metadata      |
+| Phase 4: Boundary Enforcement    | ✅ Complete | validate-boundaries.ts                 |
+| Phase 5: Evaluation Engine       | ✅ Complete | Weighted Scoring, Drift Detection      |
+| Phase 6: OSS Polish              | ⚠️ Partial  | README updated in previous work        |
+| Phase 7: Enterprise Surface      | ✅ Complete | Enterprise routes (stubbed)            |
 
 ---
 
 ## FILES CREATED
 
 ### New Type Definitions
+
 - [`packages/api/src/services/recon-core/deterministic-types.ts`](packages/api/src/services/recon-core/deterministic-types.ts)
   - `RunSnapshot` interface
-  - `ExecutionProvenance` interface  
+  - `ExecutionProvenance` interface
   - `DeterministicMatch` interface
   - Hash utilities for input fingerprinting
   - Deterministic ordering utilities
@@ -45,12 +48,14 @@ Settler has been audited and hardened to meet production-grade requirements for 
   - Historical comparison
 
 ### Database Schema
+
 - [`prisma/schema-determinism.prisma`](prisma/schema-determinism.prisma)
   - New models: `RunSnapshot`, `ExecutionProvenance`
   - Extended `ReconResult` with snapshot and input hash references
   - Migration SQL included
 
 ### Scripts Added
+
 - [`scripts/verify-determinism.ts`](scripts/verify-determinism.ts)
   - Validates run reproducibility
   - Checks snapshot existence
@@ -65,6 +70,7 @@ Settler has been audited and hardened to meet production-grade requirements for 
   - Run with: `pnpm tsx scripts/validate-boundaries.ts`
 
 ### Enterprise Routes
+
 - [`packages/api/src/routes/enterprise.ts`](packages/api/src/routes/enterprise.ts)
   - Role matrix view (stubbed)
   - Audit export endpoint (stubbed)
@@ -73,6 +79,7 @@ Settler has been audited and hardened to meet production-grade requirements for 
   - Enterprise metrics (stubbed)
 
 ### Documentation
+
 - [`docs/WEAKNESS_MAP.md`](docs/WEAKNESS_MAP.md)
   - Comprehensive weakness analysis
   - Risk classification
@@ -85,21 +92,25 @@ Settler has been audited and hardened to meet production-grade requirements for 
 ### What's Now Guaranteed
 
 ✅ **Input Reproducibility**
+
 - Every run captures immutable input snapshot
 - Input hash fingerprinting ensures same inputs = same hash
 - Data hashes for source and target records
 
 ✅ **Rule Version Locking**
+
 - Rule versions captured at run time
 - Rules cannot change retroactively
 - Historical runs can be replayed with exact same rules
 
 ✅ **Deterministic Ordering**
+
 - Records sorted by ID and timestamp
 - Matches sorted by confidence, then ID
 - Provenance sequences are strictly ordered
 
 ✅ **Execution Provenance**
+
 - Every match traces to rule that created it
 - Actor tracking (system vs human)
 - Full audit trail for compliance
@@ -119,14 +130,14 @@ interface DeterministicMatch {
   amount?: number;
   currency?: string;
   matchedFields: Record<string, unknown>;
-  
+
   // NEW: Evidence traceability
-  ruleId: string;           // Which rule produced match
-  ruleVersion: number;      // Rule version at match time
-  matchedAt: string;         // When match was created
+  ruleId: string; // Which rule produced match
+  ruleVersion: number; // Rule version at match time
+  matchedAt: string; // When match was created
   actor: "system" | "human"; // Who/what created match
-  actorUserId?: string;     // User ID if human
-  reason: string;           // Human-readable explanation
+  actorUserId?: string; // User ID if human
+  reason: string; // Human-readable explanation
 }
 ```
 
@@ -136,15 +147,16 @@ interface DeterministicMatch {
 
 ### Validated Boundaries
 
-| Boundary | Status | Enforcement |
-|----------|--------|-------------|
-| Marketing → Supabase | ✅ Clean | No Supabase imports in marketing |
-| Client → Server | ✅ Enforced | validate-boundaries.ts |
-| Auth → Public | ✅ Clean | No auth in public routes |
+| Boundary             | Status      | Enforcement                      |
+| -------------------- | ----------- | -------------------------------- |
+| Marketing → Supabase | ✅ Clean    | No Supabase imports in marketing |
+| Client → Server      | ✅ Enforced | validate-boundaries.ts           |
+| Auth → Public        | ✅ Clean    | No auth in public routes         |
 
 ### CI Integration
 
 Add to `package.json`:
+
 ```json
 {
   "scripts": {
@@ -161,14 +173,14 @@ Add to `package.json`:
 
 ### Metrics Now Available
 
-| Metric | Description |
-|--------|-------------|
-| Weighted Score | Combined accuracy, confidence, coverage, grounding |
-| Component Scores | Individual breakdowns |
-| Drift Detection | Schema, value, pattern drift |
-| FP/FN Tracking | False positive/negative rates |
-| Historical Comparison | Trend analysis |
-| Letter Grade | A-F assessment |
+| Metric                | Description                                        |
+| --------------------- | -------------------------------------------------- |
+| Weighted Score        | Combined accuracy, confidence, coverage, grounding |
+| Component Scores      | Individual breakdowns                              |
+| Drift Detection       | Schema, value, pattern drift                       |
+| FP/FN Tracking        | False positive/negative rates                      |
+| Historical Comparison | Trend analysis                                     |
+| Letter Grade          | A-F assessment                                     |
 
 ---
 
@@ -176,14 +188,14 @@ Add to `package.json`:
 
 The following endpoints are now available (stubbed):
 
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /api/enterprise/roles` | Role matrix view |
-| `GET /api/enterprise/audit-export` | Compliance export |
-| `GET /api/enterprise/organizations` | Multi-org listing |
-| `GET /api/enterprise/organizations/:id/isolation` | Isolation config |
-| `POST /api/enterprise/webhooks` | Webhook registration |
-| `GET /api/enterprise/metrics` | Enterprise metrics |
+| Endpoint                                          | Purpose              |
+| ------------------------------------------------- | -------------------- |
+| `GET /api/enterprise/roles`                       | Role matrix view     |
+| `GET /api/enterprise/audit-export`                | Compliance export    |
+| `GET /api/enterprise/organizations`               | Multi-org listing    |
+| `GET /api/enterprise/organizations/:id/isolation` | Isolation config     |
+| `POST /api/enterprise/webhooks`                   | Webhook registration |
+| `GET /api/enterprise/metrics`                     | Enterprise metrics   |
 
 ---
 
@@ -193,23 +205,23 @@ The following endpoints are now available (stubbed):
 
 **Yes** - With the following caveats:
 
-| Requirement | Status | Notes |
-|------------|--------|-------|
-| Deterministic execution | ✅ Ready | Hash-based input capture |
-| Marketing/App isolation | ✅ Ready | Boundary validation script |
-| Multi-tenant safety | ✅ Ready | RLS + tenant scoping |
-| Traceable evidence | ✅ Ready | Full provenance chain |
-| Evaluation metrics | ✅ Ready | Weighted scoring + drift |
-| Audit compliance | ⚠️ Partial | Provenance ready, export stubbed |
+| Requirement             | Status     | Notes                            |
+| ----------------------- | ---------- | -------------------------------- |
+| Deterministic execution | ✅ Ready   | Hash-based input capture         |
+| Marketing/App isolation | ✅ Ready   | Boundary validation script       |
+| Multi-tenant safety     | ✅ Ready   | RLS + tenant scoping             |
+| Traceable evidence      | ✅ Ready   | Full provenance chain            |
+| Evaluation metrics      | ✅ Ready   | Weighted scoring + drift         |
+| Audit compliance        | ⚠️ Partial | Provenance ready, export stubbed |
 
 ### What Still Blocks Enterprise?
 
-| Blocker | Severity | Action |
-|---------|----------|--------|
-| No actual webhook delivery | Low | Use existing webhook service |
-| Audit export is stubbed | Low | Implement with ReconAudit table |
-| Multi-org is stubbed | Medium | Requires tenant hierarchy |
-| Some TODOs in core paths | Medium | Prioritize encryption placeholders |
+| Blocker                    | Severity | Action                             |
+| -------------------------- | -------- | ---------------------------------- |
+| No actual webhook delivery | Low      | Use existing webhook service       |
+| Audit export is stubbed    | Low      | Implement with ReconAudit table    |
+| Multi-org is stubbed       | Medium   | Requires tenant hierarchy          |
+| Some TODOs in core paths   | Medium   | Prioritize encryption placeholders |
 
 ### What Is Now Defensible Moat?
 
@@ -249,7 +261,7 @@ psql $DATABASE_URL -f prisma/schema-determinism.prisma
 Settler is now equipped with production-grade hardening:
 
 - ✅ Deterministic execution guarantees
-- ✅ Strict marketing/app boundary isolation  
+- ✅ Strict marketing/app boundary isolation
 - ✅ Hardened multi-tenant safety
 - ✅ Traceable reconciliation evidence chains
 - ✅ Evaluation integrity (drift + scoring)

--- a/docs/PRODUCT_CAPABILITIES_MATRIX.md
+++ b/docs/PRODUCT_CAPABILITIES_MATRIX.md
@@ -1,5 +1,7 @@
 # Settler Product Capabilities Matrix (Evidence-Backed)
 
+_Last reviewed: 2026-04-08._
+
 This matrix tracks what is currently implemented in-repo and how each capability maps to operator-facing value.
 
 | Capability                       | Product/API Surface                                                                                                             | Problem Solved                                                                                | Differentiation Signal                                                             | Maturity                                                                   |

--- a/docs/verification/premium-surface-reality-report.md
+++ b/docs/verification/premium-surface-reality-report.md
@@ -1,6 +1,6 @@
 # Premium Surface Reality Report
 
-Date: 2026-03-12
+Date: 2026-04-08
 
 ## Scope
 
@@ -35,4 +35,5 @@ Validated discoverability + route viability for premium/enterprise claims:
 
 ## Residual Risk
 
+- This report is contract-oriented and must be paired with current `pnpm verify:*` command output for go-live decisions.
 - Browser E2E reality gate currently blocked by missing required startup env vars in this container; this prevents a full “click-through” truth statement for premium actions.

--- a/docs/verification/route-flow-matrix.md
+++ b/docs/verification/route-flow-matrix.md
@@ -1,6 +1,6 @@
 # Route + Flow Matrix (Reality Pass)
 
-Date: 2026-03-12
+Date: 2026-04-08
 
 ## Method
 
@@ -33,3 +33,7 @@ Date: 2026-03-12
 - **Renders confirmed:** major site, docs, console, and enterprise surfaces compile and appear in Next route manifest.
 - **Works confirmed (data/contracts):** API/data behavior mostly proven at contract/unit level (`api`, `web`, `cli` tests), including tenant isolation and degraded behavior tests.
 - **Not fully proven in this environment:** full browser E2E reality run due missing required startup env (`DATABASE_URL` / `NEXT_PUBLIC_SUPABASE_URL`).
+
+## Environment note
+
+Current validation in this pass is constrained by missing required build environment keys in this container (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `DATABASE_URL`). Route/build assertions should be interpreted as contract-level unless rerun in a fully seeded env.

--- a/packages/api/src/utils/route-validator.ts
+++ b/packages/api/src/utils/route-validator.ts
@@ -1,10 +1,13 @@
 /**
- * Route Validator
- * Validates that all routes are properly wired and accessible
+ * Route Validator (degraded helper)
+ *
+ * This module is intentionally limited to advisory messaging.
+ * Canonical route truth is verified by integration checks/scripts,
+ * not by runtime Express stack introspection in this helper.
  */
 
-import { Express } from 'express';
-import { logInfo } from './logger';
+import { Express } from "express";
+import { logInfo } from "./logger";
 
 export interface RouteInfo {
   method: string;
@@ -15,7 +18,7 @@ export interface RouteInfo {
 
 export interface RouteValidationResult {
   route: RouteInfo;
-  status: 'ok' | 'warning' | 'error';
+  status: "ok" | "warning" | "error";
   message: string;
 }
 
@@ -30,7 +33,9 @@ export function validateRoutes(_app: Express): RouteValidationResult[] {
   // parsing the Express router stack, which is complex.
   // In practice, this would be done via integration tests.
 
-  logInfo('Route validation: Routes are validated via integration tests');
+  logInfo(
+    "Route validation helper is advisory only; use verify:routes and integration tests for canonical truth"
+  );
 
   return results;
 }
@@ -48,9 +53,9 @@ export function checkDeadRoutes(): {
   return {
     potentiallyDead: [],
     recommendations: [
-      'Use test coverage reports to identify unused routes',
-      'Run integration tests to verify all routes are accessible',
-      'Check API documentation to ensure all routes are documented',
+      "Use test coverage reports to identify unused routes",
+      "Run integration tests to verify all routes are accessible",
+      "Check API documentation to ensure all routes are documented",
     ],
   };
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,4 +48,4 @@ This prints the recommended local service startup commands for web, API, event-l
 
 ## Status
 
-This package is actively expanded. Command families under `future.ts` are available but vary in maturity; treat advanced governance/arena/support flows as evolving operator tooling.
+This package is actively expanded. Commands loaded from `src/commands/future.ts` are **experimental** and not part of Settler's launch-critical CLI contract; avoid using them for production automation unless explicitly version-pinned and validated in your environment.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -113,77 +113,77 @@ const commandRegistry: Record<
   },
 
   capsule: {
-    description: "Create/verify deterministic time capsules",
+    description: "[experimental] Create/verify deterministic time capsules",
     load: async () => {
       const { capsuleCommand } = await import("./commands/future");
       return { command: capsuleCommand };
     },
   },
   proof: {
-    description: "Proof mode verification utilities",
+    description: "[experimental] Proof mode verification utilities",
     load: async () => {
       const { proofCommand } = await import("./commands/future");
       return { command: proofCommand };
     },
   },
   flow: {
-    description: "Export reconciliation flow explorer artifacts",
+    description: "[experimental] Export reconciliation flow explorer artifacts",
     load: async () => {
       const { flowCommand } = await import("./commands/future");
       return { command: flowCommand };
     },
   },
   lineage: {
-    description: "Export tenant topology/data lineage artifacts",
+    description: "[experimental] Export tenant topology/data lineage artifacts",
     load: async () => {
       const { lineageCommand } = await import("./commands/future");
       return { command: lineageCommand };
     },
   },
   rules: {
-    description: "Manage rules marketplace registry",
+    description: "[experimental] Manage rules marketplace registry",
     load: async () => {
       const { rulesCommand } = await import("./commands/future");
       return { command: rulesCommand };
     },
   },
   init: {
-    description: "Generate governed templates",
+    description: "[experimental] Generate governed templates",
     load: async () => {
       const { initCommand } = await import("./commands/future");
       return { command: initCommand };
     },
   },
   explain: {
-    description: "Human-readable reconciliation explain output",
+    description: "[experimental] Human-readable reconciliation explain output",
     load: async () => {
       const { explainCommand } = await import("./commands/future");
       return { command: explainCommand };
     },
   },
   operator: {
-    description: "Local-first operator telemetry mode",
+    description: "[experimental] Local-first operator telemetry mode",
     load: async () => {
       const { operatorCommand } = await import("./commands/future");
       return { command: operatorCommand };
     },
   },
   arena: {
-    description: "Run deterministic audit arena scorecards",
+    description: "[experimental] Run deterministic audit arena scorecards",
     load: async () => {
       const { arenaCommand } = await import("./commands/future");
       return { command: arenaCommand };
     },
   },
   support: {
-    description: "Offline-first support bot CLI",
+    description: "[experimental] Offline-first support bot CLI",
     load: async () => {
       const { supportCommand } = await import("./commands/future");
       return { command: supportCommand };
     },
   },
   profile: {
-    description: "Gamification profile (cosmetic only)",
+    description: "[experimental] Gamification profile (cosmetic only)",
     load: async () => {
       const { profileCommand } = await import("./commands/future");
       return { command: profileCommand };

--- a/packages/web/src/lib/telemetry/time-to-value.ts
+++ b/packages/web/src/lib/telemetry/time-to-value.ts
@@ -120,25 +120,14 @@ export async function trackFirstReconciliation(
 ): Promise<void> {
   try {
     // Persisted time-to-value storage is not yet implemented.
-    // Emit an explicit degraded signal instead of synthetic completion timing.
-    await ProductEvents.onboarding.completed({
-      totalDuration: 0,
-      stepsCompleted: 4,
-      completionRate: 1.0,
+    // Do not emit synthetic completion metrics that could be interpreted as measured truth.
+    await ProductEvents.engagement.featureUsed({
+      featureName: "time_to_value_tracking",
+      featureCategory: "observability",
     });
 
-    await ProductEvents.jobs.runCompleted({
-      jobId: runId,
-      executionId: runId,
-      duration: 0,
-      matched: 0,
-      unmatched: 0,
-      errors: 0,
-      success: true,
-    });
-
-    // Log metric for monitoring
-    await logger.info("Time-to-value completed", {
+    // Log degraded telemetry state for operator visibility.
+    await logger.warn("Time-to-value completion observed in degraded mode", {
       userId,
       tenantId,
       runId,


### PR DESCRIPTION
### Motivation
- Remove surfaces that implied stronger runtime truth than the code/evidence supports by stopping synthetic telemetry emissions, clarifying advisory helpers, and lowering CLI/README launch posture. 
- Reconcile key launch/readiness docs so operator and buyer-facing claims are explicitly tied to verification outputs and environment constraints.

### Description
- Replace synthetic completion telemetry in `packages/web/src/lib/telemetry/time-to-value.ts` with an explicit degraded observability signal and a warning log so we do not emit fabricated completion metrics. (file: `packages/web/src/lib/telemetry/time-to-value.ts`)
- Demote the route introspection helper to an advisory/degraded helper and point consumers to canonical verification/integration checks (`verify:routes`) in `packages/api/src/utils/route-validator.ts`.
- Mark CLI command families loaded from the `future` module as `[experimental]` in the command registry and tighten the CLI README to exclude those families from launch-critical contract (files: `packages/cli/src/index.ts`, `packages/cli/README.md`).
- Reconcile launch/verification docs with current truth by adding review dates, environment-only caveats, and a superseded-context banner for the historical hardening assessment (files: `docs/PRODUCT_CAPABILITIES_MATRIX.md`, `docs/verification/route-flow-matrix.md`, `docs/verification/premium-surface-reality-report.md`, `docs/HARDENING_ASSESSMENT.md`, `docs/reference/surface-area-convergence.md`).

### Testing
- `pnpm lint` ✅ — lint completed (warnings present in `@settler/web` but no new lint errors introduced). 
- `pnpm typecheck` ❌ — workspace `typecheck` run surfaced pre-existing `@settler/web` type failures (Supabase/SupportIntake typing drift) unrelated to these changes. 
- `pnpm test` ⚠️ — workspace tests ran many package-level suites (several packages passed) but full workspace test/build was environment-gated and the overall run failed because the web build requires Supabase/DB env keys. 
- `pnpm build` ❌ — web build fails in this environment due to missing required env groups (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `DATABASE_URL`). 
- `pnpm verify:fast` ❌ — failed at environment-contract stage for missing Supabase/DB/service-role vars. 
- `pnpm verify:routes` ✅ — route verification and console-route maturity checks passed (startup warnings about missing env were explicit). 
- `pnpm verify:claims` ✅ — site claims validation passed for the selected mode. 
- `pnpm verify:surface-docs` ✅ — surface docs regenerated and are now in sync. 
- `pnpm verify:route-classes-doc` ✅ — route class docs in sync. 
- `pnpm verify:launch:readiness` ❌ — setup failed because required build/runtime env keys are not present in this container. 
- `pnpm verify:security:fast` ✅ — security/tenant verification surfaces ran and passed with degraded evidence mode noted by scripts. 
- `pnpm verify:tenant` ✅ and `pnpm verify:tenant-isolation` ✅ — tenant/coverage checks passed. 
- `pnpm verify:determinism` ✅ and `pnpm verify:replay` ✅ — determinism and replay verification succeeded. 
- `pnpm qa:links` ✅ and `pnpm qa:routes` ✅ — internal link and route QA passed. 

Notes: the changes are intentionally conservative and focused on truth/reconciliation of product claims; a follow-on pass is recommended to close the `@settler/web` Supabase DB type drift (regenerate/repair `packages/web/src/types/database.types.ts`) so full `pnpm typecheck`/`pnpm build`/`pnpm test` can pass in a seeded environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5dc9d97b48328b60e8574ab458b2e)