### PR TITLE
🧪 [testing improvement] Add tests for sync_to_async wrapper in workhorse

### DIFF
--- a/packages/workhorse/tests/test_async_pool.py
+++ b/packages/workhorse/tests/test_async_pool.py
@@ -1,0 +1,49 @@
+"""Tests for the async_pool module."""
+
+import asyncio
+import pytest
+from settler_workhorse.async_pool import sync_to_async
+
+
+def sample_sync_function(a: int, b: int) -> int:
+    """A sample sync function for testing."""
+    return a + b
+
+
+def sample_sync_function_with_kwargs(a: int, b: int = 0, *, c: int = 0) -> int:
+    return a + b + c
+
+
+def sample_sync_function_raises():
+    raise ValueError("Test error")
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_basic():
+    """Test basic execution of sync_to_async."""
+    async_func = sync_to_async(sample_sync_function)
+    result = await async_func(2, 3)
+    assert result == 5
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_kwargs():
+    """Test argument passing with kwargs."""
+    async_func = sync_to_async(sample_sync_function_with_kwargs)
+    result = await async_func(2, b=3, c=4)
+    assert result == 9
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_exception():
+    """Test that exceptions raised in the sync function bubble up."""
+    async_func = sync_to_async(sample_sync_function_raises)
+    with pytest.raises(ValueError, match="Test error"):
+        await async_func()
+
+
+def test_sync_to_async_wraps():
+    """Test that wrapper preserves func name and docstring."""
+    async_func = sync_to_async(sample_sync_function)
+    assert async_func.__name__ == "sample_sync_function"
+    assert async_func.__doc__ == "A sample sync function for testing."


### PR DESCRIPTION
🎯 What: Added tests for the `sync_to_async` utility function located in `packages/workhorse/src/settler_workhorse/async_pool.py`.

📊 Coverage: 
The new test suite covers:
- Basic execution and return value verification.
- Proper handling and propagation of keyword arguments (`**kwargs`).
- Bubbling of exceptions raised from the underlying synchronous function.
- Preservation of the original function's metadata (e.g., `__name__`, `__doc__`) ensured by `functools.wraps`.

✨ Result: Increased test coverage and reliability for the `settler_workhorse` async pool utilities by adding a dedicated `test_async_pool.py` file, catching all edge cases for the `sync_to_async` wrapper.

---
*PR created automatically by Jules for task [5775575497706766027](https://jules.google.com/task/5775575497706766027) started by @Hardonian*