### PR TITLE
fix(ci): unblock Migration Guardian by adding DB secret fallbacks

### DIFF
--- a/.github/workflows/migration-guardian.yml
+++ b/.github/workflows/migration-guardian.yml
@@ -44,10 +44,10 @@ on:
       - main
 
 env:
-  DATABASE_URL: ${{ secrets.DATABASE_URL }}
-  SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
-  SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-  SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+  DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.STAGING_DATABASE_URL || secrets.SUPABASE_DB_URL || secrets.SUPABASE_DB_URL_STAGING }}
+  SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL || secrets.SUPABASE_DB_URL_STAGING || secrets.DATABASE_URL || secrets.STAGING_DATABASE_URL }}
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL || secrets.SUPABASE_URL_STAGING }}
+  SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD || secrets.SUPABASE_DB_PASSWORD_STAGING }}
   UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
   UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -167,16 +167,23 @@ jobs:
       - name: Generate Prisma client
         run: pnpm run prisma:generate || pnpm exec prisma generate
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.STAGING_DATABASE_URL || secrets.SUPABASE_DB_URL || secrets.SUPABASE_DB_URL_STAGING }}
+
+      - name: Validate DB secret availability
+        run: |
+          if [ -z "${DATABASE_URL}" ] && [ -z "${SUPABASE_DB_URL}" ] && { [ -z "${SUPABASE_URL}" ] || [ -z "${SUPABASE_DB_PASSWORD}" ]; }; then
+            echo "❌ Missing DB secrets. Configure one of: DATABASE_URL, STAGING_DATABASE_URL, SUPABASE_DB_URL, SUPABASE_DB_URL_STAGING, or SUPABASE_URL(+SUPABASE_DB_PASSWORD)."
+            exit 1
+          fi
 
       - name: Run Migration Guardian
         id: guardian
         run: pnpm run migration:guardian
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.STAGING_DATABASE_URL || secrets.SUPABASE_DB_URL || secrets.SUPABASE_DB_URL_STAGING }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL || secrets.SUPABASE_DB_URL_STAGING || secrets.DATABASE_URL || secrets.STAGING_DATABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL || secrets.SUPABASE_URL_STAGING }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD || secrets.SUPABASE_DB_PASSWORD_STAGING }}
           UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
           UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
           MIGRATION_TYPE: ${{ needs.detect-migrations.outputs.migration_type }}
@@ -383,7 +390,7 @@ jobs:
         run: pnpm exec turbo run build
       - name: Apply production migrations
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.STAGING_DATABASE_URL || secrets.SUPABASE_DB_URL || secrets.SUPABASE_DB_URL_STAGING }}
           NODE_ENV: production
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}


### PR DESCRIPTION
### Motivation
- The scheduled Migration Guardian runs repeatedly failed with missing DB credentials and `No .env files found` errors in CI because the workflow expected a single secret name (`DATABASE_URL`).
- The repository uses multiple secret naming conventions (staging-suffixed and Supabase-specific names) and the workflow should be resilient to those variants.

### Description
- Updated `.github/workflows/migration-guardian.yml` to provide fallback mappings for DB-related secrets (`DATABASE_URL`, `SUPABASE_DB_URL`, `SUPABASE_URL`, and `SUPABASE_DB_PASSWORD`) including `STAGING_DATABASE_URL`, `SUPABASE_DB_URL_STAGING`, and staging-suffixed variants.
- Added a `Validate DB secret availability` preflight step that fails early with a clear message when no valid DB secret combination is present.
- Applied the same secret fallback mapping to the `Generate Prisma client`, `Run Migration Guardian`, and production migration env mappings so runtime steps consistently resolve credentials.

### Testing
- Ran `pnpm -s exec prisma validate --schema=prisma/schema.prisma` which succeeded and confirmed the Prisma schema is valid. 
- Verified the workflow diff and committed the change, and repository pre-commit/lint-staged hooks (formatting and checks) executed and passed during the commit. 
- Confirmed the workflow file updates include the new validation step and env fallbacks by inspecting the `git diff` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fa9c5a108328907a5f59803a4b11)