### PR TITLE
Prior Run Delta Analyst: worker audit trail, API, and console workforce UI

### DIFF
--- a/docs/OPERATOR_MODE.md
+++ b/docs/OPERATOR_MODE.md
@@ -377,6 +377,22 @@ Operator mode metrics are exposed via Prometheus:
 3. Check database credentials are correct
 4. Review backup records: `GET /api/v1/operator/backups`
 
+## Bounded workforce — Prior Run Delta Analyst
+
+The **Prior Run Delta Analyst** is a deterministic worker over canonical `RunDelta` rows: it produces a structured briefing (headline, posture, bullets, next steps) and a SHA-256 **content hash** for audit comparison. It does not call external models; degraded signals (for example, no prior run on the delta, or config drift flagged) are explicit in the stored output.
+
+**When it runs**
+
+- Automatically when `RunDeltaService.computeDelta` completes (API / engine path): a `worker_runs` row is written with trigger `run_delta_computed`.
+- On demand from the Developer Console: `GET /api/console/workforce/run-deltas/:runDeltaId/analysis` (persists a row with trigger `api_on_demand` if none exists).
+
+**Operator surfaces**
+
+- `GET /api/console/workforce/registry` — capability disclosure (worker identity, inputs, outputs, risk, degraded conditions).
+- `GET /api/console/workforce/runs` — recent audit rows for the tenant.
+
+The Console **Intelligence** page lists registered workers, recent runs, and a field to load a briefing by Run Delta id.
+
 ## Best Practices
 
 1. **Set Alert Thresholds Early**: Configure alerts before issues occur

--- a/packages/api/src/routes/v1/index.ts
+++ b/packages/api/src/routes/v1/index.ts
@@ -18,6 +18,7 @@ import reconciliationRouter from "./reconciliation";
 import ingestionExportsRouter from "./ingestion-exports";
 import { operatorModeRouter } from "./operator-mode";
 import operatorIntelligenceRouter from "./operator-intelligence";
+import workforceRouter from "./workforce";
 import exceptionIntelligenceRouter from "./exception-intelligence";
 import { systemHealthRouter } from "./system-health";
 import { runsRouter } from "./runs";
@@ -86,6 +87,7 @@ v1Router.use("/dedicated-infrastructure", dedicatedInfrastructureRouter);
 // Operator mode routes
 v1Router.use("/", operatorModeRouter);
 v1Router.use("/", operatorIntelligenceRouter);
+v1Router.use("/", workforceRouter);
 v1Router.use("/", exceptionIntelligenceRouter);
 v1Router.use("/", systemHealthRouter);
 v1Router.use("/", runsRouter);

--- a/packages/api/src/routes/v1/workforce.ts
+++ b/packages/api/src/routes/v1/workforce.ts
@@ -1,0 +1,152 @@
+import { Router, Response } from "express";
+import { z } from "zod";
+import { AuthRequest } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/authorization";
+import { Permission } from "../../infrastructure/security/Permissions";
+import { validateRequest } from "../../middleware/validation";
+import { handleRouteError } from "../../utils/error-handler";
+import { prisma } from "../../infrastructure/db/prisma";
+import {
+  PriorRunDeltaAnalystService,
+  PRIOR_RUN_DELTA_ANALYST_KEY,
+} from "../../services/intelligence/prior-run-delta-analyst";
+import { RunDeltaService } from "../../services/intelligence/run-delta";
+
+const router: Router = Router();
+const analyst = new PriorRunDeltaAnalystService(prisma);
+const runDeltaService = new RunDeltaService(prisma);
+
+const registrySchema = z.object({
+  query: z.object({}),
+});
+
+const runDeltaParamsSchema = z.object({
+  params: z.object({
+    runDeltaId: z.string().uuid(),
+  }),
+});
+
+const listSchema = z.object({
+  query: z.object({
+    limit: z.coerce.number().int().min(1).max(100).default(20),
+  }),
+});
+
+function tenantOr400(req: AuthRequest, res: Response): string | null {
+  const tenantId = req.tenantId;
+  if (!tenantId) {
+    res.status(400).json({ error: "Missing tenant context" });
+    return null;
+  }
+  return tenantId;
+}
+
+router.get(
+  "/operator/workforce/registry",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(registrySchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+
+      return res.status(200).json({
+        data: {
+          workers: [
+            {
+              key: PRIOR_RUN_DELTA_ANALYST_KEY,
+              version: "1",
+              displayName: "Prior Run Delta Analyst",
+              description:
+                "Deterministic briefing from canonical RunDelta rows. No external inference; cites run and delta ids only.",
+              inputs: ["run_delta row (tenant-scoped)", "recon result pair"],
+              outputs: ["headline", "posture", "bullets", "recommended next steps", "contentHash"],
+              riskLevel: "low",
+              requiresApproval: false,
+              degradedWhen: [
+                "no prior run on delta",
+                "config drift flagged on delta",
+                "worker_runs table unavailable",
+              ],
+            },
+          ],
+        },
+      });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load workforce registry", 500, {
+        userId: req.userId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/workforce/runs",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(listSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      const limit = Number(req.query.limit ?? 20);
+      const runs = await analyst.listRecent(tenantId, limit);
+      return res.status(200).json({ data: runs });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to list worker runs", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+router.get(
+  "/operator/workforce/run-deltas/:runDeltaId/analysis",
+  requirePermission(Permission.ADMIN_READ),
+  validateRequest(runDeltaParamsSchema),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const tenantId = tenantOr400(req, res);
+      if (!tenantId) return;
+      const runDeltaId = req.params["runDeltaId"] as string;
+
+      const deltaRow = await prisma.runDelta.findFirst({
+        where: { id: runDeltaId, tenantId },
+      });
+      if (!deltaRow) {
+        return res.status(404).json({ error: "RUN_DELTA_NOT_FOUND", message: "Run delta not found" });
+      }
+
+      let record = await analyst.getLatestForRunDelta(tenantId, runDeltaId);
+      if (!record) {
+        const enriched = await runDeltaService.getDeltaHistory(tenantId, deltaRow.jobId, 50);
+        const match = enriched.find((d) => d.id === runDeltaId);
+        if (match) {
+          await analyst.recordAnalysis({
+            tenantId,
+            runDeltaId,
+            delta: match,
+            trigger: "api_refresh",
+          });
+          record = await analyst.getLatestForRunDelta(tenantId, runDeltaId);
+        }
+      }
+
+      if (!record) {
+        return res.status(503).json({
+          error: "WORKER_UNAVAILABLE",
+          message: "Analysis could not be produced for this delta.",
+        });
+      }
+
+      return res.status(200).json({ data: record });
+    } catch (error: unknown) {
+      return handleRouteError(res, error, "Failed to load delta analysis", 500, {
+        userId: req.userId,
+        tenantId: req.tenantId,
+      });
+    }
+  }
+);
+
+export default router;

