### PR TITLE
🔒 Fix insecure Math.random() for match ID generation

### DIFF
--- a/packages/api/src/application/matching/MatchingEngine.ts
+++ b/packages/api/src/application/matching/MatchingEngine.ts
@@ -8,6 +8,8 @@
  * - Fuzzy matching (reference ID variations, amount tolerance)
  */
 
+import { randomUUID } from "crypto";
+
 import {
   Transaction,
   Settlement,
@@ -598,6 +600,6 @@ export class MatchingEngine {
    * Generate UUID
    */
   private generateId(): string {
-    return `match_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    return `match_${Date.now()}_${randomUUID()}`;
   }
 }


### PR DESCRIPTION
🎯 **What:** Replaced the insecure Math.random() ID generator with crypto.randomUUID() in MatchingEngine.
⚠️ **Risk:** Math.random() is predictable, potentially leading to ID collisions or enabling ID guessing attacks for match records.
🛡️ **Solution:** Used Node's built-in crypto.randomUUID() which provides cryptographically secure pseudo-randomness.

---
*PR created automatically by Jules for task [4887948968746287725](https://jules.google.com/task/4887948968746287725) started by @Hardonian*