### PR TITLE
Align exception proof surfaces with canonical prior-run comparison

### DIFF
--- a/packages/reconciliation-core/src/exception-run-comparison.test.ts
+++ b/packages/reconciliation-core/src/exception-run-comparison.test.ts
@@ -1,0 +1,35 @@
+import {
+  buildExceptionRunComparisonSnapshotForRunIds,
+  resolveRunKindsForTenantRunIds,
+} from "./exception-run-comparison.js";
+
+describe("exception run comparison", () => {
+  it("resolves run kinds with recon_job preferred when both tables have the id", async () => {
+    const sharedId = "11111111-1111-4111-8111-111111111111";
+    const prisma = {
+      reconJob: {
+        findMany: jest.fn().mockResolvedValue([{ id: sharedId }]),
+      },
+      reconciliationRun: {
+        findMany: jest.fn().mockResolvedValue([{ id: sharedId }]),
+      },
+    } as any;
+
+    const kinds = await resolveRunKindsForTenantRunIds(prisma, "tenant-a", [sharedId]);
+    expect(kinds.get(sharedId)).toBe("recon_job");
+  });
+
+  it("marks ingestion runs as not comparable via unavailable index", async () => {
+    const prisma = {
+      reconJob: { findMany: jest.fn().mockResolvedValue([]) },
+      reconciliationRun: {
+        findMany: jest.fn().mockResolvedValue([{ id: "ing-1" }]),
+      },
+    } as any;
+
+    const byRun = await buildExceptionRunComparisonSnapshotForRunIds(prisma, "tenant-a", ["ing-1"]);
+    const snap = byRun.get("ing-1");
+    expect(snap?.available).toBe(false);
+    expect(snap?.reasonCodes).toContain("ingestion_run_history_not_comparable");
+  });
+});

