### PR TITLE
🧪 Add unit tests for trackApiCall metric

### DIFF
--- a/packages/adapters/src/__tests__/prometheus.test.ts
+++ b/packages/adapters/src/__tests__/prometheus.test.ts
@@ -1,0 +1,54 @@
+import { trackApiCall, metrics } from "../metrics/prometheus";
+
+describe("trackApiCall", () => {
+  let incrementCounterSpy: jest.SpyInstance;
+  let recordHistogramSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    metrics.reset();
+    incrementCounterSpy = jest.spyOn(metrics, "incrementCounter");
+    recordHistogramSpy = jest.spyOn(metrics, "recordHistogram");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("tracks successful API calls (200-299 status code)", () => {
+    trackApiCall("test-connector", 200, 1500);
+
+    expect(incrementCounterSpy).toHaveBeenCalledWith("settler_api_calls_total", {
+      connector_id: "test-connector",
+      status: "success",
+    });
+
+    expect(recordHistogramSpy).toHaveBeenCalledWith("settler_api_call_duration_seconds", 1.5, {
+      connector_id: "test-connector",
+    });
+
+    trackApiCall("test-connector-2", 299, 500);
+    expect(incrementCounterSpy).toHaveBeenCalledWith("settler_api_calls_total", {
+      connector_id: "test-connector-2",
+      status: "success",
+    });
+  });
+
+  it("tracks error API calls (non-2xx status code)", () => {
+    trackApiCall("test-connector", 400, 250);
+
+    expect(incrementCounterSpy).toHaveBeenCalledWith("settler_api_calls_total", {
+      connector_id: "test-connector",
+      status: "error",
+    });
+
+    expect(recordHistogramSpy).toHaveBeenCalledWith("settler_api_call_duration_seconds", 0.25, {
+      connector_id: "test-connector",
+    });
+
+    trackApiCall("test-connector-3", 500, 100);
+    expect(incrementCounterSpy).toHaveBeenCalledWith("settler_api_calls_total", {
+      connector_id: "test-connector-3",
+      status: "error",
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The untested `trackApiCall` function in `packages/adapters/src/metrics/prometheus.ts` now has dedicated unit test coverage.
📊 **Coverage:** Added coverage for both successful API calls (200-299 status codes) and error responses (non-2xx status codes), verifying that correct counter values and durations are tracked.
✨ **Result:** Improved test coverage and reliability for core metrics tracking in the adapters package.

---
*PR created automatically by Jules for task [13697650865776727458](https://jules.google.com/task/13697650865776727458) started by @Hardonian*