### PR TITLE
Harden schedule cron validation and surface scheduler degraded truth in console API

### DIFF
--- a/marketing/daily-run.js
+++ b/marketing/daily-run.js
@@ -1,30 +1,39 @@
 #!/usr/bin/env node
 /**
  * Daily Marketing Automation Runner
- * 
+ *
  * Runs all marketing tools in sequence
  * Usage: node daily-run.js
  */
 
-const { execSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
 
-const OUTPUT_DIR = './output';
-const TIMESTAMP = new Date().toISOString().split('T')[0];
+const OUTPUT_DIR = "./output";
+const TIMESTAMP = new Date().toISOString().split("T")[0];
 
 // Ensure output directories exist
-const dirs = ['blog', 'social', 'prospects', 'jobs', 'community', 'partnerships', 'intelligence', 'voice'];
-dirs.forEach(dir => {
+const dirs = [
+  "blog",
+  "social",
+  "prospects",
+  "jobs",
+  "community",
+  "partnerships",
+  "intelligence",
+  "voice",
+];
+dirs.forEach((dir) => {
   const fullPath = path.join(OUTPUT_DIR, dir);
   if (!fs.existsSync(fullPath)) {
     fs.mkdirSync(fullPath, { recursive: true });
   }
 });
 
-console.log('🚀 STARTING DAILY MARKETING AUTOMATION');
+console.log("🚀 STARTING DAILY MARKETING AUTOMATION");
 console.log(`📅 Date: ${TIMESTAMP}`);
-console.log('=' .repeat(60));
+console.log("=".repeat(60));
 
 let results = {
   blogPosts: 0,
@@ -34,182 +43,182 @@ let results = {
   communityPosts: 0,
   partnerships: 0,
   competitorChanges: 0,
-  voiceEntries: 0
+  voiceEntries: 0,
 };
 
 // 1. CONTENT ENGINE - Blog Posts
-console.log('\n📝 GENERATING BLOG POSTS...');
+console.log("\n📝 GENERATING BLOG POSTS...");
 try {
-  const blogOutput = path.join(OUTPUT_DIR, 'blog', TIMESTAMP);
+  const blogOutput = path.join(OUTPUT_DIR, "blog", TIMESTAMP);
   fs.mkdirSync(blogOutput, { recursive: true });
-  
+
   // Generate 3 blog posts
   const topics = [
-    { keyword: 'automated reconciliation', template: 'guide' },
-    { keyword: 'stripe reconciliation', template: 'how-to' },
-    { keyword: 'payment reconciliation tools', template: 'guide' }
+    { keyword: "automated reconciliation", template: "guide" },
+    { keyword: "stripe reconciliation", template: "how-to" },
+    { keyword: "payment reconciliation tools", template: "guide" },
   ];
-  
+
   topics.forEach((topic, i) => {
     const content = generateBlogPost(topic.keyword, topic.template);
-    const filename = `${topic.keyword.replace(/\s+/g, '-')}-${i + 1}.md`;
+    const filename = `${topic.keyword.replace(/\s+/g, "-")}-${i + 1}.md`;
     fs.writeFileSync(path.join(blogOutput, filename), content);
     results.blogPosts++;
     console.log(`  ✅ ${filename}`);
   });
-  
+
   console.log(`  Generated ${results.blogPosts} blog posts`);
 } catch (e) {
-  console.error('  ❌ Blog generation failed:', e.message);
+  console.error("  ❌ Blog generation failed:", e.message);
 }
 
 // 2. CONTENT ENGINE - Social Media
-console.log('\n📱 GENERATING SOCIAL MEDIA CONTENT...');
+console.log("\n📱 GENERATING SOCIAL MEDIA CONTENT...");
 try {
-  const socialOutput = path.join(OUTPUT_DIR, 'social', TIMESTAMP);
+  const socialOutput = path.join(OUTPUT_DIR, "social", TIMESTAMP);
   fs.mkdirSync(socialOutput, { recursive: true });
-  
+
   const ideas = [
-    'Automated reconciliation saves 20 hours/week',
-    'Real-time payment matching eliminates end-of-month panic',
-    'API-first reconciliation scales better than CSV exports'
+    "Automated reconciliation saves 20 hours/week",
+    "Real-time payment matching eliminates end-of-month panic",
+    "API-first reconciliation scales better than CSV exports",
   ];
-  
+
   ideas.forEach((idea, i) => {
     const content = generateSocialContent(idea);
     const filename = `social-${i + 1}.md`;
     fs.writeFileSync(path.join(socialOutput, filename), content);
-    results.socialPosts += content.split('---').length - 1;
-    console.log(`  ✅ ${filename} (${content.split('---').length - 1} posts)`);
+    results.socialPosts += content.split("---").length - 1;
+    console.log(`  ✅ ${filename} (${content.split("---").length - 1} posts)`);
   });
-  
+
   console.log(`  Generated social content for ${ideas.length} ideas`);
 } catch (e) {
-  console.error('  ❌ Social generation failed:', e.message);
+  console.error("  ❌ Social generation failed:", e.message);
 }
 
 // 3. LEAD GEN - Prospects
-console.log('\n🔍 RESEARCHING PROSPECTS...');
+console.log("\n🔍 RESEARCHING PROSPECTS...");
 try {
   const prospects = generateProspects();
-  const prospectsPath = path.join(OUTPUT_DIR, 'prospects', `${TIMESTAMP}.json`);
+  const prospectsPath = path.join(OUTPUT_DIR, "prospects", `${TIMESTAMP}.json`);
   fs.writeFileSync(prospectsPath, JSON.stringify(prospects, null, 2));
   results.prospects = prospects.length;
   console.log(`  ✅ Found ${prospects.length} prospects`);
-  
+
   // Generate cold emails for top 5
-  const emailsPath = path.join(OUTPUT_DIR, 'prospects', `${TIMESTAMP}-emails.md`);
-  let emailsContent = '# Cold Emails for Top Prospects\n\n';
+  const emailsPath = path.join(OUTPUT_DIR, "prospects", `${TIMESTAMP}-emails.md`);
+  let emailsContent = "# Cold Emails for Top Prospects\n\n";
   prospects.slice(0, 5).forEach((p, i) => {
     emailsContent += `## ${i + 1}. ${p.company}\n\n${generateColdEmail(p)}\n\n---\n\n`;
   });
   fs.writeFileSync(emailsPath, emailsContent);
   console.log(`  ✅ Generated ${Math.min(5, prospects.length)} cold emails`);
 } catch (e) {
-  console.error('  ❌ Prospect research failed:', e.message);
+  console.error("  ❌ Prospect research failed:", e.message);
 }
 
 // 4. LEAD GEN - Job Monitor
-console.log('\n💼 MONITORING JOB POSTINGS...');
+console.log("\n💼 MONITORING JOB POSTINGS...");
 try {
   const jobs = generateJobPostings();
-  const jobsPath = path.join(OUTPUT_DIR, 'jobs', `${TIMESTAMP}.json`);
+  const jobsPath = path.join(OUTPUT_DIR, "jobs", `${TIMESTAMP}.json`);
   fs.writeFileSync(jobsPath, JSON.stringify(jobs, null, 2));
   results.jobPostings = jobs.length;
   console.log(`  ✅ Found ${jobs.length} relevant job postings`);
-  
+
   // Generate outreach messages
-  const messagesPath = path.join(OUTPUT_DIR, 'jobs', `${TIMESTAMP}-outreach.md`);
-  let messagesContent = '# Job Posting Outreach\n\n';
+  const messagesPath = path.join(OUTPUT_DIR, "jobs", `${TIMESTAMP}-outreach.md`);
+  let messagesContent = "# Job Posting Outreach\n\n";
   jobs.forEach((j, i) => {
     messagesContent += `## ${i + 1}. ${j.company} - ${j.title}\n\n${generateJobOutreach(j)}\n\n---\n\n`;
   });
   fs.writeFileSync(messagesPath, messagesContent);
   console.log(`  ✅ Generated ${jobs.length} outreach messages`);
 } catch (e) {
-  console.error('  ❌ Job monitoring failed:', e.message);
+  console.error("  ❌ Job monitoring failed:", e.message);
 }
 
 // 5. LEAD GEN - Community Mining
-console.log('\n⛏️ MINING COMMUNITIES...');
+console.log("\n⛏️ MINING COMMUNITIES...");
 try {
   const posts = generateCommunityPosts();
-  const postsPath = path.join(OUTPUT_DIR, 'community', `${TIMESTAMP}.json`);
+  const postsPath = path.join(OUTPUT_DIR, "community", `${TIMESTAMP}.json`);
   fs.writeFileSync(postsPath, JSON.stringify(posts, null, 2));
   results.communityPosts = posts.length;
   console.log(`  ✅ Found ${posts.length} relevant community posts`);
-  
+
   // Generate responses
-  const responsesPath = path.join(OUTPUT_DIR, 'community', `${TIMESTAMP}-responses.md`);
-  let responsesContent = '# Suggested Community Responses\n\n';
+  const responsesPath = path.join(OUTPUT_DIR, "community", `${TIMESTAMP}-responses.md`);
+  let responsesContent = "# Suggested Community Responses\n\n";
   posts.forEach((p, i) => {
     responsesContent += `## ${i + 1}. ${p.platform}: ${p.title.slice(0, 60)}...\n\n${generateCommunityResponse(p)}\n\n---\n\n`;
   });
   fs.writeFileSync(responsesPath, responsesContent);
   console.log(`  ✅ Generated ${posts.length} responses`);
 } catch (e) {
-  console.error('  ❌ Community mining failed:', e.message);
+  console.error("  ❌ Community mining failed:", e.message);
 }
 
 // 6. PARTNERSHIPS
-console.log('\n🤝 IDENTIFYING PARTNERSHIP OPPORTUNITIES...');
+console.log("\n🤝 IDENTIFYING PARTNERSHIP OPPORTUNITIES...");
 try {
   const partners = generatePartnerships();
-  const partnersPath = path.join(OUTPUT_DIR, 'partnerships', `${TIMESTAMP}.json`);
+  const partnersPath = path.join(OUTPUT_DIR, "partnerships", `${TIMESTAMP}.json`);
   fs.writeFileSync(partnersPath, JSON.stringify(partners, null, 2));
   results.partnerships = partners.length;
   console.log(`  ✅ Found ${partners.length} partnership opportunities`);
-  
+
   // Generate outreach emails
-  const partnerEmailsPath = path.join(OUTPUT_DIR, 'partnerships', `${TIMESTAMP}-emails.md`);
-  let partnerEmailsContent = '# Partnership Outreach\n\n';
+  const partnerEmailsPath = path.join(OUTPUT_DIR, "partnerships", `${TIMESTAMP}-emails.md`);
+  let partnerEmailsContent = "# Partnership Outreach\n\n";
   partners.slice(0, 5).forEach((p, i) => {
     partnerEmailsContent += `## ${i + 1}. ${p.name}\n\n${generatePartnerEmail(p)}\n\n---\n\n`;
   });
   fs.writeFileSync(partnerEmailsPath, partnerEmailsContent);
   console.log(`  ✅ Generated ${Math.min(5, partners.length)} partner emails`);
 } catch (e) {
-  console.error('  ❌ Partnership finder failed:', e.message);
+  console.error("  ❌ Partnership finder failed:", e.message);
 }
 
 // 7. INTELLIGENCE - Competitors
-console.log('\n🔍 MONITORING COMPETITORS...');
+console.log("\n🔍 MONITORING COMPETITORS...");
 try {
   const intel = generateCompetitorIntel();
-  const intelPath = path.join(OUTPUT_DIR, 'intelligence', `${TIMESTAMP}.json`);
+  const intelPath = path.join(OUTPUT_DIR, "intelligence", `${TIMESTAMP}.json`);
   fs.writeFileSync(intelPath, JSON.stringify(intel, null, 2));
   results.competitorChanges = intel.changes.length;
   console.log(`  ✅ Found ${intel.changes.length} competitor changes`);
-  
+
   // Generate report
-  const reportPath = path.join(OUTPUT_DIR, 'intelligence', `${TIMESTAMP}-report.md`);
+  const reportPath = path.join(OUTPUT_DIR, "intelligence", `${TIMESTAMP}-report.md`);
   fs.writeFileSync(reportPath, generateCompetitorReport(intel));
   console.log(`  ✅ Generated competitor report`);
 } catch (e) {
-  console.error('  ❌ Competitor monitoring failed:', e.message);
+  console.error("  ❌ Competitor monitoring failed:", e.message);
 }
 
 // 8. INTELLIGENCE - Customer Voice
-console.log('\n📣 MINING CUSTOMER VOICE...');
+console.log("\n📣 MINING CUSTOMER VOICE...");
 try {
   const voice = generateCustomerVoice();
-  const voicePath = path.join(OUTPUT_DIR, 'voice', `${TIMESTAMP}.json`);
+  const voicePath = path.join(OUTPUT_DIR, "voice", `${TIMESTAMP}.json`);
   fs.writeFileSync(voicePath, JSON.stringify(voice, null, 2));
   results.voiceEntries = voice.length;
   console.log(`  ✅ Analyzed ${voice.length} voice entries`);
-  
+
   // Generate content ideas
-  const ideasPath = path.join(OUTPUT_DIR, 'voice', `${TIMESTAMP}-ideas.md`);
+  const ideasPath = path.join(OUTPUT_DIR, "voice", `${TIMESTAMP}-ideas.md`);
   fs.writeFileSync(ideasPath, generateContentIdeas(voice));
   console.log(`  ✅ Generated content ideas`);
 } catch (e) {
-  console.error('  ❌ Customer voice mining failed:', e.message);
+  console.error("  ❌ Customer voice mining failed:", e.message);
 }
 
 // Summary
-console.log('\n' + '='.repeat(60));
-console.log('📊 DAILY AUTOMATION COMPLETE');
-console.log('='.repeat(60));
+console.log("\n" + "=".repeat(60));
+console.log("📊 DAILY AUTOMATION COMPLETE");
+console.log("=".repeat(60));
 console.log(`
 Results Summary:
   📝 Blog Posts: ${results.blogPosts}
@@ -230,16 +239,16 @@ All outputs saved to: ${OUTPUT_DIR}/
 
 function generateBlogPost(keyword, template) {
   const titles = {
-    'how-to': `How to Master ${keyword}: The Complete Guide`,
-    'guide': `The Definitive Guide to ${keyword} in 2026`,
-    'vs': `${keyword} vs Manual: Which is Right for You?`
+    "how-to": `How to Master ${keyword}: The Complete Guide`,
+    guide: `The Definitive Guide to ${keyword} in 2026`,
+    vs: `${keyword} vs Manual: Which is Right for You?`,
   };
-  
+
   const title = titles[template] || titles.guide;
-  
+
   return `---
 title: "${title}"
-slug: "${keyword.replace(/\s+/g, '-')}"
+slug: "${keyword.replace(/\s+/g, "-")}"
 excerpt: "Learn how to ${keyword.toLowerCase()} with this comprehensive guide. Save time and reduce errors with proven strategies."
 keywords: ["${keyword}", "reconciliation", "automation"]
 readingTime: 8
@@ -293,7 +302,7 @@ Generated: 8 pieces
 ---
 
 TWITTER
-=======
+-------
 
 [THREAD 1]
 Best time: 9:00 AM EST
@@ -372,11 +381,41 @@ We've seen companies cut reconciliation time by 90% with the right automation.
 
 function generateProspects() {
   return [
-    { company: 'PaymentFlow', employees: 120, funding: 'Series B', techStack: ['Stripe', 'Salesforce'], signal: 'high' },
-    { company: 'MarketHub', employees: 250, funding: 'Series C', techStack: ['Adyen', 'NetSuite'], signal: 'high' },
-    { company: 'SaaSBilling', employees: 80, funding: 'Series A', techStack: ['Stripe', 'QuickBooks'], signal: 'medium' },
-    { company: 'FinTechFlow', employees: 45, funding: 'Seed', techStack: ['Stripe'], signal: 'medium' },
-    { company: 'PayStream', employees: 180, funding: 'Series B', techStack: ['PayPal', 'Xero'], signal: 'high' }
+    {
+      company: "PaymentFlow",
+      employees: 120,
+      funding: "Series B",
+      techStack: ["Stripe", "Salesforce"],
+      signal: "high",
+    },
+    {
+      company: "MarketHub",
+      employees: 250,
+      funding: "Series C",
+      techStack: ["Adyen", "NetSuite"],
+      signal: "high",
+    },
+    {
+      company: "SaaSBilling",
+      employees: 80,
+      funding: "Series A",
+      techStack: ["Stripe", "QuickBooks"],
+      signal: "medium",
+    },
+    {
+      company: "FinTechFlow",
+      employees: 45,
+      funding: "Seed",
+      techStack: ["Stripe"],
+      signal: "medium",
+    },
+    {
+      company: "PayStream",
+      employees: 180,
+      funding: "Series B",
+      techStack: ["PayPal", "Xero"],
+      signal: "high",
+    },
   ];
 }
 
@@ -402,10 +441,30 @@ P.S. - If you're not the right person for this, could you point me to whoever ha
 
 function generateJobPostings() {
   return [
-    { company: 'FastPay', title: 'Senior Finance Operations Manager', signal: 'high', keywords: ['reconciliation', 'transaction matching'] },
-    { company: 'CloudBilling', title: 'Payment Operations Specialist', signal: 'high', keywords: ['reconciliation', 'stripe'] },
-    { company: 'SaaSPlatform', title: 'Financial Analyst', signal: 'medium', keywords: ['reconciliation'] },
-    { company: 'MarketplaceX', title: 'Director of Finance', signal: 'high', keywords: ['automated reconciliation'] }
+    {
+      company: "FastPay",
+      title: "Senior Finance Operations Manager",
+      signal: "high",
+      keywords: ["reconciliation", "transaction matching"],
+    },
+    {
+      company: "CloudBilling",
+      title: "Payment Operations Specialist",
+      signal: "high",
+      keywords: ["reconciliation", "stripe"],
+    },
+    {
+      company: "SaaSPlatform",
+      title: "Financial Analyst",
+      signal: "medium",
+      keywords: ["reconciliation"],
+    },
+    {
+      company: "MarketplaceX",
+      title: "Director of Finance",
+      signal: "high",
+      keywords: ["automated reconciliation"],
+    },
   ];
 }
 
@@ -414,7 +473,7 @@ function generateJobOutreach(posting) {
 
 Hi there,
 
-I saw ${posting.company} is hiring a ${posting.title} and specifically mentioned ${posting.keywords.join(', ')}.
+I saw ${posting.company} is hiring a ${posting.title} and specifically mentioned ${posting.keywords.join(", ")}.
 
 Instead of building this in-house over 6+ months, what if you could have it running in 5 minutes?
 
@@ -429,10 +488,22 @@ settler.dev/demo`;
 
 function generateCommunityPosts() {
   return [
-    { platform: 'reddit', title: 'How do you handle Stripe reconciliation at scale?', relevance: 'high' },
-    { platform: 'hn', title: 'Ask HN: How do you automate financial reconciliation?', relevance: 'high' },
-    { platform: 'stackoverflow', title: 'Best way to match transactions from Stripe to internal database?', relevance: 'medium' },
-    { platform: 'reddit', title: 'Multi-currency reconciliation nightmare', relevance: 'high' }
+    {
+      platform: "reddit",
+      title: "How do you handle Stripe reconciliation at scale?",
+      relevance: "high",
+    },
+    {
+      platform: "hn",
+      title: "Ask HN: How do you automate financial reconciliation?",
+      relevance: "high",
+    },
+    {
+      platform: "stackoverflow",
+      title: "Best way to match transactions from Stripe to internal database?",
+      relevance: "medium",
+    },
+    { platform: "reddit", title: "Multi-currency reconciliation nightmare", relevance: "high" },
   ];
 }
 
@@ -459,19 +530,19 @@ Not a sales pitch - genuinely went through this pain and want to help.`,
 
 If you're doing significant volume, you really need proper tooling. We use Settler but there are other options.
 
-Happy to share more specifics if helpful.`
+Happy to share more specifics if helpful.`,
   };
-  
+
   return responses[post.relevance] || responses.medium;
 }
 
 function generatePartnerships() {
   return [
-    { name: 'QuickBooks', category: 'integration', fit: 'strategic', relevanceScore: 95 },
-    { name: 'Xero', category: 'integration', fit: 'strategic', relevanceScore: 90 },
-    { name: 'Stripe Atlas', category: 'co-marketing', fit: 'strategic', relevanceScore: 90 },
-    { name: 'Mercury', category: 'co-marketing', fit: 'strategic', relevanceScore: 88 },
-    { name: 'Pilot', category: 'co-marketing', fit: 'strategic', relevanceScore: 85 }
+    { name: "QuickBooks", category: "integration", fit: "strategic", relevanceScore: 95 },
+    { name: "Xero", category: "integration", fit: "strategic", relevanceScore: 90 },
+    { name: "Stripe Atlas", category: "co-marketing", fit: "strategic", relevanceScore: 90 },
+    { name: "Mercury", category: "co-marketing", fit: "strategic", relevanceScore: 88 },
+    { name: "Pilot", category: "co-marketing", fit: "strategic", relevanceScore: 85 },
   ];
 }
 
@@ -497,16 +568,26 @@ Best,
 Scott
 settler.dev
 
-P.S. - We're already integrated with ${partner.name === 'QuickBooks' ? 'Xero and Stripe' : 'QuickBooks and Stripe'}. ${partner.name} would complete the picture.`;
+P.S. - We're already integrated with ${partner.name === "QuickBooks" ? "Xero and Stripe" : "QuickBooks and Stripe"}. ${partner.name} would complete the picture.`;
 }
 
 function generateCompetitorIntel() {
   return {
     competitors: 3,
     changes: [
-      { type: 'pricing', competitor: 'BlackLine', impact: 'high', description: 'Increased enterprise pricing by 15%' },
-      { type: 'hiring', competitor: 'FloQast', impact: 'high', description: 'Hiring 50+ sales reps' }
-    ]
+      {
+        type: "pricing",
+        competitor: "BlackLine",
+        impact: "high",
+        description: "Increased enterprise pricing by 15%",
+      },
+      {
+        type: "hiring",
+        competitor: "FloQast",
+        impact: "high",
+        description: "Hiring 50+ sales reps",
+      },
+    ],
   };
 }
 
@@ -519,7 +600,7 @@ Generated: ${TIMESTAMP}
 - Changes detected: ${intel.changes.length}
 
 ## Recent Changes
-${intel.changes.map(c => `- **${c.competitor}**: ${c.description} (${c.impact} impact)`).join('\n')}
+${intel.changes.map((c) => `- **${c.competitor}**: ${c.description} (${c.impact} impact)`).join("\n")}
 
 ## Recommended Actions
 1. Target enterprise customers with "Switch and Save" campaign
@@ -530,9 +611,24 @@ ${intel.changes.map(c => `- **${c.competitor}**: ${c.description} (${c.impact} i
 
 function generateCustomerVoice() {
   return [
-    { source: 'G2', sentiment: 'negative', text: 'BlackLine is powerful but took 8 months to implement.', painPoints: ['Long implementation'] },
-    { source: 'Reddit', sentiment: 'negative', text: 'We do everything in Excel still. Looked at FloQast but too expensive.', painPoints: ['Manual process', 'Pricing'] },
-    { source: 'Twitter', sentiment: 'negative', text: 'Reconciliation day is the worst day. 3 people, 2 days, 1000s of transactions.', painPoints: ['Time consuming'] }
+    {
+      source: "G2",
+      sentiment: "negative",
+      text: "BlackLine is powerful but took 8 months to implement.",
+      painPoints: ["Long implementation"],
+    },
+    {
+      source: "Reddit",
+      sentiment: "negative",
+      text: "We do everything in Excel still. Looked at FloQast but too expensive.",
+      painPoints: ["Manual process", "Pricing"],
+    },
+    {
+      source: "Twitter",
+      sentiment: "negative",
+      text: "Reconciliation day is the worst day. 3 people, 2 days, 1000s of transactions.",
+      painPoints: ["Time consuming"],
+    },
   ];
 }
 

--- a/packages/web/src/__tests__/api/console-schedules-route.test.ts
+++ b/packages/web/src/__tests__/api/console-schedules-route.test.ts
@@ -1,0 +1,154 @@
+/** @jest-environment node */
+
+import { NextRequest } from "next/server";
+import { GET, PATCH } from "@/app/api/console/schedules/route";
+
+jest.mock("@/middleware/billing-gate-universal", () => ({
+  withUniversalBillingGate: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+const requireTenantRequestContext = jest.fn();
+const reconJobFindManyMock = jest.fn();
+const reconJobFindFirstMock = jest.fn();
+const reconJobUpdateMock = jest.fn();
+const logAuditEventMock = jest.fn();
+
+jest.mock("@/lib/api/tenant-context", () => ({
+  requireTenantRequestContext: (...args: unknown[]) => requireTenantRequestContext(...args),
+  buildTenantContextErrorResponse: (error: {
+    status: number;
+    code: string;
+    message: string;
+    capability: unknown;
+  }) =>
+    Response.json(
+      { error: error.message, code: error.code, capability: error.capability },
+      { status: error.status }
+    ),
+}));
+
+jest.mock("@/shared/db/prismaClient", () => ({
+  prisma: {
+    reconJob: {
+      findMany: (...args: unknown[]) => reconJobFindManyMock(...args),
+      findFirst: (...args: unknown[]) => reconJobFindFirstMock(...args),
+      update: (...args: unknown[]) => reconJobUpdateMock(...args),
+    },
+  },
+}));
+
+jest.mock("@/lib/audit/logger", () => ({
+  logAuditEvent: (...args: unknown[]) => logAuditEventMock(...args),
+}));
+
+jest.mock("@/lib/utils/logger", () => ({
+  appLogger: {
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/console/schedules");
+}
+
+function makePatchRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/console/schedules", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+describe("/api/console/schedules route", () => {
+  const originalSchedulerEnabled = process.env.SCHEDULER_ENABLED;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SCHEDULER_ENABLED = "true";
+    requireTenantRequestContext.mockResolvedValue({ userId: "user-1", tenantId: "tenant-1" });
+  });
+
+  afterAll(() => {
+    process.env.SCHEDULER_ENABLED = originalSchedulerEnabled;
+  });
+
+  it("GET returns degraded capability when scheduler is disabled", async () => {
+    process.env.SCHEDULER_ENABLED = "false";
+    reconJobFindManyMock.mockResolvedValue([]);
+
+    const response = await GET(makeGetRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.capability).toEqual({ state: "degraded", reason: "scheduler_disabled_by_env" });
+  });
+
+  it("PATCH keeps update truthful when scheduler is disabled", async () => {
+    process.env.SCHEDULER_ENABLED = "false";
+
+    reconJobFindFirstMock.mockResolvedValue({
+      id: "job-1",
+      tenantId: "tenant-1",
+      scheduleCron: "0 0 * * *",
+      scheduleTimezone: "UTC",
+      deletedAt: null,
+    });
+
+    reconJobUpdateMock.mockResolvedValue({
+      id: "job-1",
+      scheduleCron: "0 6 * * *",
+      scheduleTimezone: "America/New_York",
+    });
+
+    const response = await PATCH(
+      makePatchRequest({
+        jobId: "job-1",
+        scheduleCron: "0 6 * * *",
+        scheduleTimezone: "America/New_York",
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.capability).toEqual({ state: "degraded", reason: "scheduler_disabled_by_env" });
+    expect(logAuditEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        tenantId: "tenant-1",
+        action: "update",
+        resourceType: "reconciliation_job",
+        resourceId: "job-1",
+      })
+    );
+  });
+
+  it("PATCH rejects out-of-range cron expressions", async () => {
+    reconJobFindFirstMock.mockResolvedValue({
+      id: "job-1",
+      tenantId: "tenant-1",
+      scheduleCron: null,
+      scheduleTimezone: "UTC",
+      deletedAt: null,
+    });
+
+    const response = await PATCH(
+      makePatchRequest({
+        jobId: "job-1",
+        scheduleCron: "99 0 * * *",
+        scheduleTimezone: "UTC",
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.capability).toEqual({ state: "degraded", reason: "invalid_cron_expression" });
+    expect(reconJobUpdateMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/scheduling/schedule-contract.test.ts
+++ b/packages/web/src/__tests__/scheduling/schedule-contract.test.ts
@@ -1,0 +1,47 @@
+import { validateScheduleCron, validateScheduleTimezone } from "@/lib/scheduling/schedule-contract";
+
+describe("schedule-contract", () => {
+  describe("validateScheduleCron", () => {
+    it("accepts valid 5-field cron expressions", () => {
+      expect(validateScheduleCron("0 */6 * * *")).toEqual({ valid: true, errors: [] });
+      expect(validateScheduleCron("15 2 1,15 * 1-5")).toEqual({ valid: true, errors: [] });
+    });
+
+    it("accepts valid 6-field cron expressions", () => {
+      expect(validateScheduleCron("0 0 */2 * * *")).toEqual({ valid: true, errors: [] });
+    });
+
+    it("rejects out-of-range fields", () => {
+      const invalidMinute = validateScheduleCron("61 0 * * *");
+      expect(invalidMinute.valid).toBe(false);
+      expect(invalidMinute.errors[0]).toContain("out of bounds");
+
+      const invalidMonth = validateScheduleCron("0 0 * 13 *");
+      expect(invalidMonth.valid).toBe(false);
+      expect(invalidMonth.errors[0]).toContain("out of bounds");
+    });
+
+    it("rejects zero or invalid step values", () => {
+      const zeroStep = validateScheduleCron("*/0 * * * *");
+      expect(zeroStep.valid).toBe(false);
+      expect(zeroStep.errors[0]).toContain("Step must be >= 1");
+
+      const badStep = validateScheduleCron("*/foo * * * *");
+      expect(badStep.valid).toBe(false);
+      expect(badStep.errors[0]).toContain("Invalid cron token");
+    });
+  });
+
+  describe("validateScheduleTimezone", () => {
+    it("accepts valid timezones", () => {
+      expect(validateScheduleTimezone("UTC")).toEqual({ valid: true, errors: [] });
+      expect(validateScheduleTimezone("America/New_York")).toEqual({ valid: true, errors: [] });
+    });
+
+    it("rejects invalid timezones", () => {
+      const invalid = validateScheduleTimezone("Mars/Olympus");
+      expect(invalid.valid).toBe(false);
+      expect(invalid.errors[0]).toContain("Unsupported timezone");
+    });
+  });
+});

--- a/packages/web/src/app/api/console/schedules/route.ts
+++ b/packages/web/src/app/api/console/schedules/route.ts
@@ -15,6 +15,7 @@ import { appLogger } from "@/lib/utils/logger";
 import { withSecurity } from "@/lib/middleware/api-security";
 import { prisma } from "@/shared/db/prismaClient";
 import { validateScheduleCron, validateScheduleTimezone } from "@/lib/scheduling/schedule-contract";
+import { logAuditEvent } from "@/lib/audit/logger";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -158,6 +159,29 @@ export const PATCH = withSecurity(
             scheduleTimezone: scheduleTimezone || existing.scheduleTimezone,
           },
         });
+        const schedulerEnabled = process.env.SCHEDULER_ENABLED !== "false";
+
+        await logAuditEvent({
+          userId: tenantContext.userId,
+          tenantId: tenantContext.tenantId,
+          action: "update",
+          resourceType: "reconciliation_job",
+          resourceId: updated.id,
+          changes: {
+            before: {
+              scheduleCron: existing.scheduleCron,
+              scheduleTimezone: existing.scheduleTimezone,
+            },
+            after: {
+              scheduleCron: updated.scheduleCron,
+              scheduleTimezone: updated.scheduleTimezone,
+            },
+          },
+          metadata: {
+            event: "reconciliation_schedule_updated",
+            schedulerEnabled,
+          },
+        });
 
         appLogger.info("[Schedules API] Schedule updated", {
           jobId,
@@ -170,7 +194,9 @@ export const PATCH = withSecurity(
           id: updated.id,
           scheduleCron: updated.scheduleCron,
           scheduleTimezone: updated.scheduleTimezone,
-          capability: { state: "available" },
+          capability: schedulerEnabled
+            ? { state: "available" }
+            : { state: "degraded", reason: "scheduler_disabled_by_env" },
         });
       } catch (error) {
         if (

--- a/packages/web/src/lib/scheduling/schedule-contract.ts
+++ b/packages/web/src/lib/scheduling/schedule-contract.ts
@@ -4,6 +4,100 @@ export interface ScheduleValidationResult {
 }
 
 const CRON_FIELD_REGEX = /^[0-9*/,\-]+$/;
+const CRON_RANGES_FIVE_FIELDS: ReadonlyArray<{ min: number; max: number; label: string }> = [
+  { min: 0, max: 59, label: "minute" },
+  { min: 0, max: 23, label: "hour" },
+  { min: 1, max: 31, label: "day_of_month" },
+  { min: 1, max: 12, label: "month" },
+  { min: 0, max: 7, label: "day_of_week" },
+];
+
+const CRON_RANGES_SIX_FIELDS: ReadonlyArray<{ min: number; max: number; label: string }> = [
+  { min: 0, max: 59, label: "second" },
+  ...CRON_RANGES_FIVE_FIELDS,
+];
+
+function isValidInteger(input: string): boolean {
+  return /^\d+$/.test(input);
+}
+
+function validateCronRangeToken(
+  token: string,
+  min: number,
+  max: number
+): { valid: boolean; message?: string } {
+  const [startRaw, endRaw] = token.split("-");
+  if (!startRaw || !endRaw || !isValidInteger(startRaw) || !isValidInteger(endRaw)) {
+    return { valid: false, message: `Invalid range token: ${token}` };
+  }
+  const start = Number(startRaw);
+  const end = Number(endRaw);
+  if (start < min || end > max || start > end) {
+    return { valid: false, message: `Range ${token} is out of bounds (${min}-${max})` };
+  }
+  return { valid: true };
+}
+
+function validateCronAtom(
+  atom: string,
+  min: number,
+  max: number
+): { valid: boolean; message?: string } {
+  if (atom === "*") {
+    return { valid: true };
+  }
+
+  if (atom.includes("-")) {
+    return validateCronRangeToken(atom, min, max);
+  }
+
+  if (!isValidInteger(atom)) {
+    return { valid: false, message: `Invalid cron token: ${atom}` };
+  }
+
+  const value = Number(atom);
+  if (value < min || value > max) {
+    return { valid: false, message: `Value ${atom} is out of bounds (${min}-${max})` };
+  }
+
+  return { valid: true };
+}
+
+function validateCronSegment(
+  fieldValue: string,
+  min: number,
+  max: number,
+  label: string
+): { valid: boolean; message?: string } {
+  const parts = fieldValue.split(",");
+  for (const part of parts) {
+    if (!part) {
+      return { valid: false, message: `Invalid ${label} token: empty segment` };
+    }
+
+    const [base, stepRaw] = part.split("/");
+    if (!base) {
+      return { valid: false, message: `Invalid ${label} token: ${part}` };
+    }
+
+    if (stepRaw !== undefined) {
+      if (!isValidInteger(stepRaw)) {
+        return { valid: false, message: `Invalid step in ${label}: ${part}` };
+      }
+      const step = Number(stepRaw);
+      if (step < 1) {
+        return { valid: false, message: `Step must be >= 1 in ${label}: ${part}` };
+      }
+    }
+
+    const baseValidation = validateCronAtom(base, min, max);
+    if (!baseValidation.valid) {
+      return baseValidation;
+    }
+  }
+
+  return { valid: true };
+}
 
 export function validateScheduleCron(cron: string | null | undefined): ScheduleValidationResult {
   if (cron === null || cron === undefined || cron.trim().length === 0) {
@@ -24,6 +118,18 @@ export function validateScheduleCron(cron: string | null | undefined): ScheduleV
       valid: false,
       errors: [`Invalid cron token: ${invalidToken}`],
     };
+  }
+
+  const fieldBounds = parts.length === 6 ? CRON_RANGES_SIX_FIELDS : CRON_RANGES_FIVE_FIELDS;
+  for (let i = 0; i < parts.length; i += 1) {
+    const bounds = fieldBounds[i];
+    if (!bounds) continue;
+    const part = parts[i];
+    if (!part) continue;
+    const validation = validateCronSegment(part, bounds.min, bounds.max, bounds.label);
+    if (!validation.valid) {
+      return { valid: false, errors: [validation.message || "Invalid cron expression."] };
+    }
   }
 
   return { valid: true, errors: [] };


### PR DESCRIPTION
### Motivation
- Schedules could be configured with syntactically-correct but semantically-invalid cron expressions (out-of-range fields or invalid steps), which undermines deterministic automation.  
- PATCH responses always reported the scheduler as `available`, which could mislead operators when `SCHEDULER_ENABLED=false`.  
- Schedule edits lacked an audit entry capturing before/after values, reducing evidence and operator traceability.

### Description
- Strengthen `validateScheduleCron` to perform bounds-aware validation for 5- and 6-field cron syntax, including list/range/step checks and clear error messages (`packages/web/src/lib/scheduling/schedule-contract.ts`).  
- Update the console schedule PATCH route to surface truthful scheduler capability (`available` vs `degraded` with `scheduler_disabled_by_env`) based on `SCHEDULER_ENABLED` (`packages/web/src/app/api/console/schedules/route.ts`).  
- Emit an audit event on schedule updates with `before`/`after` schedule fields and scheduler state metadata via `logAuditEvent` to improve operator evidence (`packages/web/src/app/api/console/schedules/route.ts`).  
- Add focused tests: unit tests for cron/timezone validation and route tests covering disabled-scheduler truth and invalid-cron rejection (`packages/web/src/__tests__/scheduling/schedule-contract.test.ts`, `packages/web/src/__tests__/api/console-schedules-route.test.ts`).

### Testing
- Ran targeted frontend tests: `pnpm --filter @settler/web test -- --runInBand src/__tests__/scheduling/schedule-contract.test.ts src/__tests__/api/console-schedules-route.test.ts` ✅ (both added suites passed).  
- Ran package lint for the web package: `pnpm --filter @settler/web lint` ✅ (completed with warnings only, no errors in touched surfaces).  
- Attempted workspace lint: `pnpm lint` ⚠️ (blocked by repo Node runtime gate; environment uses Node 22 while repo requires Node 24, so global lint was not fully executed).  
- Ran package typecheck: `pnpm --filter @settler/web typecheck` ❌ (failing due to pre-existing, unrelated repository-wide type/module issues outside the changed surfaces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d859dd2b3083288333ae037a8bae23)