--- a/packages/reconciliation-core/src/exception-run-comparison.ts
+++ b/packages/reconciliation-core/src/exception-run-comparison.ts
@@ -1,0 +1,126 @@
+/**
+ * Canonical prior-run comparison for exception surfaces (list compact summary, exception proofpack).
+ * Delegates to {@link buildRunProofpackIndexByRunId} so exception exports align with run detail truth.
+ */
+
+import type { ReconciliationCorePrismaClient } from "./prisma-client-like.js";
+import {
+  buildRunProofpackIndexByRunId,
+  canonicalMissingProofpackReasonForRunKind,
+  unavailableRunProofpackIndex,
+  type RunDeltaChangeState,
+  type RunProofpackIndex,
+} from "./run-proofpack-index.js";
+
+export type ExceptionRunComparisonSnapshot = {
+  available: boolean;
+  state: RunProofpackIndex["comparison"]["state"];
+  certainty: RunProofpackIndex["comparison"]["certainty"];
+  reasonCodes: RunProofpackIndex["comparison"]["reasonCodes"];
+  summary: string;
+  baseline: RunProofpackIndex["comparison"]["baseline"];
+  deltas: RunProofpackIndex["comparison"]["deltas"];
+  changedSincePreviousRun: RunDeltaChangeState;
+};
+
+function snapshotFromProofpackIndex(index: RunProofpackIndex): ExceptionRunComparisonSnapshot {
+  const { comparison } = index;
+  return {
+    available: comparison.state === "available",
+    state: comparison.state,
+    certainty: comparison.certainty,
+    reasonCodes: comparison.reasonCodes,
+    summary: comparison.summary,
+    baseline: comparison.baseline,
+    deltas: comparison.deltas,
+    changedSincePreviousRun: comparison.changedSincePriorRun,
+  };
+}
+
+/**
+ * Resolve whether each run id is a recon job or ingestion-scoped reconciliation run.
+ * When both exist (UUID collision), prefers recon job — consistent with {@link resolveReconciliationRunForTenants}.
+ */
+export async function resolveRunKindsForTenantRunIds(
+  prisma: ReconciliationCorePrismaClient,
+  tenantId: string,
+  runIds: string[]
+): Promise<Map<string, "recon_job" | "ingestion_run">> {
+  const unique = [...new Set(runIds)];
+  const out = new Map<string, "recon_job" | "ingestion_run">();
+  if (unique.length === 0) {
+    return out;
+  }
+
+  const [jobs, ingestionRuns] = await Promise.all([
+    prisma.reconJob.findMany({
+      where: { tenantId, id: { in: unique }, deletedAt: null },
+      select: { id: true },
+    }),
+    prisma.reconciliationRun.findMany({
+      where: { tenantId, id: { in: unique } },
+      select: { id: true },
+    }),
+  ]);
+
+  const jobIds = new Set(jobs.map((j: { id: string }) => j.id));
+  const ingestionIds = new Set(ingestionRuns.map((r: { id: string }) => r.id));
+
+  for (const id of unique) {
+    if (jobIds.has(id)) {
+      out.set(id, "recon_job");
+    } else if (ingestionIds.has(id)) {
+      out.set(id, "ingestion_run");
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Batch-build deterministic run-over-run comparison snapshots for exception UX and exports.
+ */
+export async function buildExceptionRunComparisonSnapshotForRunIds(
+  prisma: ReconciliationCorePrismaClient,
+  tenantId: string,
+  runIds: string[]
+): Promise<Map<string, ExceptionRunComparisonSnapshot>> {
+  const unique = [...new Set(runIds)];
+  const out = new Map<string, ExceptionRunComparisonSnapshot>();
+  if (unique.length === 0) {
+    return out;
+  }
+
+  const kinds = await resolveRunKindsForTenantRunIds(prisma, tenantId, unique);
+  const reconIds = unique.filter((id) => kinds.get(id) === "recon_job");
+
+  const indexByRun =
+    reconIds.length > 0
+      ? await buildRunProofpackIndexByRunId({
+          prisma,
+          tenantId,
+          runs: reconIds.map((id) => ({ id, runKind: "recon_job" as const })),
+        })
+      : new Map<string, RunProofpackIndex>();
+
+  for (const id of unique) {
+    const kind = kinds.get(id);
+    if (kind === "recon_job") {
+      const index = indexByRun.get(id) ?? unavailableRunProofpackIndex("proofpack_index_unavailable");
+      out.set(id, snapshotFromProofpackIndex(index));
+      continue;
+    }
+    if (kind === "ingestion_run") {
+      out.set(
+        id,
+        snapshotFromProofpackIndex(
+          unavailableRunProofpackIndex(canonicalMissingProofpackReasonForRunKind("ingestion_run"))
+        )
+      );
+      continue;
+    }
+    out.set(id, snapshotFromProofpackIndex(unavailableRunProofpackIndex("proofpack_index_unavailable")));
+  }
+
+  return out;
+}

--- a/packages/reconciliation-core/src/index.ts
+++ b/packages/reconciliation-core/src/index.ts
@@ -15,6 +15,7 @@ export * from "./operator-run-detail-resolve.js";
 export * from "./exception-workbench.js";
 export * from "./exception-intelligence.js";
 export * from "./run-proofpack-index.js";
+export * from "./exception-run-comparison.js";
 export * from "./prisma-client-like.js";
 export * from "./cross-run-intelligence.js";
 export * from "./support-intake-run-context.js";

--- a/packages/web/src/__tests__/api/exceptions-runtime-integrity.test.ts
+++ b/packages/web/src/__tests__/api/exceptions-runtime-integrity.test.ts
@@ -40,8 +40,21 @@ jest.mock("@/lib/observability/trace", () => ({
 }));
 
 jest.mock("@/shared/db/prismaClient", () => ({
-  prisma: {},
+  prisma: {
+    reconJob: { findMany: jest.fn().mockResolvedValue([]) },
+    reconciliationRun: { findMany: jest.fn().mockResolvedValue([]) },
+  },
 }));
+
+jest.mock("@settler/reconciliation-core", () => {
+  const actual = jest.requireActual<typeof import("@settler/reconciliation-core")>(
+    "@settler/reconciliation-core"
+  );
+  return {
+    ...actual,
+    buildExceptionRunComparisonSnapshotForRunIds: jest.fn(),
+  };
+});
 
 jest.mock("@/lib/server/exceptions/reconciliation-workbench", () => ({
   listReconciliationWorkbenchExceptions: (...args: unknown[]) =>
@@ -66,6 +79,7 @@ jest.mock("@/lib/utils/logger", () => ({
 import { GET as getExceptions } from "@/app/api/exceptions/route";
 import { GET as getExceptionDetail } from "@/app/api/exceptions/[exceptionId]/route";
 import { GET as getExceptionProofpack } from "@/app/api/exceptions/[exceptionId]/proofpack/route";
+import { buildExceptionRunComparisonSnapshotForRunIds } from "@settler/reconciliation-core";
 
 function req(url: string) {
   return {
@@ -86,6 +100,49 @@ describe("exceptions runtime integrity", () => {
     getReconciliationWorkbenchExceptionDetailMock.mockReset();
     resolveExceptionProvenanceRunMock.mockReset();
     applyReconciliationWorkbenchActionMock.mockReset();
+    (buildExceptionRunComparisonSnapshotForRunIds as jest.Mock).mockReset();
+    (buildExceptionRunComparisonSnapshotForRunIds as jest.Mock).mockImplementation(
+      async (_prisma: unknown, _tenantId: string, runIds: string[]) => {
+        const m = new Map<
+          string,
+          {
+            available: boolean;
+            state: string;
+            certainty: string;
+            reasonCodes: string[];
+            summary: string;
+            baseline: { priorResultId: string | null; priorResultStartedAt: string | null };
+            deltas: {
+              matched: number | null;
+              unmatched: number | null;
+              conflicts: number | null;
+              proofCompleteness: string;
+              recurringFamilyConcentration: string;
+            };
+            changedSincePreviousRun: string;
+          }
+        >();
+        for (const id of runIds) {
+          m.set(id, {
+            available: false,
+            state: "unavailable",
+            certainty: "low",
+            reasonCodes: ["baseline_missing"],
+            summary: "Run has no persisted result, so prior-run comparison is unavailable.",
+            baseline: { priorResultId: null, priorResultStartedAt: null },
+            deltas: {
+              matched: null,
+              unmatched: null,
+              conflicts: null,
+              proofCompleteness: "unavailable",
+              recurringFamilyConcentration: "unavailable",
+            },
+            changedSincePreviousRun: "unavailable",
+          });
+        }
+        return m;
+      }
+    );
 
     resolveTenantMembershipScopeMock.mockResolvedValue({
       tenantIds: ["tenant-a"],

--- a/packages/web/src/app/api/exceptions/[exceptionId]/proofpack/route.ts
+++ b/packages/web/src/app/api/exceptions/[exceptionId]/proofpack/route.ts
@@ -9,6 +9,7 @@ import {
 import { withSecurity } from "@/lib/middleware/api-security";
 import { withUniversalBillingGate } from "@/middleware/billing-gate-universal";
 import { getReconciliationWorkbenchExceptionDetail } from "@/lib/server/exceptions/reconciliation-workbench";
+import { buildExceptionRunComparisonSnapshotForRunIds } from "@settler/reconciliation-core";
 
 export const runtime = "nodejs";
 
@@ -53,12 +54,38 @@ export const GET = withSecurity(
           .filter((item) => item.degraded)
           .flatMap((item) => item.degradedReasons);
 
-        const changeComparison = {
-          available: false,
-          state: "unavailable" as const,
-          summary:
-            "Prior-run proof comparison is not available from exception list context. Use run detail lineage for deterministic baseline diff.",
-        };
+        const runComparisonMap = await buildExceptionRunComparisonSnapshotForRunIds(
+          prisma,
+          tenantId,
+          [detail.runId]
+        );
+        const runComparison = runComparisonMap.get(detail.runId);
+        const changeComparison = runComparison
+          ? {
+              available: runComparison.available,
+              state: runComparison.state,
+              certainty: runComparison.certainty,
+              reasonCodes: runComparison.reasonCodes,
+              summary: runComparison.summary,
+              baseline: runComparison.baseline,
+              deltas: runComparison.deltas,
+            }
+          : {
+              available: false as const,
+              state: "unavailable" as const,
+              certainty: "low" as const,
+              reasonCodes: ["proofpack_index_unavailable"] as const,
+              summary:
+                "Prior-run comparison could not be resolved for this exception's run identifier.",
+              baseline: { priorResultId: null, priorResultStartedAt: null },
+              deltas: {
+                matched: null,
+                unmatched: null,
+                conflicts: null,
+                proofCompleteness: "unavailable" as const,
+                recurringFamilyConcentration: "unavailable" as const,
+              },
+            };
 
         const artifact = {
           schemaVersion: "proofpack.exception.v3",
@@ -115,6 +142,9 @@ export const GET = withSecurity(
               ...new Set([
                 ...detail.suggestedActions,
                 changeComparison.summary,
+                ...(runComparison && !runComparison.available
+                  ? runComparison.reasonCodes.map((code) => `comparison:${code}`)
+                  : []),
                 ...(detail.operatorSummary.proofState !== "ready"
                   ? ["Proof package is not yet fully complete or finalized."]
                   : []),

--- a/packages/web/src/lib/server/exceptions/reconciliation-workbench.ts
+++ b/packages/web/src/lib/server/exceptions/reconciliation-workbench.ts
@@ -32,6 +32,7 @@ type SimilarScoredCaseRow = {
 import {
   EXCEPTION_MATCH_TYPES,
   buildExceptionFamilySummary,
+  buildExceptionRunComparisonSnapshotForRunIds,
   normalizeExceptionResolutionReason,
   operatorStatusToCanonical,
   predictExceptionArchetype,
@@ -830,6 +831,13 @@ export async function listReconciliationWorkbenchExceptions(
     prisma.reconciliationMatch.count({ where: where as any }),
   ]);
 
+  const runIdsOnPage = [...new Set(rows.map((row: (typeof rows)[number]) => row.runId))] as string[];
+  const runComparisonByRunId = await buildExceptionRunComparisonSnapshotForRunIds(
+    prisma,
+    filters.tenantId,
+    runIdsOnPage
+  );
+
   const exceptionIds = rows.map((row: { id: string }) => row.id);
   const [topArchetypes, latestMemories, allMemories, evidenceArtifacts, proofPackages] =
     await Promise.all([
@@ -1118,6 +1126,17 @@ export async function listReconciliationWorkbenchExceptions(
       supportDegradedReasons.push("Recurring adjudication memory has not been established.");
     }
 
+    const runComparison = runComparisonByRunId.get(row.runId);
+    const proofDeltaChanged =
+      runComparison?.changedSincePreviousRun === "changed"
+        ? "changed"
+        : runComparison?.changedSincePreviousRun === "unchanged"
+          ? "unchanged"
+          : "unavailable";
+    const proofChangeSummary = runComparison?.summary
+      ? runComparison.summary
+      : "Run-over-run proof delta is unavailable; baseline or history is missing.";
+
     return {
       ...mapped,
       compactSummary: {
@@ -1140,9 +1159,8 @@ export async function listReconciliationWorkbenchExceptions(
           bestCompletenessScore: operatorSummary.bestCompletenessScore,
           missingEvidenceCount: operatorSummary.missingEvidenceCount,
           state: operatorSummary.proofState,
-          changedSincePreviousRun: "unavailable",
-          changeSummary:
-            "Run-over-run proof delta is unavailable in list context; open detail for canonical lineage.",
+          changedSincePreviousRun: proofDeltaChanged,
+          changeSummary: proofChangeSummary,
         },
         supportability: {
           degradedReasons: supportDegradedReasons,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Exception list `compactSummary.proof` and `GET /api/exceptions/[id]/proofpack` previously hard-coded “unavailable” prior-run semantics even when the same tenant had deterministic `recon_results` history. This pass reuses `buildRunProofpackIndexByRunId` via new helpers in `@settler/reconciliation-core` so exception exports and list summaries agree with run-level proofpack index truth.

## Changes

- `buildExceptionRunComparisonSnapshotForRunIds` + `resolveRunKindsForTenantRunIds` batch run-kind resolution and delegate comparison to existing proofpack index builder.
- Exception list fills `changedSincePreviousRun` / `changeSummary` from that snapshot (batched per page).
- Exception proofpack `changeSincePreviousRun` includes state, certainty, reasonCodes, baseline, and deltas when resolvable; ingestion-scoped runs get explicit not-comparable semantics.

## Verification

- `pnpm --filter @settler/reconciliation-core typecheck` ✅
- `pnpm --filter @settler/reconciliation-core test` ✅
- `pnpm --filter @settler/reconciliation-core build` ✅
- Targeted web Jest: exceptions-runtime-integrity + run-proofpack-route.contract ✅
- `pnpm lint` ❌ (fails in `@settler/api` with pre-existing parse errors in unrelated files)
- `pnpm --filter @settler/web typecheck` ❌ (pre-existing errors in unrelated files; reconciliation-workbench.ts clean)

## Classification

**Moat** — strengthens audit/export parity and removes misleading “unavailable” stubs where canonical run history exists.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c55e20d6-6c12-4caf-8592-96eeceb3f52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c55e20d6-6c12-4caf-8592-96eeceb3f52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

