### PR TITLE
Introduce workflows history-only API and UI limited-operability handling

### DIFF
--- a/packages/web/src/__tests__/api/workflows-route.test.ts
+++ b/packages/web/src/__tests__/api/workflows-route.test.ts
@@ -1,0 +1,125 @@
+/** @jest-environment node */
+
+import { NextRequest } from "next/server";
+import { GET as listWorkflows, POST as createWorkflow } from "@/app/api/workflows/route";
+import {
+  GET as getWorkflow,
+  PATCH as updateWorkflow,
+  DELETE as deleteWorkflow,
+} from "@/app/api/workflows/[id]/route";
+import { POST as testWorkflow } from "@/app/api/workflows/[id]/test/route";
+
+jest.mock("@/middleware/billing-gate-universal", () => ({
+  withUniversalBillingGate: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/middleware/api-security", () => ({
+  withSecurity: (handler: unknown) => handler,
+}));
+
+const requireTenantRequestContext = jest.fn();
+
+jest.mock("@/lib/api/tenant-context", () => ({
+  requireTenantRequestContext: (...args: unknown[]) => requireTenantRequestContext(...args),
+  buildTenantContextErrorResponse: (error: {
+    status: number;
+    code: string;
+    message: string;
+    capability: unknown;
+  }) =>
+    Response.json(
+      { error: error.message, code: error.code, capability: error.capability },
+      { status: error.status }
+    ),
+}));
+
+const findMany = jest.fn();
+const findFirst = jest.fn();
+
+jest.mock("@/shared/db/prismaClient", () => ({
+  prisma: {
+    workflowRun: {
+      findMany: (...args: unknown[]) => findMany(...args),
+      findFirst: (...args: unknown[]) => findFirst(...args),
+    },
+  },
+}));
+
+function makeRequest(url: string) {
+  return new NextRequest(url);
+}
+
+describe("workflow automation thin-surface API contract", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    requireTenantRequestContext.mockResolvedValue({ tenantId: "tenant-1", userId: "user-1" });
+  });
+
+  it("returns history list with explicit automation unavailability", async () => {
+    findMany.mockResolvedValue([
+      {
+        workflowId: "wf_1",
+        workflowName: "Nightly reconciliation",
+        status: "completed",
+        startedAt: new Date("2026-04-10T00:00:00.000Z"),
+        errorMessage: null,
+      },
+    ]);
+
+    const response = await listWorkflows(makeRequest("http://localhost/api/workflows"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.capability).toEqual({ state: "available", mode: "history_only" });
+    expect(body.automationCapability).toMatchObject({
+      state: "unavailable",
+      reason: "workflow_automation_thin_surface",
+    });
+    expect(body.workflows).toHaveLength(1);
+    expect(body.workflows[0]).toMatchObject({
+      id: "wf_1",
+      name: "Nightly reconciliation",
+      enabled: false,
+      trigger: { type: "historical.workflow_run" },
+      actions: [{ type: "history_only" }],
+      lastRun: { status: "success", timestamp: "2026-04-10T00:00:00.000Z" },
+    });
+  });
+
+  it("returns detail from tenant-scoped workflow history", async () => {
+    findFirst.mockResolvedValue({
+      workflowId: "wf_1",
+      workflowName: "Nightly reconciliation",
+      status: "failed",
+      startedAt: new Date("2026-04-10T01:00:00.000Z"),
+      errorMessage: "timeout",
+    });
+
+    const response = await getWorkflow(makeRequest("http://localhost/api/workflows/wf_1"), {
+      params: Promise.resolve({ id: "wf_1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe("wf_1");
+    expect(body.lastRun).toMatchObject({ status: "failed", error: "timeout" });
+    expect(body.automationCapability.state).toBe("unavailable");
+  });
+
+  it("returns explicit unavailable capability for mutating endpoints", async () => {
+    const createResponse = await createWorkflow(makeRequest("http://localhost/api/workflows"));
+    const patchResponse = await updateWorkflow(makeRequest("http://localhost/api/workflows/wf_1"));
+    const deleteResponse = await deleteWorkflow(makeRequest("http://localhost/api/workflows/wf_1"));
+    const testResponse = await testWorkflow(makeRequest("http://localhost/api/workflows/wf_1/test"));
+
+    for (const response of [createResponse, patchResponse, deleteResponse, testResponse]) {
+      const body = await response.json();
+      expect(response.status).toBe(409);
+      expect(body.code).toBe("WORKFLOW_AUTOMATION_UNAVAILABLE");
+      expect(body.capability).toMatchObject({
+        state: "unavailable",
+        reason: "workflow_automation_thin_surface",
+      });
+    }
+  });
+});

--- a/packages/web/src/app/api/workflows/[id]/route.ts
+++ b/packages/web/src/app/api/workflows/[id]/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  buildTenantContextErrorResponse,
+  requireTenantRequestContext,
+} from "@/lib/api/tenant-context";
+import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { appLogger } from "@/lib/utils/logger";
+import { prisma } from "@/shared/db/prismaClient";
+import {
+  WORKFLOWS_CAPABILITY,
+  WORKFLOW_HISTORY_CAPABILITY,
+  WORKFLOW_MUTATION_UNAVAILABLE_CODE,
+} from "@/lib/workflows/capability";
+
+function mutationUnavailableResponse(status = 409) {
+  return NextResponse.json(
+    {
+      error: WORKFLOWS_CAPABILITY.message,
+      code: WORKFLOW_MUTATION_UNAVAILABLE_CODE,
+      capability: WORKFLOWS_CAPABILITY,
+    },
+    { status }
+  );
+}
+
+export const GET = withSecurity(
+  withUniversalBillingGate(
+    async function GET(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+      try {
+        const tenantContext = await requireTenantRequestContext(request);
+        const { id } = await context.params;
+
+        const latestRun = await prisma.workflowRun.findFirst({
+          where: {
+            tenantId: tenantContext.tenantId,
+            workflowId: id,
+          },
+          orderBy: { startedAt: "desc" },
+          select: {
+            workflowId: true,
+            workflowName: true,
+            status: true,
+            startedAt: true,
+            errorMessage: true,
+          },
+        });
+
+        if (!latestRun) {
+          return NextResponse.json(
+            {
+              error: "Workflow history not found",
+              code: "WORKFLOW_NOT_FOUND",
+              capability: WORKFLOW_HISTORY_CAPABILITY,
+              automationCapability: WORKFLOWS_CAPABILITY,
+            },
+            { status: 404 }
+          );
+        }
+
+        return NextResponse.json({
+          id: latestRun.workflowId,
+          name: latestRun.workflowName || `Workflow ${latestRun.workflowId.slice(0, 8)}`,
+          trigger: { type: "historical.workflow_run", config: {} },
+          actions: [{ type: "history_only", config: {} }],
+          enabled: false,
+          lastRun: {
+            status: latestRun.status === "completed" ? "success" : "failed",
+            timestamp: latestRun.startedAt.toISOString(),
+            error: latestRun.errorMessage || undefined,
+          },
+          capability: WORKFLOW_HISTORY_CAPABILITY,
+          automationCapability: WORKFLOWS_CAPABILITY,
+        });
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "status" in error &&
+          "capability" in error
+        ) {
+          return buildTenantContextErrorResponse(error);
+        }
+        appLogger.error("[Workflows API] GET detail error", error);
+        return NextResponse.json(
+          {
+            error: "Failed to load workflow detail",
+            code: "WORKFLOW_DETAIL_UNAVAILABLE",
+            capability: { state: "degraded", reason: "workflow_detail_unavailable" },
+            automationCapability: WORKFLOWS_CAPABILITY,
+          },
+          { status: 503 }
+        );
+      }
+    },
+    { feature: "Workflows detail GET" }
+  ),
+  { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: true }
+);
+
+export const PATCH = withSecurity(
+  withUniversalBillingGate(
+    async function PATCH(request: NextRequest) {
+      try {
+        await requireTenantRequestContext(request);
+        return mutationUnavailableResponse(409);
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "status" in error &&
+          "capability" in error
+        ) {
+          return buildTenantContextErrorResponse(error);
+        }
+        appLogger.error("[Workflows API] PATCH error", error);
+        return mutationUnavailableResponse(503);
+      }
+    },
+    { feature: "Workflows PATCH" }
+  ),
+  { rateLimit: { windowMs: 60000, maxRequests: 30 }, requireAuth: true }
+);
+
+export const DELETE = withSecurity(
+  withUniversalBillingGate(
+    async function DELETE(request: NextRequest) {
+      try {
+        await requireTenantRequestContext(request);
+        return mutationUnavailableResponse(409);
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "status" in error &&
+          "capability" in error
+        ) {
+          return buildTenantContextErrorResponse(error);
+        }
+        appLogger.error("[Workflows API] DELETE error", error);
+        return mutationUnavailableResponse(503);
+      }
+    },
+    { feature: "Workflows DELETE" }
+  ),
+  { rateLimit: { windowMs: 60000, maxRequests: 30 }, requireAuth: true }
+);

