### PR TITLE
⚡ [Performance] Optimize scheduler check to eliminate N+1 queries

### DIFF
--- a/packages/api/src/infrastructure/MaterializedViewManager.ts
+++ b/packages/api/src/infrastructure/MaterializedViewManager.ts
@@ -143,6 +143,29 @@ export async function checkViewExists(tenantId: string, viewId: string): Promise
 }
 
 /**
+ * Check if multiple materialized views exist in a single query
+ */
+export async function checkViewsExist(
+  views: Array<{ tenantId: string; viewId: string }>
+): Promise<Set<string>> {
+  if (views.length === 0) return new Set();
+
+  const viewNames = views.map((v) => getMaterializedViewName(v.tenantId, v.viewId));
+
+  try {
+    const result = await query<{ matviewname: string }>(
+      `SELECT matviewname FROM pg_matviews WHERE matviewname = ANY($1)`,
+      [viewNames]
+    );
+
+    return new Set(result.map((r) => r.matviewname));
+  } catch (error) {
+    logError("Failed to check multiple views existence", { count: viewNames.length, error });
+    throw error;
+  }
+}
+
+/**
  * Get materialized view status
  */
 export async function getViewStatus(

--- a/packages/api/src/infrastructure/MaterializedViewScheduler.ts
+++ b/packages/api/src/infrastructure/MaterializedViewScheduler.ts
@@ -19,6 +19,8 @@ import {
   getTenantConfig,
   getActiveTenantViews,
   checkViewExists,
+  checkViewsExist,
+  getMaterializedViewName,
 } from "./MaterializedViewManager";
 
 interface ScheduledTask {
@@ -234,19 +236,30 @@ async function schedulerLoop(): Promise<void> {
 /**
  * Cleanup stale or invalid scheduled tasks
  */
-async function cleanupScheduler(): Promise<void> {
+export async function cleanupScheduler(): Promise<void> {
   let cleaned = 0;
 
-  for (const [key, task] of scheduledTasks) {
-    const exists = await checkViewExists(task.tenantId, task.viewId);
-    if (!exists) {
-      scheduledTasks.delete(key);
-      cleaned++;
-    }
-  }
+  const snapshot = Array.from(scheduledTasks.entries());
+  if (snapshot.length === 0) return;
 
-  if (cleaned > 0) {
-    logInfo("Cleaned up scheduled tasks", { cleaned, remaining: scheduledTasks.size });
+  try {
+    const existingViews = await checkViewsExist(
+      snapshot.map(([_, task]) => ({ tenantId: task.tenantId, viewId: task.viewId }))
+    );
+
+    for (const [key, task] of snapshot) {
+      const viewName = getMaterializedViewName(task.tenantId, task.viewId);
+      if (!existingViews.has(viewName)) {
+        scheduledTasks.delete(key);
+        cleaned++;
+      }
+    }
+
+    if (cleaned > 0) {
+      logInfo("Cleaned up scheduled tasks", { cleaned, remaining: scheduledTasks.size });
+    }
+  } catch (error) {
+    logError("Skipping scheduler cleanup due to database error", { error });
   }
 }
 

--- a/packages/api/src/infrastructure/__tests__/MaterializedViewScheduler.test.ts
+++ b/packages/api/src/infrastructure/__tests__/MaterializedViewScheduler.test.ts
@@ -1,0 +1,75 @@
+import {
+  scheduleViewRefresh,
+  getScheduledTasks,
+  cleanupScheduler,
+} from "../MaterializedViewScheduler";
+
+import { query } from "../../db";
+
+jest.mock("../../db", () => ({
+  query: jest.fn(),
+}));
+
+describe("MaterializedViewScheduler cleanup performance", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Clear scheduled tasks by unscheduling them or just letting them be overwritten
+  });
+
+  it("should query pg_matviews exactly once to verify multiple views", async () => {
+    // Schedule some views
+    scheduleViewRefresh("tenant1", {
+      viewId: "view1",
+      active: true,
+      refreshConfig: { strategy: "automatic", intervalMinutes: 10, maxStalenessMinutes: 60 },
+      stalenessStatus: "fresh",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    scheduleViewRefresh("tenant2", {
+      viewId: "view2",
+      active: true,
+      refreshConfig: { strategy: "automatic", intervalMinutes: 10, maxStalenessMinutes: 60 },
+      stalenessStatus: "fresh",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    scheduleViewRefresh("tenant3", {
+      viewId: "view3",
+      active: true,
+      refreshConfig: { strategy: "automatic", intervalMinutes: 10, maxStalenessMinutes: 60 },
+      stalenessStatus: "fresh",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Mock the query to return some existing views
+    const mockQuery = query as jest.Mock;
+
+    // In optimized version, it calls SELECT matviewname FROM pg_matviews WHERE matviewname IN ($1, $2, $3)
+    mockQuery.mockResolvedValue([
+      { matviewname: "mv_tenant1_view1" },
+      { matviewname: "mv_tenant3_view3" },
+    ]);
+
+    const startTime = performance.now();
+    await cleanupScheduler();
+    const endTime = performance.now();
+
+    console.info(`Cleanup took ${endTime - startTime} ms`);
+    console.info(`query was called ${mockQuery.mock.calls.length} times`);
+
+    // After optimization, it should call query exactly 1 time instead of N times
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    const tasks = getScheduledTasks();
+    // One view (mv_tenant2_view2) was missing, so it should be cleaned up
+    expect(tasks.length).toBe(2);
+
+    // Ensure the query logic uses the IN clause and parameterizes it properly
+    expect(mockQuery.mock.calls[0][0]).toContain("= ANY($1)");
+  });
+});

--- a/patch_scheduler_test2.js
+++ b/patch_scheduler_test2.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const file = 'packages/api/src/infrastructure/__tests__/MaterializedViewScheduler.test.ts';
+let code = fs.readFileSync(file, 'utf8');
+
+code = code.replace(
+    'import * as manager from "../MaterializedViewManager";',
+    ''
+);
+code = code.replace(
+    'console.log(`Cleanup took ${endTime - startTime} ms`);',
+    'console.info(`Cleanup took ${endTime - startTime} ms`);'
+);
+code = code.replace(
+    'console.log(`query was called ${mockQuery.mock.calls.length} times`);',
+    'console.info(`query was called ${mockQuery.mock.calls.length} times`);'
+);
+
+fs.writeFileSync(file, code);


### PR DESCRIPTION
🎯 What:
Replaced the iterative database checks inside `cleanupScheduler` with a single, batched database query (`= ANY($1)` array lookup) via a new `checkViewsExist` method in `MaterializedViewManager.ts`. 

💡 Why:
The previous implementation performed N individual PostgreSQL queries (N+1 query problem) during the periodic cleanup of stale materialized view refresh schedules. This batched approach drastically reduces I/O latency and CPU overhead on both the database server and the Node backend.

✅ Verification:
- Addressed race condition concerns by creating an array snapshot before awaiting database results.
- Robust error handling logs DB failures but skips cleanup safely.
- Added comprehensive unit tests strictly verifying that exactly one database query is issued.
- All global API and core tests pass successfully.

✨ Result:
Scheduler cleanup now incurs `O(1)` query roundtrips instead of `O(n)`.

---
*PR created automatically by Jules for task [8910891221054649036](https://jules.google.com/task/8910891221054649036) started by @Hardonian*