### PR TITLE
🔒 [security fix] Fix SQL injection in statement timeout configuration

### DIFF
--- a/archiver.py
+++ b/archiver.py
@@ -49,7 +49,10 @@ def run_archival_sweeper():
                 infra_settings = cur.fetchone()
                 if infra_settings:
                     timeout_ms = infra_settings[0]
-                    cur.execute(f"SET statement_timeout = {timeout_ms}")
+                    cur.execute(
+                        "SELECT set_config(%s, %s, false)",
+                        ("statement_timeout", str(timeout_ms)),
+                    )
                     logger.info(
                         f"Enforcing operator control plane statement timeout: {timeout_ms}ms"
                     )


### PR DESCRIPTION
🎯 **What**: Replaced vulnerable string interpolation in `SET statement_timeout` with a secure parameterized query using `set_config`.

⚠️ **Risk**: A maliciously crafted `timeout_ms` could allow arbitrary SQL execution with the sweeper's elevated database privileges, potentially leading to data loss or exfiltration.

🛡️ **Solution**: Used `cur.execute("SELECT set_config(%s, %s, false)", ("statement_timeout", str(timeout_ms)))` to securely parameterize the configuration setting.

---
*PR created automatically by Jules for task [15968668796675278153](https://jules.google.com/task/15968668796675278153) started by @Hardonian*