### PR TITLE
Harden integration credential and webhook validation paths

### DIFF
--- a/packages/api/src/security/__tests__/integration-security.test.ts
+++ b/packages/api/src/security/__tests__/integration-security.test.ts
@@ -1,0 +1,39 @@
+import crypto from "crypto";
+import {
+  decryptCredential,
+  encryptCredential,
+  validateWebhookSignature,
+  validateWebhookTimestamp,
+} from "../integration-security";
+
+describe("integration-security hardening", () => {
+  const key = crypto.randomBytes(32).toString("hex");
+
+  it("encrypts/decrypts with a valid key", () => {
+    const token = "secret-token";
+    const encrypted = encryptCredential(token, key);
+
+    expect(decryptCredential(encrypted.encrypted, encrypted.iv, encrypted.tag, key)).toBe(token);
+  });
+
+  it("rejects invalid key format", () => {
+    expect(() => encryptCredential("token", "abc123")).toThrow(
+      "Invalid encryption key: expected 32-byte hex string"
+    );
+  });
+
+  it("accepts prefixed webhook signatures and rejects malformed signatures", () => {
+    const payload = JSON.stringify({ ok: true });
+    const secret = "super-secret";
+    const digest = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+
+    expect(validateWebhookSignature(payload, `sha256=${digest}`, secret)).toBe(true);
+    expect(validateWebhookSignature(payload, `sha256=${digest}ZZ`, secret)).toBe(false);
+    expect(validateWebhookSignature(payload, "not-hex-signature", secret)).toBe(false);
+  });
+
+  it("rejects invalid timestamps", () => {
+    expect(validateWebhookTimestamp(Number.NaN)).toBe(false);
+    expect(validateWebhookTimestamp(0)).toBe(false);
+  });
+});

--- a/packages/api/src/security/integration-security.ts
+++ b/packages/api/src/security/integration-security.ts
@@ -11,6 +11,24 @@ import { createClient } from "@supabase/supabase-js";
 import * as crypto from "crypto";
 import { logError } from "../utils/logger";
 
+const HEX_64_CHAR_PATTERN = /^[0-9a-f]{64}$/i;
+const HEX_PATTERN = /^[0-9a-f]+$/i;
+
+function assertValidEncryptionKey(encryptionKey: string): void {
+  if (!HEX_64_CHAR_PATTERN.test(encryptionKey)) {
+    throw new Error("Invalid encryption key: expected 32-byte hex string");
+  }
+}
+
+function normalizeSignature(signature: string, algorithm: "sha256" | "sha512"): string {
+  const normalized = signature.trim().toLowerCase();
+  const expectedPrefix = `${algorithm}=`;
+  if (normalized.startsWith(expectedPrefix)) {
+    return normalized.slice(expectedPrefix.length);
+  }
+  return normalized;
+}
+
 export interface IntegrationCredential {
   id: string;
   tenantId: string;
@@ -30,6 +48,7 @@ export function encryptCredential(
   credential: string,
   encryptionKey: string
 ): { encrypted: string; iv: string; tag: string } {
+  assertValidEncryptionKey(encryptionKey);
   const algorithm = "aes-256-gcm";
   const iv = crypto.randomBytes(16);
   const cipher = crypto.createCipheriv(algorithm, Buffer.from(encryptionKey, "hex"), iv);
@@ -55,6 +74,10 @@ export function decryptCredential(
   tag: string,
   encryptionKey: string
 ): string {
+  assertValidEncryptionKey(encryptionKey);
+  if (!HEX_PATTERN.test(iv) || !HEX_PATTERN.test(tag) || !HEX_PATTERN.test(encrypted)) {
+    throw new Error("Invalid encrypted payload: expected hex-encoded cipher data");
+  }
   const algorithm = "aes-256-gcm";
   const decipher = crypto.createDecipheriv(
     algorithm,
@@ -79,18 +102,23 @@ export function validateWebhookSignature(
   secret: string,
   algorithm: "sha256" | "sha512" = "sha256"
 ): boolean {
+  const normalizedSignature = normalizeSignature(signature, algorithm);
+  if (!HEX_PATTERN.test(normalizedSignature)) {
+    return false;
+  }
+
   const hmac = crypto.createHmac(algorithm, secret);
   hmac.update(payload);
   const computedSignature = hmac.digest("hex");
 
   // Constant-time comparison
-  if (computedSignature.length !== signature.length) {
+  if (computedSignature.length !== normalizedSignature.length) {
     return false;
   }
 
   let result = 0;
   for (let i = 0; i < computedSignature.length; i++) {
-    result |= computedSignature.charCodeAt(i) ^ signature.charCodeAt(i);
+    result |= computedSignature.charCodeAt(i) ^ normalizedSignature.charCodeAt(i);
   }
 
   return result === 0;
@@ -100,6 +128,10 @@ export function validateWebhookSignature(
  * Validate webhook timestamp (prevent replay attacks)
  */
 export function validateWebhookTimestamp(timestamp: number, maxAgeSeconds: number = 300): boolean {
+  if (!Number.isFinite(timestamp) || timestamp <= 0 || !Number.isFinite(maxAgeSeconds)) {
+    return false;
+  }
+
   const now = Math.floor(Date.now() / 1000);
   const age = now - timestamp;
 


### PR DESCRIPTION
### Motivation
- Integration credential crypto paths were vulnerable to ambiguous failures from malformed keys/payloads and needed explicit validation to fail early and clearly.
- Webhook signature handling needed normalization to support common provider prefixes and to reject malformed inputs before doing a constant-time compare.
- Timestamp replay checks should explicitly reject non-finite or nonsensical values to reduce replay-attack surface.

### Description
- Added strict hex-shape validation constants and `assertValidEncryptionKey` to enforce a 32-byte (64 hex char) AES-256-GCM key prior to encryption and decryption.
- Validate `iv`, `tag`, and ciphertext as hex before attempting decryption and throw a clear error for malformed encrypted payloads.
- Implemented `normalizeSignature` to accept common provider-prefixed signatures (e.g. `sha256=`), ensure signature is hex-only, and use the normalized value in the constant-time comparison.
- Tightened `validateWebhookTimestamp` to reject non-finite or non-positive inputs and added focused Jest tests in `packages/api/src/security/__tests__/integration-security.test.ts` exercising encrypt/decrypt round-trip, invalid-key rejection, signature normalization/rejection, and timestamp validation.

### Testing
- `pnpm --filter @settler/api test -- integration-security.test.ts` ✅ pass (test suite `integration-security.test.ts` ran and all 4 tests passed).
- Pre-commit lint pipeline run via lint-staged (`eslint` + `prettier`) ✅ pass (scoped lint/format completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2e4fe7848328bf12fb15c4176556)