### PR TITLE
🧪 [testing improvement] Add error path tests for WooCommerce circuit breaker

### DIFF
--- a/packages/adapters/src/__tests__/woocommerce.test.ts
+++ b/packages/adapters/src/__tests__/woocommerce.test.ts
@@ -1,0 +1,74 @@
+import { WooCommerceAdapter, WooCommerceConfig } from "../woocommerce";
+
+// We need to mock the global fetch function
+const originalFetch = global.fetch;
+
+describe("WooCommerceAdapter", () => {
+  let adapter: WooCommerceAdapter;
+  const config: WooCommerceConfig = {
+    storeUrl: "https://example.com",
+    consumerKey: "test_key",
+    consumerSecret: "test_secret",
+  };
+
+  beforeEach(() => {
+    adapter = new WooCommerceAdapter(config);
+    // Suppress console.error for expected circuit breaker error logs
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("should exist", () => {
+    expect(adapter).toBeDefined();
+    expect(adapter.name).toBe("woocommerce");
+  });
+
+  describe("fetch error paths (circuit breaker)", () => {
+    it("should throw error and log via circuit breaker when fetch fails", async () => {
+      // Mock fetch to simulate a network error / rejection
+      global.fetch = jest.fn().mockRejectedValue(new Error("Network connection failed"));
+
+      const options = {
+        dateRange: {
+          start: new Date("2023-01-01T00:00:00Z"),
+          end: new Date("2023-01-31T23:59:59Z"),
+        },
+      };
+
+      await expect(adapter.fetch(options)).rejects.toThrow("Network connection failed");
+      expect(console.error).toHaveBeenCalledWith(
+        "[CircuitBreaker] woocommerce-api failed:",
+        expect.any(Error)
+      );
+    });
+
+    it("should throw error if API returns non-ok response", async () => {
+      // Mock fetch to simulate a successful network request but failed API status
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+      });
+
+      const options = {
+        dateRange: {
+          start: new Date("2023-01-01T00:00:00Z"),
+          end: new Date("2023-01-31T23:59:59Z"),
+        },
+      };
+
+      await expect(adapter.fetch(options)).rejects.toThrow(
+        "WooCommerce API error: 401 Unauthorized"
+      );
+      // It should NOT call the circuit breaker console.error because the catch block
+      // inside withCircuitBreaker only catches exceptions thrown during the execution of fn().
+      // The non-ok response throwing happens *after* withCircuitBreaker resolves successfully
+      // with a Response object.
+      expect(console.error).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,11 +910,11 @@ importers:
         specifier: ^2.106.1
         version: 2.106.1
       '@tanstack/react-query':
-        specifier: ^5.100.13
-        version: 5.100.13(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(react@19.2.6)
       '@tanstack/react-query-devtools':
-        specifier: ^5.100.13
-        version: 5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)
+        specifier: ^5.100.14
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
@@ -13278,15 +13278,15 @@ snapshots:
 
   '@tanstack/query-devtools@5.100.14': {}
 
-  '@tanstack/react-query-devtools@5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-query-devtools@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/query-devtools': 5.100.13
-      '@tanstack/react-query': 5.100.13(react@19.2.6)
+      '@tanstack/query-devtools': 5.100.14
+      '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
 
-  '@tanstack/react-query@5.100.13(react@19.2.6)':
+  '@tanstack/react-query@5.100.14(react@19.2.6)':
     dependencies:
-      '@tanstack/query-core': 5.100.13
+      '@tanstack/query-core': 5.100.14
       react: 19.2.6
 
   '@testing-library/dom@9.3.4':


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for the error path of the `withCircuitBreaker` function in the WooCommerce adapter.
📊 **Coverage:** Mocked network rejections (which trigger the circuit breaker) and non-ok API responses (which do not) to ensure errors are correctly logged and rethrown.
✨ **Result:** Improved test reliability and safety net for the WooCommerce adapter's error handling.

---
*PR created automatically by Jules for task [5200382485582138](https://jules.google.com/task/5200382485582138) started by @Hardonian*