### PR TITLE
Productize API reference and strengthen pricing trust surfaces

### DIFF
--- a/packages/web/src/app/docs/api/page.tsx
+++ b/packages/web/src/app/docs/api/page.tsx
@@ -1,312 +1,281 @@
 import { Metadata } from "next";
+import Link from "next/link";
 import { Navigation } from "@/components/Navigation";
 import { Footer } from "@/components/Footer";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { ArrowRight, Copy, Zap } from "lucide-react";
-import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { ArrowRight, CheckCircle2, FileJson, LifeBuoy, ShieldCheck, Terminal } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "API Reference | Settler Docs",
   description:
-    "Comprehensive API reference for integrating Settler into your financial infrastructure.",
+    "Production-facing API surfaces for deterministic runs, replayable evidence, and tenant-safe reconciliation workflows.",
 };
 
-const endpoints = [
+type Endpoint = {
+  method: "GET" | "POST";
+  path: string;
+  summary: string;
+  details: string;
+};
+
+const coreEndpoints: Endpoint[] = [
   {
     method: "POST",
-    path: "/v1/ingest",
-    title: "Batch Ingestion",
-    description: "Accepts a signed array of transaction objects for cryptographic matching.",
+    path: "/api/v1/runs",
+    summary: "Create reconciliation run",
+    details:
+      "Creates a tenant-scoped run. Requires Idempotency-Key and returns canonical run identifiers for downstream evidence and replay.",
   },
   {
     method: "GET",
-    path: "/v1/audit/{run_id}",
-    title: "Retrieve Audit Bundle",
-    description: "Exports a full deterministic proof capsule for a specific reconciliation run.",
+    path: "/api/v1/runs",
+    summary: "List runs",
+    details:
+      "Returns deterministic lifecycle, summary semantics, and provenance metadata for each run in the authenticated tenant.",
   },
   {
-    method: "PATCH",
-    path: "/v1/policies",
-    title: "Update Policy Version",
-    description: "Deploy a new reconciliation DSL snapshot to active worker nodes.",
+    method: "GET",
+    path: "/api/v1/runs/{id}",
+    summary: "Get run detail",
+    details:
+      "Provides canonical run/detail truth for a single run, including status labeling and machine-readable contract fields.",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/runs/{id}/evidence",
+    summary: "Fetch evidence payload",
+    details:
+      "Returns replay- and support-safe evidence artifacts for audit, operator handoff, and downstream control workflows.",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/runs/{id}/replay",
+    summary: "Replay run",
+    details:
+      "Re-executes a prior run contract to verify deterministic behavior and produce fresh traceable output.",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/health | /api/v1/ready | /api/v1/meta",
+    summary: "Health and posture probes",
+    details:
+      "Use liveness, readiness, and metadata probes to decide when to route traffic and surface explicit degraded states.",
   },
 ];
+
+const errorCodes = [
+  "SETTLER_AUTH_REQUIRED",
+  "SETTLER_RATE_LIMITED",
+  "SETTLER_TENANT_REQUIRED",
+  "SETTLER_INVALID_INPUT",
+  "SETTLER_CONFLICT",
+  "SETTLER_NOT_FOUND",
+  "SETTLER_NOT_IMPLEMENTED",
+  "SETTLER_INTERNAL",
+];
+
+const curlCreateRun = `curl -X POST \"https://your-host/api/v1/runs\" \\
+  -H \"X-API-Key: set_live_***\" \\
+  -H \"Idempotency-Key: run-2026-04-close-001\" \\
+  -H \"Content-Type: application/json\" \\
+  -d '{
+    "name": "April close - Stripe vs Bank",
+    "sourceAdapter": "stripe",
+    "targetAdapter": "bank_csv",
+    "rules": []
+  }'`;
+
+const curlReadEvidence = `curl \"https://your-host/api/v1/runs/<run_id>/evidence\" \\
+  -H \"X-API-Key: set_live_***\"`;
+
+function MethodBadge({ method }: { method: Endpoint["method"] }) {
+  return (
+    <Badge
+      variant="outline"
+      className={
+        method === "GET"
+          ? "border-emerald-500/40 text-emerald-500"
+          : "border-blue-500/40 text-blue-500"
+      }
+    >
+      {method}
+    </Badge>
+  );
+}
 
 export default function DocsApiPage() {
   return (
     <div className="min-h-screen bg-background">
       <Navigation />
 
-      {/* Hero Section */}
-      <section className="relative pt-32 pb-24 border-b border-border/40 overflow-hidden bg-card text-white shadow-2xl">
-        <div className="absolute inset-0 bg-grid-white/[0.05] [mask-image:radial-gradient(white,transparent_85%)]" />
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 relative z-10 space-y-10">
-          <div className="flex flex-col items-center text-center space-y-6">
-            <Badge className="bg-primary/20 text-primary border-primary/40 text-xs font-black tracking-[0.2em] uppercase px-4 py-1.5 h-auto">
-              Developer Reference
-            </Badge>
-            <h1 className="text-4xl md:text-7xl font-bold tracking-tight italic">
-              API Documentation
-            </h1>
-            <p className="text-xl text-muted-foreground/60 font-medium max-w-2xl mx-auto leading-relaxed italic underline">
-              Interact with the Settler control plane and ingestion layers programmatically. Built
-              on REST and secured with HMAC-SHA256 signatures.
-            </p>
-          </div>
-
-          <div className="flex justify-center gap-6">
-            <Button
-              size="lg"
-              className="h-14 px-8 font-extrabold shadow-2xl ring-1 ring-primary/40"
-            >
-              Download OpenAPI Spec
+      <section className="border-b border-border/50 bg-muted/20 pt-24 pb-12 sm:pt-28 sm:pb-16">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+          <Badge variant="outline" className="mb-5">
+            API Product Surface
+          </Badge>
+          <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+            API reference (truthful, tenant-safe)
+          </h1>
+          <p className="mt-4 max-w-3xl text-muted-foreground">
+            Settler APIs expose deterministic run execution, evidence retrieval, replay, and health
+            posture. Contracts are designed for operator workflows and audit handoff, not dashboard
+            theatre.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Button asChild>
+              <Link href="/openapi.json">
+                Download v1 OpenAPI
+                <FileJson className="ml-2 h-4 w-4" />
+              </Link>
             </Button>
-            <Button
-              variant="ghost"
-              className="h-14 px-8 font-bold text-muted-foreground/40 hover:text-white border border-white/10 hover:bg-white/5"
-            >
-              View Postman Collection
+            <Button asChild variant="outline">
+              <Link href="/api/docs/openapi">
+                Console API schema
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
             </Button>
           </div>
         </div>
       </section>
 
-      {/* Main Content Area */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 flex flex-col lg:flex-row gap-16">
-        {/* Table of Contents / Sidebar */}
-        <aside className="lg:w-64 space-y-8 flex-shrink-0 relative">
-          <div className="sticky top-32 space-y-10">
-            <div className="space-y-4">
-              <h3 className="text-xs font-black uppercase tracking-widest text-muted-foreground">
-                Getting Started
-              </h3>
-              <nav className="space-y-2">
-                {["Authentication", "Error Codes", "Rate Limits", "Versioning"].map((item) => (
-                  <Link
-                    key={item}
-                    href={`#${item.toLowerCase()}`}
-                    className="block text-sm font-bold text-muted-foreground hover:text-primary transition-colors italic"
-                  >
-                    {item}
-                  </Link>
-                ))}
-              </nav>
-            </div>
-            <div className="space-y-4">
-              <h3 className="text-xs font-black uppercase tracking-widest text-muted-foreground">
-                Endpoints
-              </h3>
-              <nav className="space-y-2">
-                {endpoints.map((ep) => (
-                  <Link
-                    key={ep.path}
-                    href={`#${ep.title.toLowerCase().replace(/ /g, "-")}`}
-                    className="block text-sm font-bold text-muted-foreground hover:text-primary transition-colors italic"
-                  >
-                    {ep.title}
-                  </Link>
-                ))}
-              </nav>
-            </div>
-            <div className="p-6 rounded-2xl bg-muted/20 border border-border/40 text-center space-y-3">
-              <Zap size={24} className="text-primary opacity-40 mx-auto" strokeWidth={3} />
-              <p className="text-[10px] font-black uppercase tracking-widest text-muted-foreground/60 leading-tight">
-                Current Engine Version
+      <main className="mx-auto grid max-w-6xl gap-8 px-4 py-10 sm:px-6 lg:grid-cols-[2fr,1fr] lg:px-8 lg:py-14">
+        <section className="space-y-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>Integration baseline</CardTitle>
+              <CardDescription>
+                Minimum contract expectations before first production call.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <p>
+                • Authenticate with tenant-scoped API keys via{" "}
+                <code className="text-foreground">X-API-Key</code>.
               </p>
-              <p className="text-xs font-bold text-foreground italic border-b border-primary/20 pb-2">
-                settler-core-v2.4.1
+              <p>
+                • Send <code className="text-foreground">Idempotency-Key</code> on run creation to
+                prevent duplicate financial actions.
               </p>
-            </div>
-          </div>
-        </aside>
+              <p>
+                • Expect RFC7807-style problem responses and machine-readable{" "}
+                <code className="text-foreground">code</code> values.
+              </p>
+              <p>
+                • Use <code className="text-foreground">x-request-id</code> for support escalation
+                and run-level traceability.
+              </p>
+            </CardContent>
+          </Card>
 
-        {/* Technical Spec Flow */}
-        <main className="flex-1 space-y-32">
-          {/* Auth Section */}
-          <section id="authentication" className="space-y-10">
-            <div className="space-y-6">
-              <h2 className="text-3xl font-bold tracking-tight italic underline underline-offset-8">
-                Authentication
-              </h2>
-              <p className="text-lg text-muted-foreground font-medium italic">
-                Every request to the Settler API must include a valid authentication header
-                generated from your API key secret.
-              </p>
-            </div>
-            <Card className="bg-card border-white/5 shadow-2xl overflow-hidden glass">
-              <CardHeader className="bg-white/5 border-b border-white/5 p-4 flex flex-row items-center justify-between">
-                <span className="text-[10px] font-mono text-muted-foreground/60 tracking-widest font-black">
-                  X-SETTLER-SIGNATURE HEADER
-                </span>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8 text-muted-foreground hover:text-white"
-                >
-                  <Copy size={14} />
-                </Button>
-              </CardHeader>
-              <CardContent className="p-8 font-mono text-sm text-muted-foreground/40 leading-relaxed overflow-x-auto text-nowrap">
-                <span className="text-indigo-400">Authorization:</span> Bearer{" "}
-                <span className="text-teal-400">set_prod_821sL...</span>
-                <br />
-                <span className="text-indigo-400">X-Settler-Timestamp:</span> 1710921405
-                <br />
-                <span className="text-indigo-400">X-Settler-Signature:</span>{" "}
-                <span className="text-amber-200">sha256(secret, payload)</span>
-              </CardContent>
-            </Card>
-          </section>
-
-          {/* Endpoints Loop */}
-          <section className="space-y-24">
-            {endpoints.map((ep) => (
-              <div
-                key={ep.path}
-                id={ep.title.toLowerCase().replace(/ /g, "-")}
-                className="space-y-10 border-t border-border/20 pt-24 first:border-0 first:pt-0"
-              >
-                <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
-                  <div className="space-y-4">
-                    <div className="flex items-center gap-4">
-                      <div
-                        className={`px-4 py-1 rounded-lg text-xs font-black h-auto ${ep.method === "POST" ? "bg-indigo-600 text-white" : ep.method === "GET" ? "bg-teal-600 text-white" : "bg-amber-600 text-white"}`}
-                      >
-                        {ep.method}
-                      </div>
-                      <code className="text-xl font-bold font-mono tracking-tight text-foreground">
-                        {ep.path}
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold tracking-tight">Core endpoints</h2>
+            <div className="space-y-3">
+              {coreEndpoints.map((endpoint) => (
+                <Card key={`${endpoint.method}-${endpoint.path}`}>
+                  <CardHeader className="pb-3">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <MethodBadge method={endpoint.method} />
+                      <code className="rounded bg-muted px-2 py-1 text-sm text-foreground">
+                        {endpoint.path}
                       </code>
                     </div>
-                    <h2 className="text-3xl font-bold italic underline underline-offset-8 tracking-tight">
-                      {ep.title}
-                    </h2>
-                  </div>
-                  <Button
-                    variant="outline"
-                    className="h-10 font-bold gap-2 italic underline underline-offset-4 border-primary/20 bg-primary/5 text-primary"
-                  >
-                    Try in Playground
-                    <ArrowRight size={14} />
-                  </Button>
+                    <CardTitle className="text-base">{endpoint.summary}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-0 text-sm text-muted-foreground">
+                    {endpoint.details}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Terminal className="h-4 w-4" />
+                  Create run
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-xs text-foreground">
+                  {curlCreateRun}
+                </pre>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Terminal className="h-4 w-4" />
+                  Fetch evidence
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-xs text-foreground">
+                  {curlReadEvidence}
+                </pre>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <Alert>
+            <ShieldCheck className="h-4 w-4" />
+            <AlertTitle>Degraded-state contract</AlertTitle>
+            <AlertDescription>
+              Readiness and rate-limit surfaces are explicit. If a dependency degrades, operators
+              should still receive machine-visible status, not silent success.
+            </AlertDescription>
+          </Alert>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Problem codes</CardTitle>
+              <CardDescription>Stable error semantics for workflow automation.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {errorCodes.map((code) => (
+                <div
+                  key={code}
+                  className="rounded border border-border/60 bg-muted/30 px-2 py-1 font-mono text-xs"
+                >
+                  {code}
                 </div>
+              ))}
+            </CardContent>
+          </Card>
 
-                <p className="text-lg text-muted-foreground font-medium max-w-2xl leading-relaxed italic border-l-2 border-primary/20 pl-6 shadow-sm shadow-primary/5">
-                  {ep.description}
-                </p>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                  <div className="space-y-6">
-                    <h4 className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground/60">
-                      Request Body
-                    </h4>
-                    <div className="p-6 rounded-2xl bg-card border border-border/40 shadow-sm space-y-4">
-                      {[
-                        { name: "tenant_id", type: "UUID", req: true },
-                        { name: "payload", type: "Array<Item>", req: true },
-                        { name: "tags", type: "Map<string, string>", req: false },
-                      ].map((p) => (
-                        <div
-                          key={p.name}
-                          className="flex items-center justify-between border-b last:border-0 border-border/20 pb-3 last:pb-0"
-                        >
-                          <div className="flex flex-col">
-                            <span className="text-xs font-bold font-mono">{p.name}</span>
-                            <span className="text-[10px] text-muted-foreground font-black uppercase">
-                              {p.type}
-                            </span>
-                          </div>
-                          {p.req && (
-                            <Badge className="bg-destructive/10 text-destructive border-destructive/20 text-[9px] font-black h-4 uppercase">
-                              Required
-                            </Badge>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                  <div className="space-y-6">
-                    <h4 className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground/60">
-                      Success Response
-                    </h4>
-                    <Card className="bg-card border-white/5 h-full flex flex-col glass">
-                      <CardContent className="flex-1 p-6 font-mono text-sm text-muted-foreground/60 overflow-hidden text-nowrap">
-                        {`{`}
-                        <br />
-                        &nbsp;&nbsp;<span className="text-teal-400">&quot;status&quot;</span>:{" "}
-                        <span className="text-amber-200">&quot;ok&quot;</span>,<br />
-                        &nbsp;&nbsp;<span className="text-teal-400">&quot;run_id&quot;</span>:{" "}
-                        <span className="text-amber-200">&quot;uuid-v4&quot;</span>,<br />
-                        &nbsp;&nbsp;<span className="text-teal-400">
-                          &quot;proof_hash&quot;
-                        </span>: <span className="text-amber-200">&quot;sha3_256...&quot;</span>
-                        <br />
-                        {`}`}
-                      </CardContent>
-                    </Card>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </section>
-        </main>
-      </div>
-
-      {/* Support / Help */}
-      <section className="py-32 px-4 border-t border-border/40 text-center space-y-12">
-        <div className="max-w-2xl mx-auto space-y-6">
-          <h2 className="text-3xl font-bold tracking-tight italic underline underline-offset-8">
-            Have Complex Integration Needs?
-          </h2>
-          <p className="text-lg text-muted-foreground font-medium italic underline">
-            Our SDK engineers can assist with custom adapter development and performance tuning.
-            Reach out via our developer relations portal.
-          </p>
-        </div>
-        <div className="flex justify-center gap-6">
-          <Button className="h-14 px-8 font-extrabold shadow-2xl ring-1 ring-primary/40">
-            Developer Discord
-          </Button>
-          <Button
-            variant="outline"
-            className="h-14 px-8 font-bold border-l border-primary/20 bg-primary/5 text-primary italic underline"
-          >
-            Contact DevRel
-          </Button>
-        </div>
-      </section>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Need help integrating?</CardTitle>
+              <CardDescription>
+                For enterprise onboarding, include request IDs, endpoint path, and tenant scope in
+                support intake.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Button asChild variant="outline" className="w-full justify-start">
+                <Link href="/docs/support">
+                  <LifeBuoy className="mr-2 h-4 w-4" />
+                  Support intake
+                </Link>
+              </Button>
+              <Button asChild variant="ghost" className="w-full justify-start">
+                <Link href="/docs/auth">
+                  <CheckCircle2 className="mr-2 h-4 w-4" />
+                  Auth details
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </aside>
+      </main>
 
       <Footer />
     </div>
-  );
-}
-
-function Button({
-  children,
-  className,
-  variant = "default",
-  size = "default",
-  asChild = false,
-  ...props
-}: any) {
-  const Comp = asChild ? "div" : "button";
-  const variants: any = {
-    default: "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm",
-    outline: "border border-border bg-background hover:bg-accent hover:text-accent-foreground",
-    ghost: "hover:bg-accent hover:text-accent-foreground font-black",
-  };
-  const sizes: any = {
-    default: "h-10 px-4 py-2",
-    sm: "h-9 rounded-md px-3",
-    lg: "h-11 rounded-md px-8",
-  };
-  return (
-    <Comp
-      className={`inline-flex items-center justify-center rounded-xl text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${variants[variant]} ${sizes[size]} ${className}`}
-      {...props}
-    >
-      {children}
-    </Comp>
   );
 }

--- a/packages/web/src/app/pricing/page.tsx
+++ b/packages/web/src/app/pricing/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { VisualGrid } from "@/components/site/infographics";
 import { COMMERCIAL_OFFERS, OfferCode } from "@/domain/billing/commercialModel";
 import { PREMIUM_PACKS } from "@/domain/billing/premiumPacks";
+import { calculateMonthlyCost, planConfigs } from "@/domain/billing/planConfig";
 
 export const metadata = {
   title: "Pricing | Settler",
@@ -24,6 +25,21 @@ const iconByOffer: Record<OfferCode, LucideIcon> = {
 };
 
 export default function PricingPage() {
+  const pricingScenarios = [
+    {
+      label: "Cloud API baseline",
+      plan: "growth" as const,
+      volume: 100_000,
+      exceptions: 1_000,
+    },
+    {
+      label: "Managed close operations",
+      plan: "scale" as const,
+      volume: 350_000,
+      exceptions: 6_000,
+    },
+  ];
+
   return (
     <div className="min-h-screen bg-background">
       <Navigation />
@@ -110,6 +126,52 @@ export default function PricingPage() {
       {/* Feature Comparison */}
       <FeatureComparison />
 
+      <Section className="border-t border-border/40 py-16 sm:py-20">
+        <div className="mx-auto max-w-7xl">
+          <SectionHeader
+            title="Metering truth (deterministic billing inputs)"
+            description="Settler bills by reconciliation volume and exception load using canonical plan limits. The estimator below uses the same plan config contract used by the product."
+          />
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            {pricingScenarios.map((scenario) =>
+              (() => {
+                const plan = planConfigs[scenario.plan];
+                if (!plan) return null;
+
+                return (
+                  <Card key={scenario.label} className="border-border/50">
+                    <CardHeader>
+                      <CardTitle className="text-lg">{scenario.label}</CardTitle>
+                      <CardDescription>
+                        Plan: {plan.name} · {scenario.volume.toLocaleString()} reconciliations ·{" "}
+                        {scenario.exceptions.toLocaleString()} exceptions
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="pt-0">
+                      <p className="text-sm text-muted-foreground">
+                        Estimated monthly bill:
+                        <span className="ml-2 text-base font-semibold text-foreground">
+                          $
+                          {calculateMonthlyCost(
+                            scenario.plan,
+                            scenario.volume,
+                            scenario.exceptions
+                          ).toLocaleString()}
+                        </span>
+                      </p>
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        Includes base fee plus usage under the canonical spine. Enterprise contracts
+                        can override limits, retention, and support terms.
+                      </p>
+                    </CardContent>
+                  </Card>
+                );
+              })()
+            )}
+          </div>
+        </div>
+      </Section>
+
       <Section className="border-t border-border/40 py-16 sm:py-20 bg-muted/10">
         <div className="mx-auto max-w-7xl">
           <SectionHeader
@@ -190,6 +252,26 @@ export default function PricingPage() {
 
       <Section className="bg-muted/10">
         <VisualGrid />
+      </Section>
+
+      <Section className="border-y border-border/40 py-16 sm:py-20">
+        <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 text-center">
+          <SectionHeader
+            title="API onboarding in under 30 minutes"
+            description="Start with run creation, evidence retrieval, and replay routes. Promote to Managed / Enterprise when you need contractual reliability and named operator support."
+          />
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <Button asChild>
+              <Link href="/docs/api">Review API contracts</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/openapi.json">Download OpenAPI</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/contact">Talk to solutions engineering</Link>
+            </Button>
+          </div>
+        </div>
       </Section>
 
       <CTASection

--- a/packages/web/src/lib/metadata.ts
+++ b/packages/web/src/lib/metadata.ts
@@ -105,11 +105,16 @@ export function generateMetadata({
  */
 export function generatePricingMetadata(): Metadata {
   return generateMetadata({
-    title: "Enterprise - Hosted Infrastructure",
+    title: "Pricing - Plans for OSS, Cloud API, and Enterprise",
     description:
-      "Optional hosted infrastructure for organizations that want managed deployment and scale without changing core reconciliation logic.",
-    keywords: ["enterprise hosting", "managed reconciliation", "infrastructure scale"],
-    canonical: `${getDefaultSiteUrl()}/enterprise`,
+      "Transparent Settler pricing for deterministic reconciliation: OSS, Cloud API, Managed Operations, and Enterprise deployment tiers.",
+    keywords: [
+      "reconciliation pricing",
+      "api pricing",
+      "managed reconciliation",
+      "enterprise reconciliation platform",
+    ],
+    canonical: `${getDefaultSiteUrl()}/pricing`,
   });
 }
 


### PR DESCRIPTION
### Motivation
- Align public API documentation and pricing copy with backend-owned truth so integrators and buyers see deterministic, tenant-safe contracts and concrete cost signals. 
- Improve conversion and operator trust by exposing canonical OpenAPI links, idempotency/auth guidance, explicit degraded-state messaging, and a deterministic billing estimator tied to the product plan contract.

### Description
- Rebuilt the API docs page at `packages/web/src/app/docs/api/page.tsx` to list canonical `/api/v1/*` endpoints, include runnable cURL examples, surface RFC7807 problem codes, and add explicit degraded-state guidance and OpenAPI download links.
- Added deterministic billing estimator cards to `packages/web/src/app/pricing/page.tsx` that use the canonical `calculateMonthlyCost` and `planConfigs` contract to show realistic monthly cost scenarios and an API onboarding CTA strip (docs / OpenAPI / contact) to tighten OSS→Cloud conversion flow.
- Updated pricing metadata generation in `packages/web/src/lib/metadata.ts` to use clear pricing-focused title/description/keywords and canonical `/pricing` URL.
- Defensive rendering: pricing scenario cards guard against missing `planConfigs` to avoid runtime undefined access in the UI.

### Testing
- `pnpm --filter @settler/web lint` ✅ — frontend lint completed (warnings exist elsewhere but command exits success). 
- `pnpm --filter @settler/web exec eslint src/app/docs/api/page.tsx src/app/pricing/page.tsx src/lib/metadata.ts` ✅ — targeted ESLint check for changed files passed.
- `pnpm --filter @settler/web exec jest --runInBand --findRelatedTests src/app/docs/api/page.tsx src/app/pricing/page.tsx src/lib/metadata.ts --passWithNoTests` ✅ — no related tests found (command exited 0).
- `pnpm --filter @settler/web typecheck` ❌ — TypeScript typecheck failed due to pre-existing, repo-wide type/parse issues (missing `@settler/reconciliation-core` type resolution and several parse/type errors in other packages) and an environment Node version mismatch warning; these failures are outside the surface changed by this PR and require a separate repo-wide remediation.

Notes:
- Pre-commit hooks ran staged verification during commit; the hook surfaced pre-existing parse errors in `packages/api` and staged-package verification was skipped per the hook fallback (commit completed). 
- The local environment shows Node version warnings (`node >=24 <25` required) which produced non-fatal warnings during verification commands (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda6dbe26c8328a719fb21728fc34f)