### PR TITLE
fix(schema): add integration credentials check for event logging

### DIFF
--- a/supabase/migrations/20240101000000_settler_golden_schema.sql
+++ b/supabase/migrations/20240101000000_settler_golden_schema.sql
@@ -16345,9 +16345,14 @@ BEGIN
 
   -- Server-side validation: Check if integration is configured (if integration_id provided)
   IF p_integration_id IS NOT NULL THEN
-    -- TODO: Add integration_credentials table check when implemented
-    -- For now, we'll allow but log a warning
-    NULL;
+    IF NOT EXISTS (
+      SELECT 1 FROM integration_credentials ic
+      JOIN billing_accounts ba ON ba.tenant_id = ic.tenant_id
+      WHERE ba.id = p_billing_account_id
+        AND ic.adapter = p_integration_id
+    ) THEN
+      RAISE WARNING 'Usage logged for unconfigured integration: %', p_integration_id;
+    END IF;
   END IF;
 
   -- Insert usage event
@@ -18749,8 +18754,17 @@ BEGIN
   END IF;
 
   -- If integration is specified, validate it's configured
-  -- TODO: Add integration_credentials table check when implemented
-  -- For now, we'll allow but this should be enhanced
+  IF p_integration_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM integration_credentials ic
+      JOIN billing_accounts ba ON ba.tenant_id = ic.tenant_id
+      WHERE ba.id = p_billing_account_id
+        AND ic.adapter = p_integration_id
+    ) THEN
+      -- Integration not configured, cannot log usage
+      RETURN false;
+    END IF;
+  END IF;
 
   RETURN true;
 END;


### PR DESCRIPTION
Replaces the TODOs in public.log_usage_event and public.validate_usage_event_server_side with an actual foreign key/existence check against the integration_credentials table joining against billing_accounts to ensure that the provided integration_id exists and is properly configured for the user's billing account's tenant.

---
*PR created automatically by Jules for task [12891908704016580789](https://jules.google.com/task/12891908704016580789) started by @Hardonian*