### PR TITLE
🧪 [testing improvement] Add unit tests for connector driver registry functions

### DIFF
--- a/packages/adapters/src/__tests__/drivers.test.ts
+++ b/packages/adapters/src/__tests__/drivers.test.ts
@@ -1,0 +1,45 @@
+import { getConnectorDriver, getAllConnectorMetadata, CONNECTOR_REGISTRY } from "../drivers/index";
+import { PlaidDriver } from "../drivers/plaid";
+
+describe("Drivers Registry", () => {
+  describe("getConnectorDriver", () => {
+    it("should return a driver instance for a valid connector ID", () => {
+      const driver = getConnectorDriver("plaid");
+      expect(driver).toBeInstanceOf(PlaidDriver);
+      expect(driver?.metadata.id).toBe("plaid");
+    });
+
+    it("should be case-insensitive", () => {
+      const lowerDriver = getConnectorDriver("plaid");
+      const upperDriver = getConnectorDriver("PLAID");
+      const mixedDriver = getConnectorDriver("PlAiD");
+
+      expect(lowerDriver).toBeInstanceOf(PlaidDriver);
+      expect(upperDriver).toBeInstanceOf(PlaidDriver);
+      expect(mixedDriver).toBeInstanceOf(PlaidDriver);
+    });
+
+    it("should return null for an invalid connector ID", () => {
+      const driver = getConnectorDriver("invalid-connector-id");
+      expect(driver).toBeNull();
+    });
+  });
+
+  describe("getAllConnectorMetadata", () => {
+    it("should return metadata for all registered connectors", () => {
+      const allMetadata = getAllConnectorMetadata();
+      const registrySize = Object.keys(CONNECTOR_REGISTRY).length;
+
+      expect(allMetadata).toBeInstanceOf(Array);
+      expect(allMetadata.length).toBe(registrySize);
+      expect(registrySize).toBeGreaterThan(0);
+
+      // Verify structure of a metadata item
+      const sampleMetadata = allMetadata[0];
+      expect(sampleMetadata).toHaveProperty("id");
+      expect(sampleMetadata).toHaveProperty("displayName");
+      expect(sampleMetadata).toHaveProperty("category");
+      expect(sampleMetadata).toHaveProperty("authType");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,11 +910,11 @@ importers:
         specifier: ^2.106.1
         version: 2.106.1
       '@tanstack/react-query':
-        specifier: ^5.100.13
-        version: 5.100.13(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(react@19.2.6)
       '@tanstack/react-query-devtools':
-        specifier: ^5.100.13
-        version: 5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
@@ -13278,15 +13278,15 @@ snapshots:
 
   '@tanstack/query-devtools@5.100.14': {}
 
-  '@tanstack/react-query-devtools@5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-query-devtools@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/query-devtools': 5.100.13
-      '@tanstack/react-query': 5.100.13(react@19.2.6)
+      '@tanstack/query-devtools': 5.100.14
+      '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
 
-  '@tanstack/react-query@5.100.13(react@19.2.6)':
+  '@tanstack/react-query@5.100.14(react@19.2.6)':
     dependencies:
-      '@tanstack/query-core': 5.100.13
+      '@tanstack/query-core': 5.100.14
       react: 19.2.6
 
   '@testing-library/dom@9.3.4':


### PR DESCRIPTION
🎯 **What:** The `getConnectorDriver` and `getAllConnectorMetadata` functions in `packages/adapters/src/drivers/index.ts` were completely untested. This gap is now addressed.
📊 **Coverage:** Covered happy paths (fetching a valid driver, retrieving all metadata), edge cases (case-insensitivity), and error conditions (invalid ID returns `null`).
✨ **Result:** Enhanced the overall reliability and test coverage of the `@settler/adapters` package, ensuring future changes don't inadvertently break the critical driver loading functionality.

---
*PR created automatically by Jules for task [17311357370899160531](https://jules.google.com/task/17311357370899160531) started by @Hardonian*