--- a/packages/web/src/app/api/workflows/[id]/test/route.ts
+++ b/packages/web/src/app/api/workflows/[id]/test/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  buildTenantContextErrorResponse,
+  requireTenantRequestContext,
+} from "@/lib/api/tenant-context";
+import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { appLogger } from "@/lib/utils/logger";
+import {
+  WORKFLOWS_CAPABILITY,
+  WORKFLOW_MUTATION_UNAVAILABLE_CODE,
+} from "@/lib/workflows/capability";
+
+export const POST = withSecurity(
+  withUniversalBillingGate(
+    async function POST(request: NextRequest) {
+      try {
+        await requireTenantRequestContext(request);
+        return NextResponse.json(
+          {
+            error: WORKFLOWS_CAPABILITY.message,
+            code: WORKFLOW_MUTATION_UNAVAILABLE_CODE,
+            capability: WORKFLOWS_CAPABILITY,
+          },
+          { status: 409 }
+        );
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "status" in error &&
+          "capability" in error
+        ) {
+          return buildTenantContextErrorResponse(error);
+        }
+        appLogger.error("[Workflows API] TEST error", error);
+        return NextResponse.json(
+          {
+            error: "Workflow test execution is unavailable",
+            code: WORKFLOW_MUTATION_UNAVAILABLE_CODE,
+            capability: WORKFLOWS_CAPABILITY,
+          },
+          { status: 503 }
+        );
+      }
+    },
+    { feature: "Workflows TEST" }
+  ),
+  { rateLimit: { windowMs: 60000, maxRequests: 30 }, requireAuth: true }
+);

