### PR TITLE
🔒 [security] Fix SQL Injection in Write Buffer Logs

### DIFF
--- a/packages/web/src/__tests__/lib/db/write-buffer.security.test.ts
+++ b/packages/web/src/__tests__/lib/db/write-buffer.security.test.ts
@@ -1,0 +1,116 @@
+import { flushApiCallLogs, bufferApiCallLog } from "@/lib/db/write-buffer";
+import { prisma } from "@/shared/db/prismaClient";
+
+jest.mock("@/shared/db/prismaClient", () => ({
+  prisma: {
+    $executeRaw: jest.fn().mockResolvedValue(1),
+  },
+}));
+
+jest.mock("@/lib/utils/logger", () => ({
+  appLogger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("Write Buffer Security", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should safely handle SQL injection attempts in API call logs", async () => {
+    const maliciousLog = {
+      tenantId: "tenant-1",
+      userId: "user-1",
+      method: "GET",
+      path: "/api/test",
+      statusCode: 200,
+      responseTime: 100,
+      userAgent: "') OR '1'='1",
+      ipAddress: "127.0.0.1",
+      error: "'); DROP TABLE api_call_logs; --",
+      createdAt: new Date(),
+    };
+
+    // Trigger sync write (since buffering is disabled in test env by default)
+    await bufferApiCallLog(maliciousLog);
+
+    expect(prisma.$executeRaw).toHaveBeenCalled();
+
+    // The first argument to $executeRaw should be a template strings array (or something that Prisma handles)
+    // When using tagged template literals, the parameters are passed separately from the SQL string.
+    const mockPrisma = prisma as any;
+    const call = mockPrisma.$executeRaw.mock.calls[0];
+    const sqlParts = call[0];
+
+    // Verify that malicious strings are passed as parameters, not part of the SQL string
+    const params = call.slice(1);
+
+    let foundUserAgent = false;
+    let foundError = false;
+    for (const param of params) {
+      if (param === maliciousLog.userAgent) foundUserAgent = true;
+      if (param === maliciousLog.error) foundError = true;
+    }
+    expect(foundUserAgent).toBe(true);
+    expect(foundError).toBe(true);
+
+    // Ensure the SQL itself doesn't contain the unescaped malicious strings
+    const fullSql = sqlParts.join("?");
+    expect(fullSql).not.toContain("OR '1'='1");
+    expect(fullSql).not.toContain("DROP TABLE api_call_logs");
+  });
+
+  it("should safely handle batch inserts with malicious data", async () => {
+    const maliciousLogs = [
+      {
+        tenantId: "tenant-1",
+        userId: "user-1",
+        method: "GET",
+        path: "/api/test1",
+        statusCode: 200,
+        responseTime: 100,
+        userAgent: "safe-agent",
+        ipAddress: "127.0.0.1",
+        createdAt: new Date(),
+      },
+      {
+        tenantId: "tenant-1",
+        userId: "user-1",
+        method: "POST",
+        path: "/api/test2",
+        statusCode: 500,
+        responseTime: 200,
+        userAgent: "') UNION SELECT NULL--",
+        ipAddress: "127.0.0.2",
+        error: "injection'); --",
+        createdAt: new Date(),
+      }
+    ];
+
+    // We need to put logs into the in-memory buffer first
+    const { inMemoryBuffers } = require("@/lib/db/write-buffer");
+    inMemoryBuffers.apiCallLogs.push(...maliciousLogs);
+
+    await flushApiCallLogs();
+
+    expect(prisma.$executeRaw).toHaveBeenCalled();
+
+    // Check parameters of the batch insert
+    const mockPrisma = prisma as any;
+    const call = mockPrisma.$executeRaw.mock.calls[0];
+    const params = call.slice(1);
+
+    let foundUserAgent = false;
+    let foundError = false;
+    for (const param of params) {
+      if (param === maliciousLogs[1].userAgent) foundUserAgent = true;
+      if (param === maliciousLogs[1].error) foundError = true;
+    }
+    expect(foundUserAgent).toBe(true);
+    expect(foundError).toBe(true);
+  });
+});

--- a/packages/web/src/lib/db/write-buffer.ts
+++ b/packages/web/src/lib/db/write-buffer.ts
@@ -16,6 +16,7 @@
 import { prisma } from "@/shared/db/prismaClient";
 import { appLogger } from "@/lib/utils/logger";
 import { Redis } from "@upstash/redis";
+import { Prisma } from "@prisma/client";
 
 // ============================================================================
 // CONFIGURATION
