### PR TITLE
fix(schema): validate integration configuration during usage entitlement checks

### DIFF
--- a/supabase/migrations/20240101000000_settler_golden_schema.sql
+++ b/supabase/migrations/20240101000000_settler_golden_schema.sql
@@ -16345,9 +16345,13 @@ BEGIN
 
   -- Server-side validation: Check if integration is configured (if integration_id provided)
   IF p_integration_id IS NOT NULL THEN
-    -- TODO: Add integration_credentials table check when implemented
-    -- For now, we'll allow but log a warning
-    NULL;
+    IF NOT EXISTS (
+      SELECT 1 FROM integration_credentials
+      WHERE tenant_id = COALESCE(p_tenant_id, (SELECT tenant_id FROM billing_accounts WHERE id = p_billing_account_id))
+        AND adapter = p_integration_id
+    ) THEN
+      RAISE EXCEPTION 'Integration not configured';
+    END IF;
   END IF;
 
   -- Insert usage event
@@ -18749,8 +18753,15 @@ BEGIN
   END IF;
 
   -- If integration is specified, validate it's configured
-  -- TODO: Add integration_credentials table check when implemented
-  -- For now, we'll allow but this should be enhanced
+  IF p_integration_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM integration_credentials
+      WHERE tenant_id = v_billing_account.tenant_id
+        AND adapter = p_integration_id
+    ) THEN
+      RETURN false;
+    END IF;
+  END IF;
 
   RETURN true;
 END;


### PR DESCRIPTION
When checking usage entitlements and logging usage events, verify that the specified
integration is properly configured in the `integration_credentials` table matching
the tenant ID. Replaces the placeholder TODO comments with actual exists checks.

---
*PR created automatically by Jules for task [14586787973802678130](https://jules.google.com/task/14586787973802678130) started by @Hardonian*