--- a/packages/web/src/app/api/workflows/route.ts
+++ b/packages/web/src/app/api/workflows/route.ts
@@ -1,0 +1,143 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  buildTenantContextErrorResponse,
+  requireTenantRequestContext,
+} from "@/lib/api/tenant-context";
+import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { appLogger } from "@/lib/utils/logger";
+import { prisma } from "@/shared/db/prismaClient";
+import {
+  WORKFLOWS_CAPABILITY,
+  WORKFLOW_HISTORY_CAPABILITY,
+  WORKFLOW_MUTATION_UNAVAILABLE_CODE,
+} from "@/lib/workflows/capability";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type WorkflowListItem = {
+  id: string;
+  name: string;
+  trigger: {
+    type: "historical.workflow_run";
+    config: Record<string, never>;
+  };
+  actions: Array<{
+    type: "history_only";
+    config: Record<string, never>;
+  }>;
+  enabled: false;
+  lastRun: {
+    status: "success" | "failed";
+    timestamp: string;
+    error?: string;
+  };
+};
+
+function mutationUnavailableResponse(status = 409) {
+  return NextResponse.json(
+    {
+      error: WORKFLOWS_CAPABILITY.message,
+      code: WORKFLOW_MUTATION_UNAVAILABLE_CODE,
+      capability: WORKFLOWS_CAPABILITY,
+    },
+    { status }
+  );
+}
+
+export const GET = withSecurity(
+  withUniversalBillingGate(
+    async function GET(request: NextRequest) {
+      try {
+        const tenantContext = await requireTenantRequestContext(request);
+
+        const runs = await prisma.workflowRun.findMany({
+          where: { tenantId: tenantContext.tenantId },
+          select: {
+            workflowId: true,
+            workflowName: true,
+            status: true,
+            startedAt: true,
+            errorMessage: true,
+          },
+          orderBy: [{ startedAt: "desc" }],
+          take: 100,
+        });
+
+        const seen = new Set<string>();
+        const workflows: WorkflowListItem[] = [];
+
+        for (const run of runs) {
+          if (seen.has(run.workflowId)) {
+            continue;
+          }
+          seen.add(run.workflowId);
+          workflows.push({
+            id: run.workflowId,
+            name: run.workflowName || `Workflow ${run.workflowId.slice(0, 8)}`,
+            trigger: { type: "historical.workflow_run", config: {} },
+            actions: [{ type: "history_only", config: {} }],
+            enabled: false,
+            lastRun: {
+              status: run.status === "completed" ? "success" : "failed",
+              timestamp: run.startedAt.toISOString(),
+              error: run.errorMessage || undefined,
+            },
+          });
+        }
+
+        return NextResponse.json({
+          workflows,
+          capability: WORKFLOW_HISTORY_CAPABILITY,
+          automationCapability: WORKFLOWS_CAPABILITY,
+        });
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "status" in error &&
+          "capability" in error
+        ) {
+          return buildTenantContextErrorResponse(error);
+        }
+        appLogger.error("[Workflows API] GET error", error);
+        return NextResponse.json(
+          {
+            workflows: [],
+            error: "Failed to load workflow history",
+            capability: { state: "degraded", reason: "workflow_history_unavailable" },
+            automationCapability: WORKFLOWS_CAPABILITY,
+          },
+          { status: 503 }
+        );
+      }
+    },
+    { feature: "Workflows GET" }
+  ),
+  { rateLimit: { windowMs: 60000, maxRequests: 100 }, requireAuth: true }
+);
+
+export const POST = withSecurity(
+  withUniversalBillingGate(
+    async function POST(request: NextRequest) {
+      try {
+        await requireTenantRequestContext(request);
+        return mutationUnavailableResponse(409);
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "status" in error &&
+          "capability" in error
+        ) {
+          return buildTenantContextErrorResponse(error);
+        }
+        appLogger.error("[Workflows API] POST error", error);
+        return mutationUnavailableResponse(503);
+      }
+    },
+    { feature: "Workflows POST" }
+  ),
+  { rateLimit: { windowMs: 60000, maxRequests: 30 }, requireAuth: true }
+);

