### PR TITLE
security: bump defu to ^6.1.5 (GHSA-737v-mqg7-c878)

### DIFF
--- a/package.json
+++ b/package.json
@@ -397,6 +397,7 @@
       "path-to-regexp": "^8.4.2",
       "@hono/node-server": "^1.19.10",
       "effect": "^3.20.0",
+      "defu": "^6.1.5",
       "rollup": "^4.59.0",
       "@tootallnate/once": "^3.0.1"
     },


### PR DESCRIPTION
## Executive Summary

Fix HIGH severity prototype pollution vulnerability in defu package (GHSA-737v-mqg7-c878).

## Root Cause

dfu <=6.1.4 vulnerable to prototype pollution via `__proto__` key in defaults argument. 
Path: @prisma/client > prisma > @prisma/config > c12 > defu

## Changes Made

- Added pnpm override: `defu: ^6.1.5` to package.json
- Forces all transitive dependencies to use patched version

## Verification

```bash
pnpm audit --prod --audit-level=high
# Expected: 0 vulnerabilities (defu no longer listed)
```

## Risk Notes

- **Low risk**: Patch version bump, no breaking changes
- **Scope**: Only affects dependency resolution, no code changes
- **Impact**: Blocks security scan CI failures

## Residual Gaps

- 7 moderate vulnerabilities remain (non-blocking)
- Gitleaks workflow still failing (separate issue)

## Next Tasks

- [ ] Merge this PR
- [ ] Verify Security Scan passes
- [ ] Address Gitleaks config issue (results.sarif missing)
- [ ] Evaluate remaining 7 moderate vulnerabilities