--- a/packages/api/src/services/intelligence/__tests__/prior-run-delta-analyst.test.ts
+++ b/packages/api/src/services/intelligence/__tests__/prior-run-delta-analyst.test.ts
@@ -1,0 +1,68 @@
+import { PriorRunDeltaAnalystService } from "../prior-run-delta-analyst";
+import type { RunDeltaResult } from "../run-delta";
+
+jest.mock("@settler/reconciliation-core", () =>
+  jest.requireActual<typeof import("@settler/reconciliation-core")>("@settler/reconciliation-core")
+);
+
+describe("PriorRunDeltaAnalystService", () => {
+  it("persists worker run with content hash", async () => {
+    const created: Record<string, unknown> = {};
+    const prisma = {
+      workerRun: {
+        create: jest.fn(async ({ data }: { data: Record<string, unknown> }) => {
+          Object.assign(created, data, { id: "wr-1" });
+          return {
+            id: "wr-1",
+            tenantId: data["tenantId"],
+            workerKey: data["workerKey"],
+            workerVersion: data["workerVersion"],
+            trigger: data["trigger"],
+            runDeltaId: data["runDeltaId"],
+            status: data["status"],
+            output: data["output"],
+            evidence: data["evidence"],
+            degradedReasons: data["degradedReasons"],
+            createdAt: new Date("2026-01-01T00:00:00.000Z"),
+            completedAt: new Date("2026-01-01T00:00:00.000Z"),
+          };
+        }),
+      },
+    };
+
+    const delta: RunDeltaResult = {
+      id: "delta-1",
+      tenantId: "t1",
+      currentRunId: "c1",
+      previousRunId: "p1",
+      jobId: "j1",
+      inputChanged: false,
+      sourceDataChanged: false,
+      targetDataChanged: false,
+      totalDelta: 0,
+      matchedDelta: 0,
+      unmatchedDelta: 0,
+      exceptionDelta: 1,
+      severityDeltas: { critical: 0, high: 1, medium: 0, low: 0 },
+      newExceptionPatterns: [],
+      resolvedPatterns: [],
+      configDriftDetected: false,
+      configDriftSummary: [],
+      confidenceDelta: null,
+      qualityScoreDelta: null,
+      deltaGeneratedAt: new Date(),
+    };
+
+    const svc = new PriorRunDeltaAnalystService(prisma as never);
+    const out = await svc.recordAnalysis({
+      tenantId: "t1",
+      runDeltaId: "delta-1",
+      delta,
+      trigger: "test",
+    });
+
+    expect(out).not.toBeNull();
+    expect(out?.output.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(prisma.workerRun.create).toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/intelligence/index.ts
+++ b/packages/api/src/services/intelligence/index.ts
@@ -11,6 +11,7 @@ export { PatternExtractor } from "./pattern-extractor";
 export { PredictiveRouter } from "./predictive-router";
 export { AdjudicationMemoryService } from "./adjudication-memory";
 export { RunDeltaService } from "./run-delta";
+export { PriorRunDeltaAnalystService, PRIOR_RUN_DELTA_ANALYST_KEY } from "./prior-run-delta-analyst";
 
 export type { ExtractedPattern } from "./pattern-extractor";
 export type { RoutingDecision } from "./predictive-router";

--- a/packages/api/src/services/intelligence/prior-run-delta-analyst.ts
+++ b/packages/api/src/services/intelligence/prior-run-delta-analyst.ts
@@ -1,0 +1,164 @@
+/**
+ * Prior Run Delta Analyst — bounded deterministic worker over canonical RunDelta rows.
+ * Briefing logic lives in @settler/reconciliation-core; this module persists audit rows.
+ */
+
+import crypto from "node:crypto";
+import { Prisma, PrismaClient } from "@prisma/client";
+import {
+  buildEvidenceRefs,
+  buildPriorRunDeltaBriefing,
+  type PriorRunDeltaBriefing,
+  type PriorRunDeltaSource,
+} from "@settler/reconciliation-core";
+import { logError } from "../../utils/logger";
+import type { RunDeltaResult } from "./run-delta";
+
+export const PRIOR_RUN_DELTA_ANALYST_KEY = "prior_run_delta_analyst";
+export const PRIOR_RUN_DELTA_ANALYST_VERSION = "1";
+
+export interface WorkerRunPublic {
+  id: string;
+  tenantId: string;
+  workerKey: string;
+  workerVersion: string;
+  trigger: string;
+  runDeltaId: string;
+  status: string;
+  output: PriorRunDeltaBriefing & { contentHash?: string };
+  evidence: Array<{ kind: string; ref: string; detail?: string }>;
+  degradedReasons: string[];
+  createdAt: Date;
+  completedAt: Date;
+}
+
+function runDeltaResultToSource(delta: RunDeltaResult): PriorRunDeltaSource {
+  return {
+    id: delta.id,
+    currentRunId: delta.currentRunId,
+    previousRunId: delta.previousRunId,
+    jobId: delta.jobId,
+    exceptionDelta: delta.exceptionDelta,
+    matchedDelta: delta.matchedDelta,
+    unmatchedDelta: delta.unmatchedDelta,
+    inputChanged: delta.inputChanged,
+    configDriftDetected: delta.configDriftDetected,
+    severityDeltas: delta.severityDeltas,
+    newExceptionPatterns: delta.newExceptionPatterns,
+    resolvedPatterns: delta.resolvedPatterns,
+  };
+}
+
+function hashBriefing(
+  briefing: PriorRunDeltaBriefing,
+  evidence: Array<{ kind: string; ref: string }>
+): string {
+  return crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        briefing,
+        evidenceRefs: evidence.map((e) => e.ref).sort(),
+      })
+    )
+    .digest("hex");
+}
+
+export class PriorRunDeltaAnalystService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async recordAnalysis(args: {
+    tenantId: string;
+    runDeltaId: string;
+    delta: RunDeltaResult;
+    trigger: string;
+  }): Promise<WorkerRunPublic | null> {
+    const source = runDeltaResultToSource(args.delta);
+    const briefing = buildPriorRunDeltaBriefing(source);
+    const evidence = buildEvidenceRefs(source);
+    const contentHash = hashBriefing(briefing, evidence);
+    const outputWithHash = { ...briefing, contentHash };
+
+    const degradedReasons: string[] = [];
+    if (!briefing.basis.priorRunPresent) {
+      degradedReasons.push("no_prior_run_on_delta");
+    }
+    if (args.delta.configDriftDetected) {
+      degradedReasons.push("config_drift_flagged");
+    }
+
+    try {
+      const row = await this.prisma.workerRun.create({
+        data: {
+          tenantId: args.tenantId,
+          workerKey: PRIOR_RUN_DELTA_ANALYST_KEY,
+          workerVersion: PRIOR_RUN_DELTA_ANALYST_VERSION,
+          trigger: args.trigger,
+          runDeltaId: args.runDeltaId,
+          status: "succeeded",
+          output: outputWithHash as Prisma.InputJsonValue,
+          evidence: evidence as unknown as Prisma.InputJsonValue,
+          degradedReasons: degradedReasons as unknown as Prisma.InputJsonValue,
+        },
+      });
+      return this.toPublic(row);
+    } catch (error) {
+      logError("PriorRunDeltaAnalystService.recordAnalysis failed", {
+        tenantId: args.tenantId,
+        runDeltaId: args.runDeltaId,
+        error,
+      });
+      return null;
+    }
+  }
+
+  async getLatestForRunDelta(tenantId: string, runDeltaId: string): Promise<WorkerRunPublic | null> {
+    const row = await this.prisma.workerRun.findFirst({
+      where: { tenantId, runDeltaId, workerKey: PRIOR_RUN_DELTA_ANALYST_KEY },
+      orderBy: { createdAt: "desc" },
+    });
+    return row ? this.toPublic(row) : null;
+  }
+
+  async listRecent(tenantId: string, limit: number): Promise<WorkerRunPublic[]> {
+    const rows = await this.prisma.workerRun.findMany({
+      where: { tenantId, workerKey: PRIOR_RUN_DELTA_ANALYST_KEY },
+      orderBy: { createdAt: "desc" },
+      take: Math.min(Math.max(limit, 1), 100),
+    });
+    return rows.map((r) => this.toPublic(r));
+  }
+
+  private toPublic(row: {
+    id: string;
+    tenantId: string;
+    workerKey: string;
+    workerVersion: string;
+    trigger: string;
+    runDeltaId: string;
+    status: string;
+    output: unknown;
+    evidence: unknown;
+    degradedReasons: unknown;
+    createdAt: Date;
+    completedAt: Date;
+  }): WorkerRunPublic {
+    const output = row.output as PriorRunDeltaBriefing & { contentHash?: string };
+    return {
+      id: row.id,
+      tenantId: row.tenantId,
+      workerKey: row.workerKey,
+      workerVersion: row.workerVersion,
+      trigger: row.trigger,
+      runDeltaId: row.runDeltaId,
+      status: row.status,
+      output,
+      evidence: Array.isArray(row.evidence) ? (row.evidence as WorkerRunPublic["evidence"]) : [],
+      degradedReasons: Array.isArray(row.degradedReasons)
+        ? (row.degradedReasons as string[])
+        : [],
+      createdAt: row.createdAt,
+      completedAt: row.completedAt,
+    };
+  }
+}

--- a/packages/api/src/services/intelligence/run-delta.ts
+++ b/packages/api/src/services/intelligence/run-delta.ts
@@ -7,6 +7,7 @@
 
 import { PrismaClient, Prisma } from "@prisma/client";
 import { logError } from "../../utils/logger";
+import { PriorRunDeltaAnalystService } from "./prior-run-delta-analyst";
 
 export interface RunDeltaInput {
   tenantId: string;
@@ -95,9 +96,11 @@ interface ExceptionArchetypeForDelta {
 
 export class RunDeltaService {
   private prisma: PrismaClient;
+  private analyst: PriorRunDeltaAnalystService;
 
   constructor(prisma: PrismaClient) {
     this.prisma = prisma;
+    this.analyst = new PriorRunDeltaAnalystService(prisma);
   }
 
   /**
@@ -176,7 +179,7 @@ export class RunDeltaService {
       },
     });
 
-    return this.mapToResult(delta, {
+    const mapped = this.mapToResult(delta, {
       currentSnapshot,
       previousSnapshot,
       newPatterns,
@@ -189,6 +192,15 @@ export class RunDeltaService {
       currentResult,
       previousResult,
     });
+
+    await this.analyst.recordAnalysis({
+      tenantId: input.tenantId,
+      runDeltaId: delta.id,
+      delta: mapped,
+      trigger: "run_delta_computed",
+    });
+
+    return mapped;
   }
 
   /**

--- a/packages/reconciliation-core/src/__tests__/prior-run-delta-analyst.test.ts
+++ b/packages/reconciliation-core/src/__tests__/prior-run-delta-analyst.test.ts
@@ -1,0 +1,40 @@
+import {
+  buildPriorRunDeltaBriefing,
+  buildEvidenceRefs,
+} from "../prior-run-delta-analyst.js";
+
+describe("buildPriorRunDeltaBriefing", () => {
+  const base = {
+    id: "d1",
+    currentRunId: "c1",
+    previousRunId: "p1",
+    jobId: "j1",
+    exceptionDelta: 2,
+    matchedDelta: -1,
+    unmatchedDelta: 3,
+    inputChanged: false,
+    configDriftDetected: false,
+    severityDeltas: { critical: 1, high: 0, medium: 0, low: 0 },
+    newExceptionPatterns: ["Timing gap"],
+    resolvedPatterns: [],
+  };
+
+  it("marks first run when no previous run id", () => {
+    const b = buildPriorRunDeltaBriefing({ ...base, previousRunId: null });
+    expect(b.posture).toBe("first_run_or_incomparable");
+    expect(b.basis.priorRunPresent).toBe(false);
+  });
+
+  it("flags config drift in bullets and next steps", () => {
+    const b = buildPriorRunDeltaBriefing({ ...base, configDriftDetected: true });
+    expect(b.summaryBullets.some((x) => x.includes("Configuration drift"))).toBe(true);
+    expect(b.recommendedNextSteps.some((x) => x.includes("configuration"))).toBe(true);
+  });
+
+  it("builds evidence refs including prior run when present", () => {
+    const refs = buildEvidenceRefs(base);
+    expect(refs.map((r) => r.kind)).toEqual(
+      expect.arrayContaining(["run_delta", "current_run", "previous_run", "job"])
+    );
+  });
+});

--- a/packages/reconciliation-core/src/index.ts
+++ b/packages/reconciliation-core/src/index.ts
@@ -18,3 +18,4 @@ export * from "./run-proofpack-index.js";
 export * from "./prisma-client-like.js";
 export * from "./cross-run-intelligence.js";
 export * from "./support-intake-run-context.js";
+export * from "./prior-run-delta-analyst.js";

--- a/packages/reconciliation-core/src/prior-run-delta-analyst.ts
+++ b/packages/reconciliation-core/src/prior-run-delta-analyst.ts
@@ -1,0 +1,152 @@
+/**
+ * Prior Run Delta Analyst — deterministic briefing from canonical run-delta measures.
+ * No LLM; suitable for shared use by API workers and console surfaces.
+ */
+
+/** Minimal slice of run delta truth required for analysis */
+export interface PriorRunDeltaSource {
+  id: string;
+  currentRunId: string;
+  previousRunId: string | null;
+  jobId: string;
+  exceptionDelta: number;
+  matchedDelta: number;
+  unmatchedDelta: number;
+  inputChanged: boolean;
+  configDriftDetected: boolean;
+  severityDeltas: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+  };
+  newExceptionPatterns: string[];
+  resolvedPatterns: string[];
+}
+
+export interface PriorRunDeltaBriefing {
+  headline: string;
+  posture: "improving" | "worsening" | "mixed" | "stable" | "first_run_or_incomparable";
+  summaryBullets: string[];
+  recommendedNextSteps: string[];
+  basis: {
+    exceptionDelta: number;
+    matchedDelta: number;
+    severityNet: { critical: number; high: number; medium: number; low: number };
+    newPatternCount: number;
+    resolvedPatternCount: number;
+    configDriftDetected: boolean;
+    inputChanged: boolean;
+    priorRunPresent: boolean;
+  };
+}
+
+function severityNet(delta: PriorRunDeltaSource): number {
+  const s = delta.severityDeltas;
+  return s.critical + s.high + s.medium + s.low;
+}
+
+export function buildEvidenceRefs(delta: PriorRunDeltaSource): Array<{
+  kind: string;
+  ref: string;
+  detail?: string;
+}> {
+  return [
+    { kind: "run_delta", ref: delta.id, detail: "Canonical RunDelta row" },
+    { kind: "current_run", ref: delta.currentRunId },
+    ...(delta.previousRunId ? [{ kind: "previous_run" as const, ref: delta.previousRunId }] : []),
+    { kind: "job", ref: delta.jobId },
+  ];
+}
+
+/** Exported for unit tests — deterministic template over RunDelta fields only */
+export function buildPriorRunDeltaBriefing(delta: PriorRunDeltaSource): PriorRunDeltaBriefing {
+  const priorPresent = delta.previousRunId !== null;
+  const netSev = severityNet(delta);
+
+  let posture: PriorRunDeltaBriefing["posture"] = "stable";
+  if (!priorPresent) {
+    posture = "first_run_or_incomparable";
+  } else if (delta.exceptionDelta > 0 && netSev > 0) {
+    posture = "worsening";
+  } else if (delta.exceptionDelta < 0 && netSev <= 0) {
+    posture = "improving";
+  } else if (delta.exceptionDelta !== 0 || netSev !== 0 || delta.newExceptionPatterns.length > 0) {
+    posture = "mixed";
+  }
+
+  const bullets: string[] = [];
+  if (!priorPresent) {
+    bullets.push(
+      "No prior comparable run id on this delta — period-over-period posture is not yet established."
+    );
+  } else {
+    bullets.push(
+      `Exception count delta (conflicts): ${delta.exceptionDelta >= 0 ? "+" : ""}${delta.exceptionDelta} vs prior run.`
+    );
+    bullets.push(
+      `Match delta: ${delta.matchedDelta >= 0 ? "+" : ""}${delta.matchedDelta}; unmatched volume delta: ${delta.unmatchedDelta >= 0 ? "+" : ""}${delta.unmatchedDelta}.`
+    );
+    const s = delta.severityDeltas;
+    bullets.push(
+      `Severity posture (net archetype deltas): critical ${s.critical}, high ${s.high}, medium ${s.medium}, low ${s.low}.`
+    );
+  }
+  if (delta.newExceptionPatterns.length > 0) {
+    bullets.push(`New exception patterns vs prior: ${delta.newExceptionPatterns.length} (archetype labels).`);
+  }
+  if (delta.resolvedPatterns.length > 0) {
+    bullets.push(`Patterns no longer present vs prior: ${delta.resolvedPatterns.length}.`);
+  }
+  if (delta.configDriftDetected) {
+    bullets.push("Configuration drift was flagged between snapshots — treat like-for-like comparisons cautiously.");
+  }
+  if (delta.inputChanged) {
+    bullets.push("Input hash changed vs prior run — volume and exception shifts may reflect input change, not quality.");
+  }
+
+  const nextSteps: string[] = [];
+  if (delta.configDriftDetected) {
+    nextSteps.push("Reconcile job or adapter configuration with the prior period before interpreting exception trends.");
+  }
+  if (delta.newExceptionPatterns.length > 0) {
+    nextSteps.push("Triage new archetype labels first; capture adjudications to grow institutional memory.");
+  }
+  if (delta.exceptionDelta > 0 && priorPresent) {
+    nextSteps.push("Drill into conflicts and open exceptions for this run; prioritize by severity net and materiality.");
+  }
+  if (nextSteps.length === 0 && priorPresent) {
+    nextSteps.push("Spot-check open exceptions and source trust signals; no automatic action required from delta alone.");
+  }
+  if (!priorPresent) {
+    nextSteps.push("After the next run, re-open this briefing — prior-run comparison will be available.");
+  }
+
+  const headline =
+    posture === "first_run_or_incomparable"
+      ? "Prior-run comparison not available for this delta."
+      : posture === "worsening"
+        ? "Run delta suggests increased reconciliation pressure vs prior."
+        : posture === "improving"
+          ? "Run delta suggests reduced conflict load vs prior."
+          : posture === "mixed"
+            ? "Run delta shows a mixed signal — review patterns and config context."
+            : "Run delta is stable vs prior on recorded measures.";
+
+  return {
+    headline,
+    posture,
+    summaryBullets: bullets,
+    recommendedNextSteps: nextSteps,
+    basis: {
+      exceptionDelta: delta.exceptionDelta,
+      matchedDelta: delta.matchedDelta,
+      severityNet: { ...delta.severityDeltas },
+      newPatternCount: delta.newExceptionPatterns.length,
+      resolvedPatternCount: delta.resolvedPatterns.length,
+      configDriftDetected: delta.configDriftDetected,
+      inputChanged: delta.inputChanged,
+      priorRunPresent: priorPresent,
+    },
+  };
+}

--- a/packages/web/src/app/api/console/workforce/_shared.ts
+++ b/packages/web/src/app/api/console/workforce/_shared.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { requireActiveSubscriptionOrExceptionIntelligencePack } from "@/lib/security/billing-enforcement";
+import { resolveTenantMembershipScope } from "@/lib/supabase/tenant-membership";
+import type { NextRequest } from "next/server";
+
+export type TenantGateResult =
+  | { ok: true; tenantId: string }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Fail-closed tenant for console workforce routes (matches /api/console/intelligence pattern).
+ */
+export async function gateConsoleTenant(request: NextRequest): Promise<TenantGateResult> {
+  const billing = await requireActiveSubscriptionOrExceptionIntelligencePack(request);
+  if (!billing.allowed) {
+    return {
+      ok: false,
+      response:
+        billing.error ??
+        NextResponse.json(
+          {
+            error: "Subscription or Exception Intelligence Pack required",
+            code: "INTELLIGENCE_PACK_OR_SUBSCRIPTION_REQUIRED",
+          },
+          { status: 403 }
+        ),
+    };
+  }
+
+  let tenantIds: string[];
+  try {
+    const scope = await resolveTenantMembershipScope();
+    tenantIds = scope.tenantIds;
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: "Tenant scope is unavailable.",
+          code: "TENANT_SCOPE_UNAVAILABLE",
+        },
+        { status: 503 }
+      ),
+    };
+  }
+
+  if (tenantIds.length === 0) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "No tenant membership found.", code: "TENANT_REQUIRED" },
+        { status: 409 }
+      ),
+    };
+  }
+
+  const tenantId = tenantIds[0];
+  if (!tenantId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "No tenant membership found.", code: "TENANT_REQUIRED" },
+        { status: 409 }
+      ),
+    };
+  }
+
+  return { ok: true, tenantId };
+}

