### PR TITLE
Potential fix for code scanning alert no. 486: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/root-policy.yml
+++ b/.github/workflows/root-policy.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   verify-root:
     name: Verify Root Cleanliness


### PR DESCRIPTION
Potential fix for [https://github.com/Hardonian/Settler/security/code-scanning/486](https://github.com/Hardonian/Settler/security/code-scanning/486)

To fix this, add an explicit `permissions` block in `.github/workflows/root-policy.yml` so the workflow token is constrained by default.

Best single fix without changing functionality:
- Add a workflow-level `permissions` section directly under the `on:` triggers (before `jobs:` is standard and clear).
- Set:
  - `contents: read`

This is sufficient for `actions/checkout@v4` and for running local verification commands, while preventing unintended write scopes. No imports, methods, or additional definitions are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
