### PR TITLE
🔒 Fix XSS vulnerability in StructuredData component

### DIFF
--- a/packages/web/src/__tests__/components/StructuredData.test.tsx
+++ b/packages/web/src/__tests__/components/StructuredData.test.tsx
@@ -1,0 +1,33 @@
+import { render } from "@testing-library/react";
+import { StructuredData } from "../../components/StructuredData";
+import React from "react";
+
+describe("StructuredData", () => {
+  it("escapes malicious characters to prevent XSS", () => {
+    const maliciousData = {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      name: "</script><script>alert('XSS')</script>",
+      description: "A & B > C",
+    };
+
+    const { container } = render(<StructuredData data={maliciousData} />);
+    const scriptTag = container.querySelector("script");
+
+    expect(scriptTag).not.toBeNull();
+    const html = scriptTag?.innerHTML || "";
+
+    // Check that there are no unescaped dangerous characters
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("</script>");
+    expect(html).not.toContain("<");
+    expect(html).not.toContain(">");
+    expect(html).not.toContain("&");
+
+    // Check that they are correctly escaped
+    expect(html).toContain(
+      "\\u003c/script\\u003e\\u003cscript\\u003ealert('XSS')\\u003c/script\\u003e"
+    );
+    expect(html).toContain("A \\u0026 B \\u003e C");
+  });
+});

--- a/packages/web/src/components/StructuredData.tsx
+++ b/packages/web/src/components/StructuredData.tsx
@@ -11,7 +11,12 @@ export function StructuredData({ data, id }: StructuredDataProps) {
     <script
       id={id || "structured-data"}
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(data, null, 0) }}
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data)
+          .replace(/</g, "\\u003c")
+          .replace(/>/g, "\\u003e")
+          .replace(/&/g, "\\u0026"),
+      }}
     />
   );
 }


### PR DESCRIPTION
🎯 **What:** The `StructuredData` component in `@settler/web` was using `dangerouslySetInnerHTML` with a raw `JSON.stringify` to inject structured JSON-LD data into a script tag.
⚠️ **Risk:** A malicious actor could provide a payload containing unescaped HTML script tags like `</script><script>alert(1)</script>` within the data payload. When stringified, this payload would terminate the `application/ld+json` script tag prematurely and execute the attacker's script as regular JavaScript, leading to a Cross-Site Scripting (XSS) vulnerability.
🛡️ **Solution:** Updated `JSON.stringify` to explicitly escape HTML-sensitive characters (`<`, `>`, `&`) by replacing them with their Unicode escape sequences (`\u003c`, `\u003e`, `\u0026`). This ensures the JSON is still valid while preventing premature closing of script tags, securing the component against XSS. Also added an isolated integration test checking that `<script>` and malicious chars are safely stringified.

---
*PR created automatically by Jules for task [10053694042074981783](https://jules.google.com/task/10053694042074981783) started by @Hardonian*