### PR TITLE
🧪 [testing improvement] Add tests for getRequestTimeout middleware

### DIFF
--- a/packages/api/src/__tests__/middleware/request-timeout.test.ts
+++ b/packages/api/src/__tests__/middleware/request-timeout.test.ts
@@ -1,0 +1,17 @@
+import { getRequestTimeout } from "../../middleware/request-timeout";
+
+describe("getRequestTimeout", () => {
+  it("should return 60000 for POST /jobs", () => {
+    expect(getRequestTimeout("/api/v1/jobs", "POST")).toBe(60000);
+  });
+
+  it("should return 45000 for GET /reports", () => {
+    expect(getRequestTimeout("/api/v1/reports", "GET")).toBe(45000);
+  });
+
+  it("should return default timeout 30000 for other routes", () => {
+    expect(getRequestTimeout("/api/v1/users", "GET")).toBe(30000);
+    expect(getRequestTimeout("/api/v1/jobs", "GET")).toBe(30000); // jobs but not POST
+    expect(getRequestTimeout("/api/v1/reports", "POST")).toBe(30000); // reports but not GET
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added a missing test suite for the `getRequestTimeout` middleware function in `packages/api/src/middleware/request-timeout.ts`.
📊 **Coverage:** Added tests to cover the /jobs POST route (60000ms), /reports GET route (45000ms), and the default fallback route (30000ms).
✨ **Result:** Improved test coverage and reliability for request timeout mappings.

---
*PR created automatically by Jules for task [17995410597620565693](https://jules.google.com/task/17995410597620565693) started by @Hardonian*