### PR TITLE
⚡ Bolt: Batch subscription checks to resolve N+1 query in insights engine

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-06 - N+1 Supabase Query in Loops
+**Learning:** In the ops-intelligence analytics (`generateCostInsights`), using `await supabase.from("subscriptions").select(...)` inside a tight loop over a large Map significantly degrades performance. Furthermore, failing to handle Supabase URL length limits (HTTP 414) when rewriting such loops using `.in(...)` array queries can cause unhandled silent fallbacks.
+**Action:** When extracting N+1 queries from loops using Supabase `.in(...)` operations, always chunk the candidate IDs array to avoid URL length constraints, and ensure failure states explicitly track the error to avoid processing regressions.

--- a/packages/api/src/services/ops-intelligence/insights-engine.ts
+++ b/packages/api/src/services/ops-intelligence/insights-engine.ts
@@ -215,26 +215,52 @@ async function generateCostInsights(
         });
 
         const highCostLowRevOrgs: string[] = [];
+        const candidateTenantIds = Array.from(orgCostMap.entries())
+          .filter(([, cost]) => cost > 100)
+          .map(([tenantId]) => tenantId);
+
+        let queryFailed = false;
+        const activeSubTenants = new Set<string>();
+
+        // Chunk to avoid 414 URI Too Long errors
+        const MAX_CHUNK_SIZE = 50;
+
+        for (let i = 0; i < candidateTenantIds.length; i += MAX_CHUNK_SIZE) {
+          const chunk = candidateTenantIds.slice(i, i + MAX_CHUNK_SIZE);
+          try {
+            // Single batch query for active subscriptions mapped to tenant_ids
+            const { data: activeBilling } = await supabase
+              .from("billing_accounts")
+              .select("tenant_id, subscriptions!inner(status)")
+              .in("tenant_id", chunk)
+              .eq("subscriptions.status", "active");
+
+            if (activeBilling) {
+              for (const record of activeBilling) {
+                if (record.tenant_id) {
+                  activeSubTenants.add(record.tenant_id);
+                }
+              }
+            }
+          } catch (_error) {
+            queryFailed = true;
+            break; // Stop querying if the DB is failing
+          }
+        }
+
         for (const [tenantId, cost] of orgCostMap.entries()) {
           if (cost > 100) {
-            // Check if org has active subscription
-            try {
-              const { data: subscriptions } = await supabase
-                .from("subscriptions")
-                .select("billing_account_id, status")
-                .eq("status", "active")
-                .limit(100);
-
-              const hasActiveSub = subscriptions?.some(() => true); // Simplified check
-              if (!hasActiveSub || cost > 500) {
-                highCostLowRevOrgs.push(tenantId);
-                if (highCostLowRevOrgs.length >= 10) break; // Limit results
-              }
-            } catch {
-              // If subscription check fails, still flag high-cost orgs
+            if (queryFailed) {
+              // If subscription check fails, fall back to high-cost orgs
               if (cost > 500) {
                 highCostLowRevOrgs.push(tenantId);
                 if (highCostLowRevOrgs.length >= 10) break;
+              }
+            } else {
+              const hasActiveSub = activeSubTenants.has(tenantId);
+              if (!hasActiveSub || cost > 500) {
+                highCostLowRevOrgs.push(tenantId);
+                if (highCostLowRevOrgs.length >= 10) break; // Limit results
               }
             }
           }

--- a/patch_insights3.py
+++ b/patch_insights3.py
@@ -1,0 +1,92 @@
+import re
+
+with open("packages/api/src/services/ops-intelligence/insights-engine.ts", "r") as f:
+    content = f.read()
+
+search = """        const activeSubTenants = new Set<string>();
+
+        if (candidateTenantIds.length > 0) {
+          try {
+            // Single batch query for active subscriptions mapped to tenant_ids
+            const { data: activeBilling } = await supabase
+              .from("billing_accounts")
+              .select("tenant_id, subscriptions!inner(status)")
+              .in("tenant_id", candidateTenantIds)
+              .eq("subscriptions.status", "active");
+
+            if (activeBilling) {
+              for (const record of activeBilling) {
+                if (record.tenant_id) {
+                  activeSubTenants.add(record.tenant_id);
+                }
+              }
+            }
+          } catch (_error) {
+            // Ignore error and fall back to cost > 500 check only
+          }
+        }
+
+        for (const [tenantId, cost] of orgCostMap.entries()) {
+          if (cost > 100) {
+            const hasActiveSub = activeSubTenants.has(tenantId);
+            if (!hasActiveSub || cost > 500) {
+              highCostLowRevOrgs.push(tenantId);
+              if (highCostLowRevOrgs.length >= 10) break; // Limit results
+            }
+          }
+        }"""
+
+replace = """        let queryFailed = false;
+        const activeSubTenants = new Set<string>();
+
+        // Chunk to avoid 414 URI Too Long errors
+        const MAX_CHUNK_SIZE = 50;
+
+        for (let i = 0; i < candidateTenantIds.length; i += MAX_CHUNK_SIZE) {
+          const chunk = candidateTenantIds.slice(i, i + MAX_CHUNK_SIZE);
+          try {
+            // Single batch query for active subscriptions mapped to tenant_ids
+            const { data: activeBilling } = await supabase
+              .from("billing_accounts")
+              .select("tenant_id, subscriptions!inner(status)")
+              .in("tenant_id", chunk)
+              .eq("subscriptions.status", "active");
+
+            if (activeBilling) {
+              for (const record of activeBilling) {
+                if (record.tenant_id) {
+                  activeSubTenants.add(record.tenant_id);
+                }
+              }
+            }
+          } catch (_error) {
+            queryFailed = true;
+            break; // Stop querying if the DB is failing
+          }
+        }
+
+        for (const [tenantId, cost] of orgCostMap.entries()) {
+          if (cost > 100) {
+            if (queryFailed) {
+              // If subscription check fails, fall back to high-cost orgs
+              if (cost > 500) {
+                highCostLowRevOrgs.push(tenantId);
+                if (highCostLowRevOrgs.length >= 10) break;
+              }
+            } else {
+              const hasActiveSub = activeSubTenants.has(tenantId);
+              if (!hasActiveSub || cost > 500) {
+                highCostLowRevOrgs.push(tenantId);
+                if (highCostLowRevOrgs.length >= 10) break; // Limit results
+              }
+            }
+          }
+        }"""
+
+new_content = content.replace(search, replace)
+if content == new_content:
+    print("Failed to replace string")
+else:
+    with open("packages/api/src/services/ops-intelligence/insights-engine.ts", "w") as f:
+        f.write(new_content)
+    print("Successfully replaced string")


### PR DESCRIPTION
💡 What: Refactored the `generateCostInsights` function to collect all candidate high-cost tenant IDs upfront. It then performs chunked batched requests to fetch active subscription status for these tenants in a `Set`, bypassing the N+1 `supabase` query execution inside the `orgCostMap` loop.

🎯 Why: The original code executed a database query inside the loop for every tenant with a cost > 100, which causes massive N+1 query execution bottlenecks as tenant count grows. It also fetched 100 subscriptions without actually filtering by the active `tenantId`, resulting in a logical flaw and unnecessary network overhead.

📊 Impact: Reduces `subscriptions` table database queries in `generateCostInsights` from O(N) where N is the number of tenants with `cost > 100`, to O(N/50) batched requests. This will significantly decrease analytics generation time, database load, and prevent potential timeouts.

🔬 Measurement: The optimization can be verified by observing the total execution time of `generateCostInsights` and monitoring the `usage_aggregate_daily` metrics logs. The unit tests for `insights-engine.ts` have been verified locally.

---
*PR created automatically by Jules for task [17982126189076349152](https://jules.google.com/task/17982126189076349152) started by @Hardonian*