### PR TITLE
🧪 [testing improvement generatePackageKey]

### DIFF
--- a/packages/proofs/src/proofpack/proofpack.test.ts
+++ b/packages/proofs/src/proofpack/proofpack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computePackageHash } from "./index";
+import { computePackageHash, generatePackageKey } from "./index";
 
 describe("computePackageHash", () => {
   it("produces identical hashes regardless of when called (no timestamp dependency)", () => {
@@ -41,5 +41,18 @@ describe("computePackageHash", () => {
     ]);
 
     expect(hash1).toBe(hash2);
+  });
+});
+
+
+describe("generatePackageKey", () => {
+  it("generates a key with the provided timestamp", () => {
+    const key = generatePackageKey("run_summary", "tenant", "123", "2023-01-01T00-00-00-000Z");
+    expect(key).toBe("run_summary::tenant::123::2023-01-01T00-00-00-000Z");
+  });
+
+  it("generates a key using the current timestamp if not provided", () => {
+    const key = generatePackageKey("run_summary", "tenant", "123");
+    expect(key).toMatch(/^run_summary::tenant::123::\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/);
   });
 });


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the pure utility function `generatePackageKey` within `@settler/proofs`.

📊 **Coverage:** Covered both logical branches of `generatePackageKey`:
- Scenarios where an explicit timestamp string is provided.
- Scenarios where the timestamp string is omitted and auto-generated by the function (validated via a robust regex pattern to ensure correct format without mocking temporal logic).

✨ **Result:** Improved test coverage and reliability for package key generation, ensuring future regressions in the generated string format are immediately caught.

---
*PR created automatically by Jules for task [16019788773592328097](https://jules.google.com/task/16019788773592328097) started by @Hardonian*