### PR TITLE
🧪 [testing improvement] Add tests for deprecateEndpoint middleware

### DIFF
--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     "^@settler/support-intake$": "<rootDir>/../support-intake/src/index.ts",
     "^@settler/adapters$": "<rootDir>/../adapters/dist/index.js",
     "^@settler/reconciliation-core$": "<rootDir>/../reconciliation-core/dist/index.js",
+    "^uuid$": require.resolve("uuid"),
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   setupFilesAfterEnv: ["<rootDir>/src/__tests__/setup.ts"],

--- a/packages/api/src/__tests__/middleware/versioning.test.ts
+++ b/packages/api/src/__tests__/middleware/versioning.test.ts
@@ -1,0 +1,49 @@
+import { deprecateEndpoint } from "../../middleware/versioning";
+import { Request, Response, NextFunction } from "express";
+
+describe("deprecateEndpoint Middleware", () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let nextFn: NextFunction;
+
+  beforeEach(() => {
+    mockReq = {};
+    mockRes = {
+      setHeader: jest.fn(),
+    };
+    nextFn = jest.fn() as NextFunction;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should set Deprecation and Sunset headers and call next", () => {
+    const sunsetDate = "2026-12-31T00:00:00Z";
+    const middleware = deprecateEndpoint(sunsetDate);
+
+    middleware(mockReq as Request, mockRes as Response, nextFn);
+
+    expect(mockRes.setHeader).toHaveBeenCalledWith("Deprecation", "true");
+    expect(mockRes.setHeader).toHaveBeenCalledWith("Sunset", sunsetDate);
+    expect(mockRes.setHeader).toHaveBeenCalledTimes(2);
+    expect(nextFn).toHaveBeenCalled();
+  });
+
+  it("should set Deprecation, Sunset, and Link headers when migrationGuideUrl is provided", () => {
+    const sunsetDate = "2026-12-31T00:00:00Z";
+    const migrationGuideUrl = "https://example.com/migration-guide";
+    const middleware = deprecateEndpoint(sunsetDate, migrationGuideUrl);
+
+    middleware(mockReq as Request, mockRes as Response, nextFn);
+
+    expect(mockRes.setHeader).toHaveBeenCalledWith("Deprecation", "true");
+    expect(mockRes.setHeader).toHaveBeenCalledWith("Sunset", sunsetDate);
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      "Link",
+      `<${migrationGuideUrl}>; rel="deprecation"`
+    );
+    expect(mockRes.setHeader).toHaveBeenCalledTimes(3);
+    expect(nextFn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🎯 **What:** This Pull Request addresses a testing gap by adding missing unit tests for the `deprecateEndpoint` middleware located in `packages/api/src/middleware/versioning.ts`. We have also included a configuration change in `packages/api/jest.config.js` (`"^uuid$": require.resolve("uuid")`) to help address pre-existing ESM loading issues with the `uuid` package during `jest` execution.

📊 **Coverage:** The new tests cover:
- Standard deprecation: Ensures `Deprecation` and `Sunset` headers are set correctly.
- Documentation-linked deprecation: Ensures `Deprecation`, `Sunset`, and `Link` headers are set when `migrationGuideUrl` is passed.
- Middleware progression: Ensures the `next()` function is called successfully.

✨ **Result:** Test coverage for the `deprecateEndpoint` middleware has been improved, guaranteeing it behaves exactly as expected and catches regressions early.

---
*PR created automatically by Jules for task [5329407792129437184](https://jules.google.com/task/5329407792129437184) started by @Hardonian*