### PR TITLE
🧹 [code health improvement] Remove commented-out URL in whatsapp-telegram.ts

### DIFF
--- a/packages/adapters/src/whatsapp-telegram.ts
+++ b/packages/adapters/src/whatsapp-telegram.ts
@@ -49,7 +49,6 @@ export class WhatsAppTelegramAdapter implements Adapter {
     // WhatsApp Business API doesn't have a direct payments endpoint
     // Payments are typically handled through payment links or external processors
     // This would integrate with payment link reconciliation
-    // const url = `https://graph.facebook.com/v18.0/me/messages`;
 
     // In production, this would query payment link transactions
     // For now, return empty array as WhatsApp payments are typically processed externally

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,11 +910,11 @@ importers:
         specifier: ^2.106.1
         version: 2.106.1
       '@tanstack/react-query':
-        specifier: ^5.100.13
-        version: 5.100.13(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(react@19.2.6)
       '@tanstack/react-query-devtools':
-        specifier: ^5.100.13
-        version: 5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
@@ -13278,15 +13278,15 @@ snapshots:
 
   '@tanstack/query-devtools@5.100.14': {}
 
-  '@tanstack/react-query-devtools@5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-query-devtools@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/query-devtools': 5.100.13
-      '@tanstack/react-query': 5.100.13(react@19.2.6)
+      '@tanstack/query-devtools': 5.100.14
+      '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
 
-  '@tanstack/react-query@5.100.13(react@19.2.6)':
+  '@tanstack/react-query@5.100.14(react@19.2.6)':
     dependencies:
-      '@tanstack/query-core': 5.100.13
+      '@tanstack/query-core': 5.100.14
       react: 19.2.6
 
   '@testing-library/dom@9.3.4':


### PR DESCRIPTION
🎯 **What:**
Removed a commented-out Facebook Graph API URL in the `fetchWhatsAppPayments` method within `packages/adapters/src/whatsapp-telegram.ts`.

💡 **Why:**
Commented-out code blocks add clutter. Removing dead/commented-out code improves overall code readability and maintainability without altering functionality.

✅ **Verification:**
- Verified no remaining functionality relies on the removed line.
- Successfully ran format/lint checks via `pnpm --filter @settler/adapters run lint` and `pnpm --filter @settler/adapters run typecheck`.
- Test suite executed via `pnpm --filter @settler/adapters test` with all tests passing.

✨ **Result:**
Cleaner code structure for the `fetchWhatsAppPayments` method.

---
*PR created automatically by Jules for task [9367944185962336290](https://jules.google.com/task/9367944185962336290) started by @Hardonian*