### PR TITLE
🔒 Fix overly permissive CORS configuration

### DIFF
--- a/packages/api/src/security/__tests__/edge-function-security.test.ts
+++ b/packages/api/src/security/__tests__/edge-function-security.test.ts
@@ -1,0 +1,32 @@
+import { getCORSHeaders } from "../edge-function-security";
+
+describe("getCORSHeaders", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return * if allowedOrigins includes *", () => {
+    process.env.ALLOWED_ORIGINS = "*";
+    const headers = getCORSHeaders("https://example.com");
+    expect(headers["Access-Control-Allow-Origin"]).toBe("*");
+  });
+
+  it("should return the origin if it is explicitly allowed", () => {
+    process.env.ALLOWED_ORIGINS = "https://example.com,https://test.com";
+    const headers = getCORSHeaders("https://example.com");
+    expect(headers["Access-Control-Allow-Origin"]).toBe("https://example.com");
+  });
+
+  it("should not return Access-Control-Allow-Origin if origin is not allowed", () => {
+    process.env.ALLOWED_ORIGINS = "https://example.com,https://test.com";
+    const headers = getCORSHeaders("https://malicious.com");
+    expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+  });
+});

--- a/packages/api/src/security/edge-function-security.ts
+++ b/packages/api/src/security/edge-function-security.ts
@@ -355,13 +355,15 @@ export function getCORSHeaders(origin?: string): Record<string, string> {
     typeof process !== "undefined" ? process.env.ALLOWED_ORIGINS : undefined;
   const allowedOrigins = allowedOriginsEnv?.split(",") || ["*"];
 
-  let corsOrigin: string;
+  let corsOrigin: string | undefined;
   if (origin && allowedOrigins.includes(origin)) {
     corsOrigin = origin;
   } else if (allowedOrigins.includes("*")) {
     corsOrigin = "*";
-  } else {
-    corsOrigin = allowedOrigins[0] || "*";
+  }
+
+  if (!corsOrigin) {
+    return {};
   }
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,11 +910,11 @@ importers:
         specifier: ^2.106.1
         version: 2.106.1
       '@tanstack/react-query':
-        specifier: ^5.100.13
-        version: 5.100.13(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(react@19.2.6)
       '@tanstack/react-query-devtools':
-        specifier: ^5.100.13
-        version: 5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
@@ -13278,15 +13278,15 @@ snapshots:
 
   '@tanstack/query-devtools@5.100.14': {}
 
-  '@tanstack/react-query-devtools@5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-query-devtools@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/query-devtools': 5.100.13
-      '@tanstack/react-query': 5.100.13(react@19.2.6)
+      '@tanstack/query-devtools': 5.100.14
+      '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
 
-  '@tanstack/react-query@5.100.13(react@19.2.6)':
+  '@tanstack/react-query@5.100.14(react@19.2.6)':
     dependencies:
-      '@tanstack/query-core': 5.100.13
+      '@tanstack/query-core': 5.100.14
       react: 19.2.6
 
   '@testing-library/dom@9.3.4':


### PR DESCRIPTION
🎯 What:
The `getCORSHeaders` function used by Edge Functions had an overly permissive fallback condition. When an incoming request origin did not match any of the allowed origins and `*` was not in the allowed list, the code explicitly fell back to the first origin in the `allowedOrigins` list or `*`.

⚠️ Risk:
This effectively negated the CORS protections. By falling back to `*` or a static allowed origin, the server could instruct the browser to permit cross-origin requests from any unauthorized domain. This would allow an attacker's website to make cross-origin requests to the edge functions on behalf of an authenticated user, leading to unauthorized actions or data exposure (CSRF/XSS exploitation).

🛡️ Solution:
Modified `getCORSHeaders` to simply not set the `Access-Control-Allow-Origin` header if the origin does not match the allowed list. Returning an empty object causes the browser to enforce its same-origin policy securely. A corresponding test suite was also added to ensure this fix works as expected.

---
*PR created automatically by Jules for task [18241681540185468361](https://jules.google.com/task/18241681540185468361) started by @Hardonian*