### PR TITLE
🧹 [code health] Remove false-positive TODO comment in phase5-analysis.ts

### DIFF
--- a/scripts/phase5-analysis.ts
+++ b/scripts/phase5-analysis.ts
@@ -34,7 +34,7 @@ async function analyzeCodebase(): Promise<AnalysisResult> {
       const content = await fs.readFile(file, "utf-8");
       const lines = content.split("\n");
 
-      // Check for TODOs
+      // Scan for incomplete task markers
       lines.forEach((line, index) => {
         if (line.includes("TODO") || line.includes("FIXME") || line.includes("XXX")) {
           result.todos.push({


### PR DESCRIPTION
🎯 What
Replaced the phrase `// Check for TODOs` with `// Scan for incomplete task markers` in `scripts/phase5-analysis.ts`.

💡 Why
Automated static analysis tools and TODO scanners were incorrectly flagging this descriptive comment as an actionable TODO item.

✅ Verification
Ran test suite commands locally, ensuring no regressions on script behavior were introduced.

✨ Result
False positive removed; the script comment correctly reflects its purpose without triggering tools.

---
*PR created automatically by Jules for task [10648900038093390949](https://jules.google.com/task/10648900038093390949) started by @Hardonian*