### PR TITLE
🧪 Add unit tests for connector drivers registry

### DIFF
--- a/packages/adapters/src/__tests__/drivers/index.test.ts
+++ b/packages/adapters/src/__tests__/drivers/index.test.ts
@@ -1,0 +1,37 @@
+import { getConnectorDriver, getAllConnectorMetadata, CONNECTOR_REGISTRY } from "../../drivers/index";
+
+describe("Connector Drivers Registry", () => {
+  describe("getConnectorDriver", () => {
+    it("should return a driver for a valid connector ID in lowercase", () => {
+      const driver = getConnectorDriver("plaid");
+      expect(driver).toBeDefined();
+      expect(driver?.metadata.id).toBe("plaid");
+    });
+
+    it("should return a driver for a valid connector ID with mixed case", () => {
+      const driver = getConnectorDriver("pLaId");
+      expect(driver).toBeDefined();
+      expect(driver?.metadata.id).toBe("plaid");
+    });
+
+    it("should return null for an invalid connector ID", () => {
+      const driver = getConnectorDriver("invalid-connector-id");
+      expect(driver).toBeNull();
+    });
+  });
+
+  describe("getAllConnectorMetadata", () => {
+    it("should return metadata for all registered drivers", () => {
+      const metadataList = getAllConnectorMetadata();
+      const expectedLength = Object.keys(CONNECTOR_REGISTRY).length;
+
+      expect(metadataList).toBeDefined();
+      expect(metadataList.length).toBe(expectedLength);
+
+      // Check if plaid is in the returned list
+      const plaidMetadata = metadataList.find(m => m.id === "plaid");
+      expect(plaidMetadata).toBeDefined();
+      expect(plaidMetadata?.displayName).toBe("Plaid");
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The public functions getConnectorDriver and getAllConnectorMetadata were untested in packages/adapters/src/drivers/index.ts.
📊 **Coverage:** Added test cases covering happy paths (lowercase valid IDs), edge cases (mixed-case valid IDs), and error conditions (invalid IDs) for getConnectorDriver. Also verified that getAllConnectorMetadata returns the correct number of items and valid data structures.
✨ **Result:** Improved test coverage and reliability for the connector drivers module.

---
*PR created automatically by Jules for task [11413727429126557239](https://jules.google.com/task/11413727429126557239) started by @Hardonian*