### PR TITLE
🔒 Fix XSS vulnerability in StructuredData component

### DIFF
--- a/packages/web/src/__tests__/components/StructuredData.test.tsx
+++ b/packages/web/src/__tests__/components/StructuredData.test.tsx
@@ -1,27 +1,26 @@
-import { render } from "@testing-library/react";
 import { StructuredData } from "../../components/StructuredData";
 
 describe("StructuredData", () => {
   it("escapes HTML entities in JSON payload to prevent XSS", () => {
     const maliciousData = {
       name: "Malicious <script>alert(1)</script>",
-      description: "</script><script>alert('xss')</script>",
+      description: "</script><script>alert('xss')</script>&",
     };
 
-    const { container } = render(<StructuredData data={maliciousData} id="test-schema" />);
-    const script = container.querySelector("#test-schema");
-
-    expect(script).not.toBeNull();
-    const content = script?.innerHTML;
+    // Use pure function call to avoid ReactCurrentDispatcher errors
+    const output = StructuredData({ data: maliciousData, id: "test-schema" });
+    const content = output.props.dangerouslySetInnerHTML.__html;
 
     // Should contain unicode escapes instead of raw brackets
     expect(content).toContain("\\u003cscript\\u003ealert(1)\\u003c/script\\u003e");
     expect(content).toContain(
-      "\\u003c/script\\u003e\\u003cscript\\u003ealert('xss')\\u003c/script\\u003e"
+      "\\u003c/script\\u003e\\u003cscript\\u003ealert(\\u0027xss\\u0027)\\u003c/script\\u003e\\u0026"
     );
 
-    // Should NOT contain raw brackets
+    // Should NOT contain raw brackets or unescaped elements
     expect(content).not.toContain("<script>");
     expect(content).not.toContain("</script>");
+    expect(content).not.toContain("&");
+    expect(content).not.toContain("'");
   });
 });

--- a/packages/web/src/components/StructuredData.tsx
+++ b/packages/web/src/components/StructuredData.tsx
@@ -7,7 +7,13 @@ interface StructuredDataProps {
 }
 
 export function StructuredData({ data, id }: StructuredDataProps) {
-  const safeJson = JSON.stringify(data, null, 0).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+  const safeJson = JSON.stringify(data, null, 0)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/'/g, "\\u0027")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 
   return (
     <script


### PR DESCRIPTION
🎯 **What:** Hardened the JSON stringification in the `StructuredData` component to escape single quotes, ampersands, and unicode paragraph/line separators.
⚠️ **Risk:** The previous implementation only sanitized angle brackets `<` and `>`. The JSON payload was inserted directly into an HTML `<script>` tag using `dangerouslySetInnerHTML`, leaving it vulnerable to more complex XSS vectors or encoding bypasses within the parsed script block.
🛡️ **Solution:** Extended the regex replacements on the JSON output to encompass standard unicode escapes for `&` (\u0026), `'` (\u0027), `\u2028` (\u2028), and `\u2029` (\u2029) to ensure secure embedding.

---
*PR created automatically by Jules for task [2856134309257253597](https://jules.google.com/task/2856134309257253597) started by @Hardonian*