### PR TITLE
feat: implement integration credentials check for usage logging

### DIFF
--- a/packages/reconciliation-core/src/__snapshots__/canonical-surface-consistency.test.ts.snap
+++ b/packages/reconciliation-core/src/__snapshots__/canonical-surface-consistency.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`canonical surface consistency snapshots deterministic proofpack artifact shape for export parity 1`] = `
 {

--- a/supabase/migrations/20240101000000_settler_golden_schema.sql
+++ b/supabase/migrations/20240101000000_settler_golden_schema.sql
@@ -16345,9 +16345,14 @@ BEGIN
 
   -- Server-side validation: Check if integration is configured (if integration_id provided)
   IF p_integration_id IS NOT NULL THEN
-    -- TODO: Add integration_credentials table check when implemented
-    -- For now, we'll allow but log a warning
-    NULL;
+    IF NOT EXISTS (
+      SELECT 1 FROM integration_credentials ic
+      JOIN billing_accounts ba ON ba.tenant_id = ic.tenant_id
+      WHERE ba.id = p_billing_account_id
+        AND ic.adapter = p_integration_id
+    ) THEN
+      RAISE EXCEPTION 'Integration % is not configured', p_integration_id;
+    END IF;
   END IF;
 
   -- Insert usage event
@@ -18749,8 +18754,15 @@ BEGIN
   END IF;
 
   -- If integration is specified, validate it's configured
-  -- TODO: Add integration_credentials table check when implemented
-  -- For now, we'll allow but this should be enhanced
+  IF p_integration_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM integration_credentials ic
+      WHERE ic.tenant_id = v_billing_account.tenant_id
+        AND ic.adapter = p_integration_id
+    ) THEN
+      RETURN false;
+    END IF;
+  END IF;
 
   RETURN true;
 END;


### PR DESCRIPTION
Replaced TODOs with database lookups checking the `integration_credentials` table to ensure that integration credentials exist before proceeding to log usage events. Checked via `p_integration_id` mapped to `ic.adapter` and `ba.id` mapped to `ic.tenant_id`.

---
*PR created automatically by Jules for task [10859462492310101763](https://jules.google.com/task/10859462492310101763) started by @Hardonian*