### PR TITLE
fix(scripts): Prevent false positive in TODO analysis script

### DIFF
--- a/scripts/phase5-analysis.ts
+++ b/scripts/phase5-analysis.ts
@@ -34,7 +34,7 @@ async function analyzeCodebase(): Promise<AnalysisResult> {
       const content = await fs.readFile(file, "utf-8");
       const lines = content.split("\n");
 
-      // Check for TODOs
+      // Check for task markers
       lines.forEach((line, index) => {
         if (line.includes("TODO") || line.includes("FIXME") || line.includes("XXX")) {
           result.todos.push({


### PR DESCRIPTION
Changed the `// Check for TODOs` comment in `scripts/phase5-analysis.ts` to `// Check for task markers` to prevent automated TODO scanners from falsely flagging the documentation comment itself as an actionable task.

---
*PR created automatically by Jules for task [1891631594789225070](https://jules.google.com/task/1891631594789225070) started by @Hardonian*