### PR TITLE
🧹 [code health] Refactor run-operator-mode-migration script

### DIFF
--- a/scripts/run-operator-mode-migration.ts
+++ b/scripts/run-operator-mode-migration.ts
@@ -1,126 +1,132 @@
-/**
- * Run Operator Mode Migration
- * Applies the operator mode migration to the database
- */
-
-import { query } from "../packages/api/src/db";
+import { query } from "@settler/api";
 import { readFileSync } from "fs";
 import { join } from "path";
-import { logInfo, logError } from "../packages/api/src/utils/logger";
+import { logInfo, logError } from "@settler/logger";
+
+const EXPECTED_TABLES = [
+  "alert_rules",
+  "alert_history",
+  "tenant_usage_ceilings",
+  "background_job_limits",
+  "kill_switches",
+  "backup_records",
+  "daily_intelligence",
+];
+
+function loadMigrationStatements(migrationPath: string): string[] {
+  const migrationSQL = readFileSync(migrationPath, "utf-8");
+  logInfo("Migration file loaded", { path: migrationPath });
+
+  return migrationSQL
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith("--") && !s.startsWith("/*"));
+}
+
+async function executeStatements(statements: string[]): Promise<void> {
+  logInfo("Executing migration statements", { count: statements.length });
+
+  for (let i = 0; i < statements.length; i++) {
+    const statement = statements[i];
+    if (!statement || statement.length === 0) continue;
+
+    try {
+      logInfo(`Executing statement ${i + 1}/${statements.length}`);
+      await query(statement);
+      logInfo(`Statement ${i + 1} executed successfully`);
+    } catch (error: any) {
+      // Ignore "already exists" errors (idempotent)
+      const errorMessage = error?.message || String(error);
+      if (
+        errorMessage.includes("already exists") ||
+        errorMessage.includes("duplicate") ||
+        errorMessage.includes("already enabled")
+      ) {
+        logInfo(`Statement ${i + 1} skipped (already exists)`, {
+          statement: statement.substring(0, 100),
+        });
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
+async function verifyTables(): Promise<string[]> {
+  logInfo("Verifying migration...");
+  const tables = await query<{ table_name: string }>(
+    `SELECT table_name
+     FROM information_schema.tables
+     WHERE table_schema = 'public'
+       AND table_name IN (
+         'alert_rules',
+         'alert_history',
+         'tenant_usage_ceilings',
+         'background_job_limits',
+         'kill_switches',
+         'backup_records',
+         'daily_intelligence'
+       )
+     ORDER BY table_name`
+  );
+
+  const foundTables = tables.map((t) => t.table_name);
+  const missingTables = EXPECTED_TABLES.filter((t) => !foundTables.includes(t));
+
+  if (missingTables.length > 0) {
+    throw new Error(`Missing tables: ${missingTables.join(", ")}`);
+  }
+
+  logInfo("Migration verification successful", {
+    tablesFound: foundTables.length,
+    tables: foundTables,
+  });
+
+  return foundTables;
+}
+
+async function verifyIndexes(): Promise<{ indexname: string; tablename: string }[]> {
+  logInfo("Verifying indexes...");
+  const indexes = await query<{ indexname: string; tablename: string }>(
+    `SELECT indexname, tablename
+     FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND tablename IN (
+         'alert_rules',
+         'alert_history',
+         'tenant_usage_ceilings',
+         'background_job_limits',
+         'kill_switches',
+         'backup_records',
+         'daily_intelligence'
+       )
+     ORDER BY tablename, indexname`
+  );
+
+  logInfo("Indexes verified", { count: indexes.length });
+  return indexes;
+}
 
 async function runMigration(): Promise<void> {
   logInfo("Starting operator mode migration");
 
   try {
-    // Read migration file
     const migrationPath = join(
       __dirname,
       "../supabase/migrations/20260131000001_operator_mode.sql"
     );
-    const migrationSQL = readFileSync(migrationPath, "utf-8");
 
-    logInfo("Migration file loaded", { path: migrationPath });
+    const statements = loadMigrationStatements(migrationPath);
+    await executeStatements(statements);
 
-    // Split by semicolons and execute each statement
-    // Remove comments and empty lines
-    const statements = migrationSQL
-      .split(";")
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0 && !s.startsWith("--") && !s.startsWith("/*"));
+    const foundTables = await verifyTables();
+    const indexes = await verifyIndexes();
 
-    logInfo("Executing migration statements", { count: statements.length });
-
-    // Execute each statement
-    for (let i = 0; i < statements.length; i++) {
-      const statement = statements[i];
-      if (!statement || statement.length === 0) continue;
-
-      try {
-        logInfo(`Executing statement ${i + 1}/${statements.length}`);
-        await query(statement);
-        logInfo(`Statement ${i + 1} executed successfully`);
-      } catch (error: any) {
-        // Ignore "already exists" errors (idempotent)
-        const errorMessage = error?.message || String(error);
-        if (
-          errorMessage.includes("already exists") ||
-          errorMessage.includes("duplicate") ||
-          errorMessage.includes("already enabled")
-        ) {
-          logInfo(`Statement ${i + 1} skipped (already exists)`, {
-            statement: statement.substring(0, 100),
-          });
-          continue;
-        }
-        throw error;
-      }
-    }
-
-    // Verify migration
-    logInfo("Verifying migration...");
-    const tables = await query<{ table_name: string }>(
-      `SELECT table_name 
-       FROM information_schema.tables 
-       WHERE table_schema = 'public' 
-         AND table_name IN (
-           'alert_rules',
-           'alert_history',
-           'tenant_usage_ceilings',
-           'background_job_limits',
-           'kill_switches',
-           'backup_records',
-           'daily_intelligence'
-         )
-       ORDER BY table_name`
-    );
-
-    const expectedTables = [
-      "alert_rules",
-      "alert_history",
-      "tenant_usage_ceilings",
-      "background_job_limits",
-      "kill_switches",
-      "backup_records",
-      "daily_intelligence",
-    ];
-
-    const foundTables = tables.map((t) => t.table_name);
-    const missingTables = expectedTables.filter((t) => !foundTables.includes(t));
-
-    if (missingTables.length > 0) {
-      throw new Error(`Missing tables: ${missingTables.join(", ")}`);
-    }
-
-    logInfo("Migration verification successful", {
-      tablesFound: foundTables.length,
-      tables: foundTables,
-    });
-
-    // Verify indexes
-    logInfo("Verifying indexes...");
-    const indexes = await query<{ indexname: string; tablename: string }>(
-      `SELECT indexname, tablename
-       FROM pg_indexes
-       WHERE schemaname = 'public'
-         AND tablename IN (
-           'alert_rules',
-           'alert_history',
-           'tenant_usage_ceilings',
-           'background_job_limits',
-           'kill_switches',
-           'backup_records',
-           'daily_intelligence'
-         )
-       ORDER BY tablename, indexname`
-    );
-
-    logInfo("Indexes verified", { count: indexes.length });
-
-    console.log("\n✅ Operator Mode Migration Completed Successfully!");
-    console.log(`\nTables created: ${foundTables.length}`);
-    foundTables.forEach((table) => console.log(`  - ${table}`));
-    console.log(`\nIndexes created: ${indexes.length}`);
-    console.log("\n✅ Migration verification passed");
+    console.info("\n✅ Operator Mode Migration Completed Successfully!");
+    console.info(`\nTables created: ${foundTables.length}`);
+    foundTables.forEach((table) => console.info(`  - ${table}`));
+    console.info(`\nIndexes created: ${indexes.length}`);
+    console.info("\n✅ Migration verification passed");
   } catch (error) {
     logError("Migration failed", error);
     console.error("\n❌ Migration failed:", error);
@@ -132,7 +138,7 @@ async function runMigration(): Promise<void> {
 if (require.main === module) {
   runMigration()
     .then(() => {
-      console.log("\n✅ Migration completed successfully");
+      console.info("\n✅ Migration completed successfully");
       process.exit(0);
     })
     .catch((error) => {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
🎯 **What:** Refactored the `runMigration` function in `scripts/run-operator-mode-migration.ts` to reduce its length from 133 lines and decrease complexity. Separated distinct concerns (loading SQL, execution, table verification, index verification) into clearly named helper functions. Fixed restricted internal package imports to use workspace package syntax (`@settler/api`, `@settler/logger`). Replaced `console.log` with `console.info` to satisfy `no-console` ESLint rules.

💡 **Why:** This improves maintainability by adhering to the Single Responsibility Principle, making the orchestrating `runMigration` function much easier to read and test. It also resolves lint errors and prevents tight-coupling to internal monorepo structures.

✅ **Verification:** Confirmed via ESLint, Prettier, and TypeScript checks that the refactored script is syntactically valid and type-safe. Run `pnpm test` (noting pre-existing issues un-related to this script).

✨ **Result:** A cleaner, modular, standard-compliant script that accomplishes the same operator mode migration without changing behavior.

---
*PR created automatically by Jules for task [3186746574234357670](https://jules.google.com/task/3186746574234357670) started by @Hardonian*