### PR TITLE
feat: Implement storage service integration in csv_ingestion handler

### DIFF
--- a/packages/workhorse/pyproject.toml
+++ b/packages/workhorse/pyproject.toml
@@ -119,6 +119,8 @@ extend-exclude = '''
 [tool.ruff]
 target-version = "py311"
 line-length = 100
+
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
@@ -139,7 +141,7 @@ ignore = [
     "E501",  # Line too long (handled by black)
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 [tool.mypy]

--- a/packages/workhorse/src/settler_workhorse/handlers/csv_ingestion.py
+++ b/packages/workhorse/src/settler_workhorse/handlers/csv_ingestion.py
@@ -9,6 +9,7 @@ import pandas as pd
 from dateutil import parser as date_parser
 
 from settler_workhorse.models import Job, JobResult, JobType
+from settler_workhorse.storage import get_storage_client
 from settler_workhorse.utils.logging import get_logger
 from settler_workhorse.worker import register_handler
 
@@ -325,17 +326,26 @@ def handle_csv_ingestion(job: Job) -> JobResult:
     file_url = payload.get("file_url")
     file_content_b64 = payload.get("file_content_base64")
 
-    if file_content_b64:
-        import base64
+    try:
+        if file_content_b64:
+            import base64
 
-        content = base64.b64decode(file_content_b64)
-    elif file_path:
-        # TODO: Implement storage service integration
-        raise NotImplementedError("File path storage not yet implemented")
-    elif file_url:
-        # TODO: Implement URL download
-        raise NotImplementedError("File URL download not yet implemented")
-    else:
+            content = base64.b64decode(file_content_b64)
+        elif file_path:
+            storage_client = get_storage_client()
+            content = storage_client.get_file_content(file_path)
+        elif file_url:
+            storage_client = get_storage_client()
+            content = storage_client.download_url(file_url)
+    except Exception as e:
+        return JobResult(
+            success=False,
+            error=f"Failed to retrieve file content: {e}",
+            records_processed=0,
+            records_failed=0,
+        )
+
+    if not (file_content_b64 or file_path or file_url):
         return JobResult(
             success=False,
             error="No file content provided (file_path, file_url, or file_content_base64 required)",

--- a/packages/workhorse/src/settler_workhorse/storage/__init__.py
+++ b/packages/workhorse/src/settler_workhorse/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage package."""
+
+from settler_workhorse.storage.client import StorageClient, get_storage_client
+
+__all__ = ["StorageClient", "get_storage_client"]

--- a/packages/workhorse/src/settler_workhorse/storage/client.py
+++ b/packages/workhorse/src/settler_workhorse/storage/client.py
@@ -1,0 +1,64 @@
+import os
+
+import httpx
+
+from settler_workhorse.config import get_settings
+
+
+class StorageClient:
+    """Client for interacting with storage services."""
+
+    def __init__(self):
+        self.settings = get_settings()
+        self.base_path = os.path.abspath(self.settings.storage_local_path)
+
+    def get_file_content(self, file_path: str) -> bytes:
+        """Get file content from the configured storage service.
+
+        Args:
+            file_path: The path to the file in storage
+
+        Returns:
+            The file content as bytes
+        """
+        if self.settings.storage_type == "local":
+            # Prevent directory traversal attacks
+            full_path = os.path.abspath(os.path.join(self.base_path, file_path))
+
+            # Ensure the resolved path starts with base_path + os.sep
+            # to strictly prevent sibling directory traversal
+            if not full_path.startswith(self.base_path + os.sep):
+                raise ValueError("Invalid file path: path traversal detected")
+
+            if not os.path.exists(full_path):
+                raise FileNotFoundError(f"File not found: {file_path}")
+
+            with open(full_path, "rb") as f:
+                return f.read()
+        else:
+            raise NotImplementedError(f"Storage type {self.settings.storage_type} not implemented")
+
+    def download_url(self, url: str) -> bytes:
+        """Download file content from a URL.
+
+        Args:
+            url: The URL to download
+
+        Returns:
+            The file content as bytes
+        """
+        with httpx.Client() as client:
+            response = client.get(url)
+            response.raise_for_status()
+            return response.content
+
+
+_storage_client = None
+
+
+def get_storage_client() -> StorageClient:
+    """Get the storage client singleton."""
+    global _storage_client
+    if _storage_client is None:
+        _storage_client = StorageClient()
+    return _storage_client

--- a/packages/workhorse/tests/test_storage_client.py
+++ b/packages/workhorse/tests/test_storage_client.py
@@ -1,0 +1,68 @@
+import pytest
+
+from settler_workhorse.config import Settings
+from settler_workhorse.storage.client import get_storage_client
+
+
+def test_local_storage_get_file_content(tmp_path):
+    """Test getting file content from local storage."""
+    settings = Settings(
+        database_url="postgresql://dummy", storage_type="local", storage_local_path=str(tmp_path)
+    )
+
+    test_file = tmp_path / "test.csv"
+    test_file.write_bytes(b"test content")
+
+    # We mock get_settings to return our custom settings
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("settler_workhorse.storage.client.get_settings", lambda: settings)
+
+        client = get_storage_client()
+        content = client.get_file_content("test.csv")
+        assert content == b"test content"
+
+
+def test_local_storage_path_traversal(tmp_path):
+    """Test that path traversal is prevented in local storage."""
+    settings = Settings(
+        database_url="postgresql://dummy", storage_type="local", storage_local_path=str(tmp_path)
+    )
+
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("settler_workhorse.storage.client.get_settings", lambda: settings)
+
+        client = get_storage_client()
+        with pytest.raises(ValueError, match="path traversal detected"):
+            client.get_file_content("../outside.csv")
+
+
+def test_local_storage_file_not_found(tmp_path):
+    """Test handling of non-existent files in local storage."""
+    settings = Settings(
+        database_url="postgresql://dummy", storage_type="local", storage_local_path=str(tmp_path)
+    )
+
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("settler_workhorse.storage.client.get_settings", lambda: settings)
+
+        client = get_storage_client()
+        with pytest.raises(FileNotFoundError):
+            client.get_file_content("nonexistent.csv")
+
+
+def test_download_url(respx_mock):
+    """Test downloading content from a URL."""
+    settings = Settings(
+        database_url="postgresql://dummy", storage_type="local", storage_local_path="/tmp"
+    )
+
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("settler_workhorse.storage.client.get_settings", lambda: settings)
+
+        client = get_storage_client()
+
+        url = "https://example.com/test.csv"
+        respx_mock.get(url).respond(content=b"downloaded content")
+
+        content = client.download_url(url)
+        assert content == b"downloaded content"


### PR DESCRIPTION
Implement the CSV ingestion handler to fetch file content from a storage service.
- Create `packages/workhorse/src/settler_workhorse/storage/client.py` and `packages/workhorse/src/settler_workhorse/storage/__init__.py`.
- Add local storage retrieving with path traversal prevention.
- Download content from URL using `httpx`.
- Expose `get_storage_client` method with singleton instance implementation.
- Refactor the code in `csv_ingestion.py`'s `handle_csv_ingestion` to call the service gracefully with error handling.
- Rewrite `pyproject.toml` configuration to make it Ruff-compliant for formatting and linting.
- Adding comprehensive unit tests `test_storage_client.py` for testing new changes.

---
*PR created automatically by Jules for task [9629504401296966641](https://jules.google.com/task/9629504401296966641) started by @Hardonian*