### PR TITLE
🔒 [security fix] Fix XSS in StructuredData via dangerouslySetInnerHTML

### DIFF
--- a/packages/web/src/__tests__/components/StructuredData.test.tsx
+++ b/packages/web/src/__tests__/components/StructuredData.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { StructuredData } from "../../components/StructuredData";
+
+describe("StructuredData component", () => {
+  it("escapes malicious HTML tags in JSON data", () => {
+    const maliciousData = {
+      "@type": "Person",
+      name: "</script><script>alert('xss')</script>",
+    };
+
+    const { container } = render(<StructuredData data={maliciousData} id="test-schema" />);
+    const scriptTag = container.querySelector("script");
+
+    expect(scriptTag).not.toBeNull();
+    const innerHTML = scriptTag?.innerHTML || "";
+
+    // Ensure < and > are correctly escaped to unicode
+    expect(innerHTML).toContain(
+      "\\u003c/script\\u003e\\u003cscript\\u003ealert('xss')\\u003c/script\\u003e"
+    );
+
+    // Ensure raw < and > are not present
+    expect(innerHTML).not.toContain("<script>");
+    expect(innerHTML).not.toContain("</script>");
+  });
+});

--- a/packages/web/src/components/StructuredData.tsx
+++ b/packages/web/src/components/StructuredData.tsx
@@ -11,7 +11,9 @@ export function StructuredData({ data, id }: StructuredDataProps) {
     <script
       id={id || "structured-data"}
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(data, null, 0) }}
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data, null, 0).replace(/</g, "\\u003c").replace(/>/g, "\\u003e"),
+      }}
     />
   );
 }


### PR DESCRIPTION
🎯 **What:** Fixed a Cross-Site Scripting (XSS) vulnerability in the `StructuredData` component caused by injecting unescaped JSON strings into an `application/ld+json` script block via `dangerouslySetInnerHTML`.
⚠️ **Risk:** If a malicious user were able to inject a string containing `</script><script>alert('XSS')</script>` into the structured data payload, they could break out of the script tag context and execute arbitrary Javascript in the application's context.
🛡️ **Solution:** Sanitize the JSON output string before injection using `replace(/</g, "\\u003c").replace(/>/g, "\\u003e")`. This replaces dangerous HTML tags with valid JSON unicode escapes, rendering them harmless while preserving the integrity of the structured JSON data. Added a targeted unit test to prevent regression.

---
*PR created automatically by Jules for task [4567096672621800075](https://jules.google.com/task/4567096672621800075) started by @Hardonian*