### PR TITLE
fix(ci): add explicit permissions for Migration Guardian workflow

### DIFF
--- a/.github/workflows/migration-guardian.yml
+++ b/.github/workflows/migration-guardian.yml
@@ -1,5 +1,12 @@
 name: Migration Guardian
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: read
+  actions: read
+
 on:
   schedule:
     # Run every hour to check for pending migrations


### PR DESCRIPTION
## Executive Summary

Fix GitHub Actions workflow permission issue causing Migration Guardian to fail with 'Resource not accessible by integration' (403).

## Root Cause

The Migration Guardian workflow lacked an explicit `permissions` block. GitHub Actions default token permissions are restrictive and may not include `issues: write` in certain organizational contexts.

## Changes Made

- Added explicit permissions block to `.github/workflows/migration-guardian.yml`:
  - `contents: read`
  - `issues: write` 
  - `pull-requests: write`
  - `statuses: read`
  - `actions: read`

## Verification Steps

1. Merge this PR
2. Trigger Migration Guardian manually or wait for next scheduled run
3. Verify issue creation succeeds
4. Check workflow run logs for successful issue creation

## Risk Assessment

- **Low** - Only adds permissions, no behavior change

## Follow-up Tasks

- [ ] Monitor next Migration Guardian run
- [ ] Apply similar fix to other workflows with issue/PR creation