### PR TITLE
🧹 [code health improvement] Fix false positive TODO comment in architectural compliance evaluator

### DIFF
--- a/scripts/architectural-compliance-evaluator.ts
+++ b/scripts/architectural-compliance-evaluator.ts
@@ -321,7 +321,7 @@ function scoreTechnicalCorrectness(input: EvalInput): {
     );
   }
 
-  // Placeholder / TODO content (production-grade rule)
+  // Check for placeholder or incomplete content (production-grade rule)
   if (containsPlaceholder(response)) {
     score -= 1;
     notes.push("Response contains TODO/FIXME/placeholder content");


### PR DESCRIPTION
🎯 **What:** Rephrased the comment `// Placeholder / TODO content (production-grade rule)` to `// Check for placeholder or incomplete content (production-grade rule)` in `scripts/architectural-compliance-evaluator.ts`.
💡 **Why:** The original comment was being flagged by static analysis tools as an actionable TODO item, but it was merely describing the logic below it. Rephrasing it resolves the false positive and improves code maintainability.
✅ **Verification:** Ran typechecking (`tsc --noEmit -p tsconfig.json`) and the full project test suite (`pnpm test`); no regressions observed. Verified the file change visually using `sed`.
✨ **Result:** Clean static analysis with no false positive TODO warnings.

---
*PR created automatically by Jules for task [8690578408904209092](https://jules.google.com/task/8690578408904209092) started by @Hardonian*