### PR TITLE
🧹 [code health] Remove obsolete TODO for reconciliation migration

### DIFF
--- a/scripts/verify-backend-contract.ts
+++ b/scripts/verify-backend-contract.ts
@@ -22,7 +22,6 @@ import * as fs from "fs";
 import * as path from "path";
 import { execSync } from "child_process";
 
-
 interface VerificationResult {
   component: string;
   status: "pass" | "fail" | "warning";
@@ -716,11 +715,13 @@ async function main() {
 
     if (reconcile && failures.length > 0) {
       console.log("\n🔄 Reconciliation mode: generating migration...");
-      // TODO: Generate reconciliation migration
       try {
-        execSync(`npx tsx ${path.join(__dirname, "generate-reconciliation-migration.ts")} ${outputPath}`, {
-          stdio: "inherit",
-        });
+        execSync(
+          `npx tsx ${path.join(__dirname, "generate-reconciliation-migration.ts")} ${outputPath}`,
+          {
+            stdio: "inherit",
+          }
+        );
       } catch (e) {
         console.error("Failed to generate migration:", e instanceof Error ? e.message : String(e));
       }


### PR DESCRIPTION
🎯 **What:** Removed the obsolete `// TODO: Generate reconciliation migration` comment from `scripts/verify-backend-contract.ts` and formatted the file.

💡 **Why:** The comment incorrectly suggested that the reconciliation migration generation logic was unimplemented, yet the `execSync` call executing `generate-reconciliation-migration.ts` existed immediately below it. Removing the obsolete comment prevents confusion for future maintainers.

✅ **Verification:** Verified the file visually via `cat` to ensure it looks correct. Ran the global project test suite, any failures are pre-existing issues and not related to the deletion of this single comment.

✨ **Result:** A cleaner and less misleading source file.

---
*PR created automatically by Jules for task [2601254437886607165](https://jules.google.com/task/2601254437886607165) started by @Hardonian*