### PR TITLE
🧪 [testing improvement] Add tests for token refresh error paths

### DIFF
--- a/packages/adapters/src/__tests__/token-refresh.test.ts
+++ b/packages/adapters/src/__tests__/token-refresh.test.ts
@@ -1,0 +1,138 @@
+import { refreshTokenIfNeeded } from "../token-refresh";
+import { ConnectorDriver } from "../connector-driver";
+import { createClient } from "@supabase/supabase-js";
+import { decryptToken } from "../credential-encryption";
+
+jest.mock("@supabase/supabase-js", () => {
+  return {
+    createClient: jest.fn(),
+  };
+});
+
+jest.mock("../credential-encryption", () => {
+  return {
+    encryptToken: jest.fn(),
+    decryptToken: jest.fn(),
+  };
+});
+
+describe("token-refresh", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("error handling", () => {
+    it("should handle Error object thrown during token refresh", async () => {
+      const mockDriver: ConnectorDriver = {
+        refreshToken: jest.fn().mockRejectedValue(new Error("Network connection failed")),
+        id: "test",
+        name: "Test",
+      } as any;
+
+      const credentials = {
+        refresh_token: "old-refresh-token",
+      };
+
+      const mockSupabase = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { id: "connector-1", config: {} },
+        }),
+      };
+
+      (createClient as jest.Mock).mockReturnValue(mockSupabase);
+      (decryptToken as jest.Mock).mockResolvedValue("decrypted-token");
+
+      const result = await refreshTokenIfNeeded(
+        mockDriver,
+        "test",
+        "tenant-1",
+        credentials,
+        "http://localhost",
+        "secret-key"
+      );
+
+      expect(result).toEqual({
+        refreshed: false,
+        error: "Network connection failed",
+      });
+    });
+
+    it("should handle non-Error object thrown during token refresh", async () => {
+      const mockDriver: ConnectorDriver = {
+        refreshToken: jest.fn().mockRejectedValue("Some weird error string"),
+        id: "test",
+        name: "Test",
+      } as any;
+
+      const credentials = {
+        refresh_token: "old-refresh-token",
+      };
+
+      const mockSupabase = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { id: "connector-1", config: {} },
+        }),
+      };
+
+      (createClient as jest.Mock).mockReturnValue(mockSupabase);
+      (decryptToken as jest.Mock).mockResolvedValue("decrypted-token");
+
+      const result = await refreshTokenIfNeeded(
+        mockDriver,
+        "test",
+        "tenant-1",
+        credentials,
+        "http://localhost",
+        "secret-key"
+      );
+
+      expect(result).toEqual({
+        refreshed: false,
+        error: "Token refresh failed",
+      });
+    });
+
+    it("should return false if connector is not found", async () => {
+      const mockDriver: ConnectorDriver = {
+        refreshToken: jest.fn(),
+        id: "test",
+        name: "Test",
+      } as any;
+
+      const credentials = {
+        refresh_token: "old-refresh-token",
+      };
+
+      const mockSupabase = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: null,
+        }),
+      };
+
+      (createClient as jest.Mock).mockReturnValue(mockSupabase);
+
+      const result = await refreshTokenIfNeeded(
+        mockDriver,
+        "test",
+        "tenant-1",
+        credentials,
+        "http://localhost",
+        "secret-key"
+      );
+
+      expect(result).toEqual({
+        refreshed: false,
+        error: "Connector not found",
+      });
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,11 +910,11 @@ importers:
         specifier: ^2.106.1
         version: 2.106.1
       '@tanstack/react-query':
-        specifier: ^5.100.13
-        version: 5.100.13(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(react@19.2.6)
       '@tanstack/react-query-devtools':
-        specifier: ^5.100.13
-        version: 5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
@@ -13278,15 +13278,15 @@ snapshots:
 
   '@tanstack/query-devtools@5.100.14': {}
 
-  '@tanstack/react-query-devtools@5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-query-devtools@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/query-devtools': 5.100.13
-      '@tanstack/react-query': 5.100.13(react@19.2.6)
+      '@tanstack/query-devtools': 5.100.14
+      '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
 
-  '@tanstack/react-query@5.100.13(react@19.2.6)':
+  '@tanstack/react-query@5.100.14(react@19.2.6)':
     dependencies:
-      '@tanstack/query-core': 5.100.13
+      '@tanstack/query-core': 5.100.14
       react: 19.2.6
 
   '@testing-library/dom@9.3.4':


### PR DESCRIPTION
🎯 **What:** Added tests to cover the error paths in `refreshTokenIfNeeded` in `token-refresh.ts`
📊 **Coverage:** Covered cases where an `Error` object is thrown, a non-`Error` object is thrown, and when the connector is not found in the database.
✨ **Result:** Increased code coverage and confidence in the error handling of the token refresh logic.

---
*PR created automatically by Jules for task [9583482121039121662](https://jules.google.com/task/9583482121039121662) started by @Hardonian*