### PR TITLE
fix: implement rate limit violation query in alerts function

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,11 +910,11 @@ importers:
         specifier: ^2.106.1
         version: 2.106.1
       '@tanstack/react-query':
-        specifier: ^5.100.13
-        version: 5.100.13(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(react@19.2.6)
       '@tanstack/react-query-devtools':
-        specifier: ^5.100.13
-        version: 5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
@@ -13278,15 +13278,15 @@ snapshots:
 
   '@tanstack/query-devtools@5.100.14': {}
 
-  '@tanstack/react-query-devtools@5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-query-devtools@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/query-devtools': 5.100.13
-      '@tanstack/react-query': 5.100.13(react@19.2.6)
+      '@tanstack/query-devtools': 5.100.14
+      '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
 
-  '@tanstack/react-query@5.100.13(react@19.2.6)':
+  '@tanstack/react-query@5.100.14(react@19.2.6)':
     dependencies:
-      '@tanstack/query-core': 5.100.13
+      '@tanstack/query-core': 5.100.14
       react: 19.2.6
 
   '@testing-library/dom@9.3.4':

--- a/supabase/migrations/20240101000000_settler_golden_schema.sql
+++ b/supabase/migrations/20240101000000_settler_golden_schema.sql
@@ -11883,10 +11883,15 @@ BEGIN
     RETURN;
   END IF;
 
-  -- TODO: Query actual rate limit violations from logs/metrics
-  -- For now, return empty result
-  
-  RETURN;
+  RETURN QUERY
+  SELECT DISTINCT
+    v_rule.id AS alert_id,
+    ru.tenant_id,
+    true AS rate_limit_exceeded
+  FROM public.rate_usage ru
+  JOIN public.rate_limits rl ON ru.tenant_id = rl.tenant_id AND ru.key = rl.key
+  WHERE (ru.ts_minute >= NOW() - INTERVAL '5 minutes' AND ru.count_minute > rl.max_per_minute)
+     OR (ru.ts_day = CURRENT_DATE AND ru.count_day > rl.max_per_day);
 END;
 $function$;
 


### PR DESCRIPTION
Implemented rate limit violation query joining public.rate_usage and public.rate_limits in check_rate_limit_alerts function.

---
*PR created automatically by Jules for task [15012770052717769726](https://jules.google.com/task/15012770052717769726) started by @Hardonian*