### PR TITLE
🧪 Add unit tests for connector drivers registry functions

### DIFF
--- a/packages/adapters/src/__tests__/drivers-index.test.ts
+++ b/packages/adapters/src/__tests__/drivers-index.test.ts
@@ -1,0 +1,34 @@
+import { getConnectorDriver, getAllConnectorMetadata, CONNECTOR_REGISTRY } from "../drivers/index";
+import { PlaidDriver } from "../drivers/plaid";
+
+// Ensure actual test coverage for functions
+describe("drivers/index", () => {
+  describe("getConnectorDriver", () => {
+    it("returns null for unknown connector id", () => {
+      expect(getConnectorDriver("unknown-connector-id")).toBeNull();
+    });
+
+    it("returns a driver instance for a known connector id", () => {
+      const driver = getConnectorDriver("plaid");
+      expect(driver).toBeInstanceOf(PlaidDriver);
+    });
+
+    it("is case insensitive", () => {
+      const driver = getConnectorDriver("PLAID");
+      expect(driver).toBeInstanceOf(PlaidDriver);
+    });
+  });
+
+  describe("getAllConnectorMetadata", () => {
+    it("returns metadata for all registered drivers", () => {
+      const metadataList = getAllConnectorMetadata();
+      const expectedCount = Object.keys(CONNECTOR_REGISTRY).length;
+
+      expect(metadataList.length).toBe(expectedCount);
+
+      // Ensure we got metadata objects (they should have an id)
+      expect(metadataList[0]).toHaveProperty("id");
+      expect(metadataList.some((m) => m.id === "plaid")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Addressed the testing gap in `packages/adapters/src/drivers/index.ts` where the public exported functions `getConnectorDriver` and `getAllConnectorMetadata` were untested.

📊 **Coverage:** Covered scenarios for `getConnectorDriver` (returns valid driver instances, returns null for unknown ids, handles case insensitivity) and `getAllConnectorMetadata` (returns expected count of correct metadata objects).

✨ **Result:** Improved test reliability and ensured that regressions to the connector driver registry will be caught by the test suite before shipping to production.

---
*PR created automatically by Jules for task [8456429493696654823](https://jules.google.com/task/8456429493696654823) started by @Hardonian*