--- a/packages/web/src/app/console/workflows/[id]/page.tsx
+++ b/packages/web/src/app/console/workflows/[id]/page.tsx
@@ -19,6 +19,7 @@ import { ArrowLeft, Save, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { WORKFLOWS_CAPABILITY_MESSAGE } from "@/lib/workflows/capability";
 
 interface Workflow {
   id: string;
@@ -32,6 +33,10 @@ interface Workflow {
     config: Record<string, any>;
   }>;
   enabled: boolean;
+  automationCapability?: {
+    state?: string;
+    message?: string;
+  };
 }
 
 export default function WorkflowDetailPage() {
@@ -41,6 +46,7 @@ export default function WorkflowDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const capabilityUnavailable = workflow?.automationCapability?.state === "unavailable";
 
   useEffect(() => {
     loadWorkflow();
@@ -122,16 +128,25 @@ export default function WorkflowDetailPage() {
           <p className="text-slate-600 dark:text-slate-400 mt-1">Edit workflow configuration</p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={handleDelete}>
+          <Button variant="outline" onClick={handleDelete} disabled={capabilityUnavailable}>
             <Trash2 className="w-4 h-4 mr-2" />
             Delete
           </Button>
-          <Button onClick={handleSave} disabled={saving}>
+          <Button onClick={handleSave} disabled={saving || capabilityUnavailable}>
             <Save className="w-4 h-4 mr-2" />
             {saving ? "Saving..." : "Save"}
           </Button>
         </div>
       </div>
+
+      {capabilityUnavailable && (
+        <Card className="border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30">
+          <CardHeader>
+            <CardTitle className="text-amber-900 dark:text-amber-200">Limited operability</CardTitle>
+            <p className="text-sm text-amber-800 dark:text-amber-300">{WORKFLOWS_CAPABILITY_MESSAGE}</p>
+          </CardHeader>
+        </Card>
+      )}
 
       <Card>
         <CardHeader>
@@ -145,6 +160,7 @@ export default function WorkflowDetailPage() {
               value={workflow.name}
               onChange={(e) => setWorkflow({ ...workflow, name: e.target.value })}
               className="mt-1"
+              disabled={capabilityUnavailable}
             />
           </div>
 
@@ -158,6 +174,7 @@ export default function WorkflowDetailPage() {
             <Switch
               checked={workflow.enabled}
               onCheckedChange={(enabled) => setWorkflow({ ...workflow, enabled })}
+              disabled={capabilityUnavailable}
             />
           </div>
 
@@ -165,6 +182,7 @@ export default function WorkflowDetailPage() {
             <Label>Trigger</Label>
             <Select
               value={workflow.trigger.type}
+              disabled={capabilityUnavailable}
               onValueChange={(type) =>
                 setWorkflow({ ...workflow, trigger: { ...workflow.trigger, type } })
               }

--- a/packages/web/src/app/console/workflows/new/page.tsx
+++ b/packages/web/src/app/console/workflows/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -15,7 +15,16 @@ import {
 } from "@/components/ui/select";
 import { safeFetch } from "@/lib/safe-fetch";
 import { ArrowLeft, Save, Play } from "lucide-react";
+import { WORKFLOWS_CAPABILITY_MESSAGE } from "@/lib/workflows/capability";
 import Link from "next/link";
+
+
+interface WorkflowCapabilityResponse {
+  automationCapability?: {
+    state?: string;
+    message?: string;
+  };
+}
 
 export default function NewWorkflowPage() {
   const searchParams = useSearchParams();
@@ -28,8 +37,35 @@ export default function NewWorkflowPage() {
   const [actionType, setActionType] = useState<"http_webhook" | "email" | "slack">("http_webhook");
   const [actionConfig, setActionConfig] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
+  const [capabilityUnavailable, setCapabilityUnavailable] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadCapability = async () => {
+      const result = await safeFetch<WorkflowCapabilityResponse>("/api/workflows");
+      if (cancelled) {
+        return;
+      }
+
+      if (result.success) {
+        setCapabilityUnavailable(result.data?.automationCapability?.state === "unavailable");
+      } else {
+        setCapabilityUnavailable(true);
+      }
+    };
+
+    loadCapability();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleSave = async () => {
+    if (capabilityUnavailable) {
+      return;
+    }
     if (!name.trim()) {
       alert("Please enter a workflow name");
       return;
@@ -54,7 +90,9 @@ export default function NewWorkflowPage() {
   };
 
   const handleTest = async () => {
-    alert("Dry run test would execute here");
+    if (capabilityUnavailable) {
+      return;
+    }
   };
 
   return (
@@ -72,6 +110,17 @@ export default function NewWorkflowPage() {
           </p>
         </div>
       </div>
+
+      {capabilityUnavailable && (
+        <Card className="border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30">
+          <CardHeader>
+            <CardTitle className="text-amber-900 dark:text-amber-200">Limited operability</CardTitle>
+            <CardDescription className="text-amber-800 dark:text-amber-300">
+              {WORKFLOWS_CAPABILITY_MESSAGE}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
 
       <div className="grid lg:grid-cols-2 gap-6">
         {/* Workflow Builder */}
@@ -160,11 +209,11 @@ export default function NewWorkflowPage() {
             )}
 
             <div className="flex gap-2">
-              <Button onClick={handleSave} disabled={saving} className="flex-1">
+              <Button onClick={handleSave} disabled={saving || capabilityUnavailable} className="flex-1">
                 <Save className="w-4 h-4 mr-2" />
                 {saving ? "Saving..." : "Save Workflow"}
               </Button>
-              <Button variant="outline" onClick={handleTest}>
+              <Button variant="outline" onClick={handleTest} disabled={capabilityUnavailable}>
                 <Play className="w-4 h-4 mr-2" />
                 Test
               </Button>

--- a/packages/web/src/app/console/workflows/page.tsx
+++ b/packages/web/src/app/console/workflows/page.tsx
@@ -10,6 +10,7 @@ import { safeFetch } from "@/lib/safe-fetch";
 import { Zap, Plus, Play, Pause, Settings, CheckCircle2, XCircle } from "lucide-react";
 import Link from "next/link";
 import { RBACGate, TruncateContent } from "@/lib/rbac-gate";
+import { WORKFLOWS_CAPABILITY_MESSAGE } from "@/lib/workflows/capability";
 
 interface Workflow {
   id: string;
@@ -28,6 +29,13 @@ interface Workflow {
     timestamp: Date;
     error?: string;
   };
+}
+
+
+interface WorkflowsResponse {
+  workflows: Workflow[];
+  capability?: { state?: string; mode?: string };
+  automationCapability?: { state?: string; message?: string };
 }
 
 const templates = [
@@ -52,6 +60,7 @@ export default function WorkflowsPage() {
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
   const [loading, setLoading] = useState(true);
   const [showTemplates, setShowTemplates] = useState(false);
+  const [capabilityUnavailable, setCapabilityUnavailable] = useState(false);
 
   useEffect(() => {
     loadWorkflows();
@@ -59,13 +68,14 @@ export default function WorkflowsPage() {
 
   const loadWorkflows = async () => {
     setLoading(true);
-    const result = await safeFetch<{ workflows: Workflow[] }>("/api/workflows");
+    const result = await safeFetch<WorkflowsResponse>("/api/workflows");
 
     if (result.success) {
       setWorkflows(result.data?.workflows || []);
+      setCapabilityUnavailable(result.data?.automationCapability?.state === "unavailable");
     } else {
-      // No mock data - show empty state if API fails
       setWorkflows([]);
+      setCapabilityUnavailable(true);
     }
     setLoading(false);
   };
@@ -78,6 +88,8 @@ export default function WorkflowsPage() {
 
     if (result.success) {
       setWorkflows(workflows.map((w) => (w.id === workflowId ? { ...w, enabled } : w)));
+    } else {
+      setCapabilityUnavailable(true);
     }
   };
 
@@ -86,10 +98,8 @@ export default function WorkflowsPage() {
       method: "POST",
     });
 
-    if (result.success) {
-      alert("Dry run completed successfully");
-    } else {
-      alert(result.error?.message || "Dry run failed");
+    if (!result.success) {
+      setCapabilityUnavailable(true);
     }
   };
 
@@ -109,20 +119,38 @@ export default function WorkflowsPage() {
           </div>
           <RBACGate requiredTier="subscribed_paid" feature="Create Workflows">
             <div className="flex gap-2">
-              <Button variant="outline" onClick={() => setShowTemplates(!showTemplates)}>
+              <Button variant="outline" onClick={() => setShowTemplates(!showTemplates)} disabled={capabilityUnavailable}>
                 Templates
               </Button>
-              <Button asChild>
-                <Link href="/console/workflows/new">
+              {capabilityUnavailable ? (
+                <Button disabled>
                   <Plus className="w-4 h-4 mr-2" />
                   Create Workflow
-                </Link>
-              </Button>
+                </Button>
+              ) : (
+                <Button asChild>
+                  <Link href="/console/workflows/new">
+                    <Plus className="w-4 h-4 mr-2" />
+                    Create Workflow
+                  </Link>
+                </Button>
+              )}
             </div>
           </RBACGate>
         </div>
 
-        {showTemplates && (
+        {capabilityUnavailable && (
+          <Card className="border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30">
+            <CardHeader>
+              <CardTitle className="text-amber-900 dark:text-amber-200">Limited operability</CardTitle>
+              <CardDescription className="text-amber-800 dark:text-amber-300">
+                {WORKFLOWS_CAPABILITY_MESSAGE}
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        )}
+
+        {showTemplates && !capabilityUnavailable && (
           <Card>
             <CardHeader>
               <CardTitle>Workflow Templates</CardTitle>
@@ -163,10 +191,18 @@ export default function WorkflowsPage() {
               <EmptyState
                 icon={Zap}
                 title="No workflows yet"
-                description="Create a workflow to automate actions based on events"
+                description={
+                  capabilityUnavailable
+                    ? WORKFLOWS_CAPABILITY_MESSAGE
+                    : "Create a workflow to automate actions based on events"
+                }
                 action={{
                   label: "Create Workflow",
-                  onClick: () => (window.location.href = "/console/workflows/new"),
+                  onClick: () => {
+                    if (!capabilityUnavailable) {
+                      window.location.href = "/console/workflows/new";
+                    }
+                  },
                 }}
               />
             ) : (
@@ -215,6 +251,7 @@ export default function WorkflowsPage() {
                             size="sm"
                             variant="outline"
                             onClick={() => handleTest(workflow.id)}
+                            disabled={capabilityUnavailable}
                           >
                             <Play className="w-4 h-4 mr-2" />
                             Test
@@ -223,6 +260,7 @@ export default function WorkflowsPage() {
                             size="sm"
                             variant="outline"
                             onClick={() => handleToggle(workflow.id, !workflow.enabled)}
+                            disabled={capabilityUnavailable}
                           >
                             {workflow.enabled ? (
                               <>

--- a/packages/web/src/lib/workflows/capability.ts
+++ b/packages/web/src/lib/workflows/capability.ts
@@ -1,0 +1,17 @@
+export const WORKFLOW_MUTATION_UNAVAILABLE_CODE = "WORKFLOW_AUTOMATION_UNAVAILABLE" as const;
+
+export const WORKFLOWS_CAPABILITY_REASON = "workflow_automation_thin_surface" as const;
+
+export const WORKFLOWS_CAPABILITY_MESSAGE =
+  "Workflow automation is currently limited in this build. Create, edit, delete, and dry-run actions are unavailable.";
+
+export const WORKFLOWS_CAPABILITY = {
+  state: "unavailable" as const,
+  reason: WORKFLOWS_CAPABILITY_REASON,
+  message: WORKFLOWS_CAPABILITY_MESSAGE,
+};
+
+export const WORKFLOW_HISTORY_CAPABILITY = {
+  state: "available" as const,
+  mode: "history_only" as const,
+};


### PR DESCRIPTION
### Motivation

- Provide a read-only, history-only surface for workflow automation while explicitly marking automation mutating operations as unavailable in this build.
- Surface the limited operability to the console UI so users cannot attempt create/edit/delete/dry-run actions that are blocked.

### Description

- Add server API routes to expose workflow history and to block mutations: `packages/web/src/app/api/workflows/route.ts`, `packages/web/src/app/api/workflows/[id]/route.ts`, and `packages/web/src/app/api/workflows/[id]/test/route.ts`, where GET endpoints return history and mutation endpoints return a 409 with the `WORKFLOWS_CAPABILITY` payload.
- Add capability constants in `packages/web/src/lib/workflows/capability.ts` including `WORKFLOWS_CAPABILITY`, `WORKFLOW_HISTORY_CAPABILITY`, and `WORKFLOW_MUTATION_UNAVAILABLE_CODE` plus a user-facing message.
- Update console UI to reflect limited operability by disabling create/edit/delete/test controls and showing a warning card, across `page.tsx` for the workflows list, the new-workflow page, and the workflow detail page.
- Add unit tests `packages/web/src/__tests__/api/workflows-route.test.ts` that mock tenant context and Prisma to assert listing/detail responses and that mutation/test endpoints return the unavailable capability error.

### Testing

- Added Jest unit tests in `packages/web/src/__tests__/api/workflows-route.test.ts` which mock `requireTenantRequestContext` and `prisma.workflowRun` and validate list/detail and mutation behavior; the test file was executed as part of the unit test suite and passed.
- Executed the repository test command `yarn test` and observed the test suite (including the new workflow route tests) complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85b710f348328889e3ac518160bbc)