@@ -302,18 +303,16 @@ export async function flushApiCallLogs(): Promise<void> {
 
     // Batch insert (using raw SQL for api_call_logs table)
     // Note: Adjust column names based on actual schema
-    const values = logs
-      .map(
-        (log) =>
-          `(${log.tenantId ? `'${log.tenantId}'` : "NULL"}, ${log.userId ? `'${log.userId}'` : "NULL"}, '${log.method}', '${log.path}', ${log.statusCode}, ${log.responseTime}, ${log.userAgent ? `'${log.userAgent.replace(/'/g, "''")}'` : "NULL"}, ${log.ipAddress ? `'${log.ipAddress}'` : "NULL"}, ${log.error ? `'${log.error.replace(/'/g, "''")}'` : "NULL"}, '${log.createdAt.toISOString()}')`
-      )
-      .join(",");
+    const valueRows = logs.map(
+      (log) =>
+        Prisma.sql`(${log.tenantId ?? null}, ${log.userId ?? null}, ${log.method}, ${log.path}, ${log.statusCode}, ${log.responseTime}, ${log.userAgent ?? null}, ${log.ipAddress ?? null}, ${log.error ?? null}, ${log.createdAt})`
+    );
 
-    await prisma.$executeRawUnsafe(`
+    await prisma.$executeRaw`
       INSERT INTO api_call_logs (tenant_id, user_id, method, path, status_code, response_time, user_agent, ip_address, error, created_at)
-      VALUES ${values}
+      VALUES ${Prisma.join(valueRows)}
       ON CONFLICT DO NOTHING
-    `);
+    `;
 
     const duration = Date.now() - startTime;
     appLogger.info("[Write Buffer] Flushed API call logs", {
@@ -404,10 +403,10 @@ async function syncWriteUsageEvent(event: UsageEventBuffer): Promise<void> {
 
 async function syncWriteApiCallLog(log: ApiCallLogBuffer): Promise<void> {
   try {
-    await prisma.$executeRawUnsafe(`
+    await prisma.$executeRaw`
       INSERT INTO api_call_logs (tenant_id, user_id, method, path, status_code, response_time, user_agent, ip_address, error, created_at)
-      VALUES (${log.tenantId ? `'${log.tenantId}'` : "NULL"}, ${log.userId ? `'${log.userId}'` : "NULL"}, '${log.method}', '${log.path}', ${log.statusCode}, ${log.responseTime}, ${log.userAgent ? `'${log.userAgent.replace(/'/g, "''")}'` : "NULL"}, ${log.ipAddress ? `'${log.ipAddress}'` : "NULL"}, ${log.error ? `'${log.error.replace(/'/g, "''")}'` : "NULL"}, '${log.createdAt.toISOString()}')
-    `);
+      VALUES (${log.tenantId ?? null}, ${log.userId ?? null}, ${log.method}, ${log.path}, ${log.statusCode}, ${log.responseTime}, ${log.userAgent ?? null}, ${log.ipAddress ?? null}, ${log.error ?? null}, ${log.createdAt})
+    `;
   } catch (error) {
     appLogger.error("[Write Buffer] Sync write API call log failed", { error, log });
   }

--- a/packages/web/src/lib/db/write-buffer.ts
+++ b/packages/web/src/lib/db/write-buffer.ts
@@ -13,10 +13,9 @@
  * - Write queue with periodic flush
  */
 
-import { prisma } from "@/shared/db/prismaClient";
+import { prisma, Prisma } from "@/shared/db/prismaClient";
 import { appLogger } from "@/lib/utils/logger";
 import { Redis } from "@upstash/redis";
-import { Prisma } from "@prisma/client";
 
 // ============================================================================
 // CONFIGURATION
@@ -105,7 +104,7 @@ export interface AuditLogBuffer {
 // IN-MEMORY BUFFERS (FALLBACK)
 // ============================================================================
 
-const inMemoryBuffers = {
+export const inMemoryBuffers = {
   usageEvents: [] as UsageEventBuffer[],
   apiCallLogs: [] as ApiCallLogBuffer[],
   auditLogs: [] as AuditLogBuffer[],

--- a/packages/web/src/shared/db/prismaClient.ts
+++ b/packages/web/src/shared/db/prismaClient.ts
@@ -65,9 +65,12 @@ if (typeof process !== "undefined" && process.env) {
 
 // Use require after env setup so Prisma reads the correct runtime configuration.
 
-const { PrismaClient } = require("@prisma/client") as {
+const { PrismaClient, Prisma } = require("@prisma/client") as {
   PrismaClient: typeof import("@prisma/client").PrismaClient;
+  Prisma: typeof import("@prisma/client").Prisma;
 };
+
+export { Prisma };
 
 type PrismaQueryRaw = {
   $queryRaw<T = unknown>(query: TemplateStringsArray, ...values: unknown[]): Promise<T>;


### PR DESCRIPTION
🎯 **What:** Fixed a SQL injection vulnerability in the write buffer service where API call logs were being inserted into the database using unsafe string interpolation.
⚠️ **Risk:** Malicious users could potentially execute arbitrary SQL commands by crafting malicious `userAgent` or `error` strings, leading to data breaches or database corruption.
🛡️ **Solution:** Switched from `prisma.\$executeRawUnsafe` to `prisma.\$executeRaw` with proper parameterization. Used `Prisma.join` for secure batch inserts and template literals for single inserts, ensuring all user-provided data is treated as parameters rather than executable code.

---
*PR created automatically by Jules for task [3412437822572756222](https://jules.google.com/task/3412437822572756222) started by @Hardonian*