--- a/packages/web/src/app/api/console/workforce/registry/route.ts
+++ b/packages/web/src/app/api/console/workforce/registry/route.ts
@@ -1,0 +1,49 @@
+/**
+ * GET /api/console/workforce/registry
+ * Canonical capability disclosure for bounded workforce modules (OSS-safe).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { gateConsoleTenant } from "../_shared";
+
+export const dynamic = "force-dynamic";
+
+const PRIOR_RUN_DELTA_ANALYST_KEY = "prior_run_delta_analyst";
+
+export const GET = withSecurity(
+  async function GET(request: NextRequest): Promise<NextResponse> {
+    const gate = await gateConsoleTenant(request);
+    if (!gate.ok) return gate.response;
+
+    void gate.tenantId;
+
+    return NextResponse.json({
+      data: {
+        workers: [
+          {
+            key: PRIOR_RUN_DELTA_ANALYST_KEY,
+            version: "1",
+            displayName: "Prior Run Delta Analyst",
+            description:
+              "Deterministic briefing from canonical RunDelta rows. No external inference; cites run and delta ids only.",
+            inputs: ["run_delta row (tenant-scoped)", "recon result pair"],
+            outputs: ["headline", "posture", "bullets", "recommended next steps", "contentHash"],
+            riskLevel: "low",
+            requiresApproval: false,
+            degradedWhen: [
+              "no prior run on delta",
+              "config drift flagged on delta",
+              "worker_runs table unavailable",
+            ],
+          },
+        ],
+      },
+      capability: { state: "available", worker_count: 1 },
+    });
+  },
+  {
+    rateLimit: { windowMs: 60_000, maxRequests: 60 },
+    requireAuth: true,
+  }
+);

--- a/packages/web/src/app/api/console/workforce/run-deltas/[runDeltaId]/analysis/route.ts
+++ b/packages/web/src/app/api/console/workforce/run-deltas/[runDeltaId]/analysis/route.ts
@@ -1,0 +1,195 @@
+/**
+ * GET /api/console/workforce/run-deltas/:runDeltaId/analysis
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { prisma } from "@/shared/db/prismaClient";
+import type { Prisma } from "@prisma/client";
+import {
+  buildEvidenceRefs,
+  buildPriorRunDeltaBriefing,
+  type PriorRunDeltaSource,
+} from "@settler/reconciliation-core";
+import crypto from "node:crypto";
+import { gateConsoleTenant } from "../../../_shared";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface RouteParams {
+  params: Promise<{ runDeltaId: string }>;
+}
+
+const WORKER_KEY = "prior_run_delta_analyst";
+const WORKER_VERSION = "1";
+
+function parseJsonArray(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((x): x is string => typeof x === "string");
+  }
+  if (typeof raw === "string") {
+    try {
+      const p = JSON.parse(raw) as unknown;
+      return Array.isArray(p) ? p.filter((x): x is string => typeof x === "string") : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function parseConfigDrift(raw: unknown): { length: number } {
+  if (Array.isArray(raw)) return { length: raw.length };
+  if (typeof raw === "string") {
+    try {
+      const p = JSON.parse(raw) as unknown;
+      return { length: Array.isArray(p) ? p.length : 0 };
+    } catch {
+      return { length: 0 };
+    }
+  }
+  return { length: 0 };
+}
+
+function hashBriefing(
+  briefing: ReturnType<typeof buildPriorRunDeltaBriefing>,
+  evidence: Array<{ kind: string; ref: string }>
+): string {
+  return crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        briefing,
+        evidenceRefs: evidence.map((e) => e.ref).sort(),
+      })
+    )
+    .digest("hex");
+}
+
+export const GET = withSecurity(
+  async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+    const gate = await gateConsoleTenant(request);
+    if (!gate.ok) return gate.response;
+
+    const { runDeltaId } = await params;
+
+    const deltaRow = await prisma.runDelta.findFirst({
+      where: { id: runDeltaId, tenantId: gate.tenantId },
+    });
+
+    if (!deltaRow) {
+      return NextResponse.json(
+        { error: "RUN_DELTA_NOT_FOUND", message: "Run delta not found" },
+        { status: 404 }
+      );
+    }
+
+    const existing = await prisma.workerRun.findFirst({
+      where: { tenantId: gate.tenantId, runDeltaId, workerKey: WORKER_KEY },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (existing) {
+      return NextResponse.json(
+        {
+          data: {
+            id: existing.id,
+            tenantId: existing.tenantId,
+            workerKey: existing.workerKey,
+            workerVersion: existing.workerVersion,
+            trigger: existing.trigger,
+            runDeltaId: existing.runDeltaId,
+            status: existing.status,
+            output: existing.output,
+            evidence: existing.evidence,
+            degradedReasons: existing.degradedReasons,
+            createdAt: existing.createdAt.toISOString(),
+            completedAt: existing.completedAt.toISOString(),
+          },
+          capability: { state: "available", source: "persisted" },
+        },
+        { headers: { "Cache-Control": "private, no-store" } }
+      );
+    }
+
+    const newPatterns = parseJsonArray(deltaRow.newExceptionPatterns);
+    const resolvedPatterns = parseJsonArray(deltaRow.resolvedPatterns);
+    const configDrift = parseConfigDrift(deltaRow.configDriftSummary);
+
+    let inputChanged = false;
+    const inputDelta = deltaRow.inputDelta;
+    if (inputDelta && typeof inputDelta === "object" && !Array.isArray(inputDelta)) {
+      const o = inputDelta as Record<string, unknown>;
+      inputChanged = o["currentHash"] !== o["previousHash"];
+    }
+
+    const source: PriorRunDeltaSource = {
+      id: deltaRow.id,
+      currentRunId: deltaRow.currentRunId,
+      previousRunId: deltaRow.previousRunId,
+      jobId: deltaRow.jobId,
+      exceptionDelta: deltaRow.exceptionDelta,
+      matchedDelta: deltaRow.matchedDelta,
+      unmatchedDelta: deltaRow.unmatchedDelta,
+      inputChanged,
+      configDriftDetected: deltaRow.configDriftDetected || configDrift.length > 0,
+      severityDeltas: {
+        critical: deltaRow.criticalDelta,
+        high: deltaRow.highDelta,
+        medium: deltaRow.mediumDelta,
+        low: deltaRow.lowDelta,
+      },
+      newExceptionPatterns: newPatterns,
+      resolvedPatterns,
+    };
+
+    const briefing = buildPriorRunDeltaBriefing(source);
+    const evidence = buildEvidenceRefs(source);
+    const contentHash = hashBriefing(briefing, evidence);
+    const outputWithHash = { ...briefing, contentHash };
+
+    const degradedReasons: string[] = [];
+    if (!briefing.basis.priorRunPresent) degradedReasons.push("no_prior_run_on_delta");
+    if (source.configDriftDetected) degradedReasons.push("config_drift_flagged");
+
+    const row = await prisma.workerRun.create({
+      data: {
+        tenantId: gate.tenantId,
+        workerKey: WORKER_KEY,
+        workerVersion: WORKER_VERSION,
+        trigger: "api_on_demand",
+        runDeltaId,
+        status: "succeeded",
+        output: outputWithHash as Prisma.InputJsonValue,
+        evidence: evidence as unknown as Prisma.InputJsonValue,
+        degradedReasons: degradedReasons as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    return NextResponse.json(
+      {
+        data: {
+          id: row.id,
+          tenantId: row.tenantId,
+          workerKey: row.workerKey,
+          workerVersion: row.workerVersion,
+          trigger: row.trigger,
+          runDeltaId: row.runDeltaId,
+          status: row.status,
+          output: row.output,
+          evidence: row.evidence,
+          degradedReasons: row.degradedReasons,
+          createdAt: row.createdAt.toISOString(),
+          completedAt: row.completedAt.toISOString(),
+        },
+        capability: { state: "available", source: "computed_on_demand" },
+      },
+      { headers: { "Cache-Control": "private, no-store" } }
+    );
+  },
+  {
+    rateLimit: { windowMs: 60_000, maxRequests: 60 },
+    requireAuth: true,
+  }
+);

--- a/packages/web/src/app/api/console/workforce/runs/route.ts
+++ b/packages/web/src/app/api/console/workforce/runs/route.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /api/console/workforce/runs — recent Prior Run Delta Analyst audit rows
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withSecurity } from "@/lib/middleware/api-security";
+import { prisma } from "@/shared/db/prismaClient";
+import type { WorkerRun } from "@prisma/client";
+import { gateConsoleTenant } from "../_shared";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const WORKER_KEY = "prior_run_delta_analyst";
+
+export const GET = withSecurity(
+  async function GET(request: NextRequest): Promise<NextResponse> {
+    const gate = await gateConsoleTenant(request);
+    if (!gate.ok) return gate.response;
+
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(100, Math.max(1, Number(searchParams.get("limit") ?? "20") || 20));
+
+    const rows = await prisma.workerRun.findMany({
+      where: { tenantId: gate.tenantId, workerKey: WORKER_KEY },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+    });
+
+    const data = rows.map((row: WorkerRun) => ({
+      id: row.id,
+      tenantId: row.tenantId,
+      workerKey: row.workerKey,
+      workerVersion: row.workerVersion,
+      trigger: row.trigger,
+      runDeltaId: row.runDeltaId,
+      status: row.status,
+      output: row.output,
+      evidence: row.evidence,
+      degradedReasons: row.degradedReasons,
+      createdAt: row.createdAt.toISOString(),
+      completedAt: row.completedAt.toISOString(),
+    }));
+
+    return NextResponse.json(
+      { data, capability: { state: "available" } },
+      { headers: { "Cache-Control": "private, no-store" } }
+    );
+  },
+  {
+    rateLimit: { windowMs: 60_000, maxRequests: 60 },
+    requireAuth: true,
+  }
+);

--- a/packages/web/src/app/console/intelligence/page.tsx
+++ b/packages/web/src/app/console/intelligence/page.tsx
@@ -7,7 +7,9 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ErrorState } from "@/components/ui/error-state";
 import { safeFetch } from "@/lib/safe-fetch";
-import { Brain, AlertTriangle, CheckCircle, Clock, TrendingUp } from "lucide-react";
+import { Brain, AlertTriangle, CheckCircle, Clock, TrendingUp, Cpu } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 interface SystemHealthSnapshot {
   total_runs: number;
@@ -44,6 +46,43 @@ interface RunExplorerResponse {
     status: string;
     degraded_reasons?: string[];
   };
+}
+
+interface WorkforceRegistryBody {
+  data: {
+    workers: Array<{
+      key: string;
+      version: string;
+      displayName: string;
+      description: string;
+      riskLevel: string;
+      requiresApproval: boolean;
+      degradedWhen: string[];
+    }>;
+  };
+  capability?: { state?: string };
+}
+
+interface WorkerRunRow {
+  id: string;
+  runDeltaId: string;
+  trigger: string;
+  status: string;
+  output: {
+    headline?: string;
+    posture?: string;
+    contentHash?: string;
+  };
+  degradedReasons: string[];
+  createdAt: string;
+}
+
+interface AnalysisResponse {
+  data: WorkerRunRow & {
+    output: Record<string, unknown>;
+    evidence: unknown;
+  };
+  capability?: { source?: string };
 }
 
 function CapabilityBadge({
@@ -119,6 +158,14 @@ export default function IntelligencePage() {
     null
   );
 
+  const [workforceError, setWorkforceError] = useState<string | null>(null);
+  const [registry, setRegistry] = useState<WorkforceRegistryBody["data"] | null>(null);
+  const [workerRuns, setWorkerRuns] = useState<WorkerRunRow[]>([]);
+  const [runDeltaInput, setRunDeltaInput] = useState("");
+  const [analysisLoading, setAnalysisLoading] = useState(false);
+  const [analysisError, setAnalysisError] = useState<string | null>(null);
+  const [analysisData, setAnalysisData] = useState<AnalysisResponse["data"] | null>(null);
+
   const loadHealth = useCallback(async () => {
     setHealthLoading(true);
     const result = await safeFetch<SystemHealthResponse>(
@@ -149,13 +196,31 @@ export default function IntelligencePage() {
     setRunsLoading(false);
   }, []);
 
+  const loadWorkforce = useCallback(async () => {
+    const reg = await safeFetch<WorkforceRegistryBody>("/api/console/workforce/registry");
+    const runs = await safeFetch<{ data: WorkerRunRow[] }>("/api/console/workforce/runs?limit=15");
+    if (reg.success && reg.data?.data) {
+      setRegistry(reg.data.data);
+      setWorkforceError(null);
+    } else {
+      setWorkforceError(reg.error?.message || "Failed to load workforce registry");
+    }
+    if (runs.success && runs.data?.data) {
+      setWorkerRuns(runs.data.data);
+    } else if (!runs.success) {
+      setWorkforceError((prev) => prev ?? runs.error?.message ?? "Failed to load worker runs");
+    }
+  }, []);
+
   useEffect(() => {
     void loadHealth();
     void loadRuns();
-  }, [loadHealth, loadRuns]);
+    void loadWorkforce();
+  }, [loadHealth, loadRuns, loadWorkforce]);
 
   const isLoading = healthLoading && runsLoading;
-  const hasError = healthError || runsError;
+  const hasBlockingError =
+    (healthError || runsError || workforceError) && !healthData && !runsData.length && !registry;
 
   if (isLoading) {
     return (
@@ -181,7 +246,7 @@ export default function IntelligencePage() {
     );
   }
 
-  if (hasError && !healthData && !runsData.length) {
+  if (hasBlockingError) {
     return (
       <div className="space-y-6">
         <ConsolePageHeader
@@ -195,6 +260,7 @@ export default function IntelligencePage() {
           onRetry={() => {
             void loadHealth();
             void loadRuns();
+            void loadWorkforce();
           }}
         />
       </div>
@@ -281,6 +347,155 @@ export default function IntelligencePage() {
           />
         </div>
       )}
+
+      <Card className="border-border/40">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Cpu className="h-4 w-4" />
+            Workforce
+          </CardTitle>
+          <CardDescription>
+            Bounded, evidence-backed workers with audit rows. Prior Run Delta Analyst uses only
+            canonical RunDelta fields (deterministic; no generative inference).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {workforceError && (
+            <p className="text-sm text-amber-700 dark:text-amber-300">{workforceError}</p>
+          )}
+          {registry && (
+            <div className="space-y-3">
+              <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+                Registered capabilities
+              </h4>
+              <ul className="space-y-2">
+                {registry.workers.map((w) => (
+                  <li
+                    key={w.key}
+                    className="rounded-lg border border-border/60 bg-card/40 p-3 text-sm"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium">{w.displayName}</span>
+                      <Badge variant="outline" className="text-[10px] font-mono">
+                        {w.key}@{w.version}
+                      </Badge>
+                      <Badge variant="secondary" className="text-[10px]">
+                        risk: {w.riskLevel}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">{w.description}</p>
+                    <p className="text-[10px] text-muted-foreground mt-2">
+                      Degraded when: {w.degradedWhen.join("; ")}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+              Recent analyst runs
+            </h4>
+            {workerRuns.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No persisted worker runs yet. Run a reconciliation with a prior run so RunDelta is
+                computed, or load a briefing by Run Delta id below.
+              </p>
+            ) : (
+              <ul className="space-y-2 max-h-48 overflow-y-auto">
+                {workerRuns.map((wr) => (
+                  <li
+                    key={wr.id}
+                    className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 rounded border border-border/50 p-2 text-xs"
+                  >
+                    <span className="font-mono text-[10px] break-all">{wr.runDeltaId}</span>
+                    <span className="text-muted-foreground shrink-0">
+                      {wr.output?.posture ?? wr.status} · {new Date(wr.createdAt).toLocaleString()}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="space-y-3 border-t border-border/40 pt-4">
+            <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+              Load briefing by Run Delta id
+            </h4>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Input
+                placeholder="Run Delta UUID"
+                value={runDeltaInput}
+                onChange={(e) => setRunDeltaInput(e.target.value)}
+                className="font-mono text-xs"
+              />
+              <Button
+                type="button"
+                disabled={analysisLoading || runDeltaInput.trim().length < 8}
+                onClick={async () => {
+                  const id = runDeltaInput.trim();
+                  if (!id) return;
+                  setAnalysisLoading(true);
+                  setAnalysisError(null);
+                  const res = await safeFetch<AnalysisResponse>(
+                    `/api/console/workforce/run-deltas/${encodeURIComponent(id)}/analysis`
+                  );
+                  if (res.success && res.data?.data) {
+                    setAnalysisData(res.data.data);
+                  } else {
+                    setAnalysisData(null);
+                    setAnalysisError(res.error?.message || "Failed to load analysis");
+                  }
+                  setAnalysisLoading(false);
+                }}
+              >
+                {analysisLoading ? "Loading…" : "Load briefing"}
+              </Button>
+            </div>
+            {analysisError && (
+              <p className="text-sm text-destructive">{analysisError}</p>
+            )}
+            {analysisData && (
+              <div className="rounded-lg border border-border/60 bg-muted/20 p-4 space-y-3 text-sm">
+                <div>
+                  <p className="font-medium">{String(analysisData.output?.headline ?? "")}</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Posture: {String(analysisData.output?.posture ?? "—")} · Hash:{" "}
+                    <span className="font-mono text-[10px]">
+                      {String(analysisData.output?.contentHash ?? "—")}
+                    </span>
+                  </p>
+                </div>
+                {Array.isArray(analysisData.output?.summaryBullets) && (
+                  <ul className="list-disc pl-5 space-y-1 text-xs text-muted-foreground">
+                    {(analysisData.output.summaryBullets as string[]).map((b, i) => (
+                      <li key={i}>{b}</li>
+                    ))}
+                  </ul>
+                )}
+                {Array.isArray(analysisData.output?.recommendedNextSteps) && (
+                  <div>
+                    <p className="text-xs font-semibold uppercase text-muted-foreground mb-1">
+                      Next steps
+                    </p>
+                    <ul className="list-disc pl-5 space-y-1 text-xs">
+                      {(analysisData.output.recommendedNextSteps as string[]).map((b, i) => (
+                        <li key={i}>{b}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {analysisData.degradedReasons?.length > 0 && (
+                  <p className="text-xs text-amber-700 dark:text-amber-300">
+                    Degraded signals: {analysisData.degradedReasons.join(", ")}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
 
       {runsData.length > 0 && (
         <Card>

--- a/prisma/migrations/20260411120000_worker_runs_prior_run_analyst/migration.sql
+++ b/prisma/migrations/20260411120000_worker_runs_prior_run_analyst/migration.sql
@@ -1,0 +1,23 @@
+-- Bounded workforce audit trail: worker outputs tied to RunDelta canonical truth
+CREATE TABLE "worker_runs" (
+    "id" UUID NOT NULL,
+    "tenantId" UUID NOT NULL,
+    "workerKey" TEXT NOT NULL,
+    "workerVersion" TEXT NOT NULL DEFAULT '1',
+    "trigger" TEXT NOT NULL DEFAULT 'run_delta_computed',
+    "runDeltaId" UUID NOT NULL,
+    "status" TEXT NOT NULL,
+    "output" JSONB NOT NULL DEFAULT '{}',
+    "evidence" JSONB NOT NULL DEFAULT '[]',
+    "degradedReasons" JSONB NOT NULL DEFAULT '[]',
+    "errorMessage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "worker_runs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "worker_runs_tenantId_workerKey_createdAt_idx" ON "worker_runs"("tenantId", "workerKey", "createdAt" DESC);
+CREATE INDEX "worker_runs_runDeltaId_idx" ON "worker_runs"("runDeltaId");
+
+ALTER TABLE "worker_runs" ADD CONSTRAINT "worker_runs_runDeltaId_fkey" FOREIGN KEY ("runDeltaId") REFERENCES "run_deltas"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1949,12 +1949,39 @@ model RunDelta {
   metadata           Json      @default("{}")
   createdAt         DateTime  @default(now())
 
+  workerRuns        WorkerRun[]
+
   @@unique([currentRunId])
   @@index([tenantId])
   @@index([jobId])
   @@index([previousRunId])
   @@index([createdAt(sort: Desc)])
   @@map("run_deltas")
+}
+
+// Bounded workforce runs: audited, deterministic worker outputs tied to canonical truth (e.g. RunDelta)
+model WorkerRun {
+  id                String    @id @default(uuid())
+  tenantId          String    @db.Uuid
+  workerKey         String    // e.g. prior_run_delta_analyst
+  workerVersion     String    @default("1")
+  trigger           String    @default("run_delta_computed") // run_delta_computed | api_refresh
+
+  runDeltaId        String    @db.Uuid
+  runDelta          RunDelta    @relation(fields: [runDeltaId], references: [id], onDelete: Cascade)
+
+  status            String    // succeeded | failed | insufficient_data
+  output            Json      @default("{}")
+  evidence          Json      @default("[]")
+  degradedReasons   Json      @default("[]")
+  errorMessage      String?   @db.Text
+
+  createdAt         DateTime  @default(now())
+  completedAt       DateTime  @default(now())
+
+  @@index([tenantId, workerKey, createdAt(sort: Desc)])
+  @@index([runDeltaId])
+  @@map("worker_runs")
 }
 
 model PolicyOutcomeLedger {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a **bounded Prior Run Delta Analyst** worker that turns canonical `RunDelta` truth into a deterministic, auditable briefing (headline, posture, bullets, next steps, SHA-256 content hash). Persists runs in a new `worker_runs` table, hooks `RunDeltaService.computeDelta`, and exposes console + Express v1 surfaces for capability disclosure and history.

## Why

Compounds **prior-run institutional memory** without LLM theatre: operators get reusable, evidence-cited briefings; degraded conditions (no prior run, config drift) are explicit.

## Key changes

- Prisma: `WorkerRun` model + migration; relation from `RunDelta`
- `@settler/reconciliation-core`: `prior-run-delta-analyst.ts` (deterministic briefing + evidence refs)
- API: `PriorRunDeltaAnalystService`, `RunDeltaService` records analysis after compute; `GET /api/v1/operator/workforce/*`
- Web: `GET /api/console/workforce/registry`, `/runs`, `/run-deltas/:id/analysis`; Intelligence page workforce section
- Docs: `docs/OPERATOR_MODE.md` section on the analyst

## Verification

- `pnpm --filter @settler/reconciliation-core run build` ✅
- `pnpm --filter @settler/reconciliation-core test` ✅
- `pnpm exec jest src/services/intelligence/__tests__/prior-run-delta-analyst.test.ts` (packages/api) ✅
- ESLint on touched API/web files ✅
- Full repo `pnpm typecheck` / `packages/web typecheck` / `packages/api tsc` report **pre-existing** errors in unrelated files (not introduced by this PR).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2239fd36-a8f7-4115-8c84-69dbfb9ab9d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2239fd36-a8f7-4115-8c84-69dbfb9ab9d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

