### PR TITLE
🧪 [testing improvement] Add error path tests for Meta Commerce adapter

### DIFF
--- a/packages/adapters/src/__tests__/meta-commerce.test.ts
+++ b/packages/adapters/src/__tests__/meta-commerce.test.ts
@@ -1,0 +1,79 @@
+import { MetaCommerceAdapter } from "../meta-commerce";
+import { FetchOptions } from "../base";
+
+describe("MetaCommerceAdapter", () => {
+  let adapter: MetaCommerceAdapter;
+  let originalFetch: typeof global.fetch;
+  let originalConsoleError: typeof console.error;
+
+  beforeEach(() => {
+    adapter = new MetaCommerceAdapter();
+    originalFetch = global.fetch;
+    originalConsoleError = console.error;
+
+    global.fetch = jest.fn();
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    console.error = originalConsoleError;
+  });
+
+  it("should handle errors when fetching Meta Ads spend", async () => {
+    const options: FetchOptions = {
+      config: {
+        accessToken: "test-token",
+        businessId: "test-biz-id",
+      },
+    };
+
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes("commerce_orders")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+      }
+      if (url.includes("insights")) {
+        return Promise.reject(new Error("Network failure"));
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) });
+    });
+
+    const results = await adapter.fetch(options);
+
+    expect(results).toEqual([]);
+    expect(console.error).toHaveBeenCalledWith("Error fetching Meta Ads spend:", expect.any(Error));
+  });
+
+  it("should handle errors when fetching Meta Commerce orders", async () => {
+    const options: FetchOptions = {
+      config: {
+        accessToken: "test-token",
+        businessId: "test-biz-id",
+      },
+    };
+
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes("commerce_orders")) {
+        return Promise.reject(new Error("Network failure commerce"));
+      }
+      if (url.includes("insights")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) });
+    });
+
+    const results = await adapter.fetch(options);
+
+    expect(results).toEqual([]);
+    expect(console.error).toHaveBeenCalledWith(
+      "Error fetching Meta Commerce orders:",
+      expect.any(Error)
+    );
+  });
+});


### PR DESCRIPTION
🎯 **What:** Addressed the testing gap in packages/adapters/src/meta-commerce.ts by adding missing error path tests for the Meta Commerce and Meta Ads fetch logic.
📊 **Coverage:** Covered network failure scenarios during both Commerce orders and Ads spend fetching via API mocking, ensuring the fallback console logs are executed and do not halt the method execution.
✨ **Result:** Improved test coverage and reliability for the MetaCommerceAdapter by ensuring failure gracefully logs without throwing an unhandled rejection, fulfilling the required PR testing improvement description.

---
*PR created automatically by Jules for task [5159014042573395981](https://jules.google.com/task/5159014042573395981) started by